### PR TITLE
Adding more test cases for Telemetry

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Telemetry/Event.cs
+++ b/src/Microsoft.Identity.Client/Internal/Telemetry/Event.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
     {
         protected const string EventNamePrefix = "msal.";
         public const string EventNameKey = EventNamePrefix + "event_name";
-        protected const string StartTimeKey = EventNamePrefix + "start_time";
-        protected const string ElapsedTimeKey = EventNamePrefix + "elapsed_time";
+        public const string StartTimeKey = EventNamePrefix + "start_time";
+        public const string ElapsedTimeKey = EventNamePrefix + "elapsed_time";
         private readonly long _startTimestamp;
 
         public const string TenantPlaceHolder = "<tenant>"; // It is used to replace the real tenant in telemetry info

--- a/src/Microsoft.Identity.Client/Telemetry.cs
+++ b/src/Microsoft.Identity.Client/Telemetry.cs
@@ -73,9 +73,9 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public bool TelemetryOnFailureOnly { get; set; }
 
-        private ConcurrentDictionary<Tuple<string, string>, EventBase> EventsInProgress = new ConcurrentDictionary<Tuple<string, string>, EventBase>();
+        internal ConcurrentDictionary<Tuple<string, string>, EventBase> EventsInProgress = new ConcurrentDictionary<Tuple<string, string>, EventBase>();
 
-        private ConcurrentDictionary<string, List<EventBase>> CompletedEvents = new ConcurrentDictionary<string, List<EventBase>>();
+        internal ConcurrentDictionary<string, List<EventBase>> CompletedEvents = new ConcurrentDictionary<string, List<EventBase>>();
 
         internal string GenerateNewRequestId()
         {

--- a/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
+++ b/tests/Test.MSAL.NET.Unit/TelemetryTests.cs
@@ -207,5 +207,65 @@ namespace Test.MSAL.NET.Unit
             Assert.IsTrue(myReceiver.EventsReceived[1][EventBase.EventNameKey].EndsWith("ui_event"));
             Assert.AreNotEqual(myReceiver.EventsReceived[1][EventBase.ElapsedTimeKey], "-1");
         }
+
+        [TestMethod]
+        [TestCategory("TelemetryInternalAPI")]
+        public void TelemetryStartAnEventWithoutStoppingItLater() // Such event(s) becomes an orphaned event
+        {
+            Telemetry telemetry = new Telemetry() { ClientId = "a1b2c3d4" };  // To isolate the test environment, we do not use a singleton here
+            var myReceiver = new MyReceiver();
+            telemetry.RegisterReceiver(myReceiver.OnEvents);
+
+            var reqId = telemetry.GenerateNewRequestId();
+            try
+            {
+                var apiEvent = new ApiEvent() { Authority = new Uri("https://login.microsoftonline.com"), AuthorityType = "Aad" };
+                telemetry.StartEvent(reqId, apiEvent);
+                var uiEvent = new UiEvent();
+                telemetry.StartEvent(reqId, uiEvent);
+                // Forgot to stop this event. A started event which never got stopped, becomes an orphan.
+                //telemetry.StopEvent(reqId, uiEvent);
+                telemetry.StopEvent(reqId, apiEvent);
+            }
+            finally
+            {
+                Assert.IsFalse(telemetry.CompletedEvents.IsEmpty); // There are completed event(s) inside
+                Assert.IsFalse(telemetry.EventsInProgress.IsEmpty); // There is an orphaned event inside
+                telemetry.Flush(reqId);
+                Assert.IsTrue(telemetry.CompletedEvents.IsEmpty); // Completed event(s) have been dispatched
+                Assert.IsTrue(telemetry.EventsInProgress.IsEmpty); // The orphaned event is also dispatched, so there is no memory leak here.
+            }
+            Assert.IsNotNull(myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
+                anEvent[EventBase.EventNameKey].EndsWith("ui_event") && anEvent[EventBase.ElapsedTimeKey] == "-1"));
+        }
+
+        [TestMethod]
+        [TestCategory("TelemetryInternalAPI")]
+        public void TelemetryStopAnEventWithoutStartingItBeforehand()
+        {
+            Telemetry telemetry = new Telemetry() { ClientId = "a1b2c3d4" };  // To isolate the test environment, we do not use a singleton here
+            var myReceiver = new MyReceiver();
+            telemetry.RegisterReceiver(myReceiver.OnEvents);
+
+            var reqId = telemetry.GenerateNewRequestId();
+            try
+            {
+                var apiEvent = new ApiEvent() { Authority = new Uri("https://login.microsoftonline.com"), AuthorityType = "Aad" };
+                telemetry.StartEvent(reqId, apiEvent);
+                var uiEvent = new UiEvent();
+                // Forgot to start this event
+                //telemetry.StartEvent(reqId, uiEvent);
+                // Now attempting to stop a never-started event
+                telemetry.StopEvent(reqId, uiEvent); // This line will not cause any exception. The implementation simply ignores it.
+                telemetry.StopEvent(reqId, apiEvent);
+            }
+            finally
+            {
+                telemetry.Flush(reqId);
+                Assert.IsTrue(telemetry.CompletedEvents.IsEmpty && telemetry.EventsInProgress.IsEmpty); // No memory leak here
+            }
+            Assert.IsNull(myReceiver.EventsReceived.Find(anEvent =>  // Expect NOT finding such an event
+                anEvent[EventBase.EventNameKey].EndsWith("ui_event")));
+        }
     }
 }


### PR DESCRIPTION
This PR contains unit tests for the Telemetry internal implementation in situation of asymmetric calls to StartEvent(...) and StopEvent(...). The PR also contains integration tests (from the Telemetry perspective) to see Telemetry in action for API scenarios 726 & 727. Previously we already have covered API scenarios 170, 174, 30, 31. Together with the implementation decision that all the API events share the same one code path, all the test cases above give us a good coverage of Telemetry functionality.