### PR TITLE
Modified public API to allow unit testing of User class

### DIFF
--- a/AutomationApp/TokenHandler.cs
+++ b/AutomationApp/TokenHandler.cs
@@ -34,7 +34,7 @@ namespace AutomationApp
     public class TokenHandler
     {
         #region Properties
-        public User CurrentUser { get; set; }
+        public IUser CurrentUser { get; set; }
 
         private PublicClientApplication _publicClientApplication;
         #endregion

--- a/dev apps/DesktopTestApp/MainForm.cs
+++ b/dev apps/DesktopTestApp/MainForm.cs
@@ -39,7 +39,7 @@ namespace DesktopTestApp
 
         #region Properties
 
-        public User CurrentUser { get; set; }
+        public IUser CurrentUser { get; set; }
         private PublicClientApplication _publicClientApplication;
         private ConfidentialClientApplication _confidentialClientApplication;
 

--- a/dev apps/XForms/XForms/AcquirePage.xaml.cs
+++ b/dev apps/XForms/XForms/AcquirePage.xaml.cs
@@ -56,7 +56,7 @@ namespace XForms
             SetPlatformParameters();
         }
 
-        private string ToString(User user)
+        private string ToString(IUser user)
         {
             var sb = new StringBuilder();
 
@@ -82,7 +82,7 @@ namespace XForms
             return sb.ToString();
         }
 
-        private User getUserByDisplayableId(string str)
+        private IUser getUserByDisplayableId(string str)
         {
             return App.MsalPublicClient.Users.FirstOrDefault(user => user.DisplayableId.Equals(str));
         }

--- a/samples/XForms/XForms.UWP/BundleArtifacts/x86.txt
+++ b/samples/XForms/XForms.UWP/BundleArtifacts/x86.txt
@@ -1,0 +1,6 @@
+MainPackage=C:\repos\aad\forks\msal.net\samples\XForms\XForms.UWP\bin\x86\Debug\XForms.UWP_1.0.0.0_x86_Debug.appx
+SymbolPackage=C:\repos\aad\forks\msal.net\samples\XForms\XForms.UWP\AppPackages\XForms.UWP_1.0.0.0_Debug_Test\XForms.UWP_1.0.0.0_x86_Debug.appxsym
+ResourcePack=C:\repos\aad\forks\msal.net\samples\XForms\XForms.UWP\bin\x86\Debug\XForms.UWP_1.0.0.0_scale-100.appx
+ResourcePack=C:\repos\aad\forks\msal.net\samples\XForms\XForms.UWP\bin\x86\Debug\XForms.UWP_1.0.0.0_scale-125.appx
+ResourcePack=C:\repos\aad\forks\msal.net\samples\XForms\XForms.UWP\bin\x86\Debug\XForms.UWP_1.0.0.0_scale-150.appx
+ResourcePack=C:\repos\aad\forks\msal.net\samples\XForms\XForms.UWP\bin\x86\Debug\XForms.UWP_1.0.0.0_scale-400.appx

--- a/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -72,10 +72,10 @@ namespace Microsoft.Identity.Client
         public string TenantId => _accessTokenCacheItem.IdToken?.TenantId;
 
         /// <summary>
-        /// Gets User object. Some elements in User might be null if not returned by the
+        /// Gets the user object. Some elements in User might be null if not returned by the
         /// service. It can be passed back in some API overloads to identify which user should be used.
         /// </summary>
-        public User User => _accessTokenCacheItem.User;
+        public IUser User => _accessTokenCacheItem.User;
 
         /// <summary>
         /// Gets the entire Id Token if returned by the service or null if no Id Token is returned.

--- a/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Returns a User centric view over the cache that provides a list of all the available users in the cache.
         /// </summary>
-        public IEnumerable<User> Users
+        public IEnumerable<IUser> Users
         {
             get
             {
@@ -128,7 +128,7 @@ namespace Microsoft.Identity.Client
         /// <param name="scope">Array of scopes requested for resource</param>
         /// <param name="user">User for which the token is requested. <see cref="User"/></param>
         /// <returns></returns>
-        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, User user)
+        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, IUser user)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using the refresh token if available</param>
         /// <returns></returns>
-        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, User user,
+        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, IUser user,
             string authority, bool forceRefresh)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
@@ -159,7 +159,7 @@ namespace Microsoft.Identity.Client
         
         /// <summary>
         /// </summary>
-        public void Remove(User user)
+        public void Remove(IUser user)
         {
             if(user == null || UserTokenCache == null)
             {
@@ -170,7 +170,7 @@ namespace Microsoft.Identity.Client
         }
 
         internal async Task<AuthenticationResult> AcquireTokenSilentCommonAsync(Authority authority,
-            IEnumerable<string> scope, User user, bool forceRefresh)
+            IEnumerable<string> scope, IUser user, bool forceRefresh)
         {
             var handler = new SilentRequest(
                 CreateRequestParameters(authority, scope, user, UserTokenCache),
@@ -179,7 +179,7 @@ namespace Microsoft.Identity.Client
         }
 
         internal virtual AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope,
-            User user, TokenCache cache)
+            IUser user, TokenCache cache)
         {
             return new AuthenticationRequestParameters
             {

--- a/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -32,6 +32,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Instance;
 using Microsoft.Identity.Client.Internal.Requests;
+using System.Linq;
 
 namespace Microsoft.Identity.Client
 {
@@ -112,7 +113,7 @@ namespace Microsoft.Identity.Client
                 {
                     RequestContext requestContext = new RequestContext(CorrelationId);
                     requestContext.Logger.Info("Token cache is null or empty");
-                    return new List<User>();
+                    return Enumerable.Empty<User>();
                 }
 
                 return UserTokenCache.GetUsers(new Uri(Authority).Host);

--- a/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
+++ b/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Identity.Client
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope, User user, TokenCache cache)
+        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope, IUser user, TokenCache cache)
         {
             AuthenticationRequestParameters parameters = base.CreateRequestParameters(authority, scope, user, cache);
             parameters.ClientId = ClientId;

--- a/src/Microsoft.Identity.Client/IAuthenticationResult.cs
+++ b/src/Microsoft.Identity.Client/IAuthenticationResult.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Identity.Client
         string TenantId { get; }
 
         /// <summary>
-        /// Gets User object. Some elements in User might be null if not returned by the
+        /// Gets the user object. Some elements in User might be null if not returned by the
         /// service. It can be passed back in some API overloads to identify which user should be used.
         /// </summary>
-        User User { get; }
+        IUser User { get; }
 
         /// <summary>
         /// Gets the entire Id Token if returned by the service or null if no Id Token is returned.

--- a/src/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Returns a user-centric view over the cache that provides a list of all the available users in the cache.
         /// </summary>
-        IEnumerable<User> Users { get; }
+        IEnumerable<IUser> Users { get; }
 
         /// <summary>
         /// Attempts to acquire the access token from cache. Access token is considered a match if it AT LEAST contains all the requested scopes.
@@ -67,7 +67,7 @@ namespace Microsoft.Identity.Client
         /// <param name="user">User for which the token is requested. <see cref="User"/></param>
         Task<IAuthenticationResult> AcquireTokenSilentAsync(
             IEnumerable<string> scope,
-            User user);
+            IUser user);
 
         /// <summary>
         /// Attempts to acquire the access token from cache. Access token is considered a match if it AT LEAST contains all the requested scopes.
@@ -80,13 +80,13 @@ namespace Microsoft.Identity.Client
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using the refresh token if available</param>
         Task<IAuthenticationResult> AcquireTokenSilentAsync(
             IEnumerable<string> scope,
-            User user,
+            IUser user,
             string authority,
             bool forceRefresh);
 
         /// <summary>
         /// Removes any cached token for the specified user
         /// </summary>
-        void Remove(User user);
+        void Remove(IUser user);
    }
 }

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<IAuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scope,
-            User user,
+            IUser user,
             UIBehavior behavior,
             string extraQueryParameters);
 
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<IAuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scope,
-            User user,
+            IUser user,
             UIBehavior behavior,
             string extraQueryParameters,
             IEnumerable<string> additionalScope,

--- a/src/Microsoft.Identity.Client/IUser.cs
+++ b/src/Microsoft.Identity.Client/IUser.cs
@@ -32,48 +32,26 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// Contains information of a single user. This information is used for token cache lookup and enforcing the user session on STS authorize endpont.
     /// </summary>
-    internal sealed class User: IUser
+    public interface IUser
     {
-        public User()
-        {
-        }
-
-        internal User(User other)
-        {
-            DisplayableId = other.DisplayableId;
-            Identifier = other.Identifier;
-            Name = other.Name;
-            IdentityProvider = other.IdentityProvider;
-        }
-
-        public User(string identifier, string displayableId, string name, string identityProvider)
-        {
-            if (string.IsNullOrWhiteSpace(identifier))
-            {
-                throw new ArgumentNullException(nameof(identifier));
-            }
-
-            DisplayableId = displayableId;
-            Name = name;
-            IdentityProvider = identityProvider;
-            Identifier = identifier;
-        }
-
         /// <summary>
         /// Gets a displayable value in UserPrincipalName (UPN) format. The value can be null.
         /// </summary>
-        public string DisplayableId { get; internal set; }
+        string DisplayableId { get; }
 
         /// <summary>
         /// Gets given name of the user if provided by the service. If not, the value is null.
         /// </summary>
-        public string Name { get; internal set; }
+        string Name { get; }
 
         /// <summary>
         /// Gets identity provider if returned by the service. If not, the value is null.
         /// </summary>
-        public string IdentityProvider { get; internal set; }
+        string IdentityProvider { get; }
 
-        public string Identifier { get; internal set; }
+        /// <summary>
+        /// Gets an identifier for the user for the given <see cref="IdentityProvider"/>. Cannot be null.
+        /// </summary>
+        string Identifier { get; }
    }
 }

--- a/src/Microsoft.Identity.Client/Internal/Cache/AccessTokenCacheItem.cs
+++ b/src/Microsoft.Identity.Client/Internal/Cache/AccessTokenCacheItem.cs
@@ -120,8 +120,7 @@ namespace Microsoft.Identity.Client.Internal.Cache
             ClientInfo = ClientInfo.Parse(RawClientInfo);
             if (IdToken != null)
             {
-                User = User.Create(IdToken.PreferredUsername, IdToken.Name, IdToken.Issuer,
-                    GetUserIdentifier());
+                User = new User(GetUserIdentifier(), IdToken.PreferredUsername, IdToken.Name, IdToken.Issuer);
             }
         }
 

--- a/src/Microsoft.Identity.Client/Internal/Cache/RefreshTokenCacheItem.cs
+++ b/src/Microsoft.Identity.Client/Internal/Cache/RefreshTokenCacheItem.cs
@@ -76,8 +76,7 @@ namespace Microsoft.Identity.Client.Internal.Cache
             Name = idToken.Name;
             IdentityProvider = idToken.Issuer;
 
-            User = User.Create(DisplayableId, Name, IdentityProvider,
-                GetUserIdentifier());
+            User = new User(GetUserIdentifier(), DisplayableId, Name, IdentityProvider);
         }
 
         // This method is called after the object 
@@ -86,8 +85,7 @@ namespace Microsoft.Identity.Client.Internal.Cache
         void OnDeserialized(StreamingContext context)
         {
             ClientInfo = ClientInfo.Parse(RawClientInfo);
-            User = User.Create(DisplayableId, Name, IdentityProvider,
-                GetUserIdentifier());
+            User = new User(GetUserIdentifier(), DisplayableId, Name, IdentityProvider);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public string Prompt { get; set; }
 
-        public User User { get; set; }
+        public IUser User { get; set; }
 
         public UserAssertion UserAssertion { get; set; }
 

--- a/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Client
         /// <param name="behavior">Enumeration to control UI behavior.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, User user,
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, IUser user,
             UIBehavior behavior, string extraQueryParameters)
         {
             Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
@@ -165,7 +165,7 @@ namespace Microsoft.Identity.Client
         /// <param name="additionalScope">Array of scopes for which a developer can request consent upfront.</param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, User user,
+        public async Task<IAuthenticationResult> AcquireTokenAsync(IEnumerable<string> scope, IUser user,
             UIBehavior behavior, string extraQueryParameters, IEnumerable<string> additionalScope, string authority)
         {
             Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
@@ -234,7 +234,7 @@ namespace Microsoft.Identity.Client
         }
 
         private async Task<AuthenticationResult> AcquireTokenCommonAsync(Authority authority, IEnumerable<string> scope,
-            IEnumerable<string> additionalScope, User user, UIBehavior behavior, string extraQueryParameters)
+            IEnumerable<string> additionalScope, IUser user, UIBehavior behavior, string extraQueryParameters)
         {
 
             var requestParams = CreateRequestParameters(authority, scope, user, UserTokenCache);
@@ -246,7 +246,7 @@ namespace Microsoft.Identity.Client
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope, User user, TokenCache cache)
+        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scope, IUser user, TokenCache cache)
         {
             AuthenticationRequestParameters parameters = base.CreateRequestParameters(authority, scope, user, cache);
             parameters.ClientId = ClientId;

--- a/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        internal void Remove(User user)
+        internal void Remove(IUser user)
         {
             lock (LockObject)
             {

--- a/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -45,6 +45,6 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Gets the user object.
         /// </summary>
-        public User User { get; internal set; }
+        public IUser User { get; internal set; }
     }
 }

--- a/src/Microsoft.Identity.Client/User.cs
+++ b/src/Microsoft.Identity.Client/User.cs
@@ -25,14 +25,13 @@
 //
 //------------------------------------------------------------------------------
 
-using System.Runtime.Serialization;
+using System;
 
 namespace Microsoft.Identity.Client
 {
     /// <summary>
     /// Contains information of a single user. This information is used for token cache lookup and enforcing the user session on STS authorize endpont.
     /// </summary>
-    [DataContract]
     public sealed class User
     {
         internal User()
@@ -47,37 +46,34 @@ namespace Microsoft.Identity.Client
             IdentityProvider = other.IdentityProvider;
         }
 
+        public User(string identifier, string displayableId, string name, string identityProvider)
+        {
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                throw new ArgumentNullException(nameof(identifier));
+            }
+
+            DisplayableId = displayableId;
+            Name = name;
+            IdentityProvider = identityProvider;
+            Identifier = identifier;
+        }
+
         /// <summary>
         /// Gets a displayable value in UserPrincipalName (UPN) format. The value can be null.
         /// </summary>
-        [DataMember]
         public string DisplayableId { get; internal set; }
 
         /// <summary>
         /// Gets given name of the user if provided by the service. If not, the value is null.
         /// </summary>
-        [DataMember]
         public string Name { get; internal set; }
 
         /// <summary>
         /// Gets identity provider if returned by the service. If not, the value is null.
         /// </summary>
-        [DataMember]
         public string IdentityProvider { get; internal set; }
 
-        [DataMember]
         public string Identifier { get; internal set; }
-
-
-        internal static User Create(string displayableId, string name, string identityProvider, string identifier)
-        {
-            return new User
-            {
-                DisplayableId = displayableId,
-                Name = name,
-                IdentityProvider = identityProvider,
-                Identifier = identifier
-            };
-        }
-    }
+   }
 }

--- a/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -89,24 +89,29 @@ namespace Test.MSAL.NET.Unit
         [Description("Tests the public interfaces can be mocked")]
         public void MockConfidentialClientApplication_Users()
         {
-            // This test is of limited use; since this test project can see the internals of the
-            // product assembly, we can't be sure we're actually testing the public API.
-
-            // Setup up a confidential client application
+            // Setup up a confidential client application with mocked users
             var mockApp = Substitute.For<IConfidentialClientApplication>();
-            IList<User> users = new List<User>();
-            users.Add(new User("id1", "disp1", "name1", "provider1"));
-            users.Add(new User("id2", "disp2", "name2", "provider2"));
+            IList<IUser> users = new List<IUser>();
+
+            IUser mockUser1 = Substitute.For<IUser>();
+            mockUser1.Name.Returns("Name1");
+
+            IUser mockUser2 = Substitute.For<IUser>();
+            mockUser2.Name.Returns("Name2");
+
+            users.Add(mockUser1);
+            users.Add(mockUser2);
             mockApp.Users.Returns(users);
 
             // Now call the substitute
-            IEnumerable<User> actualUsers = mockApp.Users;
+            IEnumerable<IUser> actualUsers = mockApp.Users;
 
             // Check the users property
             Assert.IsNotNull(actualUsers);
             Assert.AreEqual(2, actualUsers.Count());
 
-            Assert.AreEqual("name1", users.First().Name);
+            Assert.AreEqual("Name1", users.First().Name);
+            Assert.AreEqual("Name2", users.Last().Name);
         }
 
         [TestMethod]

--- a/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -62,7 +62,7 @@ namespace Test.MSAL.NET.Unit
         [TestMethod]
         [TestCategory("ConfidentialClientApplicationTests")]
         [Description("Tests the public interfaces can be mocked")]
-        public void MockConfidentialClientApplication()
+        public void MockConfidentialClientApplication_AcquireToken()
         {
             // Setup up a confidential client application that returns a dummy result
             var mockResult = Substitute.For<IAuthenticationResult>();
@@ -82,6 +82,31 @@ namespace Test.MSAL.NET.Unit
             Assert.IsNotNull(scopes);
             Assert.AreEqual("scope1", scopes.First());
             Assert.AreEqual("scope2", scopes.Last());
+        }
+
+        [TestMethod]
+        [TestCategory("ConfidentialClientApplicationTests")]
+        [Description("Tests the public interfaces can be mocked")]
+        public void MockConfidentialClientApplication_Users()
+        {
+            // This test is of limited use; since this test project can see the internals of the
+            // product assembly, we can't be sure we're actually testing the public API.
+
+            // Setup up a confidential client application
+            var mockApp = Substitute.For<IConfidentialClientApplication>();
+            IList<User> users = new List<User>();
+            users.Add(new User("id1", "disp1", "name1", "provider1"));
+            users.Add(new User("id2", "disp2", "name2", "provider2"));
+            mockApp.Users.Returns(users);
+
+            // Now call the substitute
+            IEnumerable<User> actualUsers = mockApp.Users;
+
+            // Check the users property
+            Assert.IsNotNull(actualUsers);
+            Assert.AreEqual(2, actualUsers.Count());
+
+            Assert.AreEqual("name1", users.First().Name);
         }
 
         [TestMethod]

--- a/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -137,7 +137,7 @@ namespace Test.MSAL.NET.Unit
         public void GetUsersTest()
         {
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId);
-            IEnumerable<User> users = app.Users;
+            IEnumerable<IUser> users = app.Users;
             Assert.IsNotNull(users);
             Assert.IsFalse(users.Any());
             cache = new TokenCache()

--- a/tests/Test.MSAL.NET.Unit/UserTests.cs
+++ b/tests/Test.MSAL.NET.Unit/UserTests.cs
@@ -1,0 +1,60 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using Microsoft.Identity.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Test.MSAL.NET.Unit
+{
+    [TestClass]
+    public class UserTests
+    {
+        [TestMethod]
+        [TestCategory("UserTests")]
+        public void Constructor_IdIsRequired()
+        {
+            // 1. Id is required
+            AssertException.Throws<ArgumentNullException>(() => new User(null, "d", "n", "id"));
+
+            // 2. Other properties are optional
+            new User("id", null, null, null);
+        }
+
+        [TestMethod]
+        [TestCategory("UserTests")]
+        public void Constructor_PropertiesSet()
+        {
+            User actual = new User("id", "disp", "name", "idp");
+
+            Assert.AreEqual("id", actual.Identifier);
+            Assert.AreEqual("disp", actual.DisplayableId);
+            Assert.AreEqual("name", actual.Name);
+            Assert.AreEqual("idp", actual.IdentityProvider);
+        }
+    }
+}


### PR DESCRIPTION
The public API exposes the _User_ class which in turn exposes properties a developer might reasonably want to use in their app such as _Name_ and _DisplayableId_ - which in turn means they will want to be able to unit test their app.