### PR TITLE
Find Access Token in cache case insensibly

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
+++ b/src/Microsoft.Identity.Client/Internal/MsalHelpers.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Internal
         {
             foreach (string otherString in otherScope)
             {
-                if (!scope.Contains(otherString))
+                if (!scope.Contains(otherString, StringComparer.OrdinalIgnoreCase))
                 {
                     return false;
                 }

--- a/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
@@ -717,7 +717,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             response.RefreshToken = "refresh-token";
             response.Scope = TestConstants.Scope.AsSingleString();
             response.TokenType = "Bearer";
-            
+
             RequestContext requestContext = new RequestContext(Guid.NewGuid());
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
@@ -786,7 +786,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             response.RefreshToken = "refresh-token";
             response.Scope = TestConstants.Scope.AsSingleString();
             response.TokenType = "Bearer";
-            
+
             RequestContext requestContext = new RequestContext(Guid.NewGuid());
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
@@ -831,6 +831,37 @@ namespace Test.MSAL.NET.Unit.CacheTests
             Assert.AreEqual(TestConstants.ClientId, rtItem.ClientId);
             Assert.AreEqual(TestConstants.UserIdentifier, rtItem.GetUserIdentifier());
             Assert.AreEqual(TestConstants.ProductionEnvironment, rtItem.Environment);
+        }
+
+        [TestMethod]
+        [TestCategory("TokenCacheTests")]
+        public void FindAccessToken_ScopeCaseInsensitive()
+        {
+            var tokenCache = new TokenCache()
+            {
+                ClientId = TestConstants.ClientId
+            };
+
+            TokenCacheHelper.PopulateCache(tokenCache.TokenCacheAccessor);
+
+            var param = new AuthenticationRequestParameters()
+            {
+                RequestContext = new RequestContext(Guid.Empty),
+                ClientId = TestConstants.ClientId,
+                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Scope = new SortedSet<string>(),
+                User = TestConstants.User
+            };
+
+            var scopeInCache = TestConstants.Scope.FirstOrDefault();
+
+            var upperCaseScope = scopeInCache.ToUpper();
+            param.Scope.Add(upperCaseScope);
+
+            var item = tokenCache.FindAccessToken(param);
+
+            Assert.IsNotNull(item);
+            Assert.IsTrue(item.ScopeSet.Contains(scopeInCache));
         }
     }
 }


### PR DESCRIPTION
Token Cache FindAccessToken should be Scope case insensitiv https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/349