### PR TITLE
Update to the API surface

### DIFF
--- a/samples/TestApp.PCL/TokenBroker.cs
+++ b/samples/TestApp.PCL/TokenBroker.cs
@@ -76,7 +76,7 @@ namespace TestApp.PCL
         {
             try
             {
-                app = new PublicClientApplication("https://login.windows.net/common", "CLIENT_ID");
+                app = new PublicClientApplication("CLIENT_ID");
                 var result = await app.AcquireTokenSilentAsync(Sts.ValidScope, null);
 
                 return result.Token;

--- a/src/MSAL.PCL/ClientApplicationBase.cs
+++ b/src/MSAL.PCL/ClientApplicationBase.cs
@@ -104,12 +104,6 @@ namespace Microsoft.Identity.Client
         public bool ValidateAuthority { get; set; }
 
         /// <summary>
-        /// .NET specific property that allows configuration of platform specific properties. For example, in iOS/Android it
-        /// would include the flag to enable/disable broker.
-        /// </summary>
-        public IPlatformParameters PlatformParameters { get; set; }
-
-        /// <summary>
         /// Returns a User centric view over the cache that provides a list of all the signed in users.
         /// </summary>
         public IEnumerable<User> Users
@@ -149,7 +143,7 @@ namespace Microsoft.Identity.Client
             Authority authority = Internal.Instance.Authority.CreateAuthority(this.Authority, this.ValidateAuthority);
             return
                 await
-                    this.AcquireTokenSilentCommonAsync(authority, scope, user, this.PlatformParameters, null, false)
+                    this.AcquireTokenSilentCommonAsync(authority, scope, user, null, false)
                         .ConfigureAwait(false);
         }
 
@@ -199,21 +193,16 @@ namespace Microsoft.Identity.Client
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, this.ValidateAuthority);
             return
                 await
-                    this.AcquireTokenSilentCommonAsync(authorityInstance, scope, user, this.PlatformParameters, policy,
+                    this.AcquireTokenSilentCommonAsync(authorityInstance, scope, user, policy,
                         forceRefresh).ConfigureAwait(false);
         }
         
         internal async Task<AuthenticationResult> AcquireTokenSilentCommonAsync(Authority authority,
-            string[] scope, User user, IPlatformParameters parameters, string policy, bool forceRefresh)
+            string[] scope, User user, string policy, bool forceRefresh)
         {
-            if (parameters == null)
-            {
-                parameters = PlatformPlugin.DefaultPlatformParameters;
-            }
-
             var handler = new SilentRequest(
                 this.CreateRequestParameters(authority, scope, policy, user, this.UserTokenCache),
-                parameters, forceRefresh);
+                forceRefresh);
             return await handler.RunAsync().ConfigureAwait(false);
         }
 

--- a/src/MSAL.PCL/ConfidentialClientApplication.cs
+++ b/src/MSAL.PCL/ConfidentialClientApplication.cs
@@ -47,19 +47,19 @@ namespace Microsoft.Identity.Client
         /// <param name="appTokenCache"></param>
         public ConfidentialClientApplication(string clientId, string redirectUri,
             ClientCredential clientCredential, TokenCache userTokenCache, TokenCache appTokenCache)
-            : this(DefaultAuthority, clientId, redirectUri, clientCredential, userTokenCache, appTokenCache)
+            : this(clientId, DefaultAuthority, redirectUri, clientCredential, userTokenCache, appTokenCache)
         {
         }
 
         /// <summary>
         /// </summary>
-        /// <param name="authority"></param>
         /// <param name="clientId"></param>
+        /// <param name="authority"></param>
         /// <param name="redirectUri"></param>
         /// <param name="clientCredential"></param>
         /// <param name="userTokenCache"></param>
         /// <param name="appTokenCache"></param>
-        public ConfidentialClientApplication(string authority, string clientId, string redirectUri,
+        public ConfidentialClientApplication(string clientId, string authority, string redirectUri,
             ClientCredential clientCredential, TokenCache userTokenCache, TokenCache appTokenCache) : base(authority, clientId, redirectUri, true)
         {
             this.ClientCredential = clientCredential;
@@ -106,8 +106,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// AcquireTokenByAuthorizationCodeAsync
         /// </summary>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string[] scope,
-            string authorizationCode)
+        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode, string[] scope)
         {
             return
                 await
@@ -118,8 +117,8 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// AcquireTokenByAuthorizationCodeAsync
         /// </summary>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string[] scope,
-            string authorizationCode, string policy)
+        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode, string[] scope,
+            string policy)
         {
             return
                 await
@@ -184,7 +183,7 @@ namespace Microsoft.Identity.Client
             requestParameters.ExtraQueryParameters = extraQueryParameters;
 
             var handler =
-                new InteractiveRequest(requestParameters, null, null, loginHint, null, null);
+                new InteractiveRequest(requestParameters, null, loginHint, null, null);
             return await handler.CreateAuthorizationUriAsync(CreateCallState(CorrelationId)).ConfigureAwait(false);
         }
 
@@ -210,8 +209,7 @@ namespace Microsoft.Identity.Client
             requestParameters.ExtraQueryParameters = extraQueryParameters;
 
             var handler =
-                new InteractiveRequest(requestParameters, additionalScope,
-                    this.PlatformParameters, loginHint, null, null);
+                new InteractiveRequest(requestParameters, additionalScope, loginHint, null, null);
             return await handler.CreateAuthorizationUriAsync(CreateCallState(CorrelationId)).ConfigureAwait(false);
         }
 

--- a/src/MSAL.PCL/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/MSAL.PCL/Internal/Requests/AuthenticationRequestParameters.cs
@@ -59,5 +59,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         public User User { get; set; }
 
         public UserAssertion UserAssertion { get; set; }
+
+        public IPlatformParameters PlatformParameters { get; set; }
     }
 }

--- a/src/MSAL.PCL/Internal/Requests/InteractiveRequest.cs
+++ b/src/MSAL.PCL/Internal/Requests/InteractiveRequest.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
     internal class InteractiveRequest : BaseRequest
     {
         private readonly SortedSet<string> _additionalScope;
-        private readonly IPlatformParameters _authorizationParameters;
         private readonly UiOptions? _uiOptions;
         private readonly IWebUI _webUi;
         private AuthorizationResult _authorizationResult;
@@ -46,16 +45,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
         private string _state;
 
         public InteractiveRequest(AuthenticationRequestParameters authenticationRequestParameters,
-            string[] additionalScope, IPlatformParameters parameters,
-            UiOptions uiOptions, IWebUI webUI)
+            string[] additionalScope, UiOptions uiOptions, IWebUI webUI)
             : this(
-                authenticationRequestParameters, additionalScope, parameters, authenticationRequestParameters.User?.DisplayableId,
+                authenticationRequestParameters, additionalScope, authenticationRequestParameters.User?.DisplayableId,
                 uiOptions, webUI)
         {
         }
 
         public InteractiveRequest(AuthenticationRequestParameters authenticationRequestParameters,
-            string[] additionalScope, IPlatformParameters parameters, string loginHint,
+            string[] additionalScope, string loginHint,
             UiOptions? uiOptions, IWebUI webUI)
             : base(authenticationRequestParameters)
         {
@@ -73,10 +71,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
 
             ValidateScopeInput(this._additionalScope);
-
-            this._authorizationParameters = parameters;
-
-
+            
             authenticationRequestParameters.LoginHint = loginHint;
             if (!string.IsNullOrWhiteSpace(authenticationRequestParameters.ExtraQueryParameters) &&
                 authenticationRequestParameters.ExtraQueryParameters[0] == '&')
@@ -94,7 +89,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 throw new ArgumentException(MsalErrorMessage.LoginHintNullForUiOption, "loginHint");
             }
 
-            PlatformPlugin.BrokerHelper.PlatformParameters = _authorizationParameters;
+            PlatformPlugin.BrokerHelper.PlatformParameters = authenticationRequestParameters.PlatformParameters;
         }
 
         internal override async Task PreTokenRequest()

--- a/src/MSAL.PCL/Internal/Requests/SilentRequest.cs
+++ b/src/MSAL.PCL/Internal/Requests/SilentRequest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
     {
         private RefreshTokenCacheItem _refreshTokenItem;
 
-        public SilentRequest(AuthenticationRequestParameters authenticationRequestParameters, IPlatformParameters parameters, bool forceRefresh)
+        public SilentRequest(AuthenticationRequestParameters authenticationRequestParameters, bool forceRefresh)
             : base(authenticationRequestParameters)
         {
             if (authenticationRequestParameters.User == null)
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 throw new ArgumentNullException(nameof(authenticationRequestParameters.User));
             }
             
-            PlatformPlugin.BrokerHelper.PlatformParameters = parameters;
+            PlatformPlugin.BrokerHelper.PlatformParameters = authenticationRequestParameters.PlatformParameters;
             this.ForceRefresh = forceRefresh;
         }
 

--- a/src/MSAL.PCL/PublicClientApplication.cs
+++ b/src/MSAL.PCL/PublicClientApplication.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Default consutructor of the application.
         /// </summary>
-        public PublicClientApplication(string clientId) : this(DefaultAuthority, clientId)
+        public PublicClientApplication(string clientId) : this(clientId, DefaultAuthority)
         {
         }
 
         /// <summary>
         /// </summary>
-        public PublicClientApplication(string authority, string clientId)
+        public PublicClientApplication(string clientId, string authority)
             : base(authority, clientId, DEFAULT_REDIRECT_URI, true)
         {
             this.UserTokenCache = new TokenCache(clientId);

--- a/src/MSAL.PCL/PublicClientApplication.cs
+++ b/src/MSAL.PCL/PublicClientApplication.cs
@@ -40,14 +40,12 @@ namespace Microsoft.Identity.Client
     public sealed class PublicClientApplication : ClientApplicationBase
     {
         private const string DEFAULT_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
-        /*
-                /// <summary>
-                /// Default consutructor of the application.
-                /// </summary>
-                public PublicClientApplication():this(DefaultAuthority)
-                {
-                }
-        */
+
+        /// <summary>
+        /// .NET specific property that allows configuration of platform specific properties. For example, in iOS/Android it
+        /// would include the flag to enable/disable broker.
+        /// </summary>
+        public IPlatformParameters PlatformParameters { get; set; }
 
         /// <summary>
         /// Default consutructor of the application.
@@ -216,17 +214,11 @@ namespace Microsoft.Identity.Client
             string[] additionalScope, string loginHint, UiOptions uiOptions,
             string extraQueryParameters, string policy)
         {
-            if (this.PlatformParameters == null)
-            {
-                this.PlatformParameters = PlatformPlugin.DefaultPlatformParameters;
-            }
-
             var requestParams = this.CreateRequestParameters(authority, scope, policy, null, this.UserTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;
-
+            
             var handler =
-                new InteractiveRequest(requestParams, additionalScope,
-                    this.PlatformParameters, loginHint, uiOptions,
+                new InteractiveRequest(requestParams, additionalScope, loginHint, uiOptions,
                     this.CreateWebAuthenticationDialog(this.PlatformParameters));
             return await handler.RunAsync().ConfigureAwait(false);
         }
@@ -235,17 +227,12 @@ namespace Microsoft.Identity.Client
             string[] additionalScope, User user, UiOptions uiOptions, string extraQueryParameters,
             string policy)
         {
-            if (this.PlatformParameters == null)
-            {
-                this.PlatformParameters = PlatformPlugin.DefaultPlatformParameters;
-            }
 
             var requestParams = this.CreateRequestParameters(authority, scope, policy, user, this.UserTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;
 
             var handler =
-                new InteractiveRequest(requestParams, additionalScope,
-                    this.PlatformParameters, uiOptions,
+                new InteractiveRequest(requestParams, additionalScope, uiOptions,
                     this.CreateWebAuthenticationDialog(this.PlatformParameters));
             return await handler.RunAsync().ConfigureAwait(false);
         }
@@ -255,6 +242,10 @@ namespace Microsoft.Identity.Client
         {
             AuthenticationRequestParameters parameters = base.CreateRequestParameters(authority, scope, policy, user, cache);
             parameters.ClientKey = new ClientKey(this.ClientId);
+            if (this.PlatformParameters == null)
+            {
+                this.PlatformParameters = PlatformPlugin.DefaultPlatformParameters;
+            }
 
             return parameters;
         }

--- a/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -78,8 +78,8 @@ namespace Test.MSAL.NET.Unit
             Assert.IsNull(app.ClientCredential.ClientAssertion);
             Assert.AreEqual(0, app.ClientCredential.ValidTo);
 
-            app = new ConfidentialClientApplication(TestConstants.AuthorityGuestTenant,
-                TestConstants.ClientId,
+            app = new ConfidentialClientApplication(TestConstants.ClientId,
+                TestConstants.AuthorityGuestTenant,
                 TestConstants.RedirectUri, new ClientCredential("secret"), new TokenCache(TestConstants.ClientId),
                 new TokenCache(TestConstants.ClientId));
             Assert.AreEqual(TestConstants.AuthorityGuestTenant, app.Authority);
@@ -303,8 +303,7 @@ namespace Test.MSAL.NET.Unit
         public void GetAuthorizationRequestUrlCustomRedirectUriTest()
         {
             ConfidentialClientApplication app =
-                new ConfidentialClientApplication(TestConstants.AuthorityGuestTenant,
-                    TestConstants.ClientId,
+                new ConfidentialClientApplication(TestConstants.ClientId, TestConstants.AuthorityGuestTenant,
                     TestConstants.RedirectUri, new ClientCredential(TestConstants.ClientSecret),
                     new TokenCache(TestConstants.ClientId), new TokenCache(TestConstants.ClientId))
                 {ValidateAuthority = false};

--- a/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -75,7 +75,7 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual("urn:ietf:wg:oauth:2.0:oob", app.RedirectUri);
             Assert.IsTrue(app.ValidateAuthority);
 
-            app = new PublicClientApplication(TestConstants.AuthorityGuestTenant, TestConstants.ClientId);
+            app = new PublicClientApplication(TestConstants.ClientId, TestConstants.AuthorityGuestTenant);
             Assert.IsNotNull(app);
             Assert.AreEqual(TestConstants.AuthorityGuestTenant, app.Authority);
             Assert.AreEqual(TestConstants.ClientId, app.ClientId);
@@ -242,8 +242,7 @@ namespace Test.MSAL.NET.Unit
         [TestCategory("PublicClientApplicationTests")]
         public void AcquireTokenSilentCacheOnlyLookupTest()
         {
-            PublicClientApplication app = new PublicClientApplication(TestConstants.AuthorityHomeTenant,
-                TestConstants.ClientId)
+            PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId, TestConstants.AuthorityHomeTenant)
             {
                 ValidateAuthority = false
             };

--- a/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
@@ -112,7 +112,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
 
             InteractiveRequest request = new InteractiveRequest(parameters,
                 TestConstants.ScopeForAnotherResource.ToArray(),
-                new PlatformParameters(), TestConstants.DisplayableId,
+                 TestConstants.DisplayableId,
                 UiOptions.SelectAccount, ui);
             Task<AuthenticationResult> task = request.RunAsync();
             task.Wait();
@@ -146,7 +146,6 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 parameters.ExtraQueryParameters = "extra=qp";
 
                 new InteractiveRequest(parameters, TestConstants.ScopeForAnotherResource.ToArray(),
-                    new PlatformParameters(),
                     (string) null, UiOptions.ForceLogin, new MockWebUI()
                     );
                 Assert.Fail("ArgumentException should be thrown here");
@@ -187,7 +186,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             parameters.ExtraQueryParameters = "extra=qp";
 
             InteractiveRequest request = new InteractiveRequest(parameters,
-                TestConstants.ScopeForAnotherResource.ToArray(), new PlatformParameters(),
+                TestConstants.ScopeForAnotherResource.ToArray(), 
                 (string) null, UiOptions.ForceLogin, webUi);
             request.PreRunAsync().Wait();
             try
@@ -208,7 +207,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 "?error=invalid_request&error_description=some error description");
 
             request = new InteractiveRequest(parameters,
-                TestConstants.ScopeForAnotherResource.ToArray(), new PlatformParameters(),
+                TestConstants.ScopeForAnotherResource.ToArray(),
                 (string) null, UiOptions.ForceLogin, webUi);
             request.PreRunAsync().Wait();
 
@@ -247,7 +246,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 parameters.ExtraQueryParameters = "extra=qp";
 
                 InteractiveRequest request = new InteractiveRequest(parameters,
-                    TestConstants.ScopeForAnotherResource.ToArray(), new PlatformParameters(),
+                    TestConstants.ScopeForAnotherResource.ToArray(),
                     (string) null, UiOptions.ActAsCurrentUser, new MockWebUI());
                 Assert.Fail("ArgumentException should be thrown here");
             }
@@ -277,7 +276,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 parameters.ExtraQueryParameters = "extra=qp";
 
                 new InteractiveRequest(parameters,
-                    TestConstants.ScopeForAnotherResource.ToArray(), new PlatformParameters(),
+                    TestConstants.ScopeForAnotherResource.ToArray(),
                     null, UiOptions.ActAsCurrentUser, new MockWebUI());
                 Assert.Fail("ArgumentException should be thrown here");
             }
@@ -314,7 +313,6 @@ namespace Test.MSAL.NET.Unit.RequestsTests
 
             InteractiveRequest request = new InteractiveRequest(parameters,
                 TestConstants.ScopeForAnotherResource.ToArray(),
-                new PlatformParameters(),
                 null, UiOptions.ForceLogin, new MockWebUI());
             request.PreRunAsync().Wait();
 

--- a/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
+++ b/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
@@ -78,7 +78,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             parameters.User = null;
             try
             {
-                new SilentRequest(parameters, new PlatformParameters(), false);
+                new SilentRequest(parameters, false);
                 Assert.Fail("ArgumentNullException should have been thrown here");
             }
             catch (ArgumentNullException exc)
@@ -90,17 +90,17 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             {
                 DisplayableId = TestConstants.DisplayableId
             };
-            SilentRequest request = new SilentRequest(parameters, new PlatformParameters(), false);
+            SilentRequest request = new SilentRequest(parameters, false);
             Assert.IsNotNull(request);
 
             parameters.User = new User()
             {
                 UniqueId = TestConstants.UniqueId
             };
-            request = new SilentRequest(parameters, new PlatformParameters(), false);
+            request = new SilentRequest(parameters, false);
             Assert.IsNotNull(request);
 
-            request = new SilentRequest(parameters, new PlatformParameters(), false);
+            request = new SilentRequest(parameters, false);
             Assert.IsNotNull(request);
         }
 
@@ -140,7 +140,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
             });
 
-            SilentRequest request = new SilentRequest(parameters, new PlatformParameters(), false);
+            SilentRequest request = new SilentRequest(parameters, false);
             Task<AuthenticationResult> task = request.RunAsync();
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
@@ -177,7 +177,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             
             try
             {
-                SilentRequest request = new SilentRequest(parameters, new PlatformParameters(), false);
+                SilentRequest request = new SilentRequest(parameters, false);
                 Task<AuthenticationResult> task = request.RunAsync();
                 var authenticationResult = task.Result;
                 Assert.Fail("MsalSilentTokenAcquisitionException should be thrown here");


### PR DESCRIPTION
This PR contains the updates for 
(#119)  change the order of first 2 parameters here into code, scope. Same applies to other overloading methods.
(#117) Coding Style: method overload parameter ordering convention for constructors in public and confidential client class.
(#115)  Remove PlatformParameters from ClientApplicationBase and move it to public client class.
