### PR TITLE
Added run settings file to limit code coverage to product assemblies

### DIFF
--- a/build/MSAL.CodeCoverage.runsettings
+++ b/build/MSAL.CodeCoverage.runsettings
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>  
+
+<!-- Customised run settings file to exclude test assemblies from coverage.
+    See https://msdn.microsoft.com/en-us/library/jj159530.aspx for more info. -->
+
+<!-- File name extension must be .runsettings -->  
+<RunSettings>  
+  <DataCollectionRunSettings>  
+    <DataCollectors>  
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">  
+        <Configuration>  
+          <CodeCoverage>  
+  
+<!--  
+About include/exclude lists:  
+Empty "Include" clauses imply all; empty "Exclude" clauses imply none.  
+Each element in the list is a regular expression (ECMAScript syntax). See http://msdn.microsoft.com/library/2k3te2cs.aspx.  
+An item must first match at least one entry in the include list to be included.  
+Included items must then not match any entries in the exclude list to remain included.  
+-->  
+  
+            <!-- Match assembly file paths: -->  
+            <ModulePaths>  
+              <Include>  
+                <ModulePath>.*\microsoft.identity.client.dll$</ModulePath>  
+              </Include>  
+              <Exclude>  
+              </Exclude>  
+            </ModulePaths>  
+    
+          </CodeCoverage>  
+        </Configuration>  
+      </DataCollector>  
+    </DataCollectors>  
+  </DataCollectionRunSettings>  
+</RunSettings>  
+  


### PR DESCRIPTION
Same change that was made recently to ADAL.Net: including the test apps and test code in the code coverage skews the numbers.

Once this changed is merged I'll update the VSTS build definition to use the settings file.