### PR TITLE
remove userassertionHash from TokenCacheItem

### DIFF
--- a/src/MSAL.PCL/Internal/Cache/BaseTokenCacheItem.cs
+++ b/src/MSAL.PCL/Internal/Cache/BaseTokenCacheItem.cs
@@ -49,8 +49,7 @@ namespace Microsoft.Identity.Client.Internal.Cache
                 TenantId = idToken.TenantId;
                 User = new User(idToken);
             }
-
-            this.UserAssertionHash = response.UserAssertionHash;
+            
             this.Authority = authority;
             this.ClientId = clientId;
             this.Policy = policy;
@@ -102,9 +101,6 @@ namespace Microsoft.Identity.Client.Internal.Cache
         /// Gets the entire Profile Info if returned by the service or null if no Id Token is returned.
         /// </summary>
         public User User { get; set; }
-
-        [DataMember(Name = "user_assertion_hash")]
-        public string UserAssertionHash { get; set; }
 
         public abstract TokenCacheKey GetTokenCacheKey();
         

--- a/src/MSAL.PCL/Internal/OAuth2/TokenResponse.cs
+++ b/src/MSAL.PCL/Internal/OAuth2/TokenResponse.cs
@@ -80,7 +80,5 @@ namespace Microsoft.Identity.Client.Internal.OAuth2
         {
             get { return DateTime.UtcNow + TimeSpan.FromSeconds(this.IdTokenExpiresIn); }
         }
-        
-        public string UserAssertionHash { get; set; }
     }
 }

--- a/src/MSAL.PCL/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/MSAL.PCL/Internal/Requests/OnBehalfOfRequest.cs
@@ -48,10 +48,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
         protected override async Task SendTokenRequestAsync()
         {
             await base.SendTokenRequestAsync().ConfigureAwait(false);
-            if (Response != null)
-            {
-                Response.UserAssertionHash = AuthenticationRequestParameters.UserAssertion.AssertionHash;
-            }
         }
 
         protected override void SetAdditionalRequestParameters(OAuth2Client client)

--- a/src/MSAL.PCL/TokenCache.cs
+++ b/src/MSAL.PCL/TokenCache.cs
@@ -249,13 +249,6 @@ namespace Microsoft.Identity.Client
                 // Access token lookup needs to be a strict match. In the JSON response from token endpoint, server only returns the scope
                 // the developer requires the token for. We store the token separately for considerations i.e. MFA.
                 TokenCacheItem tokenCacheItem = tokenCacheItems[0];
-
-                if (requestParam.UserAssertion != null &&
-                    !tokenCacheItem.UserAssertionHash.Equals(requestParam.UserAssertion.AssertionHash))
-                {
-                    return null;
-                }
-
                 if (tokenCacheItem.ExpiresOn > DateTime.UtcNow + TimeSpan.FromMinutes(DefaultExpirationBufferInMinutes))
                 {
                     return tokenCacheItem;


### PR DESCRIPTION
remove userassertionHash from TokenCacheItem as we don't need to track this information anymore. Have acquireTokenOnBehalfOf() do network call and skip cache lookup, just like AcquireToken calls. Developer can always call acquire token silent to pull from cache.  #146