### PR TITLE
auto generate version

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,7 @@
+mode: ContinuousDeployment
+next-version: 1.1.0
+branches:
+  master:
+    tag: preview
+  develop:
+    tag: preview

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+image: Visual Studio 2017     
+    
+build_script:
+  - ps: .\build.ps1
+
+skip_commits:
+  files:
+    - '**/*.md'
+    - 'changelog.txt'
+
+artifacts:
+- path: .\artifacts\*.nupkg

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,18 @@
+$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+
+$configuration = "Release"
+
+$isAppVeyor = Test-Path -Path env:\APPVEYOR
+$rootPath = (Resolve-Path .).Path
+$artifacts = Join-Path $rootPath "artifacts"
+
+New-Item -ItemType Directory -Force -Path $artifacts
+
+Write-Host "Restoring packages for $scriptPath\MSAL.sln" -Foreground Green
+msbuild "$scriptPath\MSAL.sln" /m /t:restore /p:Configuration=$configuration 
+
+Write-Host "Building $scriptPath\MSAL.sln" -Foreground Green
+msbuild "$scriptPath\MSAL.sln" /m /t:build /p:Configuration=$configuration 
+
+Write-Host "Building Packages" -Foreground Green
+msbuild "$scriptPath\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" /t:pack /p:Configuration=$configuration /p:PackageOutputPath=$artifacts /p:NoPackageAnalysis=true /p:NuGetBuildTasksPackTargets="workaround"

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard1.3;win81;MonoAndroid7;Xamarin.iOS10</TargetFrameworks>    
-    <Version>1.0.0-alpha-001</Version>
+    <TargetFrameworks>net45;netstandard1.1;netstandard1.3;win81;MonoAndroid7;Xamarin.iOS10</TargetFrameworks>        
     <Authors>Microsoft Corp.</Authors>
     <PackageTitle>Microsoft Authentication Library</PackageTitle>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=844762</PackageLicenseUrl>
@@ -17,6 +16,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\MSAL.snk</AssemblyOriginatorKeyFile>
     <!-- Workaround until Xamarin supports PPDB -->
+    <UseFullSemVerForNuGet>true</UseFullSemVerForNuGet>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />


### PR DESCRIPTION
This PR introduces GitVersion to stamp the version number on the AssemblyInfo files and the NuGet packages during build.

Currently set to do -preview.* builds with SemVer 2.0, full configuration settings are here:
http://gitversion.readthedocs.io/en/latest/

