### PR TITLE
uri comparison fix, adding redirect_uri_validation_failed msal error

### DIFF
--- a/src/Microsoft.Identity.Client/Features/PublicClient/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/Features/PublicClient/PublicClientApplication.cs
@@ -25,6 +25,8 @@
 //
 //------------------------------------------------------------------------------
 
+using Microsoft.Identity.Client.Internal;
+
 namespace Microsoft.Identity.Client
 {
     public sealed partial class PublicClientApplication : ClientApplicationBase
@@ -36,7 +38,8 @@ namespace Microsoft.Identity.Client
         /// <param name="clientId">Client id of the application</param>
         /// <param name="authority">Default authority to be used for the application</param>
         /// <param name="userTokenCache">Instance of TokenCache.</param>
-        public PublicClientApplication(string clientId, string authority, TokenCache userTokenCache) : base(clientId, authority, DEFAULT_REDIRECT_URI, true)
+        public PublicClientApplication(string clientId, string authority, TokenCache userTokenCache) : base(clientId,
+            authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
         {
             UserTokenCache = userTokenCache;
         }

--- a/src/Microsoft.Identity.Client/Internal/MsalError.cs
+++ b/src/Microsoft.Identity.Client/Internal/MsalError.cs
@@ -77,5 +77,10 @@ namespace Microsoft.Identity.Client.Internal
         /// Failed to refresh token.
         /// </summary>
         public const string FailedToRefreshToken = "failed_to_refresh_token";
+
+        /// <summary>
+        /// RedirectUri validation failed.
+        /// </summary>
+        public const string RedirectUriValidationFailed = "redirect_uri_validation_failed";
     }
 }

--- a/src/Microsoft.Identity.Client/Internal/PlatformInformationBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/PlatformInformationBase.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Identity.Client.Internal
 {
     internal abstract class PlatformInformationBase
     {
+        internal const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
+
         protected readonly RequestContext RequestContext;
         protected PlatformInformationBase(RequestContext requestContext)
         {
@@ -73,6 +75,11 @@ namespace Microsoft.Identity.Client.Internal
         public virtual string GetRedirectUriAsString(Uri redirectUri, RequestContext requestContext)
         {
             return redirectUri.OriginalString;
+        }
+
+        public virtual string GetDefaultRedirectUri(string correlationId)
+        {
+            return DefaultRedirectUri;
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Identity.Client
         {
             base.ValidateRedirectUri(redirectUri, requestContext);
 
-            if (PublicClientApplication.DEFAULT_REDIRECT_URI.Equals(redirectUri))
-                throw new MsalException("Default redirect URI - " + PublicClientApplication.DEFAULT_REDIRECT_URI +
+            if (PublicClientApplication.DEFAULT_REDIRECT_URI.Equals(redirectUri.AbsoluteUri))
+                throw new MsalException(MsalError.RedirectUriValidationFailed, "Default redirect URI - " + PublicClientApplication.DEFAULT_REDIRECT_URI +
                                         " can not be used on Android platform");
         }
     }

--- a/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client
     [Android.Runtime.Preserve(AllMembers = true)]
     internal class PlatformInformation : PlatformInformationBase
     {
-        internal const string IosDefaultRedirectUri = "msal{0}://auth";
+        internal const string AndroidDefaultRedirectUriTemplate = "msal{0}://auth";
 
         public PlatformInformation(RequestContext requestContext) : base(requestContext)
         {
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Client
 
         public override string GetDefaultRedirectUri(string clientId)
         {
-            return string.Format(IosDefaultRedirectUri, clientId);
+            return string.Format(AndroidDefaultRedirectUriTemplate, clientId);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Identity.Client
     [Android.Runtime.Preserve(AllMembers = true)]
     internal class PlatformInformation : PlatformInformationBase
     {
+        internal const string IosDefaultRedirectUri = "msal{0}://auth";
+
         public PlatformInformation(RequestContext requestContext) : base(requestContext)
         {
         }
@@ -79,9 +81,14 @@ namespace Microsoft.Identity.Client
         {
             base.ValidateRedirectUri(redirectUri, requestContext);
 
-            if (PublicClientApplication.DEFAULT_REDIRECT_URI.Equals(redirectUri.AbsoluteUri))
-                throw new MsalException(MsalError.RedirectUriValidationFailed, "Default redirect URI - " + PublicClientApplication.DEFAULT_REDIRECT_URI +
+            if (PlatformInformationBase.DefaultRedirectUri.Equals(redirectUri.AbsoluteUri))
+                throw new MsalException(MsalError.RedirectUriValidationFailed, "Default redirect URI - " + PlatformInformationBase.DefaultRedirectUri +
                                         " can not be used on Android platform");
+        }
+
+        public override string GetDefaultRedirectUri(string clientId)
+        {
+            return string.Format(IosDefaultRedirectUri, clientId);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/PlatformInformation.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/PlatformInformation.cs
@@ -73,8 +73,8 @@ namespace Microsoft.Identity.Client
         {
             base.ValidateRedirectUri(redirectUri, requestContext);
 
-            if (PublicClientApplication.DEFAULT_REDIRECT_URI.Equals(redirectUri))
-                throw new MsalException("Default redirect URI - " + PublicClientApplication.DEFAULT_REDIRECT_URI +
+            if (PublicClientApplication.DEFAULT_REDIRECT_URI.Equals(redirectUri.AbsoluteUri))
+                throw new MsalException(MsalError.RedirectUriValidationFailed, "Default redirect URI - " + PublicClientApplication.DEFAULT_REDIRECT_URI +
                                         " can not be used on iOS platform");
         }
     }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/PlatformInformation.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/PlatformInformation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client
 {
     internal class PlatformInformation : PlatformInformationBase
     {
-        internal const string IosDefaultRedirectUri = "msal{0}://auth";
+        internal const string IosDefaultRedirectUriTemplate = "msal{0}://auth";
 
         public PlatformInformation(RequestContext requestContext) : base(requestContext)
         {
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Client
 
         public override string GetDefaultRedirectUri(string clientId)
         {
-            return string.Format(IosDefaultRedirectUri, clientId);
+            return string.Format(IosDefaultRedirectUriTemplate, clientId);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/PlatformInformation.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/PlatformInformation.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Identity.Client
 {
     internal class PlatformInformation : PlatformInformationBase
     {
+        internal const string IosDefaultRedirectUri = "msal{0}://auth";
+
         public PlatformInformation(RequestContext requestContext) : base(requestContext)
         {
         }
@@ -73,9 +75,14 @@ namespace Microsoft.Identity.Client
         {
             base.ValidateRedirectUri(redirectUri, requestContext);
 
-            if (PublicClientApplication.DEFAULT_REDIRECT_URI.Equals(redirectUri.AbsoluteUri))
-                throw new MsalException(MsalError.RedirectUriValidationFailed, "Default redirect URI - " + PublicClientApplication.DEFAULT_REDIRECT_URI +
+            if (PlatformInformationBase.DefaultRedirectUri.Equals(redirectUri.AbsoluteUri))
+                throw new MsalException(MsalError.RedirectUriValidationFailed, "Default redirect URI - " + PlatformInformationBase.DefaultRedirectUri +
                                         " can not be used on iOS platform");
+        }
+
+        public override string GetDefaultRedirectUri(string clientId)
+        {
+            return string.Format(IosDefaultRedirectUri, clientId);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -41,8 +41,6 @@ namespace Microsoft.Identity.Client
     /// </summary>
     public sealed partial class PublicClientApplication : ClientApplicationBase, IPublicClientApplication
     {
-        internal const string DEFAULT_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
-
         /// <summary>
         /// Consutructor of the application. It will use https://login.microsoftonline.com/common as the default authority.
         /// </summary>
@@ -57,7 +55,7 @@ namespace Microsoft.Identity.Client
         /// <param name="clientId">Client id of the application</param>
         /// <param name="authority">Default authority to be used for the application</param>
         public PublicClientApplication(string clientId, string authority)
-            : base(clientId, authority, DEFAULT_REDIRECT_URI, true)
+            : base(clientId, authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
         {
             UserTokenCache = new TokenCache()
             {


### PR DESCRIPTION
Add support for default redirect uri in iOS and Android https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/391