### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 Build status of the dev branch
 
 ## Build status
-| Branch  | Status |
-| ------------- | ------------- |
-| dev (VSTS)  | ![](https://identitydivision.visualstudio.com/_apis/public/build/definitions/a7934fdd-dcde-4492-a406-7fad6ac00e17/10/badge)  |
-| dev (AppVeyor)  | [![Build status](https://ci.appveyor.com/api/projects/status/pqtq4xvppjm0o4ul/branch/dev?svg=true)](https://ci.appveyor.com/project/AADDevExLibraries/microsoft-authentication-library-for-dotnet/branch/dev)  |
+| Branch  | Status | Notes |
+| ------------- | ------------- |  ------------- | 
+| dev (VSTS) | ![](https://identitydivision.visualstudio.com/_apis/public/build/definitions/a7934fdd-dcde-4492-a406-7fad6ac00e17/10/badge)  | Builds the entire MSAL solution |
+| dev (AppVeyor)  | [![Build status](https://ci.appveyor.com/api/projects/status/pqtq4xvppjm0o4ul/branch/dev?svg=true)](https://ci.appveyor.com/project/AADDevExLibraries/microsoft-authentication-library-for-dotnet/branch/dev)  | Partial build - product assembly and tests only |
 
 
 Microsoft Authentication Library (MSAL) provides easy to use authentication functionality for your .NET client and Windows Store apps by taking advantage of Azure Active Directory v2 (serves Microsoft Account and AAD) and B2C.


### PR DESCRIPTION
Updated the readme to explain the differences between the AppVeyor and VSTS builds.

The badges can be confusing at present; it's not clear why one build succeeds and one fails. The additional notes make it clear the builds aren't building the same set of projects.

Once we've fixed building the dev apps on clean machines we can make the builds the same and remove the additional notes. Until then, it's useful to know that the builds are different.