### PR TITLE
Force sdk_platform in telemetry to be in lowercase

### DIFF
--- a/src/Microsoft.Identity.Client/DefaultEvent.cs
+++ b/src/Microsoft.Identity.Client/DefaultEvent.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Client
         public DefaultEvent(string clientId) : base((string) (EventBase.EventNamePrefix + "default_event"))
         {
             this[EventNamePrefix + "client_id"] = clientId;
-            this[EventNamePrefix + "sdk_platform"] = PlatformPlugin.PlatformInformation.GetProductName();
+            this[EventNamePrefix + "sdk_platform"] = PlatformPlugin.PlatformInformation.GetProductName()?.ToLower();
             this[EventNamePrefix + "sdk_version"] = MsalIdHelper.GetMsalVersion();
             // TODO: The following implementation will be used after the 3 helpers being implemented (in a separated PR)
             // this[EventNamePrefix + "application_name"] = MsalIdHelper.GetApplicationName();  // Not yet implemented


### PR DESCRIPTION
It was "MSAL.Desktop". Now this is the DefaultEvent printed on console, after this PR change:

  msal.event_name: msal.default_event
  msal.start_time: 1493230041483
  msal.elapsed_time: -1
  msal.client_id: client_id
  **msal.sdk_platform: msal.desktop**
  msal.sdk_version: 1.1.0.0

Also note that, in future the telemetry operators will need to "translate" the original SDK version "MSAL.Desktop" into lowercase before he/she constructs the query.