### PR TITLE
Added appveyor workaround to install Android SDK 24

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,11 @@ image: Visual Studio 2017
 
 configuration: Release
 
+install:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/install-android-sdk.ps1?v=2'))
+- ps: $sdks = Get-AndroidSDKs |? { $_.name -like 'sdk platform*API 24*' -or $_.name -like 'Google APIs, Android API 24' } 
+- ps: Install-AndroidSDK -sdks $sdks
+
 before_build:
   - nuget restore
     

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -23,24 +23,26 @@ $configuration = "Release"
 $isAppVeyor = Test-Path -Path env:\APPVEYOR
 $rootPath = (Resolve-Path .).Path
 $artifacts = Join-Path $rootPath "artifacts"
-$targetFrameworks = "/p:""TargetFrameworks=net45;netstandard1.1;netstandard1.3;win81;Xamarin.iOS10"""
 
 if ($isAppVeyor)
 {
     $appVeyorLogger = "/logger:""C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"""
 }
 
+# Restoring the test project will restore the product project packages too
+Log ("Restoring NuGet packages...")
+msbuild "$sourcePath\tests\Test.MSAL.NET.Unit\Test.MSAL.NET.Unit.csproj" /m /t:restore /p:Configuration=$configuration $appVeyorLoggerExitOnError
+ExitOnError
+
 Log ("Building product code...")
-msbuild "$sourcePath\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" /m /t:restore /p:Configuration=$configuration $appVeyorLogger $targetFrameworks
-msbuild "$sourcePath\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" /m /t:build /p:Configuration=$configuration $appVeyorLogger $targetFrameworks 
+msbuild "$sourcePath\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" /m /t:build /p:Configuration=$configuration $appVeyorLogger
 ExitOnError
 
 Log("Building Tests...")
-msbuild "$sourcePath\tests\Test.MSAL.NET.Unit\Test.MSAL.NET.Unit.csproj" /m /t:restore /p:Configuration=$configuration $appVeyorLogger
 msbuild "$sourcePath\tests\Test.MSAL.NET.Unit\Test.MSAL.NET.Unit.csproj" /m /t:build /p:Configuration=$configuration $appVeyorLogger
 ExitOnError
 
 
 Log("Building Packages")
-msbuild "$sourcePath\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" /t:pack /p:Configuration=$configuration /p:PackageOutputPath=$artifacts /p:NoPackageAnalysis=true /p:NuGetBuildTasksPackTargets="workaround" $appVeyorLogger $targetFrameworks
+msbuild "$sourcePath\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" /t:pack /p:Configuration=$configuration /p:PackageOutputPath=$artifacts /p:NoPackageAnalysis=true /p:NuGetBuildTasksPackTargets="workaround" $appVeyorLogger
 ExitOnError

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -31,7 +31,7 @@ if ($isAppVeyor)
 
 # Restoring the test project will restore the product project packages too
 Log ("Restoring NuGet packages...")
-msbuild "$sourcePath\tests\Test.MSAL.NET.Unit\Test.MSAL.NET.Unit.csproj" /m /t:restore /p:Configuration=$configuration $appVeyorLoggerExitOnError
+msbuild "$sourcePath\tests\Test.MSAL.NET.Unit\Test.MSAL.NET.Unit.csproj" /m /t:restore /p:Configuration=$configuration $appVeyorLogger
 ExitOnError
 
 Log ("Building product code...")


### PR DESCRIPTION
Relates to #180 

Uses the workaround from https://github.com/appveyor/ci/issues/1411#issuecomment-287678065 to install the Android SDK
