### PR TITLE
Duncanp/sqworkaround

### DIFF
--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Exclude the analysis of this framework type: workaround for https://jira.sonarsource.com/browse/SONARMSBRU-317 -->
+  <!-- NB this property has no effect on the assemblies that are built - it is only to tell the VSTS SonarQube analysis tasks
+       which assembly to analyse. -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net45' ">
-    <!-- Exclude the analysis of this framework type: workaround for https://jira.sonarsource.com/browse/SONARMSBRU-317 -->
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
 

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,4 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net45' ">
+    <!-- Exclude the analysis of this framework type: workaround for https://jira.sonarsource.com/browse/SONARMSBRU-317 -->
+    <SonarQubeExclude>true</SonarQubeExclude>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.1;netstandard1.3;win81;MonoAndroid7;Xamarin.iOS10</TargetFrameworks>        
     <Authors>Microsoft Corp.</Authors>


### PR DESCRIPTION
Add a property to the project file to allow MSAL.Net to be analysed by SonarQube.
NB this has no impact of the assemblies that are built; it's only needed to work round a bug in the analysis targets.