### PR TITLE
Fix webview bug in iOS and cache storage label issue as per #73

### DIFF
--- a/MSAL.sln
+++ b/MSAL.sln
@@ -121,6 +121,7 @@ Global
 		{91E9E564-8A44-457B-A97C-E76C9F6275D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91E9E564-8A44-457B-A97C-E76C9F6275D6}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{91E9E564-8A44-457B-A97C-E76C9F6275D6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{91E9E564-8A44-457B-A97C-E76C9F6275D6}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{91E9E564-8A44-457B-A97C-E76C9F6275D6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{91E9E564-8A44-457B-A97C-E76C9F6275D6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{91E9E564-8A44-457B-A97C-E76C9F6275D6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -204,6 +205,7 @@ Global
 		{FA2C7F08-3CCB-47C2-B359-627CC96C04A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA2C7F08-3CCB-47C2-B359-627CC96C04A3}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{FA2C7F08-3CCB-47C2-B359-627CC96C04A3}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{FA2C7F08-3CCB-47C2-B359-627CC96C04A3}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{FA2C7F08-3CCB-47C2-B359-627CC96C04A3}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{FA2C7F08-3CCB-47C2-B359-627CC96C04A3}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{FA2C7F08-3CCB-47C2-B359-627CC96C04A3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -254,6 +256,7 @@ Global
 		{826D90F4-CA79-4788-918C-B66AA5CC6DF0}.Debug|ARM.ActiveCfg = Debug|ARM
 		{826D90F4-CA79-4788-918C-B66AA5CC6DF0}.Debug|ARM.Build.0 = Debug|ARM
 		{826D90F4-CA79-4788-918C-B66AA5CC6DF0}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{826D90F4-CA79-4788-918C-B66AA5CC6DF0}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{826D90F4-CA79-4788-918C-B66AA5CC6DF0}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{826D90F4-CA79-4788-918C-B66AA5CC6DF0}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{826D90F4-CA79-4788-918C-B66AA5CC6DF0}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
@@ -344,6 +347,7 @@ Global
 		{0C5100D0-54F2-4075-B604-DDE15DA218D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C5100D0-54F2-4075-B604-DDE15DA218D5}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{0C5100D0-54F2-4075-B604-DDE15DA218D5}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0C5100D0-54F2-4075-B604-DDE15DA218D5}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{0C5100D0-54F2-4075-B604-DDE15DA218D5}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{0C5100D0-54F2-4075-B604-DDE15DA218D5}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{0C5100D0-54F2-4075-B604-DDE15DA218D5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -385,6 +389,7 @@ Global
 		{75D27855-D189-44AE-9FA9-10E729C573F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75D27855-D189-44AE-9FA9-10E729C573F4}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{75D27855-D189-44AE-9FA9-10E729C573F4}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{75D27855-D189-44AE-9FA9-10E729C573F4}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{75D27855-D189-44AE-9FA9-10E729C573F4}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{75D27855-D189-44AE-9FA9-10E729C573F4}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{75D27855-D189-44AE-9FA9-10E729C573F4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -431,6 +436,8 @@ Global
 		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|iPhone.Deploy.0 = Debug|Any CPU
 		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{6CE59CDE-3DD1-4897-959C-EF32E7F3315B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -473,6 +480,7 @@ Global
 		{8BA45C94-A047-43E0-BB98-D32FDD72F9E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8BA45C94-A047-43E0-BB98-D32FDD72F9E5}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{8BA45C94-A047-43E0-BB98-D32FDD72F9E5}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{8BA45C94-A047-43E0-BB98-D32FDD72F9E5}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{8BA45C94-A047-43E0-BB98-D32FDD72F9E5}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{8BA45C94-A047-43E0-BB98-D32FDD72F9E5}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{8BA45C94-A047-43E0-BB98-D32FDD72F9E5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -514,10 +522,10 @@ Global
 		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
 		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
 		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|ARM.ActiveCfg = Debug|iPhone
-		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhone.ActiveCfg = Debug|iPhoneSimulator
-		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhone.Build.0 = Debug|iPhoneSimulator
-		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhone
-		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhoneSimulator.Build.0 = Debug|iPhone
+		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhone.Build.0 = Debug|iPhone
+		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|Mixed Platforms.ActiveCfg = Debug|iPhone
 		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|Win32.ActiveCfg = Debug|iPhone
 		{2B675E51-98A2-4B44-8A37-A0661ABB931F}.Debug|x64.ActiveCfg = Debug|iPhone
@@ -557,6 +565,7 @@ Global
 		{C09EE601-3F07-4E8B-B12F-473B2BFBEF95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C09EE601-3F07-4E8B-B12F-473B2BFBEF95}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{C09EE601-3F07-4E8B-B12F-473B2BFBEF95}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{C09EE601-3F07-4E8B-B12F-473B2BFBEF95}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{C09EE601-3F07-4E8B-B12F-473B2BFBEF95}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{C09EE601-3F07-4E8B-B12F-473B2BFBEF95}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{C09EE601-3F07-4E8B-B12F-473B2BFBEF95}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -694,9 +703,10 @@ Global
 		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
 		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
 		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|ARM.ActiveCfg = Debug|iPhone
-		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|iPhone.ActiveCfg = Debug|iPhoneSimulator
-		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhone
-		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|iPhoneSimulator.Build.0 = Debug|iPhone
+		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|iPhone.Build.0 = Debug|iPhone
+		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|Mixed Platforms.ActiveCfg = Debug|iPhone
 		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|Mixed Platforms.Build.0 = Debug|iPhone
 		{FDED3627-94FD-4886-A540-3AC05380095B}.Debug|Win32.ActiveCfg = Debug|iPhone

--- a/src/MSAL.PCL.iOS/MsalCustomUrlProtocol.cs
+++ b/src/MSAL.PCL.iOS/MsalCustomUrlProtocol.cs
@@ -98,6 +98,13 @@ namespace Microsoft.Identity.Client
             {
                 NSMutableUrlRequest mutableRequest = (NSMutableUrlRequest) request.MutableCopy();
                 CustomHeaderHandler.ApplyHeadersTo(mutableRequest);
+
+                if (response != null)
+                {
+                    RemoveProperty("MsalCustomUrlProtocol", mutableRequest);
+                    _handler.Client.Redirected(_handler, mutableRequest, response);
+                }
+
                 return mutableRequest;
             }
 

--- a/src/MSAL.PCL.iOS/TokenCachePlugin.cs
+++ b/src/MSAL.PCL.iOS/TokenCachePlugin.cs
@@ -77,10 +77,10 @@ namespace Microsoft.Identity.Client
                     {
                         Generic = NSData.FromString(LocalSettingsContainerName),
 	                Accessible = SecAccessible.Always,
-                        Service = "ADAL.PCL.iOS Service",
-                        Account = "ADAL.PCL.iOS cache",
-                        Label = "ADAL.PCL.iOS Label",
-                        Comment = "ADAL.PCL.iOS Cache",
+                        Service = "MSAL.PCL.iOS Service",
+                        Account = "MSAL.PCL.iOS cache",
+                        Label = "MSAL.PCL.iOS Label",
+                        Comment = "MSAL.PCL.iOS Cache",
                         Description = "Storage for cache"
                     };
 


### PR DESCRIPTION
Fix webview bug in iOS and cache storage label issue. 302 redirects in iOs were not getting loaded correctly. Keychain cache was labelled incorrectly.
