### PR TITLE
Removing foo and bar in source code

### DIFF
--- a/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
+++ b/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
@@ -104,7 +104,7 @@ namespace Test.MSAL.NET.Unit
                 e1.WasSuccessful = true;
                 telemetry.StopEvent(reqId, e1);
 
-                var e2 = new HttpEvent() {HttpPath = "https://bar.com", UserAgent = "Edge", QueryParams = "foo&bar"};
+                var e2 = new HttpEvent() {HttpPath = "https://contoso.com", UserAgent = "Edge", QueryParams = "a&b"};
                 telemetry.StartEvent(reqId, e2);
                 // do some stuff...
                 e2.HttpResponseStatus = 200;


### PR DESCRIPTION
Our Jenkins build policy does not like foo bar.