### PR TITLE
Port relevant fixes from ADAL v3.

### DIFF
--- a/src/MSAL.Common/CommonAssemblyInfo.cs
+++ b/src/MSAL.Common/CommonAssemblyInfo.cs
@@ -39,7 +39,7 @@ using System.Reflection;
 // Keep major and minor versions in AssemblyFileVersion in sync with AssemblyVersion.
 // Build and revision numbers are replaced on build machine for official builds.
 
-[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.

--- a/src/MSAL.Common/CommonAssemblyInfo.cs
+++ b/src/MSAL.Common/CommonAssemblyInfo.cs
@@ -32,15 +32,14 @@ using System.Reflection;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyCompany("Microsoft Corp.")]
-[assembly: AssemblyCopyright("Copyright (c) Microsoft Corp. All rights reserved.")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("1.0.0.0")]
 
 // Keep major and minor versions in AssemblyFileVersion in sync with AssemblyVersion.
 // Build and revision numbers are replaced on build machine for official builds.
 
-[assembly: AssemblyFileVersion("1.0.00000.0000")]
+[assembly: AssemblyVersion("1.1.0.0")]
 
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.

--- a/src/MSAL.PCL.Android/AuthenticationContinuationHelper.cs
+++ b/src/MSAL.PCL.Android/AuthenticationContinuationHelper.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System.Globalization;
 using Android.App;
 using Android.Content;
 using Microsoft.Identity.Client.Internal;
@@ -39,6 +40,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public static void SetAuthenticationContinuationEventArgs(int requestCode, Result resultCode, Intent data)
         {
+            PlatformPlugin.Logger.Information(null, string.Format(CultureInfo.InvariantCulture, "Received Activity Result({0})", (int)resultCode));
             AuthorizationResult authorizationResult = null;
 
             switch ((int) resultCode)

--- a/src/MSAL.PCL.Android/WebUI.cs
+++ b/src/MSAL.PCL.Android/WebUI.cs
@@ -81,8 +81,15 @@ namespace Microsoft.Identity.Client
 
         public static void SetAuthorizationResult(AuthorizationResult authorizationResultInput)
         {
-            authorizationResult = authorizationResultInput;
-            returnedUriReady.Release();
+            if (returnedUriReady != null)
+            {
+                authorizationResult = authorizationResultInput;
+                returnedUriReady.Release();
+            }
+            else
+            {
+                PlatformPlugin.Logger.Information(null, "No pending request for response from web ui.");
+            }
         }
     }
 }

--- a/src/MSAL.PCL.Desktop/CryptographyHelper.cs
+++ b/src/MSAL.PCL.Desktop/CryptographyHelper.cs
@@ -98,31 +98,34 @@ namespace Microsoft.Identity.Client
         // This method returns an AsymmetricSignatureFormatter capable of supporting Sha256 signatures. 
         private static RSACryptoServiceProvider GetCryptoProviderForSha256(RSACryptoServiceProvider rsaProvider)
         {
-            const int PROV_RSA_AES = 24;
-            // CryptoApi provider type for an RSA provider supporting sha-256 digital signatures
-            if (rsaProvider.CspKeyContainerInfo.ProviderType == PROV_RSA_AES)
+            const int PROV_RSA_AES = 24;    // CryptoApi provider type for an RSA provider supporting sha-256 digital signatures
+
+            // ProviderType == 1(PROV_RSA_FULL) and providerType == 12(PROV_RSA_SCHANNEL) are provider types that only support SHA1. 
+            // Change them to PROV_RSA_AES=24 that supports SHA2 also. Only levels up if the associated key is not a hardware key.
+            // Another provider type related to rsa, PROV_RSA_SIG == 2 that only supports Sha1 is no longer supported
+            if ((rsaProvider.CspKeyContainerInfo.ProviderType == 1 || rsaProvider.CspKeyContainerInfo.ProviderType == 12) && !rsaProvider.CspKeyContainerInfo.HardwareDevice)
             {
-                return rsaProvider;
+                CspParameters csp = new CspParameters
+                {
+                    ProviderType = PROV_RSA_AES,
+                    KeyContainerName = rsaProvider.CspKeyContainerInfo.KeyContainerName,
+                    KeyNumber = (int)rsaProvider.CspKeyContainerInfo.KeyNumber
+                };
+
+                if (rsaProvider.CspKeyContainerInfo.MachineKeyStore)
+                {
+                    csp.Flags = CspProviderFlags.UseMachineKeyStore;
+                }
+
+                //
+                // If UseExistingKey is not specified, the CLR will generate a key for a non-existent group.
+                // With this flag, a CryptographicException is thrown instead.
+                //
+                csp.Flags |= CspProviderFlags.UseExistingKey;
+                return new RSACryptoServiceProvider(csp);
             }
 
-            CspParameters csp = new CspParameters
-            {
-                ProviderType = PROV_RSA_AES,
-                KeyContainerName = rsaProvider.CspKeyContainerInfo.KeyContainerName,
-                KeyNumber = (int) rsaProvider.CspKeyContainerInfo.KeyNumber
-            };
-
-            if (rsaProvider.CspKeyContainerInfo.MachineKeyStore)
-            {
-                csp.Flags = CspProviderFlags.UseMachineKeyStore;
-            }
-
-            //
-            // If UseExistingKey is not specified, the CLR will generate a key for a non-existent group.
-            // With this flag, a CryptographicException is thrown instead.
-            //
-            csp.Flags |= CspProviderFlags.UseExistingKey;
-            return new RSACryptoServiceProvider(csp);
+            return rsaProvider;
         }
     }
 }

--- a/src/MSAL.PCL.Desktop/Properties/AssemblyInfo.cs
+++ b/src/MSAL.PCL.Desktop/Properties/AssemblyInfo.cs
@@ -36,6 +36,9 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 
 [assembly: ComVisible(false)]
+ 
+// Allow this assembly to be serviced when run on desktop CLR
+[assembly: AssemblyMetadata("Serviceable", "True")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/src/MSAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/MSAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
@@ -117,6 +117,12 @@ namespace Microsoft.Identity.Client
         /// </summary>
         protected virtual void WebBrowserNavigatingHandler(object sender, WebBrowserNavigatingEventArgs e)
         {
+            if (this.DialogResult == DialogResult.OK)
+            {
+                e.Cancel = true;
+                return;
+            }
+
             if (this.webBrowser.IsDisposed)
             {
                 // we cancel all flows in disposed object and just do nothing, let object to close.
@@ -167,6 +173,12 @@ namespace Microsoft.Identity.Client
         /// </summary>
         protected virtual void WebBrowserNavigateErrorHandler(object sender, WebBrowserNavigateErrorEventArgs e)
         {
+            if (this.DialogResult == DialogResult.OK)
+            {
+                e.Cancel = true;
+                return;
+            }
+
             if (this.webBrowser.IsDisposed)
             {
                 // we cancel all flow in disposed object.
@@ -204,7 +216,7 @@ namespace Microsoft.Identity.Client
             }
 
             if (!readyToClose && !url.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) &&
-                !url.AbsoluteUri.Equals("about:blank", StringComparison.CurrentCultureIgnoreCase))
+                !url.AbsoluteUri.Equals("about:blank", StringComparison.CurrentCultureIgnoreCase) && !url.AbsoluteUri.Equals("javascript", StringComparison.CurrentCultureIgnoreCase))
             {
                 this.Result = new AuthorizationResult(AuthorizationStatus.ErrorHttp);
                 this.Result.Error = MsalError.NonHttpsRedirectNotSupported;

--- a/src/MSAL.PCL.WinRT/Properties/AssemblyInfo.cs
+++ b/src/MSAL.PCL.WinRT/Properties/AssemblyInfo.cs
@@ -37,6 +37,9 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
+// Allow this assembly to be serviced when run on desktop CLR
+[assembly: AssemblyMetadata("Serviceable", "True")]
+
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("ff47962a-d498-4c63-b7e9-4db3653ad7dd")]

--- a/src/MSAL.PCL/Properties/AssemblyInfo.cs
+++ b/src/MSAL.PCL/Properties/AssemblyInfo.cs
@@ -37,6 +37,9 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
+// Allow this assembly to be serviced when run on desktop CLR
+[assembly: AssemblyMetadata("Serviceable", "True")]
+
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("ff47962a-d498-4c63-b7e9-4db3653ad7db")]


### PR DESCRIPTION
Port bug fixes and features from ADAL v3 since MSAL preview release (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/131)

- AzureAD/azure-activedirectory-library-for-dotnet#451
- AzureAD/azure-activedirectory-library-for-dotnet#459
- Add semantic versioning for the library
- OnResume throws NullPointerException when no ADAL or broker activity is pending
- Ignoring Javascript:// in desktop webview as a non-https url
- Ignore webview error if dialogresult = OK in desktop webview
