### PR TITLE
Cleanup coding style: Removed unnecessary "this." qualifiers.

### DIFF
--- a/src/Microsoft.Identity.Client/Features/ConfidentialClient/ClientAssertionCertificate.cs
+++ b/src/Microsoft.Identity.Client/Features/ConfidentialClient/ClientAssertionCertificate.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Client
         public string Thumbprint
         {
             // Thumbprint should be url encoded
-            get { return Base64UrlEncoder.Encode(this.Certificate.GetCertHash()); }
+            get { return Base64UrlEncoder.Encode(Certificate.GetCertHash()); }
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Features/ConfidentialClient/ClientCredential.cs
+++ b/src/Microsoft.Identity.Client/Features/ConfidentialClient/ClientCredential.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client
         /// <param name="certificate">certificate of the client requesting the token.</param>
         public ClientCredential(ClientAssertionCertificate certificate)
         {
-            this.Certificate = certificate;
+            Certificate = certificate;
         }
 
         internal ClientAssertionCertificate Certificate { get; private set; }

--- a/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
+++ b/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Client
             AppTokenCache = appTokenCache;
             if (AppTokenCache != null)
             {
-                this.AppTokenCache.ClientId = clientId;
+                AppTokenCache.ClientId = clientId;
             }
         }
 

--- a/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                                                                                     Constants.ExpirationMarginInMinutes)));
                         if (assertionNearExpiry)
                         {
-                            JsonWebToken jwtToken = new JsonWebToken(this.ClientId,
-                                this.Authority.SelfSignedJwtAudience);
+                            JsonWebToken jwtToken = new JsonWebToken(ClientId,
+                                Authority.SelfSignedJwtAudience);
                             ClientCredential.Assertion = jwtToken.Sign(ClientCredential.Certificate);
                             ClientCredential.ValidTo = jwtToken.Payload.ValidTo;
                         }

--- a/src/Microsoft.Identity.Client/Platforms/net45/CustomWebBrowser.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/CustomWebBrowser.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client
         {
             base.CreateSink();
 
-            object activeXInstance = this.ActiveXInstance;
+            object activeXInstance = ActiveXInstance;
             if (activeXInstance != null)
             {
                 webBrowserEvent = new CustomWebBrowserEvent(this);

--- a/src/Microsoft.Identity.Client/Platforms/net45/SilentWindowsFormsAuthenticationDialog.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/SilentWindowsFormsAuthenticationDialog.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client
             : base(ownerWindow)
         {
             SuppressBrowserSubDialogs();
-            WebBrowser.DocumentCompleted += this.DocumentCompletedHandler;
+            WebBrowser.DocumentCompleted += DocumentCompletedHandler;
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Client/Platforms/net45/WinFormWebAuthenticationDialog.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/WinFormWebAuthenticationDialog.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Identity.Client
         public WindowsFormsWebAuthenticationDialog(object ownerWindow)
             : base(ownerWindow)
         {
-            this.Shown += this.FormShownHandler;
-            WebBrowser.DocumentTitleChanged += this.WebBrowserDocumentTitleChangedHandler;
+            Shown += FormShownHandler;
+            WebBrowser.DocumentTitleChanged += WebBrowserDocumentTitleChangedHandler;
             WebBrowser.ObjectForScripting = this;
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public void ShowBrowser()
         {
-            DialogResult uiResult = this.ShowDialog(ownerWindow);
+            DialogResult uiResult = ShowDialog(ownerWindow);
 
             switch (uiResult)
             {
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         protected override void OnClosingUrl()
         {
-            this.DialogResult = DialogResult.OK;
+            DialogResult = DialogResult.OK;
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Microsoft.Identity.Client
         protected override void OnNavigationCanceled(int inputStatusCode)
         {
             statusCode = inputStatusCode;
-            this.DialogResult = (inputStatusCode == 0) ? DialogResult.Cancel : DialogResult.Abort;
+            DialogResult = (inputStatusCode == 0) ? DialogResult.Cancel : DialogResult.Abort;
         }
 
         private void SetBrowserZoom()
@@ -141,15 +141,15 @@ namespace Microsoft.Identity.Client
         {
             // If we don't have an owner we need to make sure that the pop up browser 
             // window is on top of other windows.  Activating the window will accomplish this.
-            if (null == this.Owner)
+            if (null == Owner)
             {
-                this.Activate();
+                Activate();
             }
         }
 
         private void WebBrowserDocumentTitleChangedHandler(object sender, EventArgs e)
         {
-            this.Text = WebBrowser.DocumentTitle;
+            Text = WebBrowser.DocumentTitle;
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Platforms/net45/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/WindowsFormsWebAuthenticationDialogBase.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public WebBrowser WebBrowser
         {
-            get { return this.webBrowser; }
+            get { return webBrowser; }
         }
 
         private void webBrowser_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
@@ -124,7 +124,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         protected virtual void WebBrowserNavigatingHandler(object sender, WebBrowserNavigatingEventArgs e)
         {
-            if (this.DialogResult == DialogResult.OK)
+            if (DialogResult == DialogResult.OK)
             {
                 e.Cancel = true;
                 return;
@@ -178,7 +178,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         protected virtual void WebBrowserNavigateErrorHandler(object sender, WebBrowserNavigateErrorEventArgs e)
         {
-            if (this.DialogResult == DialogResult.OK)
+            if (DialogResult == DialogResult.OK)
             {
                 e.Cancel = true;
                 return;
@@ -274,8 +274,8 @@ namespace Microsoft.Identity.Client
             // The WebBrowser event handlers must not throw exceptions.
             // If they do then they may be swallowed by the native
             // browser com control.
-            webBrowser.Navigating += this.WebBrowserNavigatingHandler;
-            webBrowser.Navigated += this.WebBrowserNavigatedHandler;
+            webBrowser.Navigating += WebBrowserNavigatingHandler;
+            webBrowser.Navigated += WebBrowserNavigatedHandler;
             webBrowser.NavigateError += WebBrowserNavigateErrorHandler;
 
             webBrowser.Navigate(requestUri);
@@ -300,7 +300,7 @@ namespace Microsoft.Identity.Client
             int uiHeight = (int) (Math.Max(screen.WorkingArea.Height, 160)*70.0/DpiHelper.ZoomPercent);
             webBrowserPanel = new Panel();
             webBrowserPanel.SuspendLayout();
-            this.SuspendLayout();
+            SuspendLayout();
 
             // 
             // webBrowser
@@ -327,28 +327,28 @@ namespace Microsoft.Identity.Client
             // 
             // BrowserAuthenticationWindow
             // 
-            this.AutoScaleDimensions = new SizeF(6, 13);
-            this.AutoScaleMode = AutoScaleMode.Font;
-            this.ClientSize = new Size(UIWidth, uiHeight);
-            this.Controls.Add(webBrowserPanel);
-            this.FormBorderStyle = FormBorderStyle.FixedSingle;
-            this.Name = "BrowserAuthenticationWindow";
+            AutoScaleDimensions = new SizeF(6, 13);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(UIWidth, uiHeight);
+            Controls.Add(webBrowserPanel);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            Name = "BrowserAuthenticationWindow";
 
             // Move the window to the center of the parent window only if owner window is set.
-            this.StartPosition = (ownerWindow != null)
+            StartPosition = (ownerWindow != null)
                 ? FormStartPosition.CenterParent
                 : FormStartPosition.CenterScreen;
-            this.Text = string.Empty;
-            this.ShowIcon = false;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
+            Text = string.Empty;
+            ShowIcon = false;
+            MaximizeBox = false;
+            MinimizeBox = false;
 
             // If we don't have an owner we need to make sure that the pop up browser 
             // window is in the task bar so that it can be selected with the mouse.
-            this.ShowInTaskbar = (null == ownerWindow);
+            ShowInTaskbar = (null == ownerWindow);
 
             webBrowserPanel.ResumeLayout(false);
-            this.ResumeLayout(false);
+            ResumeLayout(false);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client
                     User = accessTokenCacheItem.User
                 };
 
-                this.HasStateChanged = true;
+                HasStateChanged = true;
                 OnBeforeAccess(args);
                 OnBeforeWrite(args);
 


### PR DESCRIPTION
> We avoid `this.` unless absolutely necessary.
- https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md