### PR TITLE
Add api_error_code into ApiEvent

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -151,6 +151,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 apiEvent.WasSuccessful = true;
                 return result;
             }
+            catch (MsalException ex)
+            {
+                apiEvent.ApiErrorCode = ex.ErrorCode;
+                AuthenticationRequestParameters.RequestContext.Logger.Error(ex);
+                throw;
+            }
             catch (Exception ex)
             {
                 AuthenticationRequestParameters.RequestContext.Logger.Error(ex);

--- a/src/Microsoft.Identity.Client/Internal/Telemetry/ApiEvent.cs
+++ b/src/Microsoft.Identity.Client/Internal/Telemetry/ApiEvent.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
         public const string CorrelationIdKey = EventNamePrefix + "correlation_id";
         public const string RequestIdKey = EventNamePrefix + "request_id";
         public const string IsConfidentialClientKey = EventNamePrefix + "is_confidential_client";
+        public const string ApiErrorCodeKey = EventNamePrefix + "api_error_code";
 
         public enum ApiIds
         {
@@ -123,6 +124,10 @@ namespace Microsoft.Identity.Client.Internal.Telemetry
         public bool IsConfidentialClient
         {
             set => this[IsConfidentialClientKey] = value.ToString().ToLowerInvariant();
+        }
+
+        public string ApiErrorCode {
+            set => this[ApiErrorCodeKey] = value;
         }
     }
 }

--- a/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -177,8 +177,9 @@ namespace Test.MSAL.NET.Unit
                 Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
             }
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "false"
-                && anEvent[ApiEvent.ApiIdKey] == "170"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.ApiIdKey] == "170"
+                && anEvent[ApiEvent.WasSuccessfulKey] == "false" && anEvent[ApiEvent.ApiErrorCodeKey] == "state_mismatch"
+                ));
         }
 
         [TestMethod]
@@ -450,8 +451,9 @@ namespace Test.MSAL.NET.Unit
                 Assert.AreEqual("user_mismatch", exc.ErrorCode);
             }
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "false"
-                && anEvent[ApiEvent.ApiIdKey] == "174"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.ApiIdKey] == "174"
+                && anEvent[ApiEvent.WasSuccessfulKey] == "false" && anEvent[ApiEvent.ApiErrorCodeKey] == "user_mismatch"
+                ));
 
             Assert.AreEqual(1, app.Users.Count());
             Assert.AreEqual(1, cache.TokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -651,8 +653,9 @@ namespace Test.MSAL.NET.Unit
                 Assert.AreEqual(MsalUiRequiredException.NoTokensFoundError, exc.ErrorCode);
             }
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
-                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "false"
-                && anEvent[ApiEvent.ApiIdKey] == "30"));
+                anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.ApiIdKey] == "30"
+                && anEvent[ApiEvent.WasSuccessfulKey] == "false" && anEvent[ApiEvent.ApiErrorCodeKey] == "no_tokens_found"
+                ));
         }
 
         [TestMethod]


### PR DESCRIPTION
Use `MsalException.ErrorCode` to populate the new `ApiEvent.ApiErrorCode`.