### PR TITLE
Removed arrays from interface inputs

### DIFF
--- a/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <param name="user">User for which the token is requested. <see cref="User"/></param>
         /// <returns></returns>
-        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(string[] scope, User user)
+        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, User user)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -146,7 +146,7 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using the refresh token if available</param>
         /// <returns></returns>
-        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(string[] scope, User user,
+        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, User user,
             string authority, bool forceRefresh)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
@@ -169,7 +169,7 @@ namespace Microsoft.Identity.Client
         }
 
         internal async Task<AuthenticationResult> AcquireTokenSilentCommonAsync(Authority authority,
-            string[] scope, User user, bool forceRefresh)
+            IEnumerable<string> scope, User user, bool forceRefresh)
         {
             var handler = new SilentRequest(
                 CreateRequestParameters(authority, scope, user, UserTokenCache),
@@ -177,7 +177,7 @@ namespace Microsoft.Identity.Client
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        internal virtual AuthenticationRequestParameters CreateRequestParameters(Authority authority, string[] scope,
+        internal virtual AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope,
             User user, TokenCache cache)
         {
             return new AuthenticationRequestParameters
@@ -185,7 +185,7 @@ namespace Microsoft.Identity.Client
                 Authority = authority,
                 TokenCache = cache,
                 User = user,
-                Scope = scope.CreateSetFromArray(),
+                Scope = scope.CreateSetFromEnumerable(),
                 RedirectUri = new Uri(RedirectUri),
                 RequestContext = CreateRequestContext(CorrelationId)
             };

--- a/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
+++ b/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
@@ -25,10 +25,11 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.Identity.Client.Internal.Instance;
 using Microsoft.Identity.Client.Internal.Requests;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client
 {
@@ -79,7 +80,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <param name="userAssertion">Instance of UserAssertion containing user's token.</param>
         /// <returns>Authentication result containing token of the user for the requested scopes</returns>
-        public async Task<IAuthenticationResult> AcquireTokenOnBehalfOfAsync(string[] scope, UserAssertion userAssertion)
+        public async Task<IAuthenticationResult> AcquireTokenOnBehalfOfAsync(IEnumerable<string> scope, UserAssertion userAssertion)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -95,7 +96,7 @@ namespace Microsoft.Identity.Client
         /// <param name="userAssertion">Instance of UserAssertion containing user's token.</param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user for the requested scopes</returns>
-        public async Task<IAuthenticationResult> AcquireTokenOnBehalfOfAsync(string[] scope, UserAssertion userAssertion,
+        public async Task<IAuthenticationResult> AcquireTokenOnBehalfOfAsync(IEnumerable<string> scope, UserAssertion userAssertion,
             string authority)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
@@ -107,12 +108,12 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Acquires security token from the authority using authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="ClientApplicationBase.AcquireTokenSilentAsync(string[], Microsoft.Identity.Client.User)"/>.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilentAsync(IEnumerable{string}, User)"/>.
         /// </summary>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <returns>Authentication result containing token of the user for the requested scopes</returns>
-        public async Task<IAuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode, string[] scope)
+        public async Task<IAuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode, IEnumerable<string> scope)
         {
             return
                 await
@@ -124,7 +125,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <returns>Authentication result containing application token for the requested scopes</returns>
-        public async Task<IAuthenticationResult> AcquireTokenForClientAsync(string[] scope)
+        public async Task<IAuthenticationResult> AcquireTokenForClientAsync(IEnumerable<string> scope)
         {
             return
                 await
@@ -137,7 +138,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using client credentials</param>
         /// <returns>Authentication result containing application token for the requested scopes</returns>
-        public async Task<IAuthenticationResult> AcquireTokenForClientAsync(string[] scope, bool forceRefresh)
+        public async Task<IAuthenticationResult> AcquireTokenForClientAsync(IEnumerable<string> scope, bool forceRefresh)
         {
             return
                 await
@@ -151,7 +152,7 @@ namespace Microsoft.Identity.Client
         /// <param name="loginHint">Identifier of the user. Generally a UPN.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>URL of the authorize endpoint including the query parameters.</returns>
-        public async Task<Uri> GetAuthorizationRequestUrlAsync(string[] scope, string loginHint,
+        public async Task<Uri> GetAuthorizationRequestUrlAsync(IEnumerable<string> scope, string loginHint,
             string extraQueryParameters)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
@@ -175,8 +176,8 @@ namespace Microsoft.Identity.Client
         /// <param name="additionalScope">Array of scopes for which a developer can request consent upfront.</param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>URL of the authorize endpoint including the query parameters.</returns>
-        public async Task<Uri> GetAuthorizationRequestUrlAsync(string[] scope, string redirectUri, string loginHint,
-            string extraQueryParameters, string[] additionalScope, string authority)
+        public async Task<Uri> GetAuthorizationRequestUrlAsync(IEnumerable<string> scope, string redirectUri, string loginHint,
+            string extraQueryParameters, IEnumerable<string> additionalScope, string authority)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
             var requestParameters = CreateRequestParameters(authorityInstance, scope, null,
@@ -194,7 +195,7 @@ namespace Microsoft.Identity.Client
 
         internal TokenCache AppTokenCache { get; }
 
-        private async Task<AuthenticationResult> AcquireTokenForClientCommonAsync(string[] scope)
+        private async Task<AuthenticationResult> AcquireTokenForClientCommonAsync(IEnumerable<string> scope)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             AuthenticationRequestParameters parameters = CreateRequestParameters(authority, scope, null,
@@ -204,7 +205,7 @@ namespace Microsoft.Identity.Client
         }
 
         private async Task<AuthenticationResult> AcquireTokenOnBehalfCommonAsync(Authority authority,
-            string[] scope, UserAssertion userAssertion)
+            IEnumerable<string> scope, UserAssertion userAssertion)
         {
             var requestParams = CreateRequestParameters(authority, scope, null, UserTokenCache);
             requestParams.UserAssertion = userAssertion;
@@ -213,7 +214,7 @@ namespace Microsoft.Identity.Client
         }
 
         private async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeCommonAsync(string authorizationCode,
-            string[] scope, Uri redirectUri)
+            IEnumerable<string> scope, Uri redirectUri)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             var requestParams = CreateRequestParameters(authority, scope, null, UserTokenCache);
@@ -224,7 +225,7 @@ namespace Microsoft.Identity.Client
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, string[] scope, User user, TokenCache cache)
+        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope, User user, TokenCache cache)
         {
             AuthenticationRequestParameters parameters = base.CreateRequestParameters(authority, scope, user, cache);
             parameters.ClientId = ClientId;

--- a/src/Microsoft.Identity.Client/Features/ConfidentialClient/IConfidentialClientApplication.cs
+++ b/src/Microsoft.Identity.Client/Features/ConfidentialClient/IConfidentialClientApplication.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client
@@ -42,7 +43,7 @@ namespace Microsoft.Identity.Client
         /// <param name="userAssertion">Instance of UserAssertion containing user's token.</param>
         /// <returns>Authentication result containing token of the user for the requested scopes</returns>
         Task<IAuthenticationResult> AcquireTokenOnBehalfOfAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             UserAssertion userAssertion);
 
         /// <summary>
@@ -53,20 +54,20 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user for the requested scopes</returns>
         Task<IAuthenticationResult> AcquireTokenOnBehalfOfAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             UserAssertion userAssertion,
             string authority);
 
         /// <summary>
         /// Acquires security token from the authority using authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="ClientApplicationBase.AcquireTokenSilentAsync(string[], Microsoft.Identity.Client.User)"/>.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable{string}, User)"/>.
         /// </summary>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <returns>Authentication result containing token of the user for the requested scopes</returns>
         Task<IAuthenticationResult> AcquireTokenByAuthorizationCodeAsync(
             string authorizationCode,
-            string[] scope);
+            IEnumerable<string> scope);
 
         /// <summary>
         /// Acquires token from the service for the confidential client. This method attempts to look up valid access token in the cache.
@@ -74,7 +75,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <returns>Authentication result containing application token for the requested scopes</returns>
         Task<IAuthenticationResult> AcquireTokenForClientAsync(
-            string[] scope);
+            IEnumerable<string> scope);
 
         /// <summary>
         /// Acquires token from the service for the confidential client. This method attempts to look up valid access token in the cache.
@@ -83,7 +84,7 @@ namespace Microsoft.Identity.Client
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using client credentials</param>
         /// <returns>Authentication result containing application token for the requested scopes</returns>
         Task<IAuthenticationResult> AcquireTokenForClientAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             bool forceRefresh);
 
         /// <summary>
@@ -94,7 +95,7 @@ namespace Microsoft.Identity.Client
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>URL of the authorize endpoint including the query parameters.</returns>
         Task<Uri> GetAuthorizationRequestUrlAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             string loginHint,
             string extraQueryParameters);
 
@@ -109,9 +110,9 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>URL of the authorize endpoint including the query parameters.</returns>
         Task<Uri> GetAuthorizationRequestUrlAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             string redirectUri,
             string loginHint,
-            string extraQueryParameters, string[] additionalScope, string authority);
+            string extraQueryParameters, IEnumerable<string> additionalScope, string authority);
     }
 }

--- a/src/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <param name="user">User for which the token is requested. <see cref="User"/></param>
         Task<IAuthenticationResult> AcquireTokenSilentAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             User user);
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using the refresh token if available</param>
         Task<IAuthenticationResult> AcquireTokenSilentAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             User user,
             string authority,
             bool forceRefresh);

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <returns>Authentication result containing token of the user</returns>
-        Task<IAuthenticationResult> AcquireTokenAsync(string[] scope);
+        Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope);
 
         /// <summary>
         /// Interactive request to acquire token. 
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client
         /// <param name="loginHint">Identifier of the user. Generally a UPN.</param>
         /// <returns>Authentication result containing token of the user</returns>
         Task<IAuthenticationResult> AcquireTokenAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             string loginHint);
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Client
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>Authentication result containing token of the user</returns>
         Task<IAuthenticationResult> AcquireTokenAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             string loginHint,
             UIBehavior behavior,
             string extraQueryParameters);
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Client
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>Authentication result containing token of the user</returns>
         Task<IAuthenticationResult> AcquireTokenAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             User user,
             UIBehavior behavior,
             string extraQueryParameters);
@@ -97,11 +97,12 @@ namespace Microsoft.Identity.Client
         /// <param name="additionalScope">Array of scopes for which a developer can request consent upfront.</param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user</returns>
-        Task<IAuthenticationResult> AcquireTokenAsync(string[] scope,
+        Task<IAuthenticationResult> AcquireTokenAsync(
+            IEnumerable<string> scope,
             string loginHint,
             UIBehavior behavior,
             string extraQueryParameters,
-            string[] additionalScope, string authority);
+            IEnumerable<string> additionalScope, string authority);
 
         /// <summary>
         /// Interactive request to acquire token. 
@@ -114,11 +115,11 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user</returns>
         Task<IAuthenticationResult> AcquireTokenAsync(
-            string[] scope,
+            IEnumerable<string> scope,
             User user,
             UIBehavior behavior,
             string extraQueryParameters,
-            string[] additionalScope,
+            IEnumerable<string> additionalScope,
             string authority);
     }
 }

--- a/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
+++ b/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
@@ -88,20 +88,13 @@ namespace Microsoft.Identity.Client.Internal
             return singleString.Split(new[] { " " }, StringSplitOptions.None);
         }
 
-        internal static SortedSet<string> CreateSetFromArray(this string[] arrayStrings)
+        internal static SortedSet<string> CreateSetFromEnumerable(this IEnumerable<string> input)
         {
-            SortedSet<string> set = new SortedSet<string>();
-            if (arrayStrings == null || arrayStrings.Length == 0)
+            if (input == null || !input.Any())
             {
-                return set;
+                return new SortedSet<string>();
             }
-
-            foreach (string str in arrayStrings)
-            {
-                set.Add(str);
-            }
-
-            return set;
+            return new SortedSet<string>(input);
         }
         
         internal static bool IsNullOrEmpty(IEnumerable<string> input)

--- a/src/Microsoft.Identity.Client/Internal/Requests/BaseRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/BaseRequest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         protected virtual SortedSet<string> GetDecoratedScope(SortedSet<string> inputScope)
         {
             SortedSet<string> set = new SortedSet<string>(inputScope.ToArray());
-            set.UnionWith(OAuth2Value.ReservedScopes.CreateSetFromArray());
+            set.UnionWith(OAuth2Value.ReservedScopes.CreateSetFromEnumerable());
             set.Remove(AuthenticationRequestParameters.ClientId);
             return set;
         }
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         protected void ValidateScopeInput(SortedSet<string> scopesToValidate)
         {
             //check if scope or additional scope contains client ID.
-            if (scopesToValidate.Intersect(OAuth2Value.ReservedScopes.CreateSetFromArray()).Any())
+            if (scopesToValidate.Intersect(OAuth2Value.ReservedScopes.CreateSetFromEnumerable()).Any())
             {
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture,
                     "API does not accept '{0}' value as user-provided scopes",

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         private string _state;
 
         public InteractiveRequest(AuthenticationRequestParameters authenticationRequestParameters,
-            string[] additionalScope, UIBehavior UIBehavior, IWebUI webUI)
+            IEnumerable<string> additionalScope, UIBehavior UIBehavior, IWebUI webUI)
             : this(
                 authenticationRequestParameters, additionalScope, authenticationRequestParameters.User?.DisplayableId,
                 UIBehavior, webUI)
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         }
 
         public InteractiveRequest(AuthenticationRequestParameters authenticationRequestParameters,
-            string[] additionalScope, string loginHint,
+            IEnumerable<string> additionalScope, string loginHint,
             UIBehavior UIBehavior, IWebUI webUI)
             : base(authenticationRequestParameters)
         {
@@ -67,7 +67,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             _additionalScope = new SortedSet<string>();
             if (!MsalHelpers.IsNullOrEmpty(additionalScope))
             {
-                _additionalScope = additionalScope.CreateSetFromArray();
+                _additionalScope = additionalScope.CreateSetFromEnumerable();
             }
 
             ValidateScopeInput(_additionalScope);

--- a/src/Microsoft.Identity.Client/Platforms/Android/AuthenticationActivity.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/AuthenticationActivity.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Identity.Client
                 return null;
             }
 
-            ISet<string> chromePackage = new HashSet<string>(_chromePackages.CreateSetFromArray());
+            ISet<string> chromePackage = new HashSet<string>(_chromePackages.CreateSetFromEnumerable());
             foreach (ResolveInfo resolveInfo in resolveInfoList)
             {
                 ServiceInfo serviceInfo = resolveInfo.ServiceInfo;

--- a/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -31,6 +31,7 @@ using Microsoft.Identity.Client.Internal.Interfaces;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Instance;
 using Microsoft.Identity.Client.Internal.Requests;
+using System.Collections.Generic;
 
 namespace Microsoft.Identity.Client
 {
@@ -74,7 +75,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(string[] scope)
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -89,7 +90,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <param name="loginHint">Identifier of the user. Generally a UPN.</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(string[] scope, string loginHint)
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, string loginHint)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -106,7 +107,7 @@ namespace Microsoft.Identity.Client
         /// <param name="behavior">Enumeration to control UI behavior.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(string[] scope, string loginHint,
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, string loginHint,
             UIBehavior behavior, string extraQueryParameters)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
@@ -124,7 +125,7 @@ namespace Microsoft.Identity.Client
         /// <param name="behavior">Enumeration to control UI behavior.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(string[] scope, User user,
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, User user,
             UIBehavior behavior, string extraQueryParameters)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
@@ -144,8 +145,8 @@ namespace Microsoft.Identity.Client
         /// <param name="additionalScope">Array of scopes for which a developer can request consent upfront.</param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(string[] scope, string loginHint,
-            UIBehavior behavior, string extraQueryParameters, string[] additionalScope, string authority)
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, string loginHint,
+            UIBehavior behavior, string extraQueryParameters, IEnumerable<string> additionalScope, string authority)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
             return
@@ -164,8 +165,8 @@ namespace Microsoft.Identity.Client
         /// <param name="additionalScope">Array of scopes for which a developer can request consent upfront.</param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(string[] scope, User user,
-            UIBehavior behavior, string extraQueryParameters, string[] additionalScope, string authority)
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, User user,
+            UIBehavior behavior, string extraQueryParameters, IEnumerable<string> additionalScope, string authority)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
             return
@@ -184,7 +185,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="scope"></param>
         /// <returns></returns>
-        internal async Task<AuthenticationResult> AcquireTokenWithIntegratedAuthInternalAsync(string[] scope)
+        internal async Task<AuthenticationResult> AcquireTokenWithIntegratedAuthInternalAsync(IEnumerable<string> scope)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -199,7 +200,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope"></param>
         /// <param name="authority"></param>
         /// <returns></returns>
-        internal async Task<AuthenticationResult> AcquireTokenWithIntegratedAuthInternalAsync(string[] scope,
+        internal async Task<AuthenticationResult> AcquireTokenWithIntegratedAuthInternalAsync(IEnumerable<string> scope,
             string authority)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
@@ -210,7 +211,7 @@ namespace Microsoft.Identity.Client
         }
 
         private async Task<AuthenticationResult> AcquireTokenUsingIntegratedAuthCommonAsync(Authority authority,
-            string[] scope, UserCredential userCredential)
+            IEnumerable<string> scope, UserCredential userCredential)
         {
 /*            var requestParams = this.CreateRequestParameters(authority, scope, policy, this.UserTokenCache);
             var handler = new SilentWebUiRequest(requestParams, userCredential);
@@ -219,8 +220,8 @@ namespace Microsoft.Identity.Client
             return null;
         }
 
-        private async Task<AuthenticationResult> AcquireTokenCommonAsync(Authority authority, string[] scope,
-            string[] additionalScope, string loginHint, UIBehavior behavior,
+        private async Task<AuthenticationResult> AcquireTokenCommonAsync(Authority authority, IEnumerable<string> scope,
+            IEnumerable<string> additionalScope, string loginHint, UIBehavior behavior,
             string extraQueryParameters)
         {
             var requestParams = CreateRequestParameters(authority, scope, null, UserTokenCache);
@@ -232,8 +233,8 @@ namespace Microsoft.Identity.Client
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        private async Task<AuthenticationResult> AcquireTokenCommonAsync(Authority authority, string[] scope,
-            string[] additionalScope, User user, UIBehavior behavior, string extraQueryParameters)
+        private async Task<AuthenticationResult> AcquireTokenCommonAsync(Authority authority, IEnumerable<string> scope,
+            IEnumerable<string> additionalScope, User user, UIBehavior behavior, string extraQueryParameters)
         {
 
             var requestParams = CreateRequestParameters(authority, scope, user, UserTokenCache);
@@ -245,7 +246,7 @@ namespace Microsoft.Identity.Client
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, string[] scope, User user, TokenCache cache)
+        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope, User user, TokenCache cache)
         {
             AuthenticationRequestParameters parameters = base.CreateRequestParameters(authority, scope, user, cache);
             parameters.ClientId = ClientId;

--- a/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
+++ b/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
@@ -122,7 +122,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             {
                 Authority = authority,
                 ClientId = TestConstants.ClientId,
-                Scope = new[] { "some-scope1", "some-scope2" }.CreateSetFromArray(),
+                Scope = new[] { "some-scope1", "some-scope2" }.CreateSetFromEnumerable(),
                 TokenCache = cache,
                 RequestContext = new RequestContext(Guid.Empty),
                 User = new User()
@@ -177,7 +177,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             {
                 Authority = authority,
                 ClientId = TestConstants.ClientId,
-                Scope = new[] { "some-scope1", "some-scope2" }.CreateSetFromArray(),
+                Scope = new[] { "some-scope1", "some-scope2" }.CreateSetFromEnumerable(),
                 TokenCache = cache,
                 User = new User(),
                 RequestContext = new RequestContext(Guid.Empty)


### PR DESCRIPTION
Related to the earlier commit to remove arrays from interface outputs.

If there are usage patterns where the consumer will make a call to MSAL and then pass the _AuthenticationResult.Scope_ to another MSAL method then this change will mean that user won't have to convert the returned scopes from an enumerable to an array.

Also, it's good practice for APIs to accept the most general-purpose type that makes sense; unless a method has a specific reason to require a string array as input then it's better to use a string enumerable as that's more flexible - the user could pass an array, a list, an enumerable etc