### PR TITLE
Proof-of-Concept of internal telemetry API

### DIFF
--- a/src/Microsoft.Identity.Client/Event.cs
+++ b/src/Microsoft.Identity.Client/Event.cs
@@ -29,34 +29,21 @@ using System.Collections.Generic;
 
 namespace Microsoft.Identity.Client
 {
-    public class Telemetry
+    internal class Event
     {
-        public delegate void Receiver(List<Dictionary<string, string>> events);
+        public string Name;
+        public int StartTimestamp;
+        public int StopTimestamp;
 
-        private Receiver _receiver = null;
-
-        public void RegisterReceiver(Receiver r)
+        public Event(string name)
         {
-            _receiver = r;
+            Name = name;
+            StartTimestamp = 1234;  // TODO
         }
 
-        private static readonly Telemetry Singleton = new Telemetry();
-
-        private Telemetry(){}
-
-        public static Telemetry GetInstance()
+        public void Stop()
         {
-            return Singleton;
-        }
-
-        internal EventCollection CreateEventCollection()  // An equivalent of CreateRequestID(...)
-        {
-            return new EventCollection(_receiver);
-        }
-
-        internal void Flush(EventCollection collection)
-        {
-            collection.Flush();
+            StopTimestamp = 2345;  // TODO
         }
     }
 }

--- a/src/Microsoft.Identity.Client/EventCollection.cs
+++ b/src/Microsoft.Identity.Client/EventCollection.cs
@@ -29,34 +29,30 @@ using System.Collections.Generic;
 
 namespace Microsoft.Identity.Client
 {
-    public class Telemetry
+    internal class EventCollection
     {
-        public delegate void Receiver(List<Dictionary<string, string>> events);
+        protected List<Event> Events = new List<Event> { };
+        protected Telemetry.Receiver Receiver;
 
-        private Receiver _receiver = null;
-
-        public void RegisterReceiver(Receiver r)
+        public EventCollection(Telemetry.Receiver receiver)
         {
-            _receiver = r;
+            Receiver = receiver;
         }
 
-        private static readonly Telemetry Singleton = new Telemetry();
-
-        private Telemetry(){}
-
-        public static Telemetry GetInstance()
+        public void Add(Event e)
         {
-            return Singleton;
+            Events.Add(e);
         }
 
-        internal EventCollection CreateEventCollection()  // An equivalent of CreateRequestID(...)
+        public void Flush()
         {
-            return new EventCollection(_receiver);
-        }
-
-        internal void Flush(EventCollection collection)
-        {
-            collection.Flush();
+            var normalized = new List<Dictionary<string, string>> { };
+            foreach(Event e in Events)
+            {
+                // TODO: This loop converts events into a list of dictionaries
+            }
+            Receiver(normalized);
+            Events = new List<Event> { };
         }
     }
 }

--- a/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
+++ b/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
@@ -75,5 +75,50 @@ namespace Test.MSAL.NET.Unit
             var t2 = Telemetry.GetInstance();
             Assert.AreEqual(t1, t2);
         }
+
+        [TestMethod]
+        [TestCategory("TelemetryInternalAPI")]
+        public void TelemetryInternalApiSample()
+        {
+            // This section demonstrates the public API
+            Telemetry telemetry = Telemetry.GetInstance();
+            telemetry.RegisterReceiver(new MyReceiver().OnEvents);
+
+            // The following section is quoted from previous ADAL Telemetry implementation,
+            // in order to see the internal API usage are largely comparable.
+            /*
+            Telemetry telemetry = Telemetry.GetInstance();
+            TestDispatcher dispatcher = new TestDispatcher();
+            telemetry.RegisterDispatcher(dispatcher, false);
+            dispatcher.clear();  // <-- This one was presumably the previous implementation detail, it is not part of the official internal API
+
+            string requestIDThree = telemetry.CreateRequestId();
+            telemetry.StartEvent(requestIDThree, "event_3");
+            // do some stuff...
+            DefaultEvent testDefaultEvent3 = new DefaultEvent();
+            telemetry.StopEvent(requestIDThree, testDefaultEvent3, "event_3");
+
+            telemetry.Flush(requestIDThree);
+            */
+
+            // This section demonstrates the MSAL internal API, with proper usage of try ... finally ... pattern
+            var collection = telemetry.CreateEventCollection();  // Equivalent to: string ReqId = telemetry.CreateRequestId()
+            try
+            {
+                var e1 = new Event("event foo");
+                collection.Add(e1); // Roughly equivalent to: telemetry.StartEvent(ReqId, "event name");
+                // do some stuff...
+                e1.Stop(); // Equivalent to: Event e = new ApiEvent(...); telemetry.StopEvent(ReqId, "event name", e);
+
+                var e2 = new Event("event bar");
+                collection.Add(e2); // Roughly equivalent to: telemetry.StartEvent(ReqId, "event name");
+                // do some stuff...
+                e2.Stop(); // Equivalent to: Event e = new ApiEvent(...); telemetry.StopEvent(ReqId, "event name", e);
+            }
+            finally
+            {
+                telemetry.Flush(collection);
+            }
+        }
     }
 }


### PR DESCRIPTION
As of today, this PR does NOT contain all the internal API. The first commit is an experiment of using a local container (which is essentially a list) to organize events happening inside an AcquireTokenBlahBlah(...) API call.