### PR TITLE
Fixing violations of the C# Coding Style Guide.

### DIFF
--- a/src/Microsoft.Identity.Client/Features/UIBehavior.cs
+++ b/src/Microsoft.Identity.Client/Features/UIBehavior.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Identity.Client.Features
         /// Only available on .NET platform. AcquireToken will send prompt=attempt_none to 
         /// authorize endpoint and the library uses a hidden webview to authenticate the user.
         /// </summary>
-        public readonly static UIBehavior Never = new UIBehavior("attempt_none");
+        public static readonly UIBehavior Never = new UIBehavior("attempt_none");
     }
 }

--- a/src/Microsoft.Identity.Client/UIBehavior.cs
+++ b/src/Microsoft.Identity.Client/UIBehavior.cs
@@ -37,19 +37,19 @@ namespace Microsoft.Identity.Client
         /// and would show a list of users from which one can be selected for 
         /// authentication.
         /// </summary>
-        public readonly static UIBehavior SelectAccount = new UIBehavior("select_account");
+        public static readonly UIBehavior SelectAccount = new UIBehavior("select_account");
 
         /// <summary>
         /// The user will be prompted for credentials by the service. It is achieved
         /// by sending prompt=login to the service.
         /// </summary>
-        public readonly static UIBehavior ForceLogin = new UIBehavior("login");
+        public static readonly UIBehavior ForceLogin = new UIBehavior("login");
 
         /// <summary>
         /// The user will be prompted to consent even if consent was granted before. It is achieved
         /// by sending prompt=consent to the service.
         /// </summary>
-        public readonly static UIBehavior Consent = new UIBehavior("consent");
+        public static readonly UIBehavior Consent = new UIBehavior("consent");
 
         internal string PromptValue { get; set; }
 


### PR DESCRIPTION
When used on static fields, readonly should come after static (i.e. static readonly not readonly static).
 - https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md