### PR TITLE
Added workaround for Xamarin targets bug

### DIFF
--- a/dev apps/XForms/PATCH.Xamarin.Common.targets
+++ b/dev apps/XForms/PATCH.Xamarin.Common.targets
@@ -1,0 +1,35 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<Target Name="GetBuiltProjectOutputRecursive" Returns="@(AllBuiltProjectOutputs)" DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence;AllProjectOutputGroups">
+
+    <!-- Note: 
+      There is a bug in the Xamarin targets file at C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets
+    
+      This file providers a workaround by redefining the buggy "GetBuiltProjectOutputRecursive".
+      This file must be imported *after* the standard targets file so that it overrides the previous definition of the target.
+      -->
+    
+		<MSBuild
+				Projects="@(_GetBuiltOutputProject)"
+				Targets="GetBuiltProjectOutputRecursive"
+				BuildInParallel="$(BuildInParallel)"
+				Properties="_BuiltProjectOutputs=$(_BuiltProjectOutputs); %(_GetBuiltOutputProject.SetConfiguration); %(_GetBuiltOutputProject.SetPlatform); %(_GetBuiltOutputProject.SetTargetFramework)"
+				ContinueOnError="!$(BuildingProject)"
+				RemoveProperties="%(_GetBuiltOutputProject.GlobalPropertiesToRemove)">
+
+			<Output TaskParameter="TargetOutputs" ItemName="_RecursiveBuiltProjectOutputs" />
+		</MSBuild> 
+
+		<ItemGroup>
+			<AllBuiltProjectOutputs Include="@(_RecursiveBuiltProjectOutputs)" />
+			<AllBuiltProjectOutputs Include="@(BuiltProjectOutputGroupKeyOutput)" />
+		</ItemGroup>
+
+		<WriteLinesToFile 
+			File="$(IntermediateOutputPath)$(CleanFile)" 
+			Lines="@(BuiltProjectOutputGroupKeyOutput -> '%(FullPath).mdb');@(BuiltProjectOutputGroupKeyOutput -> '%(FinalOutputPath).mdb')" 
+			Overwrite="false" ContinueOnError="WarnAndContinue" /> 
+
+	</Target>
+	
+</Project>

--- a/dev apps/XForms/XForms.Android/XForms.Android.csproj
+++ b/dev apps/XForms/XForms.Android/XForms.Android.csproj
@@ -110,4 +110,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+
+  <!-- Import the Xamarin targets workaround -->
+  <Import Project="..\Patch.Xamarin.Common.targets" />
 </Project>

--- a/dev apps/XForms/XForms.iOS/XForms.iOS.csproj
+++ b/dev apps/XForms/XForms.iOS/XForms.iOS.csproj
@@ -145,4 +145,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+
+  <!-- Import the Xamarin targets workaround -->
+  <Import Project="..\Patch.Xamarin.Common.targets" />
 </Project>


### PR DESCRIPTION
If a project references multiple targets with the same name then the last one to be imported wins.

This commit contains a workaround for the Xamarin targets bug by redefining the buggy target for the two projects that use it. Implementing the workaround this way avoids the need to every developer to manually patch up their machine, and it also means the fix will be applied in appveyor builds.