### PR TITLE
redirectUri - use OriginalString instead of AbsoluteUri

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             client.AddBodyParameter(OAuth2Parameter.GrantType, OAuth2GrantType.AuthorizationCode);
             client.AddBodyParameter(OAuth2Parameter.Code, _authorizationResult.Code);
-            client.AddBodyParameter(OAuth2Parameter.RedirectUri, AuthenticationRequestParameters.RedirectUri.AbsoluteUri);
+            client.AddBodyParameter(OAuth2Parameter.RedirectUri, AuthenticationRequestParameters.RedirectUri.OriginalString);
             client.AddBodyParameter(OAuth2Parameter.CodeVerifier, _codeVerifier);
         }
 
@@ -202,7 +202,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             authorizationRequestParameters[OAuth2Parameter.ClientId] = AuthenticationRequestParameters.ClientId;
             authorizationRequestParameters[OAuth2Parameter.RedirectUri] =
-                AuthenticationRequestParameters.RedirectUri.AbsoluteUri;
+                AuthenticationRequestParameters.RedirectUri.OriginalString;
 
             if (!string.IsNullOrWhiteSpace(AuthenticationRequestParameters.LoginHint))
             {

--- a/src/Microsoft.Identity.Client/Platforms/Android/WebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/WebUI.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Client
             {
                 var agentIntent = new Intent(_parent.Activity, typeof(AuthenticationActivity));
                 agentIntent.PutExtra(AndroidConstants.RequestUrlKey, authorizationUri.AbsoluteUri);
-                agentIntent.PutExtra(AndroidConstants.CustomTabRedirect, redirectUri.AbsoluteUri);
+                agentIntent.PutExtra(AndroidConstants.CustomTabRedirect, redirectUri.OriginalString);
 
                 _parent.Activity.RunOnUiThread(()=> _parent.Activity.StartActivityForResult(agentIntent, 0));
             }

--- a/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -359,8 +359,9 @@ namespace Test.MSAL.NET.Unit
                 ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(app.Authority)
             });
 
+            string CustomRedirectUri = "custom://redirect-uri";
             Task<Uri> task = app.GetAuthorizationRequestUrlAsync(TestConstants.Scope.AsArray(),
-                "custom://redirect-uri", TestConstants.DisplayableId, "extra=qp",
+                CustomRedirectUri, TestConstants.DisplayableId, "extra=qp",
                 TestConstants.ScopeForAnotherResource.AsArray(), TestConstants.AuthorityGuestTenant);
             Uri uri = task.Result;
             Assert.IsNotNull(uri);
@@ -373,7 +374,7 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual("offline_access openid profile r1/scope1 r1/scope2 r2/scope1 r2/scope2", qp["scope"]);
             Assert.AreEqual(TestConstants.ClientId, qp["client_id"]);
             Assert.AreEqual("code", qp["response_type"]);
-            Assert.AreEqual("custom://redirect-uri/", qp["redirect_uri"]);
+            Assert.AreEqual(CustomRedirectUri, qp["redirect_uri"]);
             Assert.AreEqual(TestConstants.DisplayableId, qp["login_hint"]);
             Assert.AreEqual("MSAL.Desktop", qp["x-client-sku"]);
             Assert.IsFalse(string.IsNullOrEmpty(qp["x-client-ver"]));

--- a/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -359,7 +359,7 @@ namespace Test.MSAL.NET.Unit
                 ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(app.Authority)
             });
 
-            string CustomRedirectUri = "custom://redirect-uri";
+            const string CustomRedirectUri = "custom://redirect-uri";
             Task<Uri> task = app.GetAuthorizationRequestUrlAsync(TestConstants.Scope.AsArray(),
                 CustomRedirectUri, TestConstants.DisplayableId, "extra=qp",
                 TestConstants.ScopeForAnotherResource.AsArray(), TestConstants.AuthorityGuestTenant);


### PR DESCRIPTION
redirectUri - use OriginalString instead of AbsoluteUri https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/160