### PR TITLE
Change all ConstName to NameKey

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Telemetry/ApiEvent.cs
+++ b/src/Microsoft.Identity.Client/Internal/Telemetry/ApiEvent.cs
@@ -33,17 +33,17 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
 {
     internal class ApiEvent : EventBase
     {
-        public const string ConstApiId = EventNamePrefix + "api_id";
-        public const string ConstAuthority = EventNamePrefix + "authority";
-        public const string ConstAuthorityType = EventNamePrefix + "authority_type";
-        public const string ConstUiBehavior = EventNamePrefix + "ui_behavior";
-        public const string ConstValidationStatus = EventNamePrefix + "validation_status";
-        public const string ConstTenantId = EventNamePrefix + "tenant_id";
-        public const string ConstUserId = EventNamePrefix + "user_id";
-        public const string ConstWasSuccessful = EventNamePrefix + "was_successful";
-        public const string ConstCorrelationId = EventNamePrefix + "correlation_id";
-        public const string ConstRequestId = EventNamePrefix + "request_id";
-        public const string ConstIsConfidentialClient = EventNamePrefix + "is_confidential_client";
+        public const string ApiIdKey = EventNamePrefix + "api_id";
+        public const string AuthorityKey = EventNamePrefix + "authority";
+        public const string AuthorityTypeKey = EventNamePrefix + "authority_type";
+        public const string UiBehaviorKey = EventNamePrefix + "ui_behavior";
+        public const string ValidationStatusKey = EventNamePrefix + "validation_status";
+        public const string TenantIdKey = EventNamePrefix + "tenant_id";
+        public const string UserIdKey = EventNamePrefix + "user_id";
+        public const string WasSuccessfulKey = EventNamePrefix + "was_successful";
+        public const string CorrelationIdKey = EventNamePrefix + "correlation_id";
+        public const string RequestIdKey = EventNamePrefix + "request_id";
+        public const string IsConfidentialClientKey = EventNamePrefix + "is_confidential_client";
 
         public enum ApiIds
         {
@@ -71,58 +71,58 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
 
         public ApiIds ApiId
         {
-            set => this[ConstApiId] = ((int)value).ToStringInvariant();
+            set => this[ApiIdKey] = ((int)value).ToStringInvariant();
         }
 
         public Uri Authority
         {
-            set => this[ConstAuthority] = ScrubTenant(value)?.ToLowerInvariant();
+            set => this[AuthorityKey] = ScrubTenant(value)?.ToLowerInvariant();
         }
 
         public string AuthorityType
         {
-            set => this[ConstAuthorityType] = value?.ToLowerInvariant();
+            set => this[AuthorityTypeKey] = value?.ToLowerInvariant();
         }
 
         public string UiBehavior
         {
-            set => this[ConstUiBehavior] = value?.ToLowerInvariant();
+            set => this[UiBehaviorKey] = value?.ToLowerInvariant();
         }
 
         public string ValidationStatus
         {
-            set => this[ConstValidationStatus] = value?.ToLowerInvariant();
+            set => this[ValidationStatusKey] = value?.ToLowerInvariant();
         }
 
         public string TenantId
         {
-            set => this[ConstTenantId] = (value != null) ? CryptographyHelper.CreateBase64UrlEncodedSha256Hash(value) : null;
+            set => this[TenantIdKey] = (value != null) ? CryptographyHelper.CreateBase64UrlEncodedSha256Hash(value) : null;
         }
 
         public string UserId
         {
-            set => this[ConstUserId] = value != null ? CryptographyHelper.CreateBase64UrlEncodedSha256Hash(value) : null;
+            set => this[UserIdKey] = value != null ? CryptographyHelper.CreateBase64UrlEncodedSha256Hash(value) : null;
         }
 
         public bool WasSuccessful
         {
-            set => this[ConstWasSuccessful] = value.ToString().ToLowerInvariant();
-            get => this[ConstWasSuccessful] == true.ToString().ToLowerInvariant();
+            set => this[WasSuccessfulKey] = value.ToString().ToLowerInvariant();
+            get => this[WasSuccessfulKey] == true.ToString().ToLowerInvariant();
         }
 
         public string CorrelationId
         {
-            set => this[ConstCorrelationId] = value;
+            set => this[CorrelationIdKey] = value;
         }
 
         public string RequestId
         {
-            set => this[ConstRequestId] = value;
+            set => this[RequestIdKey] = value;
         }
 
         public bool IsConfidentialClient
         {
-            set => this[ConstIsConfidentialClient] = value.ToString().ToLowerInvariant();
+            set => this[IsConfidentialClientKey] = value.ToString().ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Internal/Telemetry/CacheEvent.cs
+++ b/src/Microsoft.Identity.Client/Internal/Telemetry/CacheEvent.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
         public const string TokenCacheBeforeWrite = EventNamePrefix + "token_cache_before_write";
         public const string TokenCacheDelete = EventNamePrefix + "token_cache_delete";
 
-        public const string ConstTokenType = EventNamePrefix + "token_type";
+        public const string TokenTypeKey = EventNamePrefix + "token_type";
 
         public CacheEvent(string eventName) : base(eventName)
         {
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
                     {TokenTypes.AT, "at"},
                     {TokenTypes.RT, "rt"}
                 };
-                this[ConstTokenType] = types[value];
+                this[TokenTypeKey] = types[value];
             }
         }
     }

--- a/src/Microsoft.Identity.Client/Internal/Telemetry/Event.cs
+++ b/src/Microsoft.Identity.Client/Internal/Telemetry/Event.cs
@@ -35,9 +35,9 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
     internal abstract class EventBase : Dictionary<string, string>
     {
         protected const string EventNamePrefix = "msal.";
-        public const string EventName = EventNamePrefix + "event_name";
-        protected const string StartTime = EventNamePrefix + "start_time";
-        protected const string ElapsedTime = EventNamePrefix + "elapsed_time";
+        public const string EventNameKey = EventNamePrefix + "event_name";
+        protected const string StartTimeKey = EventNamePrefix + "start_time";
+        protected const string ElapsedTimeKey = EventNamePrefix + "elapsed_time";
         private readonly long _startTimestamp;
 
         public const string TenantPlaceHolder = "<tenant>"; // It is used to replace the real tenant in telemetry info
@@ -51,15 +51,15 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
 
         public EventBase(string eventName, IDictionary<string, string> predefined) : base(predefined)
         {
-            this[EventName] = eventName;
+            this[EventNameKey] = eventName;
             _startTimestamp = CurrentUnixTimeMilliseconds();
-            this[StartTime] = _startTimestamp.ToStringInvariant();
-            this[ElapsedTime] = "-1";
+            this[StartTimeKey] = _startTimestamp.ToStringInvariant();
+            this[ElapsedTimeKey] = "-1";
         }
 
         public void Stop()
         {
-            this[ElapsedTime] = (CurrentUnixTimeMilliseconds() - _startTimestamp).ToStringInvariant();  // It is a duration
+            this[ElapsedTimeKey] = (CurrentUnixTimeMilliseconds() - _startTimestamp).ToStringInvariant();  // It is a duration
         }
 
         public static string ScrubTenant(Uri uri) // Note: There is also a Unit Test case for this helper

--- a/src/Microsoft.Identity.Client/Internal/Telemetry/HttpEvent.cs
+++ b/src/Microsoft.Identity.Client/Internal/Telemetry/HttpEvent.cs
@@ -32,43 +32,43 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
 {
     internal class HttpEvent : EventBase
     {
-        public const string ConstHttpPath = EventNamePrefix + "http_path";
-        public const string ConstUserAgent = EventNamePrefix + "user_agent";
-        public const string ConstQueryParameters = EventNamePrefix + "query_parameters";
-        public const string ConstApiVersion = EventNamePrefix + "api_version";
-        public const string ConstResponseCode = EventNamePrefix + "response_code";
-        public const string ConstOauthErrorCode = EventNamePrefix + "oauth_error_code";
+        public const string HttpPathKey = EventNamePrefix + "http_path";
+        public const string UserAgentKey = EventNamePrefix + "user_agent";
+        public const string QueryParametersKey = EventNamePrefix + "query_parameters";
+        public const string ApiVersionKey = EventNamePrefix + "api_version";
+        public const string ResponseCodeKey = EventNamePrefix + "response_code";
+        public const string OauthErrorCodeKey = EventNamePrefix + "oauth_error_code";
 
         public HttpEvent() : base(EventNamePrefix + "http_event") {}
 
         public Uri HttpPath
         {
-            set => this[ConstHttpPath] = ScrubTenant(value); // http path is case-sensitive
+            set => this[HttpPathKey] = ScrubTenant(value); // http path is case-sensitive
         }
 
         public string UserAgent
         {
-            set => this[ConstUserAgent] = value;
+            set => this[UserAgentKey] = value;
         }
 
         public string QueryParams
         {
-            set => this[ConstQueryParameters] = String.Join( // query parameters are case-sensitive
+            set => this[QueryParametersKey] = String.Join( // query parameters are case-sensitive
                 "&", MsalHelpers.ParseKeyValueList(value, '&', false, true, null).Keys); // It turns out ParseKeyValueList(..., null) is valid
         }
 
         public string ApiVersion {
-            set => this[ConstApiVersion] = value?.ToLowerInvariant();
+            set => this[ApiVersionKey] = value?.ToLowerInvariant();
         }
 
         public int HttpResponseStatus
         {
-            set => this[ConstResponseCode] = value.ToStringInvariant();
+            set => this[ResponseCodeKey] = value.ToStringInvariant();
         }
 
         public string OauthErrorCode
         {
-            set => this[ConstOauthErrorCode] = value;
+            set => this[OauthErrorCodeKey] = value;
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Internal/Telemetry/UiEvent.cs
+++ b/src/Microsoft.Identity.Client/Internal/Telemetry/UiEvent.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
 {
     internal class UiEvent : EventBase
     {
-        public const string ConstUserCancelled = EventNamePrefix + "user_cancelled";
+        public const string UserCancelledKey = EventNamePrefix + "user_cancelled";
 
         public UiEvent(): base(EventNamePrefix + "ui_event") {}
 
         public bool UserCancelled
         {
-            set => this[ConstUserCancelled] = value.ToString().ToLowerInvariant();
+            set => this[UserCancelledKey] = value.ToString().ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Telemetry.cs
+++ b/src/Microsoft.Identity.Client/Telemetry.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Client
         {
             if (_receiver != null && requestId != null)
             {
-                EventsInProgress[new Tuple<string, string>(requestId, eventToStart[EventBase.EventName])] = eventToStart;
+                EventsInProgress[new Tuple<string, string>(requestId, eventToStart[EventBase.EventNameKey])] = eventToStart;
             }
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Client
             {
                 return;
             }
-            Tuple<string, string> eventKey = new Tuple<string, string>(requestId, eventToStop[EventBase.EventName]);
+            Tuple<string, string> eventKey = new Tuple<string, string>(requestId, eventToStop[EventBase.EventNameKey]);
 
             // Locate the same name event in the EventsInProgress map
             EventBase eventStarted = null;

--- a/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -321,8 +321,8 @@ namespace Test.MSAL.NET.Unit
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
 
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent => // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("http_event") && anEvent[HttpEvent.ConstResponseCode] == "200"
-                && anEvent[HttpEvent.ConstHttpPath].Contains(EventBase.TenantPlaceHolder) // The tenant info is expected to be replaced by a holder
+                anEvent[EventBase.EventNameKey].EndsWith("http_event") && anEvent[HttpEvent.ResponseCodeKey] == "200"
+                && anEvent[HttpEvent.HttpPathKey].Contains(EventBase.TenantPlaceHolder) // The tenant info is expected to be replaced by a holder
                 ));
         }
 
@@ -336,9 +336,9 @@ namespace Test.MSAL.NET.Unit
             Task<AuthenticationResult> task = app.AcquireTokenForClientAsync(TestConstants.Scope.ToArray());
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent => // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("token_cache_lookup") && anEvent[CacheEvent.ConstTokenType] == "at"));
+                anEvent[EventBase.EventNameKey].EndsWith("token_cache_lookup") && anEvent[CacheEvent.TokenTypeKey] == "at"));
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent => // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("token_cache_write") && anEvent[CacheEvent.ConstTokenType] == "at"));
+                anEvent[EventBase.EventNameKey].EndsWith("token_cache_write") && anEvent[CacheEvent.TokenTypeKey] == "at"));
         }
 
         [TestMethod]

--- a/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -177,8 +177,8 @@ namespace Test.MSAL.NET.Unit
                 Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
             }
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("api_event") && anEvent[ApiEvent.ConstWasSuccessful] == "false"
-                && anEvent[ApiEvent.ConstApiId] == "170"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "false"
+                && anEvent[ApiEvent.ApiIdKey] == "170"));
         }
 
         [TestMethod]
@@ -450,8 +450,8 @@ namespace Test.MSAL.NET.Unit
                 Assert.AreEqual("user_mismatch", exc.ErrorCode);
             }
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("api_event") && anEvent[ApiEvent.ConstWasSuccessful] == "false"
-                && anEvent[ApiEvent.ConstApiId] == "174"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "false"
+                && anEvent[ApiEvent.ApiIdKey] == "174"));
 
             Assert.AreEqual(1, app.Users.Count());
             Assert.AreEqual(1, cache.TokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -651,8 +651,8 @@ namespace Test.MSAL.NET.Unit
                 Assert.AreEqual(MsalUiRequiredException.NoTokensFoundError, exc.ErrorCode);
             }
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("api_event") && anEvent[ApiEvent.ConstWasSuccessful] == "false"
-                && anEvent[ApiEvent.ConstApiId] == "30"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "false"
+                && anEvent[ApiEvent.ApiIdKey] == "30"));
         }
 
         [TestMethod]
@@ -840,8 +840,8 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("api_event") && anEvent[ApiEvent.ConstWasSuccessful] == "true"
-                && anEvent[ApiEvent.ConstApiId] == "31"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "true"
+                && anEvent[ApiEvent.ApiIdKey] == "31"));
         }
 
         [TestMethod]

--- a/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
@@ -205,9 +205,9 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
 
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("ui_event") && anEvent[UiEvent.ConstUserCancelled] == "false"));
+                anEvent[EventBase.EventNameKey].EndsWith("ui_event") && anEvent[UiEvent.UserCancelledKey] == "false"));
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventName].EndsWith("api_event") && anEvent[ApiEvent.ConstUiBehavior] == "select_account"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.UiBehaviorKey] == "select_account"));
         }
 
         [TestMethod]

--- a/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
+++ b/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
@@ -48,7 +48,7 @@ namespace Test.MSAL.NET.Unit
             Console.WriteLine("{0} event(s) received", events.Count);
             foreach(var e in events)
             {
-                Console.WriteLine("Event: {0}", e[EventBase.EventName]);
+                Console.WriteLine("Event: {0}", e[EventBase.EventNameKey]);
                 foreach(var entry in e)
                 {
                     Console.WriteLine("  {0}: {1}", entry.Key, entry.Value);


### PR DESCRIPTION
Those fields used to contain a "Const-" prefix, in order to differentiate
their property name and their const string key names in the dictionary.

"-Key" suffix is now chosen because it has been a naming principle for years.
