### PR TITLE
use GetCertHash() instead of Thumbprint

### DIFF
--- a/src/MSAL.Common/ClientAssertionCertificate.cs
+++ b/src/MSAL.Common/ClientAssertionCertificate.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Client
         public string Thumbprint
         {
             // Thumbprint should be url encoded
-            get { return Base64UrlEncoder.Encode(this.Certificate.Thumbprint); }
+            get { return Base64UrlEncoder.Encode(this.Certificate.GetCertHash()); }
         }
     }
 }


### PR DESCRIPTION
use GetCertHash() instead of Thumbprint per #124 as it would cause the server to fail the request