### PR TITLE
Update cache lookup per #127. Also includes fix for #301

### DIFF
--- a/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -164,7 +164,12 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, IUser user,
             string authority, bool forceRefresh)
         {
-            Authority authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = null;
+            if (!string.IsNullOrEmpty(authority))
+            {
+                authorityInstance = Internal.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            }
+
             return
                 await
                     AcquireTokenSilentCommonAsync(authorityInstance, scope, user,

--- a/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client
     /// <Summary>
     /// Abstract class containing common API methods and properties. Both PublicClientApplication and ConfidentialClientApplication extend this class.
     /// </Summary>
-    public abstract class ClientApplicationBase : IClientApplicationBase
+    public abstract class ClientApplicationBase
     {
         private TokenCache _userTokenCache;
 
@@ -145,10 +145,9 @@ namespace Microsoft.Identity.Client
         /// <returns></returns>
         public async Task<AuthenticationResult> AcquireTokenSilentAsync(IEnumerable<string> scope, IUser user)
         {
-            Authority authority = Internal.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
                 await
-                    AcquireTokenSilentCommonAsync(authority, scope, user, false)
+                    AcquireTokenSilentCommonAsync(null, scope, user, false)
                         .ConfigureAwait(false);
         }
 
@@ -203,7 +202,8 @@ namespace Microsoft.Identity.Client
                 User = user,
                 Scope = scope.CreateSetFromEnumerable(),
                 RedirectUri = new Uri(RedirectUri),
-                RequestContext = CreateRequestContext(Guid.Empty)
+                RequestContext = CreateRequestContext(Guid.Empty),
+                ValidateAuthority = ValidateAuthority
             };
         }
 

--- a/src/Microsoft.Identity.Client/Internal/Instance/Authority.cs
+++ b/src/Microsoft.Identity.Client/Internal/Instance/Authority.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Client.Internal.Instance
 
     internal abstract class Authority
     {
-        private static readonly string[] TenantlessTenantName = {"common", "organizations", "consumers"};
+        private static readonly string[] TenantlessTenantName = {"common", "organizations"};
         private bool _resolved;
 
         internal static readonly ConcurrentDictionary<string, Authority> ValidatedAuthorities =
@@ -221,15 +221,6 @@ namespace Microsoft.Identity.Client.Internal.Instance
                 await
                     client.ExecuteRequest<TenantDiscoveryResponse>(new Uri(openIdConfigurationEndpoint),
                         HttpMethod.Get, requestContext).ConfigureAwait(false);
-        }
-
-        public static bool IsTenantLessAuthority(string authority)
-        {
-            var authorityUri = new Uri(authority);
-            string path = authorityUri.AbsolutePath.Substring(1);
-            string tenant = path.Substring(0, path.IndexOf("/", StringComparison.Ordinal));
-            return
-                TenantlessTenantName.Any(name => string.Compare(tenant, name, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
         public void UpdateTenantId(string tenantId)

--- a/src/Microsoft.Identity.Client/Internal/PlatformPlugin.cs
+++ b/src/Microsoft.Identity.Client/Internal/PlatformPlugin.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Internal
 
         public static void InitializeByAssemblyDynamicLinking()
         {
-#if !NETSTANDARD1_1
+#if !FACADE
             InjectDependecies(
                 (IWebUIFactory) new WebUIFactory(),
                 (ILogger) new PlatformLogger(),

--- a/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public Authority Authority { get; set; }
 
+        public bool ValidateAuthority { get; set; }
+
         public TokenCache TokenCache { get; set; }
 
         public SortedSet<string> Scope { get; set; }

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -88,8 +88,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         internal override async Task PreTokenRequest()
         {
             await base.PreTokenRequest().ConfigureAwait(false);
-
-            // We do not have async interactive API in .NET, so we call this synchronous method instead.
+            
             await AcquireAuthorizationAsync().ConfigureAwait(false);
             VerifyAuthorizationResult();
         }
@@ -108,7 +107,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             //this method is used in confidential clients to create authorization URLs.
             RequestContext = requestContext;
-            await Authority.ResolveEndpointsAsync(AuthenticationRequestParameters.LoginHint, RequestContext).ConfigureAwait(false);
+            await AuthenticationRequestParameters.Authority.ResolveEndpointsAsync(AuthenticationRequestParameters.LoginHint, RequestContext).ConfigureAwait(false);
             return CreateAuthorizationUri();
         }
 
@@ -185,7 +184,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 qp += "&" + AuthenticationRequestParameters.ExtraQueryParameters;
             }
 
-            UriBuilder builder = new UriBuilder(new Uri(Authority.AuthorizationEndpoint)) {Query = qp};
+            UriBuilder builder = new UriBuilder(new Uri(AuthenticationRequestParameters.Authority.AuthorizationEndpoint)) {Query = qp};
             return new Uri(MsalHelpers.CheckForExtraQueryParameter(builder.ToString()));
 
         }

--- a/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -42,15 +42,21 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
         }
 
-        protected override async Task SendTokenRequestAsync()
+        internal override async Task PreTokenRequest()
         {
+            await base.PreTokenRequest().ConfigureAwait(false);
+
             // look for access token in the cache first.
             // no access token is found, then it means token does not exist
             // or new assertion has been passed. We should not use Refresh Token
             // for the user because the new incoming token may have updated claims
             // like mfa etc.
             AccessTokenItem
-                 = TokenCache.FindAccessToken(AuthenticationRequestParameters);
+                = TokenCache.FindAccessToken(AuthenticationRequestParameters);
+        }
+
+        protected override async Task SendTokenRequestAsync()
+        {
             if (AccessTokenItem == null)
             {
                 await base.SendTokenRequestAsync().ConfigureAwait(false);

--- a/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
@@ -61,11 +61,13 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     "Token cache is set to null. Silent requests cannot be executed.");
             }
 
-            //look for access token first because force refresh is not set
-            if (!ForceRefresh)
-            {
+            //look for access token.
                 AccessTokenItem
                     = TokenCache.FindAccessToken(AuthenticationRequestParameters);
+            
+            if (ForceRefresh)
+            {
+                AccessTokenItem = null;
             }
 
             await CompletedTask.ConfigureAwait(false);

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard1.3;win81;MonoAndroid7;Xamarin.iOS10</TargetFrameworks>        
+    <TargetFrameworks>net45;netstandard1.1;netstandard1.3;win81;MonoAndroid7;Xamarin.iOS10;portable-net45+win8</TargetFrameworks>        
     <Authors>Microsoft Corp.</Authors>
     <PackageTitle>Microsoft Authentication Library</PackageTitle>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=844762</PackageLicenseUrl>
@@ -19,7 +19,7 @@
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <DebugType>full</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'portable-net45+win8' ">
     <DefineConstants>$(DefineConstants);FACADE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'win81' or '$(TargetFramework)' == 'uap10.0' ">
@@ -48,11 +48,11 @@
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'portable-net45+win8' ">
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" Condition="'$(TargetFramework)' != 'netstandard1.1'" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" Condition="'$(TargetFramework)' != 'netstandard1.1' and '$(TargetFramework)' != 'portable-net45+win8' " />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
@@ -84,7 +84,7 @@
     <Compile Include="Features\PublicClient\**\*.cs" />
     <Compile Include="Features\*.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'portable-net45+win8'">
     <Compile Include="Features\TokenCache\**\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard1.3;win81;MonoAndroid7;Xamarin.iOS10;portable-net45+win8</TargetFrameworks>        
+    <TargetFrameworks>net45;netstandard1.1;netstandard1.3;win81;MonoAndroid7;Xamarin.iOS10</TargetFrameworks>        
     <Authors>Microsoft Corp.</Authors>
     <PackageTitle>Microsoft Authentication Library</PackageTitle>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=844762</PackageLicenseUrl>
@@ -19,7 +19,7 @@
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <DebugType>full</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'portable-net45+win8' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1' ">
     <DefineConstants>$(DefineConstants);FACADE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'win81' or '$(TargetFramework)' == 'uap10.0' ">
@@ -48,11 +48,11 @@
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'portable-net45+win8' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" Condition="'$(TargetFramework)' != 'netstandard1.1' and '$(TargetFramework)' != 'portable-net45+win8' " />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" Condition="'$(TargetFramework)' != 'netstandard1.1'" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
@@ -84,7 +84,7 @@
     <Compile Include="Features\PublicClient\**\*.cs" />
     <Compile Include="Features\*.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'portable-net45+win8'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <Compile Include="Features\TokenCache\**\*.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Cache;
+using Microsoft.Identity.Client.Internal.Instance;
 using Microsoft.Identity.Client.Internal.OAuth2;
 using Microsoft.Identity.Client.Internal.Requests;
 
@@ -183,6 +184,7 @@ namespace Microsoft.Identity.Client
         {
             lock (LockObject)
             {
+                AccessTokenCacheItem accessTokenCacheItem = null;
                 TokenCacheNotificationArgs args = new TokenCacheNotificationArgs
                 {
                     TokenCache = this,
@@ -191,18 +193,9 @@ namespace Microsoft.Identity.Client
                 };
 
                 OnBeforeAccess(args);
+                //filtered by client id.
                 ICollection<AccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensForClient();
-
                 OnAfterAccess(args);
-
-                //first filter the list by authority, client id and scopes
-                tokenCacheItems =
-                    tokenCacheItems.Where(
-                        item =>
-                            item.Authority.Equals(requestParam.Authority.CanonicalAuthority) &&
-                            item.ClientId.Equals(requestParam.ClientId) &&
-                            item.ScopeSet.ScopeContains(requestParam.Scope))
-                        .ToList();
 
                 // this is OBO flow. match the cache entry with assertion hash,
                 // Authority, ScopeSet and client Id.
@@ -210,9 +203,10 @@ namespace Microsoft.Identity.Client
                 {
                     tokenCacheItems =
                         tokenCacheItems.Where(
-                            item =>
-                                !string.IsNullOrEmpty(item.UserAssertionHash) &&
-                                item.UserAssertionHash.Equals(requestParam.UserAssertion.AssertionHash)).ToList();
+                                item =>
+                                    !string.IsNullOrEmpty(item.UserAssertionHash) &&
+                                    item.UserAssertionHash.Equals(requestParam.UserAssertion.AssertionHash))
+                            .ToList();
                 }
                 else
                 {
@@ -222,27 +216,85 @@ namespace Microsoft.Identity.Client
                     if (!requestParam.HasCredential)
 #endif
                     {
-                        //filter by home_oid of the user instead
+                        //filter by identifier of the user instead
                         tokenCacheItems =
-                            tokenCacheItems.Where(item => item.GetUserIdentifier().Equals(requestParam.User?.Identifier))
+                            tokenCacheItems
+                                .Where(item => item.GetUserIdentifier().Equals(requestParam.User?.Identifier))
                                 .ToList();
                     }
                 }
 
-                if (tokenCacheItems.Count == 0)
+                //no match found after initial filtering
+                if (!tokenCacheItems.Any())
                 {
-                    // TODO: log access token not found
                     return null;
                 }
-                
-                if (tokenCacheItems.Count > 1)
+
+                IEnumerable<AccessTokenCacheItem> filteredItems =
+                    tokenCacheItems.Where(
+                            item =>
+                                item.ScopeSet.ScopeContains(requestParam.Scope))
+                        .ToList();
+                //no authority passed
+                if (requestParam.Authority == null)
                 {
-                    //TODO: log PII for authorities found.
-                    throw new MsalClientException(MsalClientException.MultipleTokensMatchedError, MsalErrorMessage.MultipleTokensMatched);
+                    //if only one cached token found
+                    if (filteredItems.Count() == 1)
+                    {
+                        accessTokenCacheItem = filteredItems.First();
+                    }
+                    else if (filteredItems.Count() > 1)
+                    {
+                        //more than 1 match found
+                        //TODO: log PII for authorities found.
+                        throw new MsalClientException(MsalClientException.MultipleTokensMatchedError,
+                            MsalErrorMessage.MultipleTokensMatched);
+                    }
+                    else
+                    {
+                        //no match found. check if there was a single authority used
+                        IEnumerable<string> authorityList = tokenCacheItems.Select(tci => tci.Authority).Distinct();
+                        if (authorityList.Count() > 1)
+                        {
+                            throw new MsalClientException(MsalClientException.MultipleTokensMatchedError,
+                                "Multiple authorities found in the cache. Pass in authority in the API overload.");
+                        }
+
+                        requestParam.Authority =
+                            Authority.CreateAuthority(authorityList.First(), requestParam.ValidateAuthority);
+                    }
+                }
+                else
+                {
+                    //authority was passed in the API
+                    filteredItems =
+                        filteredItems.Where(
+                                item =>
+                                    item.Authority.Equals(requestParam.Authority.CanonicalAuthority))
+                            .ToList();
+                    
+                    //no match
+                    if (!filteredItems.Any())
+                    {
+                        // TODO: log access token not found
+                        return null;
+                    }
+
+                    //if only one cached token found
+                    if (filteredItems.Count() == 1)
+                    {
+                        accessTokenCacheItem = filteredItems.First();
+                    }
+                    else
+                    {
+                        //more than 1 match found
+                        //TODO: log PII for authorities found.
+                        throw new MsalClientException(MsalClientException.MultipleTokensMatchedError,
+                            MsalErrorMessage.MultipleTokensMatched);
+                    }
                 }
 
-                AccessTokenCacheItem accessTokenCacheItem = tokenCacheItems.First();
-                if (accessTokenCacheItem.ExpiresOn >
+                if (accessTokenCacheItem != null && accessTokenCacheItem.ExpiresOn >
                     DateTime.UtcNow + TimeSpan.FromMinutes(DefaultExpirationBufferInMinutes))
                 {
                     return accessTokenCacheItem;
@@ -257,6 +309,11 @@ namespace Microsoft.Identity.Client
         {
             lock (LockObject)
             {
+                if (requestParam.Authority == null)
+                {
+                    return null;
+                }
+
                 RefreshTokenCacheKey key = new RefreshTokenCacheKey(
                     requestParam.Authority.Host, requestParam.ClientId,
                     requestParam.User?.Identifier);

--- a/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.cs
@@ -242,6 +242,8 @@ namespace Microsoft.Identity.Client
                     if (filteredItems.Count() == 1)
                     {
                         accessTokenCacheItem = filteredItems.First();
+                        requestParam.Authority =
+                            Authority.CreateAuthority(accessTokenCacheItem.Authority, requestParam.ValidateAuthority);
                     }
                     else if (filteredItems.Count() > 1)
                     {

--- a/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -760,7 +760,7 @@ namespace Test.MSAL.NET.Unit
                 {
                     DisplayableId = TestConstants.DisplayableId,
                     Identifier = TestConstants.UserIdentifier,
-                }, app.Authority, true);
+                }, null, true);
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
             Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);

--- a/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -506,13 +506,86 @@ namespace Test.MSAL.NET.Unit
 
         [TestMethod]
         [TestCategory("PublicClientApplicationTests")]
-        public void AcquireTokenSilentCacheOnlyLookupTest()
+        public async Task AcquireTokenSilentScopeAndEmptyCacheTest()
         {
             PublicClientApplication app =
-                new PublicClientApplication(TestConstants.ClientId, TestConstants.AuthorityHomeTenant)
+                new PublicClientApplication(TestConstants.ClientId)
                 {
                     ValidateAuthority = false
                 };
+
+            cache = new TokenCache()
+            {
+                ClientId = TestConstants.ClientId
+            };
+
+            app.UserTokenCache = cache;
+            try
+            {
+                AuthenticationResult result = await app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(),
+                        new User()
+                        {
+                            DisplayableId = TestConstants.DisplayableId,
+                            Identifier = TestConstants.UserIdentifier,
+                        })
+                    .ConfigureAwait(false);
+            }
+            catch (MsalUiRequiredException exc)
+            {
+                Assert.AreEqual(MsalUiRequiredException.NoTokensFoundError, exc.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("PublicClientApplicationTests")]
+        public async Task AcquireTokenSilentScopeAndUserMultipleTokensFoundTest()
+        {
+            PublicClientApplication app =
+                new PublicClientApplication(TestConstants.ClientId)
+                {
+                    ValidateAuthority = false
+                };
+
+            cache = new TokenCache()
+            {
+                ClientId = TestConstants.ClientId
+            };
+
+            app.UserTokenCache = cache;
+            TokenCacheHelper.PopulateCache(cache.TokenCacheAccessor);
+            try
+            {
+                AuthenticationResult result = await app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(),
+                        new User()
+                        {
+                            DisplayableId = TestConstants.DisplayableId,
+                            Identifier = TestConstants.UserIdentifier,
+                        })
+                    .ConfigureAwait(false);
+            }
+            catch (MsalClientException exc)
+            {
+                Assert.AreEqual(MsalClientException.MultipleTokensMatchedError, exc.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("PublicClientApplicationTests")]
+        public void AcquireTokenSilentScopeAndUserOverloadWithNoMatchingScopesInCacheTest()
+        {
+            // this test ensures that the API can
+            // get authority (if unique) from the cache entries where scope does not match.
+            // it should only happen for case where no authority is passed.
+            PublicClientApplication app =
+                new PublicClientApplication(TestConstants.ClientId)
+                {
+                    ValidateAuthority = false
+                };
+
+            cache = new TokenCache()
+            {
+                ClientId = TestConstants.ClientId
+            };
 
             //add mock response for tenant endpoint discovery
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler
@@ -520,6 +593,110 @@ namespace Test.MSAL.NET.Unit
                 Method = HttpMethod.Get,
                 ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(TestConstants.AuthorityHomeTenant)
             });
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage =
+                    MockHelpers.CreateSuccessTokenResponseMessage(TestConstants.UniqueId,
+                        TestConstants.DisplayableId,
+                        TestConstants.ScopeForAnotherResource.ToArray())
+            });
+
+            app.UserTokenCache = cache;
+            TokenCacheHelper.PopulateCache(cache.TokenCacheAccessor);
+            cache.TokenCacheAccessor.AccessTokenCacheDictionary.Remove(new AccessTokenCacheKey(
+                TestConstants.AuthorityGuestTenant,
+                TestConstants.ScopeForAnotherResource, TestConstants.ClientId,
+                TestConstants.UserIdentifier).ToString());
+
+            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.ScopeForAnotherResource.ToArray(), new User()
+            {
+                DisplayableId = TestConstants.DisplayableId,
+                Identifier = TestConstants.UserIdentifier,
+            });
+
+            AuthenticationResult result = task.Result;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.ScopeForAnotherResource.AsSingleString(), result.Scope.AsSingleString());
+            Assert.AreEqual(2, cache.TokenCacheAccessor.GetAllAccessTokensAsString().Count());
+        }
+
+        [TestMethod]
+        [TestCategory("PublicClientApplicationTests")]
+        public void AcquireTokenSilentScopeAndUserOverloadDefaultAuthorityTest()
+        {
+            PublicClientApplication app =
+                new PublicClientApplication(TestConstants.ClientId)
+                {
+                    ValidateAuthority = false
+                };
+
+            cache = new TokenCache()
+            {
+                ClientId = TestConstants.ClientId
+            };
+
+            app.UserTokenCache = cache;
+            TokenCacheHelper.PopulateCache(cache.TokenCacheAccessor);
+            cache.TokenCacheAccessor.AccessTokenCacheDictionary.Remove(new AccessTokenCacheKey(
+                TestConstants.AuthorityGuestTenant,
+                TestConstants.ScopeForAnotherResource, TestConstants.ClientId,
+                TestConstants.UserIdentifier).ToString());
+
+            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new User()
+            {
+                DisplayableId = TestConstants.DisplayableId,
+                Identifier = TestConstants.UserIdentifier,
+            });
+            AuthenticationResult result = task.Result;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scope.AsSingleString());
+        }
+
+        [TestMethod]
+        [TestCategory("PublicClientApplicationTests")]
+        public void AcquireTokenSilentScopeAndUserOverloadTenantSpecificAuthorityTest()
+        {
+            PublicClientApplication app =
+                new PublicClientApplication(TestConstants.ClientId, TestConstants.AuthorityGuestTenant)
+                {
+                    ValidateAuthority = false
+                };
+
+            cache = new TokenCache()
+            {
+                ClientId = TestConstants.ClientId
+            };
+
+            app.UserTokenCache = cache;
+            TokenCacheHelper.PopulateCache(cache.TokenCacheAccessor);
+            cache.TokenCacheAccessor.AccessTokenCacheDictionary.Remove(new AccessTokenCacheKey(
+                TestConstants.AuthorityGuestTenant,
+                TestConstants.ScopeForAnotherResource, TestConstants.ClientId,
+                TestConstants.UserIdentifier).ToString());
+
+            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new User()
+            {
+                DisplayableId = TestConstants.DisplayableId,
+                Identifier = TestConstants.UserIdentifier,
+            });
+            AuthenticationResult result = task.Result;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scope.AsSingleString());
+        }
+
+        [TestMethod]
+        [TestCategory("PublicClientApplicationTests")]
+        public void AcquireTokenSilentCacheOnlyLookupTest()
+        {
+            PublicClientApplication app =
+                new PublicClientApplication(TestConstants.ClientId, TestConstants.AuthorityHomeTenant)
+                {
+                    ValidateAuthority = false
+                };
 
             cache = new TokenCache()
             {
@@ -538,12 +715,11 @@ namespace Test.MSAL.NET.Unit
                 DisplayableId = TestConstants.DisplayableId,
                 Identifier = TestConstants.UserIdentifier,
             }, app.Authority, false);
+
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
             Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scope.AsSingleString());
-
-            Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
         }
 
         [TestMethod]
@@ -634,7 +810,7 @@ namespace Test.MSAL.NET.Unit
                             Identifier = TestConstants.UserIdentifier,
                         }, app.Authority, false);
                 AuthenticationResult result = task.Result;
-                Assert.Fail("AdalSilentTokenAcquisitionException was expected");
+                Assert.Fail("MsalUiRequiredException was expected");
             }
             catch (AggregateException ex)
             {

--- a/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
@@ -199,7 +199,6 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             InteractiveRequest request = new InteractiveRequest(parameters,
                 TestConstants.ScopeForAnotherResource.ToArray(), 
                 (string) null, UIBehavior.ForceLogin, webUi);
-            request.PreRunAsync().Wait();
             try
             {
                 request.PreTokenRequest().Wait();
@@ -220,7 +219,6 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             request = new InteractiveRequest(parameters,
                 TestConstants.ScopeForAnotherResource.ToArray(),
                 (string) null, UIBehavior.ForceLogin, webUi);
-            request.PreRunAsync().Wait();
 
             try
             {
@@ -265,7 +263,6 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             InteractiveRequest request = new InteractiveRequest(parameters,
                 TestConstants.ScopeForAnotherResource.ToArray(),
                 null, UIBehavior.ForceLogin, new MockWebUI());
-            request.PreRunAsync().Wait();
 
             try
             {

--- a/tests/Test.MSAL.NET.Unit/TestConstants.cs
+++ b/tests/Test.MSAL.NET.Unit/TestConstants.cs
@@ -41,6 +41,7 @@ namespace Test.MSAL.NET.Unit
         public static readonly string AuthorityHomeTenant = "https://" + ProductionEnvironment + "/home/";
         public static readonly string AuthorityGuestTenant = "https://" + ProductionEnvironment + "/guest/";
         public static readonly string AuthorityCommonTenant = "https://" + ProductionEnvironment + "/common/";
+        public static readonly string AuthorityOrganizationsTenant = "https://" + ProductionEnvironment + "/organizations/";
         public static readonly string ClientId = "client_id";
         public static readonly string UniqueId = "unique_id";
         public static readonly string IdentityProvider = "my-idp";


### PR DESCRIPTION
Update cache lookup per #127. Also includes fix for #301 

Cache lookup works as follows
1) filter by client_id and user.
    1.1) if nothing found, fail.
    1.2) if no authority passed,
        1.2.1) filter by scope.
            1.2.1.1) if 1 entry found, save the authority (for later use).             
               1.2.1.1.1) if AT expired, return null (use authority for RT redemption)
               1.2.1.1.2) if AT not expired, then return.
            1.2.1.2) if more than 1 entry found, FAIL.
            1.2.1.3) if NO entry found, check if all cache entries from 1) were from single authority
                1.2.1.3.1) if NO, then FAIL.
                1.2.1.3.2) if YES, then save it for Refresh token redemption.
    1.2) if authority is passed,
        1.2.1) filter by scope + authority.
            1.2.1.1) if 1 entry found, return it.             
               1.2.1.1.1) if AT expired, return null
               1.2.1.1.2) if AT not expired, then return AT.
            1.2.1.2) if more than 1 entry found, FAIL.
            1.2.1.3) if NO entry found then use passed in authority for Refresh token redemption.  