### PR TITLE
fix to check for javascript as the scheme in net45

### DIFF
--- a/src/Microsoft.Identity.Client/Platforms/net45/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/WindowsFormsWebAuthenticationDialogBase.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Identity.Client
             }
 
             if (!readyToClose && !url.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) &&
-                !url.AbsoluteUri.Equals("about:blank", StringComparison.CurrentCultureIgnoreCase) && !url.AbsoluteUri.Equals("javascript", StringComparison.CurrentCultureIgnoreCase))
+                !url.AbsoluteUri.Equals("about:blank", StringComparison.OrdinalIgnoreCase) && !url.Scheme.Equals("javascript", StringComparison.OrdinalIgnoreCase))
             {
                 Result = new AuthorizationResult(AuthorizationStatus.ErrorHttp)
                 {


### PR DESCRIPTION
fix to check for javascript as the scheme in net45 and not absolute URI. Also made the fix to do OrginalIgnoreCase check. This fix was validated with Desktop dev app. #284