### PR TITLE
Fix for dropped QPs from endpoints

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Instance/Authority.cs
+++ b/src/Microsoft.Identity.Client/Internal/Instance/Authority.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Identity.Client.Internal.Instance
 
         public async Task ResolveEndpointsAsync(string userPrincipalName, RequestContext requestContext)
         {
+            requestContext.Logger.Info("Resolving authority endpoints... Already resolved? - " + _resolved);
             if (!_resolved)
             {
                 var authorityUri = new Uri(CanonicalAuthority);
@@ -203,6 +204,8 @@ namespace Microsoft.Identity.Client.Internal.Instance
 
                 AddToValidatedAuthorities(userPrincipalName);
             }
+
+            requestContext.Logger.Info("");
         }
 
         protected abstract bool ExistsInValidatedAuthorityCache(string userPrincipalName);

--- a/src/Microsoft.Identity.Client/Internal/Instance/Authority.cs
+++ b/src/Microsoft.Identity.Client/Internal/Instance/Authority.cs
@@ -204,8 +204,6 @@ namespace Microsoft.Identity.Client.Internal.Instance
 
                 AddToValidatedAuthorities(userPrincipalName);
             }
-
-            requestContext.Logger.Info("");
         }
 
         protected abstract bool ExistsInValidatedAuthorityCache(string userPrincipalName);

--- a/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
+++ b/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
@@ -359,9 +359,13 @@ namespace Microsoft.Identity.Client.Internal
             }
 
             if (builder.Query.Length > 1)
+            {
                 builder.Query = builder.Query.Substring(1) + "&" + queryParams;
+            }
             else
+            {
                 builder.Query = queryParams;
+            }
         }
 
         private static void AddKeyValueString(StringBuilder messageBuilder, string key, char[] value)

--- a/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
+++ b/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
@@ -351,6 +351,19 @@ namespace Microsoft.Identity.Client.Internal
             return url;
         }
 
+        public static void AppendQueryParameters(this UriBuilder builder, string queryParams)
+        {
+            if (builder == null || string.IsNullOrEmpty(queryParams))
+            {
+                return;
+            }
+
+            if (builder.Query.Length > 1)
+                builder.Query = builder.Query.Substring(1) + "&" + queryParams;
+            else
+                builder.Query = queryParams;
+        }
+
         private static void AddKeyValueString(StringBuilder messageBuilder, string key, char[] value)
         {
             string delimiter = (messageBuilder.Length == 0) ? string.Empty : "&";

--- a/src/Microsoft.Identity.Client/Internal/OAuth2/OAuth2Client.cs
+++ b/src/Microsoft.Identity.Client/Internal/OAuth2/OAuth2Client.cs
@@ -152,10 +152,7 @@ namespace Microsoft.Identity.Client.Internal.OAuth2
         {
             UriBuilder endpointUri = new UriBuilder(endPoint);
             string extraQp = _queryParameters.ToQueryParameter();
-            if (!string.IsNullOrEmpty(extraQp))
-            {
-                endpointUri.Query += extraQp;
-            }
+            endpointUri.AppendQueryParameters(extraQp);
             
             return new Uri(MsalHelpers.CheckForExtraQueryParameter(endpointUri.Uri.AbsoluteUri));
         }

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -186,9 +186,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 qp += "&" + AuthenticationRequestParameters.ExtraQueryParameters;
             }
 
-            UriBuilder builder = new UriBuilder(new Uri(AuthenticationRequestParameters.Authority.AuthorizationEndpoint)) {Query = qp};
+            UriBuilder builder =
+                new UriBuilder(new Uri(AuthenticationRequestParameters.Authority.AuthorizationEndpoint));
+            builder.AppendQueryParameters(qp);
             return new Uri(MsalHelpers.CheckForExtraQueryParameter(builder.ToString()));
-
         }
 
         private Dictionary<string, string> CreateAuthorizationRequestParameters()

--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -212,10 +212,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private async Task SendHttpMessageAsync(OAuth2Client client)
         {
+            UriBuilder builder = new UriBuilder(AuthenticationRequestParameters.Authority.TokenEndpoint);
+            builder.AppendQueryParameters("slice=testslice&uid=true");
             Response =
                 await client
-                    .GetToken(
-                        new Uri(AuthenticationRequestParameters.Authority.TokenEndpoint + "?slice=testslice&uid=true"),
+                    .GetToken(builder.Uri,
                         AuthenticationRequestParameters.RequestContext)
                     .ConfigureAwait(false);
 

--- a/tests/Test.MSAL.NET.Unit/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Test.MSAL.NET.Unit/InstanceTests/AadAuthorityTests.cs
@@ -95,9 +95,9 @@ namespace Test.MSAL.NET.Unit.InstanceTests
                 .GetAwaiter()
                 .GetResult();
 
-            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/authorize",
+            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/authorize",
                 instance.AuthorizationEndpoint);
-            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/token",
+            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/token",
                 instance.TokenEndpoint);
             Assert.AreEqual("https://sts.windows.net/6babcaad-604b-40ac-a9d7-9fd97c0b779f/",
                 instance.SelfSignedJwtAudience);
@@ -126,9 +126,9 @@ namespace Test.MSAL.NET.Unit.InstanceTests
                 .GetAwaiter()
                 .GetResult();
 
-            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/authorize",
+            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/authorize",
                 instance.AuthorizationEndpoint);
-            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/token",
+            Assert.AreEqual("https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/token",
                 instance.TokenEndpoint);
             Assert.AreEqual("https://sts.windows.net/6babcaad-604b-40ac-a9d7-9fd97c0b779f/",
                 instance.SelfSignedJwtAudience);

--- a/tests/Test.MSAL.NET.Unit/Resources/OpenidConfiguration-B2C.json
+++ b/tests/Test.MSAL.NET.Unit/Resources/OpenidConfiguration-B2C.json
@@ -1,6 +1,6 @@
 ﻿{
-  "authorization_endpoint": "https://login.microsoftonline.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/my-policy/oauth2/authorize",
-  "token_endpoint": "https://login.microsoftonline.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/my-policy/oauth2/token",
+  "authorization_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/authorize?p=my-policy",
+  "token_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/token?p=my-policy",
   "token_endpoint_auth_methods_supported": [ "client_secret_post", "private_key_jwt" ],
   "jwks_uri": "https://login.microsoftonline.com/common/discovery/keys",
   "response_modes_supported": [ "query", "fragment", "form_post" ],
@@ -11,7 +11,7 @@
   "scopes_supported": [ "openid" ],
   "issuer": "https://sts.windows.net/6babcaad-604b-40ac-a9d7-9fd97c0b779f/",
   "claims_supported": [ "sub", "iss", "cloud_instance_name", "aud", "exp", "iat", "auth_time", "acr", "amr", "nonce", "email", "given_name", "family_name", "nickname" ],
-  "check_session_iframe": "https://login.microsoftonline.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/my-policy/oauth2/checksession",
-  "end_session_endpoint": "https://login.microsoftonline.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/my-policy/oauth2/logout",
-  "userinfo_endpoint": "https://login.microsoftonline.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/my-policy/openid/userinfo"
+  "check_session_iframe": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/checksession?p=my-policy",
+  "end_session_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/logout",
+  "userinfo_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/my-policy/openid/userinfo"
 }

--- a/tests/Test.MSAL.NET.Unit/Resources/OpenidConfiguration-MissingFields.json
+++ b/tests/Test.MSAL.NET.Unit/Resources/OpenidConfiguration-MissingFields.json
@@ -1,5 +1,5 @@
 ﻿{
-  "authorization_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/authorize",
+  "authorization_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/authorize",
   "token_endpoint_auth_methods_supported": [ "client_secret_post", "private_key_jwt" ],
   "jwks_uri": "https://login.microsoftonline.com/common/discovery/keys",
   "response_modes_supported": [ "query", "fragment", "form_post" ],
@@ -8,9 +8,9 @@
   "http_logout_supported": true,
   "response_types_supported": [ "code", "id_token", "code id_token", "token id_token", "token" ],
   "scopes_supported": [ "openid" ],
-  "issuer": "https://sts.windows.net/6babcaad-604b-40ac-a9d7-9fd97c0b779f/",
+  "issuer": "https://sts.windows.net/6babcaad-604b-40ac-a9d7-9fd97c0b779f/v2.0/",
   "claims_supported": [ "sub", "iss", "cloud_instance_name", "aud", "exp", "iat", "auth_time", "acr", "amr", "nonce", "email", "given_name", "family_name", "nickname" ],
-  "check_session_iframe": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/checksession",
-  "end_session_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/logout",
+  "check_session_iframe": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/checksession",
+  "end_session_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/logout",
   "userinfo_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/openid/userinfo"
 }

--- a/tests/Test.MSAL.NET.Unit/Resources/OpenidConfiguration.json
+++ b/tests/Test.MSAL.NET.Unit/Resources/OpenidConfiguration.json
@@ -1,8 +1,8 @@
 ﻿{
-  "authorization_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/authorize",
-  "token_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/token",
+  "authorization_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/authorize",
+  "token_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/token",
   "token_endpoint_auth_methods_supported": [ "client_secret_post", "private_key_jwt" ],
-  "jwks_uri": "https://login.microsoftonline.com/common/discovery/keys",
+  "jwks_uri": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/discovery/keys",
   "response_modes_supported": [ "query", "fragment", "form_post" ],
   "subject_types_supported": [ "pairwise" ],
   "id_token_signing_alg_values_supported": [ "RS256" ],
@@ -11,7 +11,7 @@
   "scopes_supported": [ "openid" ],
   "issuer": "https://sts.windows.net/6babcaad-604b-40ac-a9d7-9fd97c0b779f/",
   "claims_supported": [ "sub", "iss", "cloud_instance_name", "aud", "exp", "iat", "auth_time", "acr", "amr", "nonce", "email", "given_name", "family_name", "nickname" ],
-  "check_session_iframe": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/checksession",
-  "end_session_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/logout",
+  "check_session_iframe": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/checksession",
+  "end_session_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/oauth2/v2.0/logout",
   "userinfo_endpoint": "https://login.microsoftonline.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/openid/userinfo"
 }


### PR DESCRIPTION
Fix for dropped QPs from endpoints, per #238. B2C openid configuration endpoint returns auth urls with QPs and MSAL was dropping those QPs when constructing network requests.