### PR TITLE
Updated Xamarin Forms Android support libraries to 25.3.1.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,9 @@ branches:
 
 image: Visual Studio 2017     
 
+# clone directory
+clone_folder: c:\projects\msal-dotnet
+
 configuration: Release
 
 before_build:

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -26,9 +26,6 @@
     <!-- Workaround until Xamarin supports PPDB -->
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <DebugType>full</DebugType>
-    <ApplicationIcon />
-    <OutputTypeEx>library</OutputTypeEx>
-    <StartupObject />
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1' ">
     <DefineConstants>$(DefineConstants);FACADE</DefineConstants>
@@ -142,8 +139,6 @@
     <Compile Include="Platforms\Android\**\*.cs" />
     <AndroidResource Include="Resources\**\*.axml" />
     <AndroidResource Include="Resources\**\*.xml" />
-    <!--<PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="23.3.0" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="23.3.0" />-->    
   </ItemGroup>
   
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -3,9 +3,6 @@
   <!-- Exclude the analysis of this framework type: workaround for https://jira.sonarsource.com/browse/SONARMSBRU-317 -->
   <!-- NB this property has no effect on the assemblies that are built - it is only to tell the VSTS SonarQube analysis tasks
        which assembly to analyse. -->
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'net45' ">
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -3,6 +3,9 @@
   <!-- Exclude the analysis of this framework type: workaround for https://jira.sonarsource.com/browse/SONARMSBRU-317 -->
   <!-- NB this property has no effect on the assemblies that are built - it is only to tell the VSTS SonarQube analysis tasks
        which assembly to analyse. -->
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'net45' ">
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
@@ -26,6 +29,9 @@
     <!-- Workaround until Xamarin supports PPDB -->
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <DebugType>full</DebugType>
+    <ApplicationIcon />
+    <OutputTypeEx>library</OutputTypeEx>
+    <StartupObject />
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1' ">
     <DefineConstants>$(DefineConstants);FACADE</DefineConstants>
@@ -53,7 +59,7 @@
     <EmbeddedResource Include="Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.6" PrivateAssets="All" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">
@@ -139,8 +145,8 @@
     <Compile Include="Platforms\Android\**\*.cs" />
     <AndroidResource Include="Resources\**\*.axml" />
     <AndroidResource Include="Resources\**\*.xml" />
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="23.3.0" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="23.3.0" />    
+    <!--<PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="23.3.0" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="23.3.0" />-->    
   </ItemGroup>
   
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
@@ -153,5 +159,13 @@
     <None Update="Platforms\net45\WinFormWebAuthenticationDialog.cs" SubType="Form" />
     <None Update="Platforms\net45\WindowsFormsWebAuthenticationDialogBase.cs" SubType="Form" />
     <None Update="Platforms\net45\SilentWindowsFormsAuthenticationDialog.cs" SubType="Form" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid7'">
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs">
+      <Version>25.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+      <Version>25.3.1</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/tests/Test.MSAL.NET.Unit/Test.MSAL.NET.Unit.csproj
+++ b/tests/Test.MSAL.NET.Unit/Test.MSAL.NET.Unit.csproj
@@ -83,10 +83,10 @@
       <Project>{3433eb33-114a-4db7-bc57-14f17f55da3c}</Project>
       <Name>Microsoft.Identity.Client</Name>
     </ProjectReference>
-    <PackageReference Include="NSubstitute" Version="1.9.1" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/dev apps/WebTestApp/WebApi/WebApi.csproj
+++ b/tests/dev apps/WebTestApp/WebApi/WebApi.csproj
@@ -17,15 +17,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dev apps/WebTestApp/WebApp/WebApp.csproj
+++ b/tests/dev apps/WebTestApp/WebApp/WebApp.csproj
@@ -17,24 +17,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Session" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Session" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
     <PackageReference Include="System.Private.DataContractSerialization" Version="4.3.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dev apps/XForms/XForms.Android/Resources/Resource.Designer.cs
+++ b/tests/dev apps/XForms/XForms.Android/Resources/Resource.Designer.cs
@@ -75,6 +75,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.alertDialogStyle = global::XForms.Droid.Resource.Attribute.alertDialogStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.alertDialogTheme = global::XForms.Droid.Resource.Attribute.alertDialogTheme;
 			global::Microsoft.Identity.Client.Resource.Attribute.allowStacking = global::XForms.Droid.Resource.Attribute.allowStacking;
+			global::Microsoft.Identity.Client.Resource.Attribute.alpha = global::XForms.Droid.Resource.Attribute.alpha;
 			global::Microsoft.Identity.Client.Resource.Attribute.arrowHeadLength = global::XForms.Droid.Resource.Attribute.arrowHeadLength;
 			global::Microsoft.Identity.Client.Resource.Attribute.arrowShaftLength = global::XForms.Droid.Resource.Attribute.arrowShaftLength;
 			global::Microsoft.Identity.Client.Resource.Attribute.autoCompleteTextViewStyle = global::XForms.Droid.Resource.Attribute.autoCompleteTextViewStyle;
@@ -90,6 +91,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.buttonBarNeutralButtonStyle = global::XForms.Droid.Resource.Attribute.buttonBarNeutralButtonStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.buttonBarPositiveButtonStyle = global::XForms.Droid.Resource.Attribute.buttonBarPositiveButtonStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.buttonBarStyle = global::XForms.Droid.Resource.Attribute.buttonBarStyle;
+			global::Microsoft.Identity.Client.Resource.Attribute.buttonGravity = global::XForms.Droid.Resource.Attribute.buttonGravity;
 			global::Microsoft.Identity.Client.Resource.Attribute.buttonPanelSideLayout = global::XForms.Droid.Resource.Attribute.buttonPanelSideLayout;
 			global::Microsoft.Identity.Client.Resource.Attribute.buttonStyle = global::XForms.Droid.Resource.Attribute.buttonStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.buttonStyleSmall = global::XForms.Droid.Resource.Attribute.buttonStyleSmall;
@@ -103,6 +105,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.collapseIcon = global::XForms.Droid.Resource.Attribute.collapseIcon;
 			global::Microsoft.Identity.Client.Resource.Attribute.color = global::XForms.Droid.Resource.Attribute.color;
 			global::Microsoft.Identity.Client.Resource.Attribute.colorAccent = global::XForms.Droid.Resource.Attribute.colorAccent;
+			global::Microsoft.Identity.Client.Resource.Attribute.colorBackgroundFloating = global::XForms.Droid.Resource.Attribute.colorBackgroundFloating;
 			global::Microsoft.Identity.Client.Resource.Attribute.colorButtonNormal = global::XForms.Droid.Resource.Attribute.colorButtonNormal;
 			global::Microsoft.Identity.Client.Resource.Attribute.colorControlActivated = global::XForms.Droid.Resource.Attribute.colorControlActivated;
 			global::Microsoft.Identity.Client.Resource.Attribute.colorControlHighlight = global::XForms.Droid.Resource.Attribute.colorControlHighlight;
@@ -112,9 +115,11 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.colorSwitchThumbNormal = global::XForms.Droid.Resource.Attribute.colorSwitchThumbNormal;
 			global::Microsoft.Identity.Client.Resource.Attribute.commitIcon = global::XForms.Droid.Resource.Attribute.commitIcon;
 			global::Microsoft.Identity.Client.Resource.Attribute.contentInsetEnd = global::XForms.Droid.Resource.Attribute.contentInsetEnd;
+			global::Microsoft.Identity.Client.Resource.Attribute.contentInsetEndWithActions = global::XForms.Droid.Resource.Attribute.contentInsetEndWithActions;
 			global::Microsoft.Identity.Client.Resource.Attribute.contentInsetLeft = global::XForms.Droid.Resource.Attribute.contentInsetLeft;
 			global::Microsoft.Identity.Client.Resource.Attribute.contentInsetRight = global::XForms.Droid.Resource.Attribute.contentInsetRight;
 			global::Microsoft.Identity.Client.Resource.Attribute.contentInsetStart = global::XForms.Droid.Resource.Attribute.contentInsetStart;
+			global::Microsoft.Identity.Client.Resource.Attribute.contentInsetStartWithNavigation = global::XForms.Droid.Resource.Attribute.contentInsetStartWithNavigation;
 			global::Microsoft.Identity.Client.Resource.Attribute.controlBackground = global::XForms.Droid.Resource.Attribute.controlBackground;
 			global::Microsoft.Identity.Client.Resource.Attribute.customNavigationLayout = global::XForms.Droid.Resource.Attribute.customNavigationLayout;
 			global::Microsoft.Identity.Client.Resource.Attribute.defaultQueryHint = global::XForms.Droid.Resource.Attribute.defaultQueryHint;
@@ -152,6 +157,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.listDividerAlertDialog = global::XForms.Droid.Resource.Attribute.listDividerAlertDialog;
 			global::Microsoft.Identity.Client.Resource.Attribute.listItemLayout = global::XForms.Droid.Resource.Attribute.listItemLayout;
 			global::Microsoft.Identity.Client.Resource.Attribute.listLayout = global::XForms.Droid.Resource.Attribute.listLayout;
+			global::Microsoft.Identity.Client.Resource.Attribute.listMenuViewStyle = global::XForms.Droid.Resource.Attribute.listMenuViewStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.listPopupWindowStyle = global::XForms.Droid.Resource.Attribute.listPopupWindowStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.listPreferredItemHeight = global::XForms.Droid.Resource.Attribute.listPreferredItemHeight;
 			global::Microsoft.Identity.Client.Resource.Attribute.listPreferredItemHeightLarge = global::XForms.Droid.Resource.Attribute.listPreferredItemHeightLarge;
@@ -167,8 +173,10 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.navigationIcon = global::XForms.Droid.Resource.Attribute.navigationIcon;
 			global::Microsoft.Identity.Client.Resource.Attribute.navigationMode = global::XForms.Droid.Resource.Attribute.navigationMode;
 			global::Microsoft.Identity.Client.Resource.Attribute.overlapAnchor = global::XForms.Droid.Resource.Attribute.overlapAnchor;
+			global::Microsoft.Identity.Client.Resource.Attribute.paddingBottomNoButtons = global::XForms.Droid.Resource.Attribute.paddingBottomNoButtons;
 			global::Microsoft.Identity.Client.Resource.Attribute.paddingEnd = global::XForms.Droid.Resource.Attribute.paddingEnd;
 			global::Microsoft.Identity.Client.Resource.Attribute.paddingStart = global::XForms.Droid.Resource.Attribute.paddingStart;
+			global::Microsoft.Identity.Client.Resource.Attribute.paddingTopNoTitle = global::XForms.Droid.Resource.Attribute.paddingTopNoTitle;
 			global::Microsoft.Identity.Client.Resource.Attribute.panelBackground = global::XForms.Droid.Resource.Attribute.panelBackground;
 			global::Microsoft.Identity.Client.Resource.Attribute.panelMenuListTheme = global::XForms.Droid.Resource.Attribute.panelMenuListTheme;
 			global::Microsoft.Identity.Client.Resource.Attribute.panelMenuListWidth = global::XForms.Droid.Resource.Attribute.panelMenuListWidth;
@@ -193,6 +201,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.showAsAction = global::XForms.Droid.Resource.Attribute.showAsAction;
 			global::Microsoft.Identity.Client.Resource.Attribute.showDividers = global::XForms.Droid.Resource.Attribute.showDividers;
 			global::Microsoft.Identity.Client.Resource.Attribute.showText = global::XForms.Droid.Resource.Attribute.showText;
+			global::Microsoft.Identity.Client.Resource.Attribute.showTitle = global::XForms.Droid.Resource.Attribute.showTitle;
 			global::Microsoft.Identity.Client.Resource.Attribute.singleChoiceItemLayout = global::XForms.Droid.Resource.Attribute.singleChoiceItemLayout;
 			global::Microsoft.Identity.Client.Resource.Attribute.spinBars = global::XForms.Droid.Resource.Attribute.spinBars;
 			global::Microsoft.Identity.Client.Resource.Attribute.spinnerDropDownItemStyle = global::XForms.Droid.Resource.Attribute.spinnerDropDownItemStyle;
@@ -200,6 +209,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.splitTrack = global::XForms.Droid.Resource.Attribute.splitTrack;
 			global::Microsoft.Identity.Client.Resource.Attribute.srcCompat = global::XForms.Droid.Resource.Attribute.srcCompat;
 			global::Microsoft.Identity.Client.Resource.Attribute.state_above_anchor = global::XForms.Droid.Resource.Attribute.state_above_anchor;
+			global::Microsoft.Identity.Client.Resource.Attribute.subMenuArrow = global::XForms.Droid.Resource.Attribute.subMenuArrow;
 			global::Microsoft.Identity.Client.Resource.Attribute.submitBackground = global::XForms.Droid.Resource.Attribute.submitBackground;
 			global::Microsoft.Identity.Client.Resource.Attribute.subtitle = global::XForms.Droid.Resource.Attribute.subtitle;
 			global::Microsoft.Identity.Client.Resource.Attribute.subtitleTextAppearance = global::XForms.Droid.Resource.Attribute.subtitleTextAppearance;
@@ -214,6 +224,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.textAppearanceLargePopupMenu = global::XForms.Droid.Resource.Attribute.textAppearanceLargePopupMenu;
 			global::Microsoft.Identity.Client.Resource.Attribute.textAppearanceListItem = global::XForms.Droid.Resource.Attribute.textAppearanceListItem;
 			global::Microsoft.Identity.Client.Resource.Attribute.textAppearanceListItemSmall = global::XForms.Droid.Resource.Attribute.textAppearanceListItemSmall;
+			global::Microsoft.Identity.Client.Resource.Attribute.textAppearancePopupMenuHeader = global::XForms.Droid.Resource.Attribute.textAppearancePopupMenuHeader;
 			global::Microsoft.Identity.Client.Resource.Attribute.textAppearanceSearchResultSubtitle = global::XForms.Droid.Resource.Attribute.textAppearanceSearchResultSubtitle;
 			global::Microsoft.Identity.Client.Resource.Attribute.textAppearanceSearchResultTitle = global::XForms.Droid.Resource.Attribute.textAppearanceSearchResultTitle;
 			global::Microsoft.Identity.Client.Resource.Attribute.textAppearanceSmallPopupMenu = global::XForms.Droid.Resource.Attribute.textAppearanceSmallPopupMenu;
@@ -222,7 +233,13 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.theme = global::XForms.Droid.Resource.Attribute.theme;
 			global::Microsoft.Identity.Client.Resource.Attribute.thickness = global::XForms.Droid.Resource.Attribute.thickness;
 			global::Microsoft.Identity.Client.Resource.Attribute.thumbTextPadding = global::XForms.Droid.Resource.Attribute.thumbTextPadding;
+			global::Microsoft.Identity.Client.Resource.Attribute.thumbTint = global::XForms.Droid.Resource.Attribute.thumbTint;
+			global::Microsoft.Identity.Client.Resource.Attribute.thumbTintMode = global::XForms.Droid.Resource.Attribute.thumbTintMode;
+			global::Microsoft.Identity.Client.Resource.Attribute.tickMark = global::XForms.Droid.Resource.Attribute.tickMark;
+			global::Microsoft.Identity.Client.Resource.Attribute.tickMarkTint = global::XForms.Droid.Resource.Attribute.tickMarkTint;
+			global::Microsoft.Identity.Client.Resource.Attribute.tickMarkTintMode = global::XForms.Droid.Resource.Attribute.tickMarkTintMode;
 			global::Microsoft.Identity.Client.Resource.Attribute.title = global::XForms.Droid.Resource.Attribute.title;
+			global::Microsoft.Identity.Client.Resource.Attribute.titleMargin = global::XForms.Droid.Resource.Attribute.titleMargin;
 			global::Microsoft.Identity.Client.Resource.Attribute.titleMarginBottom = global::XForms.Droid.Resource.Attribute.titleMarginBottom;
 			global::Microsoft.Identity.Client.Resource.Attribute.titleMarginEnd = global::XForms.Droid.Resource.Attribute.titleMarginEnd;
 			global::Microsoft.Identity.Client.Resource.Attribute.titleMarginStart = global::XForms.Droid.Resource.Attribute.titleMarginStart;
@@ -234,6 +251,8 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.toolbarNavigationButtonStyle = global::XForms.Droid.Resource.Attribute.toolbarNavigationButtonStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.toolbarStyle = global::XForms.Droid.Resource.Attribute.toolbarStyle;
 			global::Microsoft.Identity.Client.Resource.Attribute.track = global::XForms.Droid.Resource.Attribute.track;
+			global::Microsoft.Identity.Client.Resource.Attribute.trackTint = global::XForms.Droid.Resource.Attribute.trackTint;
+			global::Microsoft.Identity.Client.Resource.Attribute.trackTintMode = global::XForms.Droid.Resource.Attribute.trackTintMode;
 			global::Microsoft.Identity.Client.Resource.Attribute.voiceIcon = global::XForms.Droid.Resource.Attribute.voiceIcon;
 			global::Microsoft.Identity.Client.Resource.Attribute.windowActionBar = global::XForms.Droid.Resource.Attribute.windowActionBar;
 			global::Microsoft.Identity.Client.Resource.Attribute.windowActionBarOverlay = global::XForms.Droid.Resource.Attribute.windowActionBarOverlay;
@@ -246,16 +265,17 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Attribute.windowMinWidthMinor = global::XForms.Droid.Resource.Attribute.windowMinWidthMinor;
 			global::Microsoft.Identity.Client.Resource.Attribute.windowNoTitle = global::XForms.Droid.Resource.Attribute.windowNoTitle;
 			global::Microsoft.Identity.Client.Resource.Boolean.abc_action_bar_embed_tabs = global::XForms.Droid.Resource.Boolean.abc_action_bar_embed_tabs;
-			global::Microsoft.Identity.Client.Resource.Boolean.abc_action_bar_embed_tabs_pre_jb = global::XForms.Droid.Resource.Boolean.abc_action_bar_embed_tabs_pre_jb;
-			global::Microsoft.Identity.Client.Resource.Boolean.abc_action_bar_expanded_action_views_exclusive = global::XForms.Droid.Resource.Boolean.abc_action_bar_expanded_action_views_exclusive;
 			global::Microsoft.Identity.Client.Resource.Boolean.abc_allow_stacked_button_bar = global::XForms.Droid.Resource.Boolean.abc_allow_stacked_button_bar;
 			global::Microsoft.Identity.Client.Resource.Boolean.abc_config_actionMenuItemAllCaps = global::XForms.Droid.Resource.Boolean.abc_config_actionMenuItemAllCaps;
-			global::Microsoft.Identity.Client.Resource.Boolean.abc_config_allowActionMenuItemTextWithIcon = global::XForms.Droid.Resource.Boolean.abc_config_allowActionMenuItemTextWithIcon;
 			global::Microsoft.Identity.Client.Resource.Boolean.abc_config_closeDialogWhenTouchOutside = global::XForms.Droid.Resource.Boolean.abc_config_closeDialogWhenTouchOutside;
 			global::Microsoft.Identity.Client.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent = global::XForms.Droid.Resource.Boolean.abc_config_showMenuShortcutsWhenKeyboardPresent;
 			global::Microsoft.Identity.Client.Resource.Color.abc_background_cache_hint_selector_material_dark = global::XForms.Droid.Resource.Color.abc_background_cache_hint_selector_material_dark;
 			global::Microsoft.Identity.Client.Resource.Color.abc_background_cache_hint_selector_material_light = global::XForms.Droid.Resource.Color.abc_background_cache_hint_selector_material_light;
+			global::Microsoft.Identity.Client.Resource.Color.abc_btn_colored_borderless_text_material = global::XForms.Droid.Resource.Color.abc_btn_colored_borderless_text_material;
+			global::Microsoft.Identity.Client.Resource.Color.abc_btn_colored_text_material = global::XForms.Droid.Resource.Color.abc_btn_colored_text_material;
 			global::Microsoft.Identity.Client.Resource.Color.abc_color_highlight_material = global::XForms.Droid.Resource.Color.abc_color_highlight_material;
+			global::Microsoft.Identity.Client.Resource.Color.abc_hint_foreground_material_dark = global::XForms.Droid.Resource.Color.abc_hint_foreground_material_dark;
+			global::Microsoft.Identity.Client.Resource.Color.abc_hint_foreground_material_light = global::XForms.Droid.Resource.Color.abc_hint_foreground_material_light;
 			global::Microsoft.Identity.Client.Resource.Color.abc_input_method_navigation_guard = global::XForms.Droid.Resource.Color.abc_input_method_navigation_guard;
 			global::Microsoft.Identity.Client.Resource.Color.abc_primary_text_disable_only_material_dark = global::XForms.Droid.Resource.Color.abc_primary_text_disable_only_material_dark;
 			global::Microsoft.Identity.Client.Resource.Color.abc_primary_text_disable_only_material_light = global::XForms.Droid.Resource.Color.abc_primary_text_disable_only_material_light;
@@ -267,6 +287,13 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Color.abc_search_url_text_selected = global::XForms.Droid.Resource.Color.abc_search_url_text_selected;
 			global::Microsoft.Identity.Client.Resource.Color.abc_secondary_text_material_dark = global::XForms.Droid.Resource.Color.abc_secondary_text_material_dark;
 			global::Microsoft.Identity.Client.Resource.Color.abc_secondary_text_material_light = global::XForms.Droid.Resource.Color.abc_secondary_text_material_light;
+			global::Microsoft.Identity.Client.Resource.Color.abc_tint_btn_checkable = global::XForms.Droid.Resource.Color.abc_tint_btn_checkable;
+			global::Microsoft.Identity.Client.Resource.Color.abc_tint_default = global::XForms.Droid.Resource.Color.abc_tint_default;
+			global::Microsoft.Identity.Client.Resource.Color.abc_tint_edittext = global::XForms.Droid.Resource.Color.abc_tint_edittext;
+			global::Microsoft.Identity.Client.Resource.Color.abc_tint_seek_thumb = global::XForms.Droid.Resource.Color.abc_tint_seek_thumb;
+			global::Microsoft.Identity.Client.Resource.Color.abc_tint_spinner = global::XForms.Droid.Resource.Color.abc_tint_spinner;
+			global::Microsoft.Identity.Client.Resource.Color.abc_tint_switch_thumb = global::XForms.Droid.Resource.Color.abc_tint_switch_thumb;
+			global::Microsoft.Identity.Client.Resource.Color.abc_tint_switch_track = global::XForms.Droid.Resource.Color.abc_tint_switch_track;
 			global::Microsoft.Identity.Client.Resource.Color.accent_material_dark = global::XForms.Droid.Resource.Color.accent_material_dark;
 			global::Microsoft.Identity.Client.Resource.Color.accent_material_light = global::XForms.Droid.Resource.Color.accent_material_light;
 			global::Microsoft.Identity.Client.Resource.Color.background_floating_material_dark = global::XForms.Droid.Resource.Color.background_floating_material_dark;
@@ -289,8 +316,6 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Color.foreground_material_light = global::XForms.Droid.Resource.Color.foreground_material_light;
 			global::Microsoft.Identity.Client.Resource.Color.highlighted_text_material_dark = global::XForms.Droid.Resource.Color.highlighted_text_material_dark;
 			global::Microsoft.Identity.Client.Resource.Color.highlighted_text_material_light = global::XForms.Droid.Resource.Color.highlighted_text_material_light;
-			global::Microsoft.Identity.Client.Resource.Color.hint_foreground_material_dark = global::XForms.Droid.Resource.Color.hint_foreground_material_dark;
-			global::Microsoft.Identity.Client.Resource.Color.hint_foreground_material_light = global::XForms.Droid.Resource.Color.hint_foreground_material_light;
 			global::Microsoft.Identity.Client.Resource.Color.material_blue_grey_800 = global::XForms.Droid.Resource.Color.material_blue_grey_800;
 			global::Microsoft.Identity.Client.Resource.Color.material_blue_grey_900 = global::XForms.Droid.Resource.Color.material_blue_grey_900;
 			global::Microsoft.Identity.Client.Resource.Color.material_blue_grey_950 = global::XForms.Droid.Resource.Color.material_blue_grey_950;
@@ -303,6 +328,9 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Color.material_grey_800 = global::XForms.Droid.Resource.Color.material_grey_800;
 			global::Microsoft.Identity.Client.Resource.Color.material_grey_850 = global::XForms.Droid.Resource.Color.material_grey_850;
 			global::Microsoft.Identity.Client.Resource.Color.material_grey_900 = global::XForms.Droid.Resource.Color.material_grey_900;
+			global::Microsoft.Identity.Client.Resource.Color.notification_action_color_filter = global::XForms.Droid.Resource.Color.notification_action_color_filter;
+			global::Microsoft.Identity.Client.Resource.Color.notification_icon_bg_color = global::XForms.Droid.Resource.Color.notification_icon_bg_color;
+			global::Microsoft.Identity.Client.Resource.Color.notification_material_background_media_default_color = global::XForms.Droid.Resource.Color.notification_material_background_media_default_color;
 			global::Microsoft.Identity.Client.Resource.Color.primary_dark_material_dark = global::XForms.Droid.Resource.Color.primary_dark_material_dark;
 			global::Microsoft.Identity.Client.Resource.Color.primary_dark_material_light = global::XForms.Droid.Resource.Color.primary_dark_material_light;
 			global::Microsoft.Identity.Client.Resource.Color.primary_material_dark = global::XForms.Droid.Resource.Color.primary_material_dark;
@@ -324,9 +352,11 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Color.switch_thumb_normal_material_dark = global::XForms.Droid.Resource.Color.switch_thumb_normal_material_dark;
 			global::Microsoft.Identity.Client.Resource.Color.switch_thumb_normal_material_light = global::XForms.Droid.Resource.Color.switch_thumb_normal_material_light;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_content_inset_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_content_inset_material;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_content_inset_with_nav = global::XForms.Droid.Resource.Dimension.abc_action_bar_content_inset_with_nav;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_default_height_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_default_height_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_default_padding_end_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_default_padding_end_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_default_padding_start_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_default_padding_start_material;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_elevation_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_elevation_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_icon_vertical_padding_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_icon_vertical_padding_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_overflow_padding_end_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_overflow_padding_end_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_action_bar_overflow_padding_start_material = global::XForms.Droid.Resource.Dimension.abc_action_bar_overflow_padding_start_material;
@@ -343,6 +373,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_button_inset_vertical_material = global::XForms.Droid.Resource.Dimension.abc_button_inset_vertical_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_button_padding_horizontal_material = global::XForms.Droid.Resource.Dimension.abc_button_padding_horizontal_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_button_padding_vertical_material = global::XForms.Droid.Resource.Dimension.abc_button_padding_vertical_material;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_cascading_menus_min_smallest_width = global::XForms.Droid.Resource.Dimension.abc_cascading_menus_min_smallest_width;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_config_prefDialogWidth = global::XForms.Droid.Resource.Dimension.abc_config_prefDialogWidth;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_control_corner_material = global::XForms.Droid.Resource.Dimension.abc_control_corner_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_control_inset_material = global::XForms.Droid.Resource.Dimension.abc_control_inset_material;
@@ -351,11 +382,13 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_fixed_height_minor = global::XForms.Droid.Resource.Dimension.abc_dialog_fixed_height_minor;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_fixed_width_major = global::XForms.Droid.Resource.Dimension.abc_dialog_fixed_width_major;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_fixed_width_minor = global::XForms.Droid.Resource.Dimension.abc_dialog_fixed_width_minor;
-			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_list_padding_vertical_material = global::XForms.Droid.Resource.Dimension.abc_dialog_list_padding_vertical_material;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_list_padding_bottom_no_buttons = global::XForms.Droid.Resource.Dimension.abc_dialog_list_padding_bottom_no_buttons;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_list_padding_top_no_title = global::XForms.Droid.Resource.Dimension.abc_dialog_list_padding_top_no_title;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_min_width_major = global::XForms.Droid.Resource.Dimension.abc_dialog_min_width_major;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_min_width_minor = global::XForms.Droid.Resource.Dimension.abc_dialog_min_width_minor;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_padding_material = global::XForms.Droid.Resource.Dimension.abc_dialog_padding_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_padding_top_material = global::XForms.Droid.Resource.Dimension.abc_dialog_padding_top_material;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_dialog_title_divider_material = global::XForms.Droid.Resource.Dimension.abc_dialog_title_divider_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_disabled_alpha_material_dark = global::XForms.Droid.Resource.Dimension.abc_disabled_alpha_material_dark;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_disabled_alpha_material_light = global::XForms.Droid.Resource.Dimension.abc_disabled_alpha_material_light;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_dropdownitem_icon_width = global::XForms.Droid.Resource.Dimension.abc_dropdownitem_icon_width;
@@ -367,8 +400,9 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_floating_window_z = global::XForms.Droid.Resource.Dimension.abc_floating_window_z;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_list_item_padding_horizontal_material = global::XForms.Droid.Resource.Dimension.abc_list_item_padding_horizontal_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_panel_menu_list_width = global::XForms.Droid.Resource.Dimension.abc_panel_menu_list_width;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_progress_bar_height_material = global::XForms.Droid.Resource.Dimension.abc_progress_bar_height_material;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_search_view_preferred_height = global::XForms.Droid.Resource.Dimension.abc_search_view_preferred_height;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_search_view_preferred_width = global::XForms.Droid.Resource.Dimension.abc_search_view_preferred_width;
-			global::Microsoft.Identity.Client.Resource.Dimension.abc_search_view_text_min_width = global::XForms.Droid.Resource.Dimension.abc_search_view_text_min_width;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_seekbar_track_background_height_material = global::XForms.Droid.Resource.Dimension.abc_seekbar_track_background_height_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_seekbar_track_progress_height_material = global::XForms.Droid.Resource.Dimension.abc_seekbar_track_progress_height_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_select_dialog_padding_start_material = global::XForms.Droid.Resource.Dimension.abc_select_dialog_padding_start_material;
@@ -384,6 +418,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_text_size_headline_material = global::XForms.Droid.Resource.Dimension.abc_text_size_headline_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_text_size_large_material = global::XForms.Droid.Resource.Dimension.abc_text_size_large_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_text_size_medium_material = global::XForms.Droid.Resource.Dimension.abc_text_size_medium_material;
+			global::Microsoft.Identity.Client.Resource.Dimension.abc_text_size_menu_header_material = global::XForms.Droid.Resource.Dimension.abc_text_size_menu_header_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_text_size_menu_material = global::XForms.Droid.Resource.Dimension.abc_text_size_menu_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_text_size_small_material = global::XForms.Droid.Resource.Dimension.abc_text_size_small_material;
 			global::Microsoft.Identity.Client.Resource.Dimension.abc_text_size_subhead_material = global::XForms.Droid.Resource.Dimension.abc_text_size_subhead_material;
@@ -395,9 +430,25 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Dimension.highlight_alpha_material_colored = global::XForms.Droid.Resource.Dimension.highlight_alpha_material_colored;
 			global::Microsoft.Identity.Client.Resource.Dimension.highlight_alpha_material_dark = global::XForms.Droid.Resource.Dimension.highlight_alpha_material_dark;
 			global::Microsoft.Identity.Client.Resource.Dimension.highlight_alpha_material_light = global::XForms.Droid.Resource.Dimension.highlight_alpha_material_light;
+			global::Microsoft.Identity.Client.Resource.Dimension.hint_alpha_material_dark = global::XForms.Droid.Resource.Dimension.hint_alpha_material_dark;
+			global::Microsoft.Identity.Client.Resource.Dimension.hint_alpha_material_light = global::XForms.Droid.Resource.Dimension.hint_alpha_material_light;
+			global::Microsoft.Identity.Client.Resource.Dimension.hint_pressed_alpha_material_dark = global::XForms.Droid.Resource.Dimension.hint_pressed_alpha_material_dark;
+			global::Microsoft.Identity.Client.Resource.Dimension.hint_pressed_alpha_material_light = global::XForms.Droid.Resource.Dimension.hint_pressed_alpha_material_light;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_action_icon_size = global::XForms.Droid.Resource.Dimension.notification_action_icon_size;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_action_text_size = global::XForms.Droid.Resource.Dimension.notification_action_text_size;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_big_circle_margin = global::XForms.Droid.Resource.Dimension.notification_big_circle_margin;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_content_margin_start = global::XForms.Droid.Resource.Dimension.notification_content_margin_start;
 			global::Microsoft.Identity.Client.Resource.Dimension.notification_large_icon_height = global::XForms.Droid.Resource.Dimension.notification_large_icon_height;
 			global::Microsoft.Identity.Client.Resource.Dimension.notification_large_icon_width = global::XForms.Droid.Resource.Dimension.notification_large_icon_width;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_main_column_padding_top = global::XForms.Droid.Resource.Dimension.notification_main_column_padding_top;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_media_narrow_margin = global::XForms.Droid.Resource.Dimension.notification_media_narrow_margin;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_right_icon_size = global::XForms.Droid.Resource.Dimension.notification_right_icon_size;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_right_side_padding_top = global::XForms.Droid.Resource.Dimension.notification_right_side_padding_top;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_small_icon_background_padding = global::XForms.Droid.Resource.Dimension.notification_small_icon_background_padding;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_small_icon_size_as_large = global::XForms.Droid.Resource.Dimension.notification_small_icon_size_as_large;
 			global::Microsoft.Identity.Client.Resource.Dimension.notification_subtext_size = global::XForms.Droid.Resource.Dimension.notification_subtext_size;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_top_pad = global::XForms.Droid.Resource.Dimension.notification_top_pad;
+			global::Microsoft.Identity.Client.Resource.Dimension.notification_top_pad_large_text = global::XForms.Droid.Resource.Dimension.notification_top_pad_large_text;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ab_share_pack_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ab_share_pack_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_action_bar_item_background_material = global::XForms.Droid.Resource.Drawable.abc_action_bar_item_background_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_borderless_material = global::XForms.Droid.Resource.Drawable.abc_btn_borderless_material;
@@ -409,33 +460,33 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_radio_material = global::XForms.Droid.Resource.Drawable.abc_btn_radio_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_radio_to_on_mtrl_000 = global::XForms.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_000;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_radio_to_on_mtrl_015 = global::XForms.Droid.Resource.Drawable.abc_btn_radio_to_on_mtrl_015;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_rating_star_off_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_btn_rating_star_off_mtrl_alpha;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_rating_star_on_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_btn_rating_star_on_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_switch_to_on_mtrl_00001 = global::XForms.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00001;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_btn_switch_to_on_mtrl_00012 = global::XForms.Droid.Resource.Drawable.abc_btn_switch_to_on_mtrl_00012;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_cab_background_internal_bg = global::XForms.Droid.Resource.Drawable.abc_cab_background_internal_bg;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_cab_background_top_material = global::XForms.Droid.Resource.Drawable.abc_cab_background_top_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_cab_background_top_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_cab_background_top_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_control_background_material = global::XForms.Droid.Resource.Drawable.abc_control_background_material;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_dialog_material_background_dark = global::XForms.Droid.Resource.Drawable.abc_dialog_material_background_dark;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_dialog_material_background_light = global::XForms.Droid.Resource.Drawable.abc_dialog_material_background_light;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_dialog_material_background = global::XForms.Droid.Resource.Drawable.abc_dialog_material_background;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_edit_text_material = global::XForms.Droid.Resource.Drawable.abc_edit_text_material;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_ab_back_mtrl_am_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_ab_back_mtrl_am_alpha;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_clear_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_clear_mtrl_alpha;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_ab_back_material = global::XForms.Droid.Resource.Drawable.abc_ic_ab_back_material;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_arrow_drop_right_black_24dp = global::XForms.Droid.Resource.Drawable.abc_ic_arrow_drop_right_black_24dp;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_clear_material = global::XForms.Droid.Resource.Drawable.abc_ic_clear_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_commit_search_api_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_commit_search_api_mtrl_alpha;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_go_search_api_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_go_search_api_mtrl_alpha;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_go_search_api_material = global::XForms.Droid.Resource.Drawable.abc_ic_go_search_api_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_menu_copy_mtrl_am_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_menu_copy_mtrl_am_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_menu_cut_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_menu_cut_mtrl_alpha;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_menu_moreoverflow_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_menu_moreoverflow_mtrl_alpha;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_menu_overflow_material = global::XForms.Droid.Resource.Drawable.abc_ic_menu_overflow_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_menu_paste_mtrl_am_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_menu_paste_mtrl_am_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_menu_selectall_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_menu_selectall_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_menu_share_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_menu_share_mtrl_alpha;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_search_api_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_search_api_mtrl_alpha;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_search_api_material = global::XForms.Droid.Resource.Drawable.abc_ic_search_api_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_star_black_16dp = global::XForms.Droid.Resource.Drawable.abc_ic_star_black_16dp;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_star_black_36dp = global::XForms.Droid.Resource.Drawable.abc_ic_star_black_36dp;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_star_black_48dp = global::XForms.Droid.Resource.Drawable.abc_ic_star_black_48dp;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_star_half_black_16dp = global::XForms.Droid.Resource.Drawable.abc_ic_star_half_black_16dp;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_star_half_black_36dp = global::XForms.Droid.Resource.Drawable.abc_ic_star_half_black_36dp;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_voice_search_api_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_ic_voice_search_api_mtrl_alpha;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_star_half_black_48dp = global::XForms.Droid.Resource.Drawable.abc_ic_star_half_black_48dp;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ic_voice_search_api_material = global::XForms.Droid.Resource.Drawable.abc_ic_voice_search_api_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_item_background_holo_dark = global::XForms.Droid.Resource.Drawable.abc_item_background_holo_dark;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_item_background_holo_light = global::XForms.Droid.Resource.Drawable.abc_item_background_holo_light;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_list_divider_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_list_divider_mtrl_alpha;
@@ -451,8 +502,8 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_list_selector_holo_light = global::XForms.Droid.Resource.Drawable.abc_list_selector_holo_light;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_menu_hardkey_panel_mtrl_mult = global::XForms.Droid.Resource.Drawable.abc_menu_hardkey_panel_mtrl_mult;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_popup_background_mtrl_mult = global::XForms.Droid.Resource.Drawable.abc_popup_background_mtrl_mult;
-			global::Microsoft.Identity.Client.Resource.Drawable.abc_ratingbar_full_material = global::XForms.Droid.Resource.Drawable.abc_ratingbar_full_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ratingbar_indicator_material = global::XForms.Droid.Resource.Drawable.abc_ratingbar_indicator_material;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_ratingbar_material = global::XForms.Droid.Resource.Drawable.abc_ratingbar_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_ratingbar_small_material = global::XForms.Droid.Resource.Drawable.abc_ratingbar_small_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_scrubber_control_off_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_scrubber_control_off_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_scrubber_control_to_pressed_mtrl_000 = global::XForms.Droid.Resource.Drawable.abc_scrubber_control_to_pressed_mtrl_000;
@@ -460,6 +511,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_scrubber_primary_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_scrubber_primary_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_scrubber_track_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_scrubber_track_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_seekbar_thumb_material = global::XForms.Droid.Resource.Drawable.abc_seekbar_thumb_material;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_seekbar_tick_mark_material = global::XForms.Droid.Resource.Drawable.abc_seekbar_tick_mark_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_seekbar_track_material = global::XForms.Droid.Resource.Drawable.abc_seekbar_track_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_spinner_mtrl_am_alpha = global::XForms.Droid.Resource.Drawable.abc_spinner_mtrl_am_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_spinner_textfield_background_material = global::XForms.Droid.Resource.Drawable.abc_spinner_textfield_background_material;
@@ -468,12 +520,30 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_tab_indicator_material = global::XForms.Droid.Resource.Drawable.abc_tab_indicator_material;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_tab_indicator_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_tab_indicator_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_text_cursor_material = global::XForms.Droid.Resource.Drawable.abc_text_cursor_material;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_text_select_handle_left_mtrl_dark = global::XForms.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_dark;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_text_select_handle_left_mtrl_light = global::XForms.Droid.Resource.Drawable.abc_text_select_handle_left_mtrl_light;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_text_select_handle_middle_mtrl_dark = global::XForms.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_dark;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_text_select_handle_middle_mtrl_light = global::XForms.Droid.Resource.Drawable.abc_text_select_handle_middle_mtrl_light;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_text_select_handle_right_mtrl_dark = global::XForms.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_dark;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_text_select_handle_right_mtrl_light = global::XForms.Droid.Resource.Drawable.abc_text_select_handle_right_mtrl_light;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_textfield_activated_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_textfield_activated_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_textfield_default_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_textfield_default_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_textfield_search_activated_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_textfield_search_activated_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_textfield_search_default_mtrl_alpha = global::XForms.Droid.Resource.Drawable.abc_textfield_search_default_mtrl_alpha;
 			global::Microsoft.Identity.Client.Resource.Drawable.abc_textfield_search_material = global::XForms.Droid.Resource.Drawable.abc_textfield_search_material;
+			global::Microsoft.Identity.Client.Resource.Drawable.abc_vector_test = global::XForms.Droid.Resource.Drawable.abc_vector_test;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_action_background = global::XForms.Droid.Resource.Drawable.notification_action_background;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_bg = global::XForms.Droid.Resource.Drawable.notification_bg;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_bg_low = global::XForms.Droid.Resource.Drawable.notification_bg_low;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_bg_low_normal = global::XForms.Droid.Resource.Drawable.notification_bg_low_normal;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_bg_low_pressed = global::XForms.Droid.Resource.Drawable.notification_bg_low_pressed;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_bg_normal = global::XForms.Droid.Resource.Drawable.notification_bg_normal;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_bg_normal_pressed = global::XForms.Droid.Resource.Drawable.notification_bg_normal_pressed;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_icon_background = global::XForms.Droid.Resource.Drawable.notification_icon_background;
 			global::Microsoft.Identity.Client.Resource.Drawable.notification_template_icon_bg = global::XForms.Droid.Resource.Drawable.notification_template_icon_bg;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_template_icon_low_bg = global::XForms.Droid.Resource.Drawable.notification_template_icon_low_bg;
+			global::Microsoft.Identity.Client.Resource.Drawable.notification_tile_bg = global::XForms.Droid.Resource.Drawable.notification_tile_bg;
+			global::Microsoft.Identity.Client.Resource.Drawable.notify_panel_notification_icon_bg = global::XForms.Droid.Resource.Drawable.notify_panel_notification_icon_bg;
 			global::Microsoft.Identity.Client.Resource.Id.action0 = global::XForms.Droid.Resource.Id.action0;
 			global::Microsoft.Identity.Client.Resource.Id.action_bar = global::XForms.Droid.Resource.Id.action_bar;
 			global::Microsoft.Identity.Client.Resource.Id.action_bar_activity_content = global::XForms.Droid.Resource.Id.action_bar_activity_content;
@@ -482,18 +552,24 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Id.action_bar_spinner = global::XForms.Droid.Resource.Id.action_bar_spinner;
 			global::Microsoft.Identity.Client.Resource.Id.action_bar_subtitle = global::XForms.Droid.Resource.Id.action_bar_subtitle;
 			global::Microsoft.Identity.Client.Resource.Id.action_bar_title = global::XForms.Droid.Resource.Id.action_bar_title;
+			global::Microsoft.Identity.Client.Resource.Id.action_container = global::XForms.Droid.Resource.Id.action_container;
 			global::Microsoft.Identity.Client.Resource.Id.action_context_bar = global::XForms.Droid.Resource.Id.action_context_bar;
 			global::Microsoft.Identity.Client.Resource.Id.action_divider = global::XForms.Droid.Resource.Id.action_divider;
+			global::Microsoft.Identity.Client.Resource.Id.action_image = global::XForms.Droid.Resource.Id.action_image;
 			global::Microsoft.Identity.Client.Resource.Id.action_menu_divider = global::XForms.Droid.Resource.Id.action_menu_divider;
 			global::Microsoft.Identity.Client.Resource.Id.action_menu_presenter = global::XForms.Droid.Resource.Id.action_menu_presenter;
 			global::Microsoft.Identity.Client.Resource.Id.action_mode_bar = global::XForms.Droid.Resource.Id.action_mode_bar;
 			global::Microsoft.Identity.Client.Resource.Id.action_mode_bar_stub = global::XForms.Droid.Resource.Id.action_mode_bar_stub;
 			global::Microsoft.Identity.Client.Resource.Id.action_mode_close_button = global::XForms.Droid.Resource.Id.action_mode_close_button;
+			global::Microsoft.Identity.Client.Resource.Id.action_text = global::XForms.Droid.Resource.Id.action_text;
+			global::Microsoft.Identity.Client.Resource.Id.actions = global::XForms.Droid.Resource.Id.actions;
 			global::Microsoft.Identity.Client.Resource.Id.activity_chooser_view_content = global::XForms.Droid.Resource.Id.activity_chooser_view_content;
+			global::Microsoft.Identity.Client.Resource.Id.add = global::XForms.Droid.Resource.Id.add;
 			global::Microsoft.Identity.Client.Resource.Id.agentWebView = global::XForms.Droid.Resource.Id.agentWebView;
 			global::Microsoft.Identity.Client.Resource.Id.alertTitle = global::XForms.Droid.Resource.Id.alertTitle;
 			global::Microsoft.Identity.Client.Resource.Id.always = global::XForms.Droid.Resource.Id.always;
 			global::Microsoft.Identity.Client.Resource.Id.beginning = global::XForms.Droid.Resource.Id.beginning;
+			global::Microsoft.Identity.Client.Resource.Id.bottom = global::XForms.Droid.Resource.Id.bottom;
 			global::Microsoft.Identity.Client.Resource.Id.buttonPanel = global::XForms.Droid.Resource.Id.buttonPanel;
 			global::Microsoft.Identity.Client.Resource.Id.cancel_action = global::XForms.Droid.Resource.Id.cancel_action;
 			global::Microsoft.Identity.Client.Resource.Id.checkbox = global::XForms.Droid.Resource.Id.checkbox;
@@ -513,6 +589,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Id.home = global::XForms.Droid.Resource.Id.home;
 			global::Microsoft.Identity.Client.Resource.Id.homeAsUp = global::XForms.Droid.Resource.Id.homeAsUp;
 			global::Microsoft.Identity.Client.Resource.Id.icon = global::XForms.Droid.Resource.Id.icon;
+			global::Microsoft.Identity.Client.Resource.Id.icon_group = global::XForms.Droid.Resource.Id.icon_group;
 			global::Microsoft.Identity.Client.Resource.Id.ifRoom = global::XForms.Droid.Resource.Id.ifRoom;
 			global::Microsoft.Identity.Client.Resource.Id.image = global::XForms.Droid.Resource.Id.image;
 			global::Microsoft.Identity.Client.Resource.Id.info = global::XForms.Droid.Resource.Id.info;
@@ -526,10 +603,15 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Id.never = global::XForms.Droid.Resource.Id.never;
 			global::Microsoft.Identity.Client.Resource.Id.none = global::XForms.Droid.Resource.Id.none;
 			global::Microsoft.Identity.Client.Resource.Id.normal = global::XForms.Droid.Resource.Id.normal;
+			global::Microsoft.Identity.Client.Resource.Id.notification_background = global::XForms.Droid.Resource.Id.notification_background;
+			global::Microsoft.Identity.Client.Resource.Id.notification_main_column = global::XForms.Droid.Resource.Id.notification_main_column;
+			global::Microsoft.Identity.Client.Resource.Id.notification_main_column_container = global::XForms.Droid.Resource.Id.notification_main_column_container;
 			global::Microsoft.Identity.Client.Resource.Id.parentPanel = global::XForms.Droid.Resource.Id.parentPanel;
 			global::Microsoft.Identity.Client.Resource.Id.progress_circular = global::XForms.Droid.Resource.Id.progress_circular;
 			global::Microsoft.Identity.Client.Resource.Id.progress_horizontal = global::XForms.Droid.Resource.Id.progress_horizontal;
 			global::Microsoft.Identity.Client.Resource.Id.radio = global::XForms.Droid.Resource.Id.radio;
+			global::Microsoft.Identity.Client.Resource.Id.right_icon = global::XForms.Droid.Resource.Id.right_icon;
+			global::Microsoft.Identity.Client.Resource.Id.right_side = global::XForms.Droid.Resource.Id.right_side;
 			global::Microsoft.Identity.Client.Resource.Id.screen = global::XForms.Droid.Resource.Id.screen;
 			global::Microsoft.Identity.Client.Resource.Id.scrollIndicatorDown = global::XForms.Droid.Resource.Id.scrollIndicatorDown;
 			global::Microsoft.Identity.Client.Resource.Id.scrollIndicatorUp = global::XForms.Droid.Resource.Id.scrollIndicatorUp;
@@ -555,14 +637,18 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Id.src_in = global::XForms.Droid.Resource.Id.src_in;
 			global::Microsoft.Identity.Client.Resource.Id.src_over = global::XForms.Droid.Resource.Id.src_over;
 			global::Microsoft.Identity.Client.Resource.Id.status_bar_latest_event_content = global::XForms.Droid.Resource.Id.status_bar_latest_event_content;
+			global::Microsoft.Identity.Client.Resource.Id.submenuarrow = global::XForms.Droid.Resource.Id.submenuarrow;
 			global::Microsoft.Identity.Client.Resource.Id.submit_area = global::XForms.Droid.Resource.Id.submit_area;
 			global::Microsoft.Identity.Client.Resource.Id.tabMode = global::XForms.Droid.Resource.Id.tabMode;
 			global::Microsoft.Identity.Client.Resource.Id.text = global::XForms.Droid.Resource.Id.text;
 			global::Microsoft.Identity.Client.Resource.Id.text2 = global::XForms.Droid.Resource.Id.text2;
 			global::Microsoft.Identity.Client.Resource.Id.textSpacerNoButtons = global::XForms.Droid.Resource.Id.textSpacerNoButtons;
+			global::Microsoft.Identity.Client.Resource.Id.textSpacerNoTitle = global::XForms.Droid.Resource.Id.textSpacerNoTitle;
 			global::Microsoft.Identity.Client.Resource.Id.time = global::XForms.Droid.Resource.Id.time;
 			global::Microsoft.Identity.Client.Resource.Id.title = global::XForms.Droid.Resource.Id.title;
+			global::Microsoft.Identity.Client.Resource.Id.titleDividerNoCustom = global::XForms.Droid.Resource.Id.titleDividerNoCustom;
 			global::Microsoft.Identity.Client.Resource.Id.title_template = global::XForms.Droid.Resource.Id.title_template;
+			global::Microsoft.Identity.Client.Resource.Id.top = global::XForms.Droid.Resource.Id.top;
 			global::Microsoft.Identity.Client.Resource.Id.topPanel = global::XForms.Droid.Resource.Id.topPanel;
 			global::Microsoft.Identity.Client.Resource.Id.up = global::XForms.Droid.Resource.Id.up;
 			global::Microsoft.Identity.Client.Resource.Id.useLogo = global::XForms.Droid.Resource.Id.useLogo;
@@ -570,7 +656,6 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Id.wrap_content = global::XForms.Droid.Resource.Id.wrap_content;
 			global::Microsoft.Identity.Client.Resource.Integer.abc_config_activityDefaultDur = global::XForms.Droid.Resource.Integer.abc_config_activityDefaultDur;
 			global::Microsoft.Identity.Client.Resource.Integer.abc_config_activityShortDur = global::XForms.Droid.Resource.Integer.abc_config_activityShortDur;
-			global::Microsoft.Identity.Client.Resource.Integer.abc_max_action_buttons = global::XForms.Droid.Resource.Integer.abc_max_action_buttons;
 			global::Microsoft.Identity.Client.Resource.Integer.cancel_button_image_alpha = global::XForms.Droid.Resource.Integer.cancel_button_image_alpha;
 			global::Microsoft.Identity.Client.Resource.Integer.status_bar_notification_info_maxnum = global::XForms.Droid.Resource.Integer.status_bar_notification_info_maxnum;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_action_bar_title_item = global::XForms.Droid.Resource.Layout.abc_action_bar_title_item;
@@ -584,12 +669,14 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Layout.abc_activity_chooser_view_list_item = global::XForms.Droid.Resource.Layout.abc_activity_chooser_view_list_item;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_alert_dialog_button_bar_material = global::XForms.Droid.Resource.Layout.abc_alert_dialog_button_bar_material;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_alert_dialog_material = global::XForms.Droid.Resource.Layout.abc_alert_dialog_material;
+			global::Microsoft.Identity.Client.Resource.Layout.abc_alert_dialog_title_material = global::XForms.Droid.Resource.Layout.abc_alert_dialog_title_material;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_dialog_title_material = global::XForms.Droid.Resource.Layout.abc_dialog_title_material;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_expanded_menu_layout = global::XForms.Droid.Resource.Layout.abc_expanded_menu_layout;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_list_menu_item_checkbox = global::XForms.Droid.Resource.Layout.abc_list_menu_item_checkbox;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_list_menu_item_icon = global::XForms.Droid.Resource.Layout.abc_list_menu_item_icon;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_list_menu_item_layout = global::XForms.Droid.Resource.Layout.abc_list_menu_item_layout;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_list_menu_item_radio = global::XForms.Droid.Resource.Layout.abc_list_menu_item_radio;
+			global::Microsoft.Identity.Client.Resource.Layout.abc_popup_menu_header_item_layout = global::XForms.Droid.Resource.Layout.abc_popup_menu_header_item_layout;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_popup_menu_item_layout = global::XForms.Droid.Resource.Layout.abc_popup_menu_item_layout;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_screen_content_include = global::XForms.Droid.Resource.Layout.abc_screen_content_include;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_screen_simple = global::XForms.Droid.Resource.Layout.abc_screen_simple;
@@ -598,12 +685,19 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Layout.abc_search_dropdown_item_icons_2line = global::XForms.Droid.Resource.Layout.abc_search_dropdown_item_icons_2line;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_search_view = global::XForms.Droid.Resource.Layout.abc_search_view;
 			global::Microsoft.Identity.Client.Resource.Layout.abc_select_dialog_material = global::XForms.Droid.Resource.Layout.abc_select_dialog_material;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_action = global::XForms.Droid.Resource.Layout.notification_action;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_action_tombstone = global::XForms.Droid.Resource.Layout.notification_action_tombstone;
 			global::Microsoft.Identity.Client.Resource.Layout.notification_media_action = global::XForms.Droid.Resource.Layout.notification_media_action;
 			global::Microsoft.Identity.Client.Resource.Layout.notification_media_cancel_action = global::XForms.Droid.Resource.Layout.notification_media_cancel_action;
 			global::Microsoft.Identity.Client.Resource.Layout.notification_template_big_media = global::XForms.Droid.Resource.Layout.notification_template_big_media;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_template_big_media_custom = global::XForms.Droid.Resource.Layout.notification_template_big_media_custom;
 			global::Microsoft.Identity.Client.Resource.Layout.notification_template_big_media_narrow = global::XForms.Droid.Resource.Layout.notification_template_big_media_narrow;
-			global::Microsoft.Identity.Client.Resource.Layout.notification_template_lines = global::XForms.Droid.Resource.Layout.notification_template_lines;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_template_big_media_narrow_custom = global::XForms.Droid.Resource.Layout.notification_template_big_media_narrow_custom;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_template_custom_big = global::XForms.Droid.Resource.Layout.notification_template_custom_big;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_template_icon_group = global::XForms.Droid.Resource.Layout.notification_template_icon_group;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_template_lines_media = global::XForms.Droid.Resource.Layout.notification_template_lines_media;
 			global::Microsoft.Identity.Client.Resource.Layout.notification_template_media = global::XForms.Droid.Resource.Layout.notification_template_media;
+			global::Microsoft.Identity.Client.Resource.Layout.notification_template_media_custom = global::XForms.Droid.Resource.Layout.notification_template_media_custom;
 			global::Microsoft.Identity.Client.Resource.Layout.notification_template_part_chronometer = global::XForms.Droid.Resource.Layout.notification_template_part_chronometer;
 			global::Microsoft.Identity.Client.Resource.Layout.notification_template_part_time = global::XForms.Droid.Resource.Layout.notification_template_part_time;
 			global::Microsoft.Identity.Client.Resource.Layout.select_dialog_item_material = global::XForms.Droid.Resource.Layout.select_dialog_item_material;
@@ -622,6 +716,18 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.String.abc_activitychooserview_choose_application = global::XForms.Droid.Resource.String.abc_activitychooserview_choose_application;
 			global::Microsoft.Identity.Client.Resource.String.abc_capital_off = global::XForms.Droid.Resource.String.abc_capital_off;
 			global::Microsoft.Identity.Client.Resource.String.abc_capital_on = global::XForms.Droid.Resource.String.abc_capital_on;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_body_1_material = global::XForms.Droid.Resource.String.abc_font_family_body_1_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_body_2_material = global::XForms.Droid.Resource.String.abc_font_family_body_2_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_button_material = global::XForms.Droid.Resource.String.abc_font_family_button_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_caption_material = global::XForms.Droid.Resource.String.abc_font_family_caption_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_display_1_material = global::XForms.Droid.Resource.String.abc_font_family_display_1_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_display_2_material = global::XForms.Droid.Resource.String.abc_font_family_display_2_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_display_3_material = global::XForms.Droid.Resource.String.abc_font_family_display_3_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_display_4_material = global::XForms.Droid.Resource.String.abc_font_family_display_4_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_headline_material = global::XForms.Droid.Resource.String.abc_font_family_headline_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_menu_material = global::XForms.Droid.Resource.String.abc_font_family_menu_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_subhead_material = global::XForms.Droid.Resource.String.abc_font_family_subhead_material;
+			global::Microsoft.Identity.Client.Resource.String.abc_font_family_title_material = global::XForms.Droid.Resource.String.abc_font_family_title_material;
 			global::Microsoft.Identity.Client.Resource.String.abc_search_hint = global::XForms.Droid.Resource.String.abc_search_hint;
 			global::Microsoft.Identity.Client.Resource.String.abc_searchview_description_clear = global::XForms.Droid.Resource.String.abc_searchview_description_clear;
 			global::Microsoft.Identity.Client.Resource.String.abc_searchview_description_query = global::XForms.Droid.Resource.String.abc_searchview_description_query;
@@ -631,6 +737,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.String.abc_shareactionprovider_share_with = global::XForms.Droid.Resource.String.abc_shareactionprovider_share_with;
 			global::Microsoft.Identity.Client.Resource.String.abc_shareactionprovider_share_with_application = global::XForms.Droid.Resource.String.abc_shareactionprovider_share_with_application;
 			global::Microsoft.Identity.Client.Resource.String.abc_toolbar_collapse_description = global::XForms.Droid.Resource.String.abc_toolbar_collapse_description;
+			global::Microsoft.Identity.Client.Resource.String.search_menu_title = global::XForms.Droid.Resource.String.search_menu_title;
 			global::Microsoft.Identity.Client.Resource.String.status_bar_notification_info_overflow = global::XForms.Droid.Resource.String.status_bar_notification_info_overflow;
 			global::Microsoft.Identity.Client.Resource.Style.AlertDialog_AppCompat = global::XForms.Droid.Resource.Style.AlertDialog_AppCompat;
 			global::Microsoft.Identity.Client.Resource.Style.AlertDialog_AppCompat_Light = global::XForms.Droid.Resource.Style.AlertDialog_AppCompat_Light;
@@ -677,8 +784,11 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle;
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Title = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_ActionMode_Title;
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button;
+			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored;
+			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Colored = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Colored;
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Inverse = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Button_Inverse;
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_DropDownItem = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_DropDownItem;
+			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Header;
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Large;
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_PopupMenu_Small;
 			global::Microsoft.Identity.Client.Resource.Style.Base_TextAppearance_AppCompat_Widget_Switch = global::XForms.Droid.Resource.Style.Base_TextAppearance_AppCompat_Widget_Switch;
@@ -704,15 +814,19 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar = global::XForms.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_ActionBar;
 			global::Microsoft.Identity.Client.Resource.Style.Base_ThemeOverlay_AppCompat_Dark = global::XForms.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark;
 			global::Microsoft.Identity.Client.Resource.Style.Base_ThemeOverlay_AppCompat_Dark_ActionBar = global::XForms.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dark_ActionBar;
+			global::Microsoft.Identity.Client.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog = global::XForms.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog;
+			global::Microsoft.Identity.Client.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert = global::XForms.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Dialog_Alert;
 			global::Microsoft.Identity.Client.Resource.Style.Base_ThemeOverlay_AppCompat_Light = global::XForms.Droid.Resource.Style.Base_ThemeOverlay_AppCompat_Light;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V11_Theme_AppCompat_Dialog = global::XForms.Droid.Resource.Style.Base_V11_Theme_AppCompat_Dialog;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog = global::XForms.Droid.Resource.Style.Base_V11_Theme_AppCompat_Light_Dialog;
+			global::Microsoft.Identity.Client.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog = global::XForms.Droid.Resource.Style.Base_V11_ThemeOverlay_AppCompat_Dialog;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView = global::XForms.Droid.Resource.Style.Base_V12_Widget_AppCompat_AutoCompleteTextView;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V12_Widget_AppCompat_EditText = global::XForms.Droid.Resource.Style.Base_V12_Widget_AppCompat_EditText;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V21_Theme_AppCompat = global::XForms.Droid.Resource.Style.Base_V21_Theme_AppCompat;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V21_Theme_AppCompat_Dialog = global::XForms.Droid.Resource.Style.Base_V21_Theme_AppCompat_Dialog;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V21_Theme_AppCompat_Light = global::XForms.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog = global::XForms.Droid.Resource.Style.Base_V21_Theme_AppCompat_Light_Dialog;
+			global::Microsoft.Identity.Client.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog = global::XForms.Droid.Resource.Style.Base_V21_ThemeOverlay_AppCompat_Dialog;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V22_Theme_AppCompat = global::XForms.Droid.Resource.Style.Base_V22_Theme_AppCompat;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V22_Theme_AppCompat_Light = global::XForms.Droid.Resource.Style.Base_V22_Theme_AppCompat_Light;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V23_Theme_AppCompat = global::XForms.Droid.Resource.Style.Base_V23_Theme_AppCompat;
@@ -721,6 +835,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Base_V7_Theme_AppCompat_Dialog = global::XForms.Droid.Resource.Style.Base_V7_Theme_AppCompat_Dialog;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V7_Theme_AppCompat_Light = global::XForms.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V7_Theme_AppCompat_Light_Dialog = global::XForms.Droid.Resource.Style.Base_V7_Theme_AppCompat_Light_Dialog;
+			global::Microsoft.Identity.Client.Resource.Style.Base_V7_ThemeOverlay_AppCompat_Dialog = global::XForms.Droid.Resource.Style.Base_V7_ThemeOverlay_AppCompat_Dialog;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V7_Widget_AppCompat_AutoCompleteTextView = global::XForms.Droid.Resource.Style.Base_V7_Widget_AppCompat_AutoCompleteTextView;
 			global::Microsoft.Identity.Client.Resource.Style.Base_V7_Widget_AppCompat_EditText = global::XForms.Droid.Resource.Style.Base_V7_Widget_AppCompat_EditText;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_ActionBar = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_ActionBar;
@@ -758,6 +873,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_Light_ActionBar_TabView = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_Light_ActionBar_TabView;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu_Overflow = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_Light_PopupMenu_Overflow;
+			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_ListMenuView = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_ListMenuView;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_ListPopupWindow = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_ListPopupWindow;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_ListView = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_ListView;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_ListView_DropDown = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_ListView_DropDown;
@@ -773,6 +889,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_SearchView = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_SearchView;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_SearchView_ActionBar = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_SearchView_ActionBar;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_SeekBar = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar;
+			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_SeekBar_Discrete = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_SeekBar_Discrete;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_Spinner = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_Spinner;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_Spinner_Underlined = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_Spinner_Underlined;
 			global::Microsoft.Identity.Client.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem = global::XForms.Droid.Resource.Style.Base_Widget_AppCompat_TextView_SpinnerItem;
@@ -787,6 +904,8 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Platform_V11_AppCompat_Light = global::XForms.Droid.Resource.Style.Platform_V11_AppCompat_Light;
 			global::Microsoft.Identity.Client.Resource.Style.Platform_V14_AppCompat = global::XForms.Droid.Resource.Style.Platform_V14_AppCompat;
 			global::Microsoft.Identity.Client.Resource.Style.Platform_V14_AppCompat_Light = global::XForms.Droid.Resource.Style.Platform_V14_AppCompat_Light;
+			global::Microsoft.Identity.Client.Resource.Style.Platform_V21_AppCompat = global::XForms.Droid.Resource.Style.Platform_V21_AppCompat;
+			global::Microsoft.Identity.Client.Resource.Style.Platform_V21_AppCompat_Light = global::XForms.Droid.Resource.Style.Platform_V21_AppCompat_Light;
 			global::Microsoft.Identity.Client.Resource.Style.Platform_Widget_AppCompat_Spinner = global::XForms.Droid.Resource.Style.Platform_Widget_AppCompat_Spinner;
 			global::Microsoft.Identity.Client.Resource.Style.RtlOverlay_DialogWindowTitle_AppCompat = global::XForms.Droid.Resource.Style.RtlOverlay_DialogWindowTitle_AppCompat;
 			global::Microsoft.Identity.Client.Resource.Style.RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = global::XForms.Droid.Resource.Style.RtlOverlay_Widget_AppCompat_ActionBar_TitleItem;
@@ -822,6 +941,16 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Medium = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Medium;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Medium_Inverse = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Medium_Inverse;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Menu = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Menu;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Info = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Info_Media = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Info_Media;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Line2 = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Line2_Media = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Line2_Media;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Media = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Media;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Time = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Time_Media = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Time_Media;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Title = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Notification_Title_Media = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Notification_Title_Media;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_SearchResult_Subtitle = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Subtitle;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_SearchResult_Title = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_SearchResult_Title;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Small = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Small;
@@ -840,8 +969,11 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_Button = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_Button_Borderless_Colored = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Borderless_Colored;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_Button_Colored = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Colored;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_Button_Inverse = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Button_Inverse;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_DropDownItem = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_DropDownItem;
+			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Header = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Header;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Large = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Large;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Small = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_PopupMenu_Small;
 			global::Microsoft.Identity.Client.Resource.Style.TextAppearance_AppCompat_Widget_Switch = global::XForms.Droid.Resource.Style.TextAppearance_AppCompat_Widget_Switch;
@@ -879,6 +1011,8 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.ThemeOverlay_AppCompat_ActionBar = global::XForms.Droid.Resource.Style.ThemeOverlay_AppCompat_ActionBar;
 			global::Microsoft.Identity.Client.Resource.Style.ThemeOverlay_AppCompat_Dark = global::XForms.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark;
 			global::Microsoft.Identity.Client.Resource.Style.ThemeOverlay_AppCompat_Dark_ActionBar = global::XForms.Droid.Resource.Style.ThemeOverlay_AppCompat_Dark_ActionBar;
+			global::Microsoft.Identity.Client.Resource.Style.ThemeOverlay_AppCompat_Dialog = global::XForms.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog;
+			global::Microsoft.Identity.Client.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert = global::XForms.Droid.Resource.Style.ThemeOverlay_AppCompat_Dialog_Alert;
 			global::Microsoft.Identity.Client.Resource.Style.ThemeOverlay_AppCompat_Light = global::XForms.Droid.Resource.Style.ThemeOverlay_AppCompat_Light;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_ActionBar = global::XForms.Droid.Resource.Style.Widget_AppCompat_ActionBar;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_ActionBar_Solid = global::XForms.Droid.Resource.Style.Widget_AppCompat_ActionBar_Solid;
@@ -928,10 +1062,13 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_Light_PopupMenu_Overflow = global::XForms.Droid.Resource.Style.Widget_AppCompat_Light_PopupMenu_Overflow;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_Light_SearchView = global::XForms.Droid.Resource.Style.Widget_AppCompat_Light_SearchView;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_Light_Spinner_DropDown_ActionBar = global::XForms.Droid.Resource.Style.Widget_AppCompat_Light_Spinner_DropDown_ActionBar;
+			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_ListMenuView = global::XForms.Droid.Resource.Style.Widget_AppCompat_ListMenuView;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_ListPopupWindow = global::XForms.Droid.Resource.Style.Widget_AppCompat_ListPopupWindow;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_ListView = global::XForms.Droid.Resource.Style.Widget_AppCompat_ListView;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_ListView_DropDown = global::XForms.Droid.Resource.Style.Widget_AppCompat_ListView_DropDown;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_ListView_Menu = global::XForms.Droid.Resource.Style.Widget_AppCompat_ListView_Menu;
+			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_NotificationActionContainer = global::XForms.Droid.Resource.Style.Widget_AppCompat_NotificationActionContainer;
+			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_NotificationActionText = global::XForms.Droid.Resource.Style.Widget_AppCompat_NotificationActionText;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_PopupMenu = global::XForms.Droid.Resource.Style.Widget_AppCompat_PopupMenu;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_PopupMenu_Overflow = global::XForms.Droid.Resource.Style.Widget_AppCompat_PopupMenu_Overflow;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_PopupWindow = global::XForms.Droid.Resource.Style.Widget_AppCompat_PopupWindow;
@@ -943,6 +1080,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_SearchView = global::XForms.Droid.Resource.Style.Widget_AppCompat_SearchView;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_SearchView_ActionBar = global::XForms.Droid.Resource.Style.Widget_AppCompat_SearchView_ActionBar;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_SeekBar = global::XForms.Droid.Resource.Style.Widget_AppCompat_SeekBar;
+			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_SeekBar_Discrete = global::XForms.Droid.Resource.Style.Widget_AppCompat_SeekBar_Discrete;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_Spinner = global::XForms.Droid.Resource.Style.Widget_AppCompat_Spinner;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_Spinner_DropDown = global::XForms.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown;
 			global::Microsoft.Identity.Client.Resource.Style.Widget_AppCompat_Spinner_DropDown_ActionBar = global::XForms.Droid.Resource.Style.Widget_AppCompat_Spinner_DropDown_ActionBar;
@@ -955,9 +1093,11 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_backgroundSplit = global::XForms.Droid.Resource.Styleable.ActionBar_backgroundSplit;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_backgroundStacked = global::XForms.Droid.Resource.Styleable.ActionBar_backgroundStacked;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_contentInsetEnd = global::XForms.Droid.Resource.Styleable.ActionBar_contentInsetEnd;
+			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_contentInsetEndWithActions = global::XForms.Droid.Resource.Styleable.ActionBar_contentInsetEndWithActions;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_contentInsetLeft = global::XForms.Droid.Resource.Styleable.ActionBar_contentInsetLeft;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_contentInsetRight = global::XForms.Droid.Resource.Styleable.ActionBar_contentInsetRight;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_contentInsetStart = global::XForms.Droid.Resource.Styleable.ActionBar_contentInsetStart;
+			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_contentInsetStartWithNavigation = global::XForms.Droid.Resource.Styleable.ActionBar_contentInsetStartWithNavigation;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_customNavigationLayout = global::XForms.Droid.Resource.Styleable.ActionBar_customNavigationLayout;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_displayOptions = global::XForms.Droid.Resource.Styleable.ActionBar_displayOptions;
 			global::Microsoft.Identity.Client.Resource.Styleable.ActionBar_divider = global::XForms.Droid.Resource.Styleable.ActionBar_divider;
@@ -999,10 +1139,24 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.AlertDialog_listItemLayout = global::XForms.Droid.Resource.Styleable.AlertDialog_listItemLayout;
 			global::Microsoft.Identity.Client.Resource.Styleable.AlertDialog_listLayout = global::XForms.Droid.Resource.Styleable.AlertDialog_listLayout;
 			global::Microsoft.Identity.Client.Resource.Styleable.AlertDialog_multiChoiceItemLayout = global::XForms.Droid.Resource.Styleable.AlertDialog_multiChoiceItemLayout;
+			global::Microsoft.Identity.Client.Resource.Styleable.AlertDialog_showTitle = global::XForms.Droid.Resource.Styleable.AlertDialog_showTitle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AlertDialog_singleChoiceItemLayout = global::XForms.Droid.Resource.Styleable.AlertDialog_singleChoiceItemLayout;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatImageView = global::XForms.Droid.Resource.Styleable.AppCompatImageView;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatImageView_android_src = global::XForms.Droid.Resource.Styleable.AppCompatImageView_android_src;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatImageView_srcCompat = global::XForms.Droid.Resource.Styleable.AppCompatImageView_srcCompat;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatSeekBar = global::XForms.Droid.Resource.Styleable.AppCompatSeekBar;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatSeekBar_android_thumb = global::XForms.Droid.Resource.Styleable.AppCompatSeekBar_android_thumb;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatSeekBar_tickMark = global::XForms.Droid.Resource.Styleable.AppCompatSeekBar_tickMark;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatSeekBar_tickMarkTint = global::XForms.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTint;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatSeekBar_tickMarkTintMode = global::XForms.Droid.Resource.Styleable.AppCompatSeekBar_tickMarkTintMode;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper_android_drawableBottom = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableBottom;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper_android_drawableEnd = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableEnd;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper_android_drawableLeft = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableLeft;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper_android_drawableRight = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableRight;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper_android_drawableStart = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableStart;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper_android_drawableTop = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper_android_drawableTop;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextHelper_android_textAppearance = global::XForms.Droid.Resource.Styleable.AppCompatTextHelper_android_textAppearance;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextView = global::XForms.Droid.Resource.Styleable.AppCompatTextView;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextView_android_textAppearance = global::XForms.Droid.Resource.Styleable.AppCompatTextView_android_textAppearance;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTextView_textAllCaps = global::XForms.Droid.Resource.Styleable.AppCompatTextView_textAllCaps;
@@ -1056,6 +1210,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_checkboxStyle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_checkboxStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_checkedTextViewStyle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_checkedTextViewStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_colorAccent = global::XForms.Droid.Resource.Styleable.AppCompatTheme_colorAccent;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_colorBackgroundFloating = global::XForms.Droid.Resource.Styleable.AppCompatTheme_colorBackgroundFloating;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_colorButtonNormal = global::XForms.Droid.Resource.Styleable.AppCompatTheme_colorButtonNormal;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_colorControlActivated = global::XForms.Droid.Resource.Styleable.AppCompatTheme_colorControlActivated;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_colorControlHighlight = global::XForms.Droid.Resource.Styleable.AppCompatTheme_colorControlHighlight;
@@ -1077,6 +1232,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_imageButtonStyle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_imageButtonStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_listChoiceBackgroundIndicator = global::XForms.Droid.Resource.Styleable.AppCompatTheme_listChoiceBackgroundIndicator;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_listDividerAlertDialog = global::XForms.Droid.Resource.Styleable.AppCompatTheme_listDividerAlertDialog;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_listMenuViewStyle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_listMenuViewStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_listPopupWindowStyle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_listPopupWindowStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_listPreferredItemHeight = global::XForms.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeight;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_listPreferredItemHeightLarge = global::XForms.Droid.Resource.Styleable.AppCompatTheme_listPreferredItemHeightLarge;
@@ -1102,6 +1258,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_textAppearanceLargePopupMenu = global::XForms.Droid.Resource.Styleable.AppCompatTheme_textAppearanceLargePopupMenu;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_textAppearanceListItem = global::XForms.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItem;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_textAppearanceListItemSmall = global::XForms.Droid.Resource.Styleable.AppCompatTheme_textAppearanceListItemSmall;
+			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_textAppearancePopupMenuHeader = global::XForms.Droid.Resource.Styleable.AppCompatTheme_textAppearancePopupMenuHeader;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultSubtitle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultSubtitle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultTitle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSearchResultTitle;
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_textAppearanceSmallPopupMenu = global::XForms.Droid.Resource.Styleable.AppCompatTheme_textAppearanceSmallPopupMenu;
@@ -1121,6 +1278,10 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.AppCompatTheme_windowNoTitle = global::XForms.Droid.Resource.Styleable.AppCompatTheme_windowNoTitle;
 			global::Microsoft.Identity.Client.Resource.Styleable.ButtonBarLayout = global::XForms.Droid.Resource.Styleable.ButtonBarLayout;
 			global::Microsoft.Identity.Client.Resource.Styleable.ButtonBarLayout_allowStacking = global::XForms.Droid.Resource.Styleable.ButtonBarLayout_allowStacking;
+			global::Microsoft.Identity.Client.Resource.Styleable.ColorStateListItem = global::XForms.Droid.Resource.Styleable.ColorStateListItem;
+			global::Microsoft.Identity.Client.Resource.Styleable.ColorStateListItem_alpha = global::XForms.Droid.Resource.Styleable.ColorStateListItem_alpha;
+			global::Microsoft.Identity.Client.Resource.Styleable.ColorStateListItem_android_alpha = global::XForms.Droid.Resource.Styleable.ColorStateListItem_android_alpha;
+			global::Microsoft.Identity.Client.Resource.Styleable.ColorStateListItem_android_color = global::XForms.Droid.Resource.Styleable.ColorStateListItem_android_color;
 			global::Microsoft.Identity.Client.Resource.Styleable.CompoundButton = global::XForms.Droid.Resource.Styleable.CompoundButton;
 			global::Microsoft.Identity.Client.Resource.Styleable.CompoundButton_android_button = global::XForms.Droid.Resource.Styleable.CompoundButton_android_button;
 			global::Microsoft.Identity.Client.Resource.Styleable.CompoundButton_buttonTint = global::XForms.Droid.Resource.Styleable.CompoundButton_buttonTint;
@@ -1186,11 +1347,16 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.MenuView_android_verticalDivider = global::XForms.Droid.Resource.Styleable.MenuView_android_verticalDivider;
 			global::Microsoft.Identity.Client.Resource.Styleable.MenuView_android_windowAnimationStyle = global::XForms.Droid.Resource.Styleable.MenuView_android_windowAnimationStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.MenuView_preserveIconSpacing = global::XForms.Droid.Resource.Styleable.MenuView_preserveIconSpacing;
+			global::Microsoft.Identity.Client.Resource.Styleable.MenuView_subMenuArrow = global::XForms.Droid.Resource.Styleable.MenuView_subMenuArrow;
 			global::Microsoft.Identity.Client.Resource.Styleable.PopupWindow = global::XForms.Droid.Resource.Styleable.PopupWindow;
+			global::Microsoft.Identity.Client.Resource.Styleable.PopupWindow_android_popupAnimationStyle = global::XForms.Droid.Resource.Styleable.PopupWindow_android_popupAnimationStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.PopupWindow_android_popupBackground = global::XForms.Droid.Resource.Styleable.PopupWindow_android_popupBackground;
 			global::Microsoft.Identity.Client.Resource.Styleable.PopupWindow_overlapAnchor = global::XForms.Droid.Resource.Styleable.PopupWindow_overlapAnchor;
 			global::Microsoft.Identity.Client.Resource.Styleable.PopupWindowBackgroundState = global::XForms.Droid.Resource.Styleable.PopupWindowBackgroundState;
 			global::Microsoft.Identity.Client.Resource.Styleable.PopupWindowBackgroundState_state_above_anchor = global::XForms.Droid.Resource.Styleable.PopupWindowBackgroundState_state_above_anchor;
+			global::Microsoft.Identity.Client.Resource.Styleable.RecycleListView = global::XForms.Droid.Resource.Styleable.RecycleListView;
+			global::Microsoft.Identity.Client.Resource.Styleable.RecycleListView_paddingBottomNoButtons = global::XForms.Droid.Resource.Styleable.RecycleListView_paddingBottomNoButtons;
+			global::Microsoft.Identity.Client.Resource.Styleable.RecycleListView_paddingTopNoTitle = global::XForms.Droid.Resource.Styleable.RecycleListView_paddingTopNoTitle;
 			global::Microsoft.Identity.Client.Resource.Styleable.SearchView = global::XForms.Droid.Resource.Styleable.SearchView;
 			global::Microsoft.Identity.Client.Resource.Styleable.SearchView_android_focusable = global::XForms.Droid.Resource.Styleable.SearchView_android_focusable;
 			global::Microsoft.Identity.Client.Resource.Styleable.SearchView_android_imeOptions = global::XForms.Droid.Resource.Styleable.SearchView_android_imeOptions;
@@ -1225,13 +1391,18 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_switchPadding = global::XForms.Droid.Resource.Styleable.SwitchCompat_switchPadding;
 			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_switchTextAppearance = global::XForms.Droid.Resource.Styleable.SwitchCompat_switchTextAppearance;
 			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_thumbTextPadding = global::XForms.Droid.Resource.Styleable.SwitchCompat_thumbTextPadding;
+			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_thumbTint = global::XForms.Droid.Resource.Styleable.SwitchCompat_thumbTint;
+			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_thumbTintMode = global::XForms.Droid.Resource.Styleable.SwitchCompat_thumbTintMode;
 			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_track = global::XForms.Droid.Resource.Styleable.SwitchCompat_track;
+			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_trackTint = global::XForms.Droid.Resource.Styleable.SwitchCompat_trackTint;
+			global::Microsoft.Identity.Client.Resource.Styleable.SwitchCompat_trackTintMode = global::XForms.Droid.Resource.Styleable.SwitchCompat_trackTintMode;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance = global::XForms.Droid.Resource.Styleable.TextAppearance;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_shadowColor = global::XForms.Droid.Resource.Styleable.TextAppearance_android_shadowColor;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_shadowDx = global::XForms.Droid.Resource.Styleable.TextAppearance_android_shadowDx;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_shadowDy = global::XForms.Droid.Resource.Styleable.TextAppearance_android_shadowDy;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_shadowRadius = global::XForms.Droid.Resource.Styleable.TextAppearance_android_shadowRadius;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_textColor = global::XForms.Droid.Resource.Styleable.TextAppearance_android_textColor;
+			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_textColorHint = global::XForms.Droid.Resource.Styleable.TextAppearance_android_textColorHint;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_textSize = global::XForms.Droid.Resource.Styleable.TextAppearance_android_textSize;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_textStyle = global::XForms.Droid.Resource.Styleable.TextAppearance_android_textStyle;
 			global::Microsoft.Identity.Client.Resource.Styleable.TextAppearance_android_typeface = global::XForms.Droid.Resource.Styleable.TextAppearance_android_typeface;
@@ -1239,12 +1410,15 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar = global::XForms.Droid.Resource.Styleable.Toolbar;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_android_gravity = global::XForms.Droid.Resource.Styleable.Toolbar_android_gravity;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_android_minHeight = global::XForms.Droid.Resource.Styleable.Toolbar_android_minHeight;
+			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_buttonGravity = global::XForms.Droid.Resource.Styleable.Toolbar_buttonGravity;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_collapseContentDescription = global::XForms.Droid.Resource.Styleable.Toolbar_collapseContentDescription;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_collapseIcon = global::XForms.Droid.Resource.Styleable.Toolbar_collapseIcon;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_contentInsetEnd = global::XForms.Droid.Resource.Styleable.Toolbar_contentInsetEnd;
+			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_contentInsetEndWithActions = global::XForms.Droid.Resource.Styleable.Toolbar_contentInsetEndWithActions;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_contentInsetLeft = global::XForms.Droid.Resource.Styleable.Toolbar_contentInsetLeft;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_contentInsetRight = global::XForms.Droid.Resource.Styleable.Toolbar_contentInsetRight;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_contentInsetStart = global::XForms.Droid.Resource.Styleable.Toolbar_contentInsetStart;
+			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_contentInsetStartWithNavigation = global::XForms.Droid.Resource.Styleable.Toolbar_contentInsetStartWithNavigation;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_logo = global::XForms.Droid.Resource.Styleable.Toolbar_logo;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_logoDescription = global::XForms.Droid.Resource.Styleable.Toolbar_logoDescription;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_maxButtonHeight = global::XForms.Droid.Resource.Styleable.Toolbar_maxButtonHeight;
@@ -1255,6 +1429,7 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_subtitleTextAppearance = global::XForms.Droid.Resource.Styleable.Toolbar_subtitleTextAppearance;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_subtitleTextColor = global::XForms.Droid.Resource.Styleable.Toolbar_subtitleTextColor;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_title = global::XForms.Droid.Resource.Styleable.Toolbar_title;
+			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_titleMargin = global::XForms.Droid.Resource.Styleable.Toolbar_titleMargin;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_titleMarginBottom = global::XForms.Droid.Resource.Styleable.Toolbar_titleMarginBottom;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_titleMarginEnd = global::XForms.Droid.Resource.Styleable.Toolbar_titleMarginEnd;
 			global::Microsoft.Identity.Client.Resource.Styleable.Toolbar_titleMarginStart = global::XForms.Droid.Resource.Styleable.Toolbar_titleMarginStart;
@@ -1346,200 +1521,206 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f010004
 			public const int MediaRouteControllerWindowBackground = 2130771972;
 			
-			// aapt resource value: 0x7f010061
-			public const int actionBarDivider = 2130772065;
-			
-			// aapt resource value: 0x7f010062
-			public const int actionBarItemBackground = 2130772066;
-			
-			// aapt resource value: 0x7f01005b
-			public const int actionBarPopupTheme = 2130772059;
-			
-			// aapt resource value: 0x7f010060
-			public const int actionBarSize = 2130772064;
-			
-			// aapt resource value: 0x7f01005d
-			public const int actionBarSplitStyle = 2130772061;
-			
-			// aapt resource value: 0x7f01005c
-			public const int actionBarStyle = 2130772060;
-			
-			// aapt resource value: 0x7f010057
-			public const int actionBarTabBarStyle = 2130772055;
-			
-			// aapt resource value: 0x7f010056
-			public const int actionBarTabStyle = 2130772054;
-			
-			// aapt resource value: 0x7f010058
-			public const int actionBarTabTextStyle = 2130772056;
-			
-			// aapt resource value: 0x7f01005e
-			public const int actionBarTheme = 2130772062;
-			
-			// aapt resource value: 0x7f01005f
-			public const int actionBarWidgetTheme = 2130772063;
-			
-			// aapt resource value: 0x7f01007b
-			public const int actionButtonStyle = 2130772091;
-			
-			// aapt resource value: 0x7f010077
-			public const int actionDropDownStyle = 2130772087;
-			
-			// aapt resource value: 0x7f0100c9
-			public const int actionLayout = 2130772169;
-			
-			// aapt resource value: 0x7f010063
-			public const int actionMenuTextAppearance = 2130772067;
-			
-			// aapt resource value: 0x7f010064
-			public const int actionMenuTextColor = 2130772068;
-			
-			// aapt resource value: 0x7f010067
-			public const int actionModeBackground = 2130772071;
-			
-			// aapt resource value: 0x7f010066
-			public const int actionModeCloseButtonStyle = 2130772070;
-			
-			// aapt resource value: 0x7f010069
-			public const int actionModeCloseDrawable = 2130772073;
-			
-			// aapt resource value: 0x7f01006b
-			public const int actionModeCopyDrawable = 2130772075;
-			
-			// aapt resource value: 0x7f01006a
-			public const int actionModeCutDrawable = 2130772074;
-			
-			// aapt resource value: 0x7f01006f
-			public const int actionModeFindDrawable = 2130772079;
-			
-			// aapt resource value: 0x7f01006c
-			public const int actionModePasteDrawable = 2130772076;
-			
-			// aapt resource value: 0x7f010071
-			public const int actionModePopupWindowStyle = 2130772081;
-			
-			// aapt resource value: 0x7f01006d
-			public const int actionModeSelectAllDrawable = 2130772077;
-			
-			// aapt resource value: 0x7f01006e
-			public const int actionModeShareDrawable = 2130772078;
-			
-			// aapt resource value: 0x7f010068
-			public const int actionModeSplitBackground = 2130772072;
-			
-			// aapt resource value: 0x7f010065
-			public const int actionModeStyle = 2130772069;
-			
-			// aapt resource value: 0x7f010070
-			public const int actionModeWebSearchDrawable = 2130772080;
-			
-			// aapt resource value: 0x7f010059
-			public const int actionOverflowButtonStyle = 2130772057;
-			
-			// aapt resource value: 0x7f01005a
-			public const int actionOverflowMenuStyle = 2130772058;
-			
-			// aapt resource value: 0x7f0100cb
-			public const int actionProviderClass = 2130772171;
-			
-			// aapt resource value: 0x7f0100ca
-			public const int actionViewClass = 2130772170;
-			
-			// aapt resource value: 0x7f010083
-			public const int activityChooserViewStyle = 2130772099;
-			
-			// aapt resource value: 0x7f0100a6
-			public const int alertDialogButtonGroupStyle = 2130772134;
-			
-			// aapt resource value: 0x7f0100a7
-			public const int alertDialogCenterButtons = 2130772135;
-			
-			// aapt resource value: 0x7f0100a5
-			public const int alertDialogStyle = 2130772133;
-			
-			// aapt resource value: 0x7f0100a8
-			public const int alertDialogTheme = 2130772136;
-			
-			// aapt resource value: 0x7f0100ba
-			public const int allowStacking = 2130772154;
-			
-			// aapt resource value: 0x7f0100c1
-			public const int arrowHeadLength = 2130772161;
-			
-			// aapt resource value: 0x7f0100c2
-			public const int arrowShaftLength = 2130772162;
+			// aapt resource value: 0x7f0100ac
+			public const int actionBarDivider = 2130772140;
 			
 			// aapt resource value: 0x7f0100ad
-			public const int autoCompleteTextViewStyle = 2130772141;
+			public const int actionBarItemBackground = 2130772141;
 			
-			// aapt resource value: 0x7f010032
-			public const int background = 2130772018;
-			
-			// aapt resource value: 0x7f010034
-			public const int backgroundSplit = 2130772020;
-			
-			// aapt resource value: 0x7f010033
-			public const int backgroundStacked = 2130772019;
-			
-			// aapt resource value: 0x7f0100f5
-			public const int backgroundTint = 2130772213;
-			
-			// aapt resource value: 0x7f0100f6
-			public const int backgroundTintMode = 2130772214;
-			
-			// aapt resource value: 0x7f0100c3
-			public const int barLength = 2130772163;
-			
-			// aapt resource value: 0x7f0100fb
-			public const int behavior_hideable = 2130772219;
-			
-			// aapt resource value: 0x7f010121
-			public const int behavior_overlapTop = 2130772257;
-			
-			// aapt resource value: 0x7f0100fa
-			public const int behavior_peekHeight = 2130772218;
-			
-			// aapt resource value: 0x7f010117
-			public const int borderWidth = 2130772247;
-			
-			// aapt resource value: 0x7f010080
-			public const int borderlessButtonStyle = 2130772096;
-			
-			// aapt resource value: 0x7f010111
-			public const int bottomSheetDialogTheme = 2130772241;
-			
-			// aapt resource value: 0x7f010112
-			public const int bottomSheetStyle = 2130772242;
-			
-			// aapt resource value: 0x7f01007d
-			public const int buttonBarButtonStyle = 2130772093;
+			// aapt resource value: 0x7f0100a6
+			public const int actionBarPopupTheme = 2130772134;
 			
 			// aapt resource value: 0x7f0100ab
-			public const int buttonBarNegativeButtonStyle = 2130772139;
+			public const int actionBarSize = 2130772139;
 			
-			// aapt resource value: 0x7f0100ac
-			public const int buttonBarNeutralButtonStyle = 2130772140;
+			// aapt resource value: 0x7f0100a8
+			public const int actionBarSplitStyle = 2130772136;
+			
+			// aapt resource value: 0x7f0100a7
+			public const int actionBarStyle = 2130772135;
+			
+			// aapt resource value: 0x7f0100a2
+			public const int actionBarTabBarStyle = 2130772130;
+			
+			// aapt resource value: 0x7f0100a1
+			public const int actionBarTabStyle = 2130772129;
+			
+			// aapt resource value: 0x7f0100a3
+			public const int actionBarTabTextStyle = 2130772131;
+			
+			// aapt resource value: 0x7f0100a9
+			public const int actionBarTheme = 2130772137;
 			
 			// aapt resource value: 0x7f0100aa
-			public const int buttonBarPositiveButtonStyle = 2130772138;
+			public const int actionBarWidgetTheme = 2130772138;
 			
-			// aapt resource value: 0x7f01007c
-			public const int buttonBarStyle = 2130772092;
+			// aapt resource value: 0x7f0100c7
+			public const int actionButtonStyle = 2130772167;
 			
-			// aapt resource value: 0x7f010045
-			public const int buttonPanelSideLayout = 2130772037;
+			// aapt resource value: 0x7f0100c3
+			public const int actionDropDownStyle = 2130772163;
+			
+			// aapt resource value: 0x7f010118
+			public const int actionLayout = 2130772248;
 			
 			// aapt resource value: 0x7f0100ae
-			public const int buttonStyle = 2130772142;
+			public const int actionMenuTextAppearance = 2130772142;
 			
 			// aapt resource value: 0x7f0100af
-			public const int buttonStyleSmall = 2130772143;
+			public const int actionMenuTextColor = 2130772143;
 			
-			// aapt resource value: 0x7f0100bb
-			public const int buttonTint = 2130772155;
+			// aapt resource value: 0x7f0100b2
+			public const int actionModeBackground = 2130772146;
+			
+			// aapt resource value: 0x7f0100b1
+			public const int actionModeCloseButtonStyle = 2130772145;
+			
+			// aapt resource value: 0x7f0100b4
+			public const int actionModeCloseDrawable = 2130772148;
+			
+			// aapt resource value: 0x7f0100b6
+			public const int actionModeCopyDrawable = 2130772150;
+			
+			// aapt resource value: 0x7f0100b5
+			public const int actionModeCutDrawable = 2130772149;
+			
+			// aapt resource value: 0x7f0100ba
+			public const int actionModeFindDrawable = 2130772154;
+			
+			// aapt resource value: 0x7f0100b7
+			public const int actionModePasteDrawable = 2130772151;
 			
 			// aapt resource value: 0x7f0100bc
-			public const int buttonTintMode = 2130772156;
+			public const int actionModePopupWindowStyle = 2130772156;
+			
+			// aapt resource value: 0x7f0100b8
+			public const int actionModeSelectAllDrawable = 2130772152;
+			
+			// aapt resource value: 0x7f0100b9
+			public const int actionModeShareDrawable = 2130772153;
+			
+			// aapt resource value: 0x7f0100b3
+			public const int actionModeSplitBackground = 2130772147;
+			
+			// aapt resource value: 0x7f0100b0
+			public const int actionModeStyle = 2130772144;
+			
+			// aapt resource value: 0x7f0100bb
+			public const int actionModeWebSearchDrawable = 2130772155;
+			
+			// aapt resource value: 0x7f0100a4
+			public const int actionOverflowButtonStyle = 2130772132;
+			
+			// aapt resource value: 0x7f0100a5
+			public const int actionOverflowMenuStyle = 2130772133;
+			
+			// aapt resource value: 0x7f01011a
+			public const int actionProviderClass = 2130772250;
+			
+			// aapt resource value: 0x7f010119
+			public const int actionViewClass = 2130772249;
+			
+			// aapt resource value: 0x7f0100cf
+			public const int activityChooserViewStyle = 2130772175;
+			
+			// aapt resource value: 0x7f0100f3
+			public const int alertDialogButtonGroupStyle = 2130772211;
+			
+			// aapt resource value: 0x7f0100f4
+			public const int alertDialogCenterButtons = 2130772212;
+			
+			// aapt resource value: 0x7f0100f2
+			public const int alertDialogStyle = 2130772210;
+			
+			// aapt resource value: 0x7f0100f5
+			public const int alertDialogTheme = 2130772213;
+			
+			// aapt resource value: 0x7f010108
+			public const int allowStacking = 2130772232;
+			
+			// aapt resource value: 0x7f010109
+			public const int alpha = 2130772233;
+			
+			// aapt resource value: 0x7f010110
+			public const int arrowHeadLength = 2130772240;
+			
+			// aapt resource value: 0x7f010111
+			public const int arrowShaftLength = 2130772241;
+			
+			// aapt resource value: 0x7f0100fa
+			public const int autoCompleteTextViewStyle = 2130772218;
+			
+			// aapt resource value: 0x7f010077
+			public const int background = 2130772087;
+			
+			// aapt resource value: 0x7f010079
+			public const int backgroundSplit = 2130772089;
+			
+			// aapt resource value: 0x7f010078
+			public const int backgroundStacked = 2130772088;
+			
+			// aapt resource value: 0x7f01014d
+			public const int backgroundTint = 2130772301;
+			
+			// aapt resource value: 0x7f01014e
+			public const int backgroundTintMode = 2130772302;
+			
+			// aapt resource value: 0x7f010112
+			public const int barLength = 2130772242;
+			
+			// aapt resource value: 0x7f01002a
+			public const int behavior_hideable = 2130772010;
+			
+			// aapt resource value: 0x7f010050
+			public const int behavior_overlapTop = 2130772048;
+			
+			// aapt resource value: 0x7f010029
+			public const int behavior_peekHeight = 2130772009;
+			
+			// aapt resource value: 0x7f010046
+			public const int borderWidth = 2130772038;
+			
+			// aapt resource value: 0x7f0100cc
+			public const int borderlessButtonStyle = 2130772172;
+			
+			// aapt resource value: 0x7f010040
+			public const int bottomSheetDialogTheme = 2130772032;
+			
+			// aapt resource value: 0x7f010041
+			public const int bottomSheetStyle = 2130772033;
+			
+			// aapt resource value: 0x7f0100c9
+			public const int buttonBarButtonStyle = 2130772169;
+			
+			// aapt resource value: 0x7f0100f8
+			public const int buttonBarNegativeButtonStyle = 2130772216;
+			
+			// aapt resource value: 0x7f0100f9
+			public const int buttonBarNeutralButtonStyle = 2130772217;
+			
+			// aapt resource value: 0x7f0100f7
+			public const int buttonBarPositiveButtonStyle = 2130772215;
+			
+			// aapt resource value: 0x7f0100c8
+			public const int buttonBarStyle = 2130772168;
+			
+			// aapt resource value: 0x7f010142
+			public const int buttonGravity = 2130772290;
+			
+			// aapt resource value: 0x7f01008c
+			public const int buttonPanelSideLayout = 2130772108;
+			
+			// aapt resource value: 0x7f0100fb
+			public const int buttonStyle = 2130772219;
+			
+			// aapt resource value: 0x7f0100fc
+			public const int buttonStyleSmall = 2130772220;
+			
+			// aapt resource value: 0x7f01010a
+			public const int buttonTint = 2130772234;
+			
+			// aapt resource value: 0x7f01010b
+			public const int buttonTintMode = 2130772235;
 			
 			// aapt resource value: 0x7f01001b
 			public const int cardBackgroundColor = 2130771995;
@@ -1559,71 +1740,80 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f01001f
 			public const int cardUseCompatPadding = 2130771999;
 			
-			// aapt resource value: 0x7f0100b0
-			public const int checkboxStyle = 2130772144;
+			// aapt resource value: 0x7f0100fd
+			public const int checkboxStyle = 2130772221;
 			
-			// aapt resource value: 0x7f0100b1
-			public const int checkedTextViewStyle = 2130772145;
+			// aapt resource value: 0x7f0100fe
+			public const int checkedTextViewStyle = 2130772222;
 			
-			// aapt resource value: 0x7f0100d3
-			public const int closeIcon = 2130772179;
+			// aapt resource value: 0x7f010125
+			public const int closeIcon = 2130772261;
 			
-			// aapt resource value: 0x7f010042
-			public const int closeItemLayout = 2130772034;
+			// aapt resource value: 0x7f010089
+			public const int closeItemLayout = 2130772105;
+			
+			// aapt resource value: 0x7f010144
+			public const int collapseContentDescription = 2130772292;
+			
+			// aapt resource value: 0x7f010143
+			public const int collapseIcon = 2130772291;
+			
+			// aapt resource value: 0x7f010037
+			public const int collapsedTitleGravity = 2130772023;
+			
+			// aapt resource value: 0x7f010033
+			public const int collapsedTitleTextAppearance = 2130772019;
+			
+			// aapt resource value: 0x7f01010c
+			public const int color = 2130772236;
+			
+			// aapt resource value: 0x7f0100ea
+			public const int colorAccent = 2130772202;
+			
+			// aapt resource value: 0x7f0100f1
+			public const int colorBackgroundFloating = 2130772209;
+			
+			// aapt resource value: 0x7f0100ee
+			public const int colorButtonNormal = 2130772206;
 			
 			// aapt resource value: 0x7f0100ec
-			public const int collapseContentDescription = 2130772204;
+			public const int colorControlActivated = 2130772204;
+			
+			// aapt resource value: 0x7f0100ed
+			public const int colorControlHighlight = 2130772205;
 			
 			// aapt resource value: 0x7f0100eb
-			public const int collapseIcon = 2130772203;
+			public const int colorControlNormal = 2130772203;
 			
-			// aapt resource value: 0x7f010108
-			public const int collapsedTitleGravity = 2130772232;
+			// aapt resource value: 0x7f0100e8
+			public const int colorPrimary = 2130772200;
 			
-			// aapt resource value: 0x7f010104
-			public const int collapsedTitleTextAppearance = 2130772228;
+			// aapt resource value: 0x7f0100e9
+			public const int colorPrimaryDark = 2130772201;
 			
-			// aapt resource value: 0x7f0100bd
-			public const int color = 2130772157;
+			// aapt resource value: 0x7f0100ef
+			public const int colorSwitchThumbNormal = 2130772207;
 			
-			// aapt resource value: 0x7f01009e
-			public const int colorAccent = 2130772126;
+			// aapt resource value: 0x7f01012a
+			public const int commitIcon = 2130772266;
 			
-			// aapt resource value: 0x7f0100a2
-			public const int colorButtonNormal = 2130772130;
+			// aapt resource value: 0x7f010082
+			public const int contentInsetEnd = 2130772098;
 			
-			// aapt resource value: 0x7f0100a0
-			public const int colorControlActivated = 2130772128;
+			// aapt resource value: 0x7f010086
+			public const int contentInsetEndWithActions = 2130772102;
 			
-			// aapt resource value: 0x7f0100a1
-			public const int colorControlHighlight = 2130772129;
+			// aapt resource value: 0x7f010083
+			public const int contentInsetLeft = 2130772099;
 			
-			// aapt resource value: 0x7f01009f
-			public const int colorControlNormal = 2130772127;
+			// aapt resource value: 0x7f010084
+			public const int contentInsetRight = 2130772100;
 			
-			// aapt resource value: 0x7f01009c
-			public const int colorPrimary = 2130772124;
+			// aapt resource value: 0x7f010081
+			public const int contentInsetStart = 2130772097;
 			
-			// aapt resource value: 0x7f01009d
-			public const int colorPrimaryDark = 2130772125;
-			
-			// aapt resource value: 0x7f0100a3
-			public const int colorSwitchThumbNormal = 2130772131;
-			
-			// aapt resource value: 0x7f0100d8
-			public const int commitIcon = 2130772184;
-			
-			// aapt resource value: 0x7f01003d
-			public const int contentInsetEnd = 2130772029;
-			
-			// aapt resource value: 0x7f01003e
-			public const int contentInsetLeft = 2130772030;
-			
-			// aapt resource value: 0x7f01003f
-			public const int contentInsetRight = 2130772031;
-			
-			// aapt resource value: 0x7f01003c
-			public const int contentInsetStart = 2130772028;
+			// aapt resource value: 0x7f010085
+			public const int contentInsetStartWithNavigation = 2130772101;
 			
 			// aapt resource value: 0x7f010021
 			public const int contentPadding = 2130772001;
@@ -1640,260 +1830,263 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f010024
 			public const int contentPaddingTop = 2130772004;
 			
-			// aapt resource value: 0x7f010105
-			public const int contentScrim = 2130772229;
+			// aapt resource value: 0x7f010034
+			public const int contentScrim = 2130772020;
 			
-			// aapt resource value: 0x7f0100a4
-			public const int controlBackground = 2130772132;
+			// aapt resource value: 0x7f0100f0
+			public const int controlBackground = 2130772208;
 			
-			// aapt resource value: 0x7f010137
-			public const int counterEnabled = 2130772279;
+			// aapt resource value: 0x7f010066
+			public const int counterEnabled = 2130772070;
 			
-			// aapt resource value: 0x7f010138
-			public const int counterMaxLength = 2130772280;
+			// aapt resource value: 0x7f010067
+			public const int counterMaxLength = 2130772071;
 			
-			// aapt resource value: 0x7f01013a
-			public const int counterOverflowTextAppearance = 2130772282;
+			// aapt resource value: 0x7f010069
+			public const int counterOverflowTextAppearance = 2130772073;
 			
-			// aapt resource value: 0x7f010139
-			public const int counterTextAppearance = 2130772281;
+			// aapt resource value: 0x7f010068
+			public const int counterTextAppearance = 2130772072;
 			
-			// aapt resource value: 0x7f010035
-			public const int customNavigationLayout = 2130772021;
+			// aapt resource value: 0x7f01007a
+			public const int customNavigationLayout = 2130772090;
 			
-			// aapt resource value: 0x7f0100d2
-			public const int defaultQueryHint = 2130772178;
+			// aapt resource value: 0x7f010124
+			public const int defaultQueryHint = 2130772260;
 			
-			// aapt resource value: 0x7f010075
-			public const int dialogPreferredPadding = 2130772085;
+			// aapt resource value: 0x7f0100c1
+			public const int dialogPreferredPadding = 2130772161;
 			
-			// aapt resource value: 0x7f010074
-			public const int dialogTheme = 2130772084;
+			// aapt resource value: 0x7f0100c0
+			public const int dialogTheme = 2130772160;
 			
-			// aapt resource value: 0x7f01002b
-			public const int displayOptions = 2130772011;
+			// aapt resource value: 0x7f010070
+			public const int displayOptions = 2130772080;
 			
-			// aapt resource value: 0x7f010031
-			public const int divider = 2130772017;
+			// aapt resource value: 0x7f010076
+			public const int divider = 2130772086;
 			
-			// aapt resource value: 0x7f010082
-			public const int dividerHorizontal = 2130772098;
+			// aapt resource value: 0x7f0100ce
+			public const int dividerHorizontal = 2130772174;
 			
-			// aapt resource value: 0x7f0100c7
-			public const int dividerPadding = 2130772167;
+			// aapt resource value: 0x7f010116
+			public const int dividerPadding = 2130772246;
 			
-			// aapt resource value: 0x7f010081
-			public const int dividerVertical = 2130772097;
+			// aapt resource value: 0x7f0100cd
+			public const int dividerVertical = 2130772173;
 			
-			// aapt resource value: 0x7f0100bf
-			public const int drawableSize = 2130772159;
+			// aapt resource value: 0x7f01010e
+			public const int drawableSize = 2130772238;
 			
-			// aapt resource value: 0x7f010026
-			public const int drawerArrowStyle = 2130772006;
+			// aapt resource value: 0x7f01006b
+			public const int drawerArrowStyle = 2130772075;
 			
-			// aapt resource value: 0x7f010094
-			public const int dropDownListViewStyle = 2130772116;
+			// aapt resource value: 0x7f0100e0
+			public const int dropDownListViewStyle = 2130772192;
 			
-			// aapt resource value: 0x7f010078
-			public const int dropdownListPreferredItemHeight = 2130772088;
+			// aapt resource value: 0x7f0100c4
+			public const int dropdownListPreferredItemHeight = 2130772164;
 			
-			// aapt resource value: 0x7f010089
-			public const int editTextBackground = 2130772105;
+			// aapt resource value: 0x7f0100d5
+			public const int editTextBackground = 2130772181;
 			
-			// aapt resource value: 0x7f010088
-			public const int editTextColor = 2130772104;
-			
-			// aapt resource value: 0x7f0100b2
-			public const int editTextStyle = 2130772146;
-			
-			// aapt resource value: 0x7f010040
-			public const int elevation = 2130772032;
-			
-			// aapt resource value: 0x7f010135
-			public const int errorEnabled = 2130772277;
-			
-			// aapt resource value: 0x7f010136
-			public const int errorTextAppearance = 2130772278;
-			
-			// aapt resource value: 0x7f010044
-			public const int expandActivityOverflowButtonDrawable = 2130772036;
-			
-			// aapt resource value: 0x7f0100f7
-			public const int expanded = 2130772215;
-			
-			// aapt resource value: 0x7f010109
-			public const int expandedTitleGravity = 2130772233;
-			
-			// aapt resource value: 0x7f0100fe
-			public const int expandedTitleMargin = 2130772222;
-			
-			// aapt resource value: 0x7f010102
-			public const int expandedTitleMarginBottom = 2130772226;
-			
-			// aapt resource value: 0x7f010101
-			public const int expandedTitleMarginEnd = 2130772225;
+			// aapt resource value: 0x7f0100d4
+			public const int editTextColor = 2130772180;
 			
 			// aapt resource value: 0x7f0100ff
-			public const int expandedTitleMarginStart = 2130772223;
+			public const int editTextStyle = 2130772223;
 			
-			// aapt resource value: 0x7f010100
-			public const int expandedTitleMarginTop = 2130772224;
+			// aapt resource value: 0x7f010087
+			public const int elevation = 2130772103;
 			
-			// aapt resource value: 0x7f010103
-			public const int expandedTitleTextAppearance = 2130772227;
+			// aapt resource value: 0x7f010064
+			public const int errorEnabled = 2130772068;
+			
+			// aapt resource value: 0x7f010065
+			public const int errorTextAppearance = 2130772069;
+			
+			// aapt resource value: 0x7f01008b
+			public const int expandActivityOverflowButtonDrawable = 2130772107;
+			
+			// aapt resource value: 0x7f010026
+			public const int expanded = 2130772006;
+			
+			// aapt resource value: 0x7f010038
+			public const int expandedTitleGravity = 2130772024;
+			
+			// aapt resource value: 0x7f01002d
+			public const int expandedTitleMargin = 2130772013;
+			
+			// aapt resource value: 0x7f010031
+			public const int expandedTitleMarginBottom = 2130772017;
+			
+			// aapt resource value: 0x7f010030
+			public const int expandedTitleMarginEnd = 2130772016;
+			
+			// aapt resource value: 0x7f01002e
+			public const int expandedTitleMarginStart = 2130772014;
+			
+			// aapt resource value: 0x7f01002f
+			public const int expandedTitleMarginTop = 2130772015;
+			
+			// aapt resource value: 0x7f010032
+			public const int expandedTitleTextAppearance = 2130772018;
 			
 			// aapt resource value: 0x7f01001a
 			public const int externalRouteEnabledDrawable = 2130771994;
 			
-			// aapt resource value: 0x7f010115
-			public const int fabSize = 2130772245;
+			// aapt resource value: 0x7f010044
+			public const int fabSize = 2130772036;
 			
-			// aapt resource value: 0x7f010119
-			public const int foregroundInsidePadding = 2130772249;
+			// aapt resource value: 0x7f010048
+			public const int foregroundInsidePadding = 2130772040;
 			
-			// aapt resource value: 0x7f0100c0
-			public const int gapBetweenBars = 2130772160;
+			// aapt resource value: 0x7f01010f
+			public const int gapBetweenBars = 2130772239;
 			
-			// aapt resource value: 0x7f0100d4
-			public const int goIcon = 2130772180;
+			// aapt resource value: 0x7f010126
+			public const int goIcon = 2130772262;
 			
-			// aapt resource value: 0x7f01011f
-			public const int headerLayout = 2130772255;
+			// aapt resource value: 0x7f01004e
+			public const int headerLayout = 2130772046;
 			
-			// aapt resource value: 0x7f010027
-			public const int height = 2130772007;
+			// aapt resource value: 0x7f01006c
+			public const int height = 2130772076;
 			
-			// aapt resource value: 0x7f01003b
-			public const int hideOnContentScroll = 2130772027;
+			// aapt resource value: 0x7f010080
+			public const int hideOnContentScroll = 2130772096;
 			
-			// aapt resource value: 0x7f01013b
-			public const int hintAnimationEnabled = 2130772283;
+			// aapt resource value: 0x7f01006a
+			public const int hintAnimationEnabled = 2130772074;
 			
-			// aapt resource value: 0x7f010134
-			public const int hintEnabled = 2130772276;
+			// aapt resource value: 0x7f010063
+			public const int hintEnabled = 2130772067;
 			
-			// aapt resource value: 0x7f010133
-			public const int hintTextAppearance = 2130772275;
+			// aapt resource value: 0x7f010062
+			public const int hintTextAppearance = 2130772066;
 			
-			// aapt resource value: 0x7f01007a
-			public const int homeAsUpIndicator = 2130772090;
+			// aapt resource value: 0x7f0100c6
+			public const int homeAsUpIndicator = 2130772166;
 			
-			// aapt resource value: 0x7f010036
-			public const int homeLayout = 2130772022;
+			// aapt resource value: 0x7f01007b
+			public const int homeLayout = 2130772091;
 			
-			// aapt resource value: 0x7f01002f
-			public const int icon = 2130772015;
+			// aapt resource value: 0x7f010074
+			public const int icon = 2130772084;
 			
-			// aapt resource value: 0x7f0100d0
-			public const int iconifiedByDefault = 2130772176;
+			// aapt resource value: 0x7f010122
+			public const int iconifiedByDefault = 2130772258;
+			
+			// aapt resource value: 0x7f0100d6
+			public const int imageButtonStyle = 2130772182;
+			
+			// aapt resource value: 0x7f01007d
+			public const int indeterminateProgressStyle = 2130772093;
 			
 			// aapt resource value: 0x7f01008a
-			public const int imageButtonStyle = 2130772106;
+			public const int initialActivityCount = 2130772106;
 			
-			// aapt resource value: 0x7f010038
-			public const int indeterminateProgressStyle = 2130772024;
+			// aapt resource value: 0x7f01004f
+			public const int insetForeground = 2130772047;
 			
-			// aapt resource value: 0x7f010043
-			public const int initialActivityCount = 2130772035;
+			// aapt resource value: 0x7f01006d
+			public const int isLightTheme = 2130772077;
 			
-			// aapt resource value: 0x7f010120
-			public const int insetForeground = 2130772256;
+			// aapt resource value: 0x7f01004c
+			public const int itemBackground = 2130772044;
 			
-			// aapt resource value: 0x7f010028
-			public const int isLightTheme = 2130772008;
+			// aapt resource value: 0x7f01004a
+			public const int itemIconTint = 2130772042;
 			
-			// aapt resource value: 0x7f01011d
-			public const int itemBackground = 2130772253;
+			// aapt resource value: 0x7f01007f
+			public const int itemPadding = 2130772095;
 			
-			// aapt resource value: 0x7f01011b
-			public const int itemIconTint = 2130772251;
+			// aapt resource value: 0x7f01004d
+			public const int itemTextAppearance = 2130772045;
+			
+			// aapt resource value: 0x7f01004b
+			public const int itemTextColor = 2130772043;
 			
 			// aapt resource value: 0x7f01003a
-			public const int itemPadding = 2130772026;
+			public const int keylines = 2130772026;
 			
-			// aapt resource value: 0x7f01011e
-			public const int itemTextAppearance = 2130772254;
-			
-			// aapt resource value: 0x7f01011c
-			public const int itemTextColor = 2130772252;
-			
-			// aapt resource value: 0x7f01010b
-			public const int keylines = 2130772235;
-			
-			// aapt resource value: 0x7f0100cf
-			public const int layout = 2130772175;
+			// aapt resource value: 0x7f010121
+			public const int layout = 2130772257;
 			
 			// aapt resource value: 0x7f010000
 			public const int layoutManager = 2130771968;
 			
-			// aapt resource value: 0x7f01010e
-			public const int layout_anchor = 2130772238;
+			// aapt resource value: 0x7f01003d
+			public const int layout_anchor = 2130772029;
 			
-			// aapt resource value: 0x7f010110
-			public const int layout_anchorGravity = 2130772240;
+			// aapt resource value: 0x7f01003f
+			public const int layout_anchorGravity = 2130772031;
 			
-			// aapt resource value: 0x7f01010d
-			public const int layout_behavior = 2130772237;
+			// aapt resource value: 0x7f01003c
+			public const int layout_behavior = 2130772028;
 			
-			// aapt resource value: 0x7f0100fc
-			public const int layout_collapseMode = 2130772220;
+			// aapt resource value: 0x7f01002b
+			public const int layout_collapseMode = 2130772011;
 			
-			// aapt resource value: 0x7f0100fd
-			public const int layout_collapseParallaxMultiplier = 2130772221;
+			// aapt resource value: 0x7f01002c
+			public const int layout_collapseParallaxMultiplier = 2130772012;
 			
-			// aapt resource value: 0x7f01010f
-			public const int layout_keyline = 2130772239;
+			// aapt resource value: 0x7f01003e
+			public const int layout_keyline = 2130772030;
 			
-			// aapt resource value: 0x7f0100f8
-			public const int layout_scrollFlags = 2130772216;
+			// aapt resource value: 0x7f010027
+			public const int layout_scrollFlags = 2130772007;
 			
-			// aapt resource value: 0x7f0100f9
-			public const int layout_scrollInterpolator = 2130772217;
+			// aapt resource value: 0x7f010028
+			public const int layout_scrollInterpolator = 2130772008;
 			
-			// aapt resource value: 0x7f01009b
-			public const int listChoiceBackgroundIndicator = 2130772123;
+			// aapt resource value: 0x7f0100e7
+			public const int listChoiceBackgroundIndicator = 2130772199;
 			
-			// aapt resource value: 0x7f010076
-			public const int listDividerAlertDialog = 2130772086;
-			
-			// aapt resource value: 0x7f010049
-			public const int listItemLayout = 2130772041;
-			
-			// aapt resource value: 0x7f010046
-			public const int listLayout = 2130772038;
-			
-			// aapt resource value: 0x7f010095
-			public const int listPopupWindowStyle = 2130772117;
-			
-			// aapt resource value: 0x7f01008f
-			public const int listPreferredItemHeight = 2130772111;
-			
-			// aapt resource value: 0x7f010091
-			public const int listPreferredItemHeightLarge = 2130772113;
+			// aapt resource value: 0x7f0100c2
+			public const int listDividerAlertDialog = 2130772162;
 			
 			// aapt resource value: 0x7f010090
-			public const int listPreferredItemHeightSmall = 2130772112;
+			public const int listItemLayout = 2130772112;
 			
-			// aapt resource value: 0x7f010092
-			public const int listPreferredItemPaddingLeft = 2130772114;
+			// aapt resource value: 0x7f01008d
+			public const int listLayout = 2130772109;
 			
-			// aapt resource value: 0x7f010093
-			public const int listPreferredItemPaddingRight = 2130772115;
+			// aapt resource value: 0x7f010107
+			public const int listMenuViewStyle = 2130772231;
 			
-			// aapt resource value: 0x7f010030
-			public const int logo = 2130772016;
+			// aapt resource value: 0x7f0100e1
+			public const int listPopupWindowStyle = 2130772193;
 			
-			// aapt resource value: 0x7f0100ef
-			public const int logoDescription = 2130772207;
+			// aapt resource value: 0x7f0100db
+			public const int listPreferredItemHeight = 2130772187;
 			
-			// aapt resource value: 0x7f010122
-			public const int maxActionInlineWidth = 2130772258;
+			// aapt resource value: 0x7f0100dd
+			public const int listPreferredItemHeightLarge = 2130772189;
 			
-			// aapt resource value: 0x7f0100ea
-			public const int maxButtonHeight = 2130772202;
+			// aapt resource value: 0x7f0100dc
+			public const int listPreferredItemHeightSmall = 2130772188;
 			
-			// aapt resource value: 0x7f0100c5
-			public const int measureWithLargestChild = 2130772165;
+			// aapt resource value: 0x7f0100de
+			public const int listPreferredItemPaddingLeft = 2130772190;
+			
+			// aapt resource value: 0x7f0100df
+			public const int listPreferredItemPaddingRight = 2130772191;
+			
+			// aapt resource value: 0x7f010075
+			public const int logo = 2130772085;
+			
+			// aapt resource value: 0x7f010147
+			public const int logoDescription = 2130772295;
+			
+			// aapt resource value: 0x7f010051
+			public const int maxActionInlineWidth = 2130772049;
+			
+			// aapt resource value: 0x7f010141
+			public const int maxButtonHeight = 2130772289;
+			
+			// aapt resource value: 0x7f010114
+			public const int measureWithLargestChild = 2130772244;
 			
 			// aapt resource value: 0x7f010005
 			public const int mediaRouteAudioTrackDrawable = 2130771973;
@@ -1958,338 +2151,377 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f010019
 			public const int mediaRouteTvIconDrawable = 2130771993;
 			
-			// aapt resource value: 0x7f01011a
-			public const int menu = 2130772250;
+			// aapt resource value: 0x7f010049
+			public const int menu = 2130772041;
 			
-			// aapt resource value: 0x7f010047
-			public const int multiChoiceItemLayout = 2130772039;
+			// aapt resource value: 0x7f01008e
+			public const int multiChoiceItemLayout = 2130772110;
 			
-			// aapt resource value: 0x7f0100ee
-			public const int navigationContentDescription = 2130772206;
+			// aapt resource value: 0x7f010146
+			public const int navigationContentDescription = 2130772294;
 			
-			// aapt resource value: 0x7f0100ed
-			public const int navigationIcon = 2130772205;
+			// aapt resource value: 0x7f010145
+			public const int navigationIcon = 2130772293;
 			
-			// aapt resource value: 0x7f01002a
-			public const int navigationMode = 2130772010;
+			// aapt resource value: 0x7f01006f
+			public const int navigationMode = 2130772079;
 			
-			// aapt resource value: 0x7f0100cd
-			public const int overlapAnchor = 2130772173;
+			// aapt resource value: 0x7f01011d
+			public const int overlapAnchor = 2130772253;
 			
-			// aapt resource value: 0x7f0100f3
-			public const int paddingEnd = 2130772211;
+			// aapt resource value: 0x7f01011f
+			public const int paddingBottomNoButtons = 2130772255;
 			
-			// aapt resource value: 0x7f0100f2
-			public const int paddingStart = 2130772210;
+			// aapt resource value: 0x7f01014b
+			public const int paddingEnd = 2130772299;
 			
-			// aapt resource value: 0x7f010098
-			public const int panelBackground = 2130772120;
+			// aapt resource value: 0x7f01014a
+			public const int paddingStart = 2130772298;
 			
-			// aapt resource value: 0x7f01009a
-			public const int panelMenuListTheme = 2130772122;
+			// aapt resource value: 0x7f010120
+			public const int paddingTopNoTitle = 2130772256;
 			
-			// aapt resource value: 0x7f010099
-			public const int panelMenuListWidth = 2130772121;
+			// aapt resource value: 0x7f0100e4
+			public const int panelBackground = 2130772196;
 			
-			// aapt resource value: 0x7f010086
-			public const int popupMenuStyle = 2130772102;
+			// aapt resource value: 0x7f0100e6
+			public const int panelMenuListTheme = 2130772198;
 			
-			// aapt resource value: 0x7f010041
-			public const int popupTheme = 2130772033;
+			// aapt resource value: 0x7f0100e5
+			public const int panelMenuListWidth = 2130772197;
 			
-			// aapt resource value: 0x7f010087
-			public const int popupWindowStyle = 2130772103;
+			// aapt resource value: 0x7f0100d2
+			public const int popupMenuStyle = 2130772178;
 			
-			// aapt resource value: 0x7f0100cc
-			public const int preserveIconSpacing = 2130772172;
+			// aapt resource value: 0x7f010088
+			public const int popupTheme = 2130772104;
 			
-			// aapt resource value: 0x7f010116
-			public const int pressedTranslationZ = 2130772246;
+			// aapt resource value: 0x7f0100d3
+			public const int popupWindowStyle = 2130772179;
 			
-			// aapt resource value: 0x7f010039
-			public const int progressBarPadding = 2130772025;
+			// aapt resource value: 0x7f01011b
+			public const int preserveIconSpacing = 2130772251;
 			
-			// aapt resource value: 0x7f010037
-			public const int progressBarStyle = 2130772023;
+			// aapt resource value: 0x7f010045
+			public const int pressedTranslationZ = 2130772037;
 			
-			// aapt resource value: 0x7f0100da
-			public const int queryBackground = 2130772186;
+			// aapt resource value: 0x7f01007e
+			public const int progressBarPadding = 2130772094;
 			
-			// aapt resource value: 0x7f0100d1
-			public const int queryHint = 2130772177;
+			// aapt resource value: 0x7f01007c
+			public const int progressBarStyle = 2130772092;
 			
-			// aapt resource value: 0x7f0100b3
-			public const int radioButtonStyle = 2130772147;
+			// aapt resource value: 0x7f01012c
+			public const int queryBackground = 2130772268;
 			
-			// aapt resource value: 0x7f0100b4
-			public const int ratingBarStyle = 2130772148;
+			// aapt resource value: 0x7f010123
+			public const int queryHint = 2130772259;
 			
-			// aapt resource value: 0x7f0100b5
-			public const int ratingBarStyleIndicator = 2130772149;
+			// aapt resource value: 0x7f010100
+			public const int radioButtonStyle = 2130772224;
 			
-			// aapt resource value: 0x7f0100b6
-			public const int ratingBarStyleSmall = 2130772150;
+			// aapt resource value: 0x7f010101
+			public const int ratingBarStyle = 2130772225;
+			
+			// aapt resource value: 0x7f010102
+			public const int ratingBarStyleIndicator = 2130772226;
+			
+			// aapt resource value: 0x7f010103
+			public const int ratingBarStyleSmall = 2130772227;
 			
 			// aapt resource value: 0x7f010002
 			public const int reverseLayout = 2130771970;
 			
-			// aapt resource value: 0x7f010114
-			public const int rippleColor = 2130772244;
+			// aapt resource value: 0x7f010043
+			public const int rippleColor = 2130772035;
 			
-			// aapt resource value: 0x7f0100d6
-			public const int searchHintIcon = 2130772182;
+			// aapt resource value: 0x7f010128
+			public const int searchHintIcon = 2130772264;
 			
-			// aapt resource value: 0x7f0100d5
-			public const int searchIcon = 2130772181;
+			// aapt resource value: 0x7f010127
+			public const int searchIcon = 2130772263;
 			
-			// aapt resource value: 0x7f01008e
-			public const int searchViewStyle = 2130772110;
+			// aapt resource value: 0x7f0100da
+			public const int searchViewStyle = 2130772186;
 			
-			// aapt resource value: 0x7f0100b7
-			public const int seekBarStyle = 2130772151;
+			// aapt resource value: 0x7f010104
+			public const int seekBarStyle = 2130772228;
 			
-			// aapt resource value: 0x7f01007e
-			public const int selectableItemBackground = 2130772094;
+			// aapt resource value: 0x7f0100ca
+			public const int selectableItemBackground = 2130772170;
 			
-			// aapt resource value: 0x7f01007f
-			public const int selectableItemBackgroundBorderless = 2130772095;
+			// aapt resource value: 0x7f0100cb
+			public const int selectableItemBackgroundBorderless = 2130772171;
 			
-			// aapt resource value: 0x7f0100c8
-			public const int showAsAction = 2130772168;
+			// aapt resource value: 0x7f010117
+			public const int showAsAction = 2130772247;
 			
-			// aapt resource value: 0x7f0100c6
-			public const int showDividers = 2130772166;
+			// aapt resource value: 0x7f010115
+			public const int showDividers = 2130772245;
 			
-			// aapt resource value: 0x7f0100e2
-			public const int showText = 2130772194;
+			// aapt resource value: 0x7f010138
+			public const int showText = 2130772280;
 			
-			// aapt resource value: 0x7f010048
-			public const int singleChoiceItemLayout = 2130772040;
+			// aapt resource value: 0x7f010091
+			public const int showTitle = 2130772113;
+			
+			// aapt resource value: 0x7f01008f
+			public const int singleChoiceItemLayout = 2130772111;
 			
 			// aapt resource value: 0x7f010001
 			public const int spanCount = 2130771969;
 			
-			// aapt resource value: 0x7f0100be
-			public const int spinBars = 2130772158;
+			// aapt resource value: 0x7f01010d
+			public const int spinBars = 2130772237;
 			
-			// aapt resource value: 0x7f010079
-			public const int spinnerDropDownItemStyle = 2130772089;
+			// aapt resource value: 0x7f0100c5
+			public const int spinnerDropDownItemStyle = 2130772165;
 			
-			// aapt resource value: 0x7f0100b8
-			public const int spinnerStyle = 2130772152;
+			// aapt resource value: 0x7f010105
+			public const int spinnerStyle = 2130772229;
 			
-			// aapt resource value: 0x7f0100e1
-			public const int splitTrack = 2130772193;
+			// aapt resource value: 0x7f010137
+			public const int splitTrack = 2130772279;
 			
-			// aapt resource value: 0x7f01004a
-			public const int srcCompat = 2130772042;
+			// aapt resource value: 0x7f010092
+			public const int srcCompat = 2130772114;
 			
 			// aapt resource value: 0x7f010003
 			public const int stackFromEnd = 2130771971;
 			
-			// aapt resource value: 0x7f0100ce
-			public const int state_above_anchor = 2130772174;
+			// aapt resource value: 0x7f01011e
+			public const int state_above_anchor = 2130772254;
 			
-			// aapt resource value: 0x7f01010c
-			public const int statusBarBackground = 2130772236;
+			// aapt resource value: 0x7f01003b
+			public const int statusBarBackground = 2130772027;
 			
-			// aapt resource value: 0x7f010106
-			public const int statusBarScrim = 2130772230;
+			// aapt resource value: 0x7f010035
+			public const int statusBarScrim = 2130772021;
 			
-			// aapt resource value: 0x7f0100db
-			public const int submitBackground = 2130772187;
-			
-			// aapt resource value: 0x7f01002c
-			public const int subtitle = 2130772012;
-			
-			// aapt resource value: 0x7f0100e4
-			public const int subtitleTextAppearance = 2130772196;
-			
-			// aapt resource value: 0x7f0100f1
-			public const int subtitleTextColor = 2130772209;
-			
-			// aapt resource value: 0x7f01002e
-			public const int subtitleTextStyle = 2130772014;
-			
-			// aapt resource value: 0x7f0100d9
-			public const int suggestionRowLayout = 2130772185;
-			
-			// aapt resource value: 0x7f0100df
-			public const int switchMinWidth = 2130772191;
-			
-			// aapt resource value: 0x7f0100e0
-			public const int switchPadding = 2130772192;
-			
-			// aapt resource value: 0x7f0100b9
-			public const int switchStyle = 2130772153;
-			
-			// aapt resource value: 0x7f0100de
-			public const int switchTextAppearance = 2130772190;
-			
-			// aapt resource value: 0x7f010126
-			public const int tabBackground = 2130772262;
-			
-			// aapt resource value: 0x7f010125
-			public const int tabContentStart = 2130772261;
-			
-			// aapt resource value: 0x7f010128
-			public const int tabGravity = 2130772264;
-			
-			// aapt resource value: 0x7f010123
-			public const int tabIndicatorColor = 2130772259;
-			
-			// aapt resource value: 0x7f010124
-			public const int tabIndicatorHeight = 2130772260;
-			
-			// aapt resource value: 0x7f01012a
-			public const int tabMaxWidth = 2130772266;
-			
-			// aapt resource value: 0x7f010129
-			public const int tabMinWidth = 2130772265;
-			
-			// aapt resource value: 0x7f010127
-			public const int tabMode = 2130772263;
-			
-			// aapt resource value: 0x7f010132
-			public const int tabPadding = 2130772274;
-			
-			// aapt resource value: 0x7f010131
-			public const int tabPaddingBottom = 2130772273;
-			
-			// aapt resource value: 0x7f010130
-			public const int tabPaddingEnd = 2130772272;
-			
-			// aapt resource value: 0x7f01012e
-			public const int tabPaddingStart = 2130772270;
-			
-			// aapt resource value: 0x7f01012f
-			public const int tabPaddingTop = 2130772271;
+			// aapt resource value: 0x7f01011c
+			public const int subMenuArrow = 2130772252;
 			
 			// aapt resource value: 0x7f01012d
-			public const int tabSelectedTextColor = 2130772269;
+			public const int submitBackground = 2130772269;
 			
-			// aapt resource value: 0x7f01012b
-			public const int tabTextAppearance = 2130772267;
+			// aapt resource value: 0x7f010071
+			public const int subtitle = 2130772081;
 			
-			// aapt resource value: 0x7f01012c
-			public const int tabTextColor = 2130772268;
+			// aapt resource value: 0x7f01013a
+			public const int subtitleTextAppearance = 2130772282;
 			
-			// aapt resource value: 0x7f01004b
-			public const int textAllCaps = 2130772043;
-			
-			// aapt resource value: 0x7f010072
-			public const int textAppearanceLargePopupMenu = 2130772082;
-			
-			// aapt resource value: 0x7f010096
-			public const int textAppearanceListItem = 2130772118;
-			
-			// aapt resource value: 0x7f010097
-			public const int textAppearanceListItemSmall = 2130772119;
-			
-			// aapt resource value: 0x7f01008c
-			public const int textAppearanceSearchResultSubtitle = 2130772108;
-			
-			// aapt resource value: 0x7f01008b
-			public const int textAppearanceSearchResultTitle = 2130772107;
+			// aapt resource value: 0x7f010149
+			public const int subtitleTextColor = 2130772297;
 			
 			// aapt resource value: 0x7f010073
-			public const int textAppearanceSmallPopupMenu = 2130772083;
+			public const int subtitleTextStyle = 2130772083;
 			
-			// aapt resource value: 0x7f0100a9
-			public const int textColorAlertDialogListItem = 2130772137;
+			// aapt resource value: 0x7f01012b
+			public const int suggestionRowLayout = 2130772267;
 			
-			// aapt resource value: 0x7f010113
-			public const int textColorError = 2130772243;
+			// aapt resource value: 0x7f010135
+			public const int switchMinWidth = 2130772277;
 			
-			// aapt resource value: 0x7f01008d
-			public const int textColorSearchUrl = 2130772109;
+			// aapt resource value: 0x7f010136
+			public const int switchPadding = 2130772278;
 			
-			// aapt resource value: 0x7f0100f4
-			public const int theme = 2130772212;
+			// aapt resource value: 0x7f010106
+			public const int switchStyle = 2130772230;
 			
-			// aapt resource value: 0x7f0100c4
-			public const int thickness = 2130772164;
-			
-			// aapt resource value: 0x7f0100dd
-			public const int thumbTextPadding = 2130772189;
-			
-			// aapt resource value: 0x7f010029
-			public const int title = 2130772009;
-			
-			// aapt resource value: 0x7f01010a
-			public const int titleEnabled = 2130772234;
-			
-			// aapt resource value: 0x7f0100e9
-			public const int titleMarginBottom = 2130772201;
-			
-			// aapt resource value: 0x7f0100e7
-			public const int titleMarginEnd = 2130772199;
-			
-			// aapt resource value: 0x7f0100e6
-			public const int titleMarginStart = 2130772198;
-			
-			// aapt resource value: 0x7f0100e8
-			public const int titleMarginTop = 2130772200;
-			
-			// aapt resource value: 0x7f0100e5
-			public const int titleMargins = 2130772197;
-			
-			// aapt resource value: 0x7f0100e3
-			public const int titleTextAppearance = 2130772195;
-			
-			// aapt resource value: 0x7f0100f0
-			public const int titleTextColor = 2130772208;
-			
-			// aapt resource value: 0x7f01002d
-			public const int titleTextStyle = 2130772013;
-			
-			// aapt resource value: 0x7f010107
-			public const int toolbarId = 2130772231;
-			
-			// aapt resource value: 0x7f010085
-			public const int toolbarNavigationButtonStyle = 2130772101;
-			
-			// aapt resource value: 0x7f010084
-			public const int toolbarStyle = 2130772100;
-			
-			// aapt resource value: 0x7f0100dc
-			public const int track = 2130772188;
-			
-			// aapt resource value: 0x7f010118
-			public const int useCompatPadding = 2130772248;
-			
-			// aapt resource value: 0x7f0100d7
-			public const int voiceIcon = 2130772183;
-			
-			// aapt resource value: 0x7f01004c
-			public const int windowActionBar = 2130772044;
-			
-			// aapt resource value: 0x7f01004e
-			public const int windowActionBarOverlay = 2130772046;
-			
-			// aapt resource value: 0x7f01004f
-			public const int windowActionModeOverlay = 2130772047;
-			
-			// aapt resource value: 0x7f010053
-			public const int windowFixedHeightMajor = 2130772051;
-			
-			// aapt resource value: 0x7f010051
-			public const int windowFixedHeightMinor = 2130772049;
-			
-			// aapt resource value: 0x7f010050
-			public const int windowFixedWidthMajor = 2130772048;
-			
-			// aapt resource value: 0x7f010052
-			public const int windowFixedWidthMinor = 2130772050;
-			
-			// aapt resource value: 0x7f010054
-			public const int windowMinWidthMajor = 2130772052;
+			// aapt resource value: 0x7f010134
+			public const int switchTextAppearance = 2130772276;
 			
 			// aapt resource value: 0x7f010055
-			public const int windowMinWidthMinor = 2130772053;
+			public const int tabBackground = 2130772053;
 			
-			// aapt resource value: 0x7f01004d
-			public const int windowNoTitle = 2130772045;
+			// aapt resource value: 0x7f010054
+			public const int tabContentStart = 2130772052;
+			
+			// aapt resource value: 0x7f010057
+			public const int tabGravity = 2130772055;
+			
+			// aapt resource value: 0x7f010052
+			public const int tabIndicatorColor = 2130772050;
+			
+			// aapt resource value: 0x7f010053
+			public const int tabIndicatorHeight = 2130772051;
+			
+			// aapt resource value: 0x7f010059
+			public const int tabMaxWidth = 2130772057;
+			
+			// aapt resource value: 0x7f010058
+			public const int tabMinWidth = 2130772056;
+			
+			// aapt resource value: 0x7f010056
+			public const int tabMode = 2130772054;
+			
+			// aapt resource value: 0x7f010061
+			public const int tabPadding = 2130772065;
+			
+			// aapt resource value: 0x7f010060
+			public const int tabPaddingBottom = 2130772064;
+			
+			// aapt resource value: 0x7f01005f
+			public const int tabPaddingEnd = 2130772063;
+			
+			// aapt resource value: 0x7f01005d
+			public const int tabPaddingStart = 2130772061;
+			
+			// aapt resource value: 0x7f01005e
+			public const int tabPaddingTop = 2130772062;
+			
+			// aapt resource value: 0x7f01005c
+			public const int tabSelectedTextColor = 2130772060;
+			
+			// aapt resource value: 0x7f01005a
+			public const int tabTextAppearance = 2130772058;
+			
+			// aapt resource value: 0x7f01005b
+			public const int tabTextColor = 2130772059;
+			
+			// aapt resource value: 0x7f010096
+			public const int textAllCaps = 2130772118;
+			
+			// aapt resource value: 0x7f0100bd
+			public const int textAppearanceLargePopupMenu = 2130772157;
+			
+			// aapt resource value: 0x7f0100e2
+			public const int textAppearanceListItem = 2130772194;
+			
+			// aapt resource value: 0x7f0100e3
+			public const int textAppearanceListItemSmall = 2130772195;
+			
+			// aapt resource value: 0x7f0100bf
+			public const int textAppearancePopupMenuHeader = 2130772159;
+			
+			// aapt resource value: 0x7f0100d8
+			public const int textAppearanceSearchResultSubtitle = 2130772184;
+			
+			// aapt resource value: 0x7f0100d7
+			public const int textAppearanceSearchResultTitle = 2130772183;
+			
+			// aapt resource value: 0x7f0100be
+			public const int textAppearanceSmallPopupMenu = 2130772158;
+			
+			// aapt resource value: 0x7f0100f6
+			public const int textColorAlertDialogListItem = 2130772214;
+			
+			// aapt resource value: 0x7f010042
+			public const int textColorError = 2130772034;
+			
+			// aapt resource value: 0x7f0100d9
+			public const int textColorSearchUrl = 2130772185;
+			
+			// aapt resource value: 0x7f01014c
+			public const int theme = 2130772300;
+			
+			// aapt resource value: 0x7f010113
+			public const int thickness = 2130772243;
+			
+			// aapt resource value: 0x7f010133
+			public const int thumbTextPadding = 2130772275;
+			
+			// aapt resource value: 0x7f01012e
+			public const int thumbTint = 2130772270;
+			
+			// aapt resource value: 0x7f01012f
+			public const int thumbTintMode = 2130772271;
+			
+			// aapt resource value: 0x7f010093
+			public const int tickMark = 2130772115;
+			
+			// aapt resource value: 0x7f010094
+			public const int tickMarkTint = 2130772116;
+			
+			// aapt resource value: 0x7f010095
+			public const int tickMarkTintMode = 2130772117;
+			
+			// aapt resource value: 0x7f01006e
+			public const int title = 2130772078;
+			
+			// aapt resource value: 0x7f010039
+			public const int titleEnabled = 2130772025;
+			
+			// aapt resource value: 0x7f01013b
+			public const int titleMargin = 2130772283;
+			
+			// aapt resource value: 0x7f01013f
+			public const int titleMarginBottom = 2130772287;
+			
+			// aapt resource value: 0x7f01013d
+			public const int titleMarginEnd = 2130772285;
+			
+			// aapt resource value: 0x7f01013c
+			public const int titleMarginStart = 2130772284;
+			
+			// aapt resource value: 0x7f01013e
+			public const int titleMarginTop = 2130772286;
+			
+			// aapt resource value: 0x7f010140
+			public const int titleMargins = 2130772288;
+			
+			// aapt resource value: 0x7f010139
+			public const int titleTextAppearance = 2130772281;
+			
+			// aapt resource value: 0x7f010148
+			public const int titleTextColor = 2130772296;
+			
+			// aapt resource value: 0x7f010072
+			public const int titleTextStyle = 2130772082;
+			
+			// aapt resource value: 0x7f010036
+			public const int toolbarId = 2130772022;
+			
+			// aapt resource value: 0x7f0100d1
+			public const int toolbarNavigationButtonStyle = 2130772177;
+			
+			// aapt resource value: 0x7f0100d0
+			public const int toolbarStyle = 2130772176;
+			
+			// aapt resource value: 0x7f010130
+			public const int track = 2130772272;
+			
+			// aapt resource value: 0x7f010131
+			public const int trackTint = 2130772273;
+			
+			// aapt resource value: 0x7f010132
+			public const int trackTintMode = 2130772274;
+			
+			// aapt resource value: 0x7f010047
+			public const int useCompatPadding = 2130772039;
+			
+			// aapt resource value: 0x7f010129
+			public const int voiceIcon = 2130772265;
+			
+			// aapt resource value: 0x7f010097
+			public const int windowActionBar = 2130772119;
+			
+			// aapt resource value: 0x7f010099
+			public const int windowActionBarOverlay = 2130772121;
+			
+			// aapt resource value: 0x7f01009a
+			public const int windowActionModeOverlay = 2130772122;
+			
+			// aapt resource value: 0x7f01009e
+			public const int windowFixedHeightMajor = 2130772126;
+			
+			// aapt resource value: 0x7f01009c
+			public const int windowFixedHeightMinor = 2130772124;
+			
+			// aapt resource value: 0x7f01009b
+			public const int windowFixedWidthMajor = 2130772123;
+			
+			// aapt resource value: 0x7f01009d
+			public const int windowFixedWidthMinor = 2130772125;
+			
+			// aapt resource value: 0x7f01009f
+			public const int windowMinWidthMajor = 2130772127;
+			
+			// aapt resource value: 0x7f0100a0
+			public const int windowMinWidthMinor = 2130772128;
+			
+			// aapt resource value: 0x7f010098
+			public const int windowNoTitle = 2130772120;
 			
 			static Attribute()
 			{
@@ -2304,29 +2536,20 @@ namespace XForms.Droid
 		public partial class Boolean
 		{
 			
-			// aapt resource value: 0x7f0c0003
-			public const int abc_action_bar_embed_tabs = 2131492867;
+			// aapt resource value: 0x7f0c0000
+			public const int abc_action_bar_embed_tabs = 2131492864;
 			
 			// aapt resource value: 0x7f0c0001
-			public const int abc_action_bar_embed_tabs_pre_jb = 2131492865;
-			
-			// aapt resource value: 0x7f0c0004
-			public const int abc_action_bar_expanded_action_views_exclusive = 2131492868;
-			
-			// aapt resource value: 0x7f0c0000
-			public const int abc_allow_stacked_button_bar = 2131492864;
-			
-			// aapt resource value: 0x7f0c0005
-			public const int abc_config_actionMenuItemAllCaps = 2131492869;
+			public const int abc_allow_stacked_button_bar = 2131492865;
 			
 			// aapt resource value: 0x7f0c0002
-			public const int abc_config_allowActionMenuItemTextWithIcon = 2131492866;
+			public const int abc_config_actionMenuItemAllCaps = 2131492866;
 			
-			// aapt resource value: 0x7f0c0006
-			public const int abc_config_closeDialogWhenTouchOutside = 2131492870;
+			// aapt resource value: 0x7f0c0003
+			public const int abc_config_closeDialogWhenTouchOutside = 2131492867;
 			
-			// aapt resource value: 0x7f0c0007
-			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131492871;
+			// aapt resource value: 0x7f0c0004
+			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131492868;
 			
 			static Boolean()
 			{
@@ -2341,89 +2564,122 @@ namespace XForms.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0b0048
-			public const int abc_background_cache_hint_selector_material_dark = 2131427400;
-			
 			// aapt resource value: 0x7f0b0049
-			public const int abc_background_cache_hint_selector_material_light = 2131427401;
+			public const int abc_background_cache_hint_selector_material_dark = 2131427401;
 			
 			// aapt resource value: 0x7f0b004a
-			public const int abc_color_highlight_material = 2131427402;
-			
-			// aapt resource value: 0x7f0b0004
-			public const int abc_input_method_navigation_guard = 2131427332;
+			public const int abc_background_cache_hint_selector_material_light = 2131427402;
 			
 			// aapt resource value: 0x7f0b004b
-			public const int abc_primary_text_disable_only_material_dark = 2131427403;
+			public const int abc_btn_colored_borderless_text_material = 2131427403;
 			
 			// aapt resource value: 0x7f0b004c
-			public const int abc_primary_text_disable_only_material_light = 2131427404;
+			public const int abc_btn_colored_text_material = 2131427404;
 			
 			// aapt resource value: 0x7f0b004d
-			public const int abc_primary_text_material_dark = 2131427405;
+			public const int abc_color_highlight_material = 2131427405;
 			
 			// aapt resource value: 0x7f0b004e
-			public const int abc_primary_text_material_light = 2131427406;
+			public const int abc_hint_foreground_material_dark = 2131427406;
 			
 			// aapt resource value: 0x7f0b004f
-			public const int abc_search_url_text = 2131427407;
-			
-			// aapt resource value: 0x7f0b0005
-			public const int abc_search_url_text_normal = 2131427333;
-			
-			// aapt resource value: 0x7f0b0006
-			public const int abc_search_url_text_pressed = 2131427334;
-			
-			// aapt resource value: 0x7f0b0007
-			public const int abc_search_url_text_selected = 2131427335;
-			
-			// aapt resource value: 0x7f0b0050
-			public const int abc_secondary_text_material_dark = 2131427408;
-			
-			// aapt resource value: 0x7f0b0051
-			public const int abc_secondary_text_material_light = 2131427409;
-			
-			// aapt resource value: 0x7f0b0008
-			public const int accent_material_dark = 2131427336;
-			
-			// aapt resource value: 0x7f0b0009
-			public const int accent_material_light = 2131427337;
-			
-			// aapt resource value: 0x7f0b000a
-			public const int background_floating_material_dark = 2131427338;
-			
-			// aapt resource value: 0x7f0b000b
-			public const int background_floating_material_light = 2131427339;
-			
-			// aapt resource value: 0x7f0b000c
-			public const int background_material_dark = 2131427340;
-			
-			// aapt resource value: 0x7f0b000d
-			public const int background_material_light = 2131427341;
-			
-			// aapt resource value: 0x7f0b000e
-			public const int bright_foreground_disabled_material_dark = 2131427342;
+			public const int abc_hint_foreground_material_light = 2131427407;
 			
 			// aapt resource value: 0x7f0b000f
-			public const int bright_foreground_disabled_material_light = 2131427343;
+			public const int abc_input_method_navigation_guard = 2131427343;
+			
+			// aapt resource value: 0x7f0b0050
+			public const int abc_primary_text_disable_only_material_dark = 2131427408;
+			
+			// aapt resource value: 0x7f0b0051
+			public const int abc_primary_text_disable_only_material_light = 2131427409;
+			
+			// aapt resource value: 0x7f0b0052
+			public const int abc_primary_text_material_dark = 2131427410;
+			
+			// aapt resource value: 0x7f0b0053
+			public const int abc_primary_text_material_light = 2131427411;
+			
+			// aapt resource value: 0x7f0b0054
+			public const int abc_search_url_text = 2131427412;
 			
 			// aapt resource value: 0x7f0b0010
-			public const int bright_foreground_inverse_material_dark = 2131427344;
+			public const int abc_search_url_text_normal = 2131427344;
 			
 			// aapt resource value: 0x7f0b0011
-			public const int bright_foreground_inverse_material_light = 2131427345;
+			public const int abc_search_url_text_pressed = 2131427345;
 			
 			// aapt resource value: 0x7f0b0012
-			public const int bright_foreground_material_dark = 2131427346;
+			public const int abc_search_url_text_selected = 2131427346;
+			
+			// aapt resource value: 0x7f0b0055
+			public const int abc_secondary_text_material_dark = 2131427413;
+			
+			// aapt resource value: 0x7f0b0056
+			public const int abc_secondary_text_material_light = 2131427414;
+			
+			// aapt resource value: 0x7f0b0057
+			public const int abc_tint_btn_checkable = 2131427415;
+			
+			// aapt resource value: 0x7f0b0058
+			public const int abc_tint_default = 2131427416;
+			
+			// aapt resource value: 0x7f0b0059
+			public const int abc_tint_edittext = 2131427417;
+			
+			// aapt resource value: 0x7f0b005a
+			public const int abc_tint_seek_thumb = 2131427418;
+			
+			// aapt resource value: 0x7f0b005b
+			public const int abc_tint_spinner = 2131427419;
+			
+			// aapt resource value: 0x7f0b005c
+			public const int abc_tint_switch_thumb = 2131427420;
+			
+			// aapt resource value: 0x7f0b005d
+			public const int abc_tint_switch_track = 2131427421;
 			
 			// aapt resource value: 0x7f0b0013
-			public const int bright_foreground_material_light = 2131427347;
+			public const int accent_material_dark = 2131427347;
 			
 			// aapt resource value: 0x7f0b0014
-			public const int button_material_dark = 2131427348;
+			public const int accent_material_light = 2131427348;
 			
 			// aapt resource value: 0x7f0b0015
-			public const int button_material_light = 2131427349;
+			public const int background_floating_material_dark = 2131427349;
+			
+			// aapt resource value: 0x7f0b0016
+			public const int background_floating_material_light = 2131427350;
+			
+			// aapt resource value: 0x7f0b0017
+			public const int background_material_dark = 2131427351;
+			
+			// aapt resource value: 0x7f0b0018
+			public const int background_material_light = 2131427352;
+			
+			// aapt resource value: 0x7f0b0019
+			public const int bright_foreground_disabled_material_dark = 2131427353;
+			
+			// aapt resource value: 0x7f0b001a
+			public const int bright_foreground_disabled_material_light = 2131427354;
+			
+			// aapt resource value: 0x7f0b001b
+			public const int bright_foreground_inverse_material_dark = 2131427355;
+			
+			// aapt resource value: 0x7f0b001c
+			public const int bright_foreground_inverse_material_light = 2131427356;
+			
+			// aapt resource value: 0x7f0b001d
+			public const int bright_foreground_material_dark = 2131427357;
+			
+			// aapt resource value: 0x7f0b001e
+			public const int bright_foreground_material_light = 2131427358;
+			
+			// aapt resource value: 0x7f0b001f
+			public const int button_material_dark = 2131427359;
+			
+			// aapt resource value: 0x7f0b0020
+			public const int button_material_light = 2131427360;
 			
 			// aapt resource value: 0x7f0b0000
 			public const int cardview_dark_background = 2131427328;
@@ -2437,161 +2693,164 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f0b0003
 			public const int cardview_shadow_start_color = 2131427331;
 			
-			// aapt resource value: 0x7f0b003e
-			public const int design_fab_shadow_end_color = 2131427390;
+			// aapt resource value: 0x7f0b0004
+			public const int design_fab_shadow_end_color = 2131427332;
 			
-			// aapt resource value: 0x7f0b003f
-			public const int design_fab_shadow_mid_color = 2131427391;
+			// aapt resource value: 0x7f0b0005
+			public const int design_fab_shadow_mid_color = 2131427333;
 			
-			// aapt resource value: 0x7f0b0040
-			public const int design_fab_shadow_start_color = 2131427392;
+			// aapt resource value: 0x7f0b0006
+			public const int design_fab_shadow_start_color = 2131427334;
 			
-			// aapt resource value: 0x7f0b0041
-			public const int design_fab_stroke_end_inner_color = 2131427393;
+			// aapt resource value: 0x7f0b0007
+			public const int design_fab_stroke_end_inner_color = 2131427335;
 			
-			// aapt resource value: 0x7f0b0042
-			public const int design_fab_stroke_end_outer_color = 2131427394;
+			// aapt resource value: 0x7f0b0008
+			public const int design_fab_stroke_end_outer_color = 2131427336;
 			
-			// aapt resource value: 0x7f0b0043
-			public const int design_fab_stroke_top_inner_color = 2131427395;
+			// aapt resource value: 0x7f0b0009
+			public const int design_fab_stroke_top_inner_color = 2131427337;
 			
-			// aapt resource value: 0x7f0b0044
-			public const int design_fab_stroke_top_outer_color = 2131427396;
+			// aapt resource value: 0x7f0b000a
+			public const int design_fab_stroke_top_outer_color = 2131427338;
 			
-			// aapt resource value: 0x7f0b0045
-			public const int design_snackbar_background_color = 2131427397;
+			// aapt resource value: 0x7f0b000b
+			public const int design_snackbar_background_color = 2131427339;
 			
-			// aapt resource value: 0x7f0b0046
-			public const int design_textinput_error_color_dark = 2131427398;
+			// aapt resource value: 0x7f0b000c
+			public const int design_textinput_error_color_dark = 2131427340;
 			
-			// aapt resource value: 0x7f0b0047
-			public const int design_textinput_error_color_light = 2131427399;
-			
-			// aapt resource value: 0x7f0b0016
-			public const int dim_foreground_disabled_material_dark = 2131427350;
-			
-			// aapt resource value: 0x7f0b0017
-			public const int dim_foreground_disabled_material_light = 2131427351;
-			
-			// aapt resource value: 0x7f0b0018
-			public const int dim_foreground_material_dark = 2131427352;
-			
-			// aapt resource value: 0x7f0b0019
-			public const int dim_foreground_material_light = 2131427353;
-			
-			// aapt resource value: 0x7f0b001a
-			public const int foreground_material_dark = 2131427354;
-			
-			// aapt resource value: 0x7f0b001b
-			public const int foreground_material_light = 2131427355;
-			
-			// aapt resource value: 0x7f0b001c
-			public const int highlighted_text_material_dark = 2131427356;
-			
-			// aapt resource value: 0x7f0b001d
-			public const int highlighted_text_material_light = 2131427357;
-			
-			// aapt resource value: 0x7f0b001e
-			public const int hint_foreground_material_dark = 2131427358;
-			
-			// aapt resource value: 0x7f0b001f
-			public const int hint_foreground_material_light = 2131427359;
-			
-			// aapt resource value: 0x7f0b0020
-			public const int material_blue_grey_800 = 2131427360;
+			// aapt resource value: 0x7f0b000d
+			public const int design_textinput_error_color_light = 2131427341;
 			
 			// aapt resource value: 0x7f0b0021
-			public const int material_blue_grey_900 = 2131427361;
+			public const int dim_foreground_disabled_material_dark = 2131427361;
 			
 			// aapt resource value: 0x7f0b0022
-			public const int material_blue_grey_950 = 2131427362;
+			public const int dim_foreground_disabled_material_light = 2131427362;
 			
 			// aapt resource value: 0x7f0b0023
-			public const int material_deep_teal_200 = 2131427363;
+			public const int dim_foreground_material_dark = 2131427363;
 			
 			// aapt resource value: 0x7f0b0024
-			public const int material_deep_teal_500 = 2131427364;
+			public const int dim_foreground_material_light = 2131427364;
 			
 			// aapt resource value: 0x7f0b0025
-			public const int material_grey_100 = 2131427365;
+			public const int foreground_material_dark = 2131427365;
 			
 			// aapt resource value: 0x7f0b0026
-			public const int material_grey_300 = 2131427366;
+			public const int foreground_material_light = 2131427366;
 			
 			// aapt resource value: 0x7f0b0027
-			public const int material_grey_50 = 2131427367;
+			public const int highlighted_text_material_dark = 2131427367;
 			
 			// aapt resource value: 0x7f0b0028
-			public const int material_grey_600 = 2131427368;
+			public const int highlighted_text_material_light = 2131427368;
 			
 			// aapt resource value: 0x7f0b0029
-			public const int material_grey_800 = 2131427369;
+			public const int material_blue_grey_800 = 2131427369;
 			
 			// aapt resource value: 0x7f0b002a
-			public const int material_grey_850 = 2131427370;
+			public const int material_blue_grey_900 = 2131427370;
 			
 			// aapt resource value: 0x7f0b002b
-			public const int material_grey_900 = 2131427371;
+			public const int material_blue_grey_950 = 2131427371;
 			
 			// aapt resource value: 0x7f0b002c
-			public const int primary_dark_material_dark = 2131427372;
+			public const int material_deep_teal_200 = 2131427372;
 			
 			// aapt resource value: 0x7f0b002d
-			public const int primary_dark_material_light = 2131427373;
+			public const int material_deep_teal_500 = 2131427373;
 			
 			// aapt resource value: 0x7f0b002e
-			public const int primary_material_dark = 2131427374;
+			public const int material_grey_100 = 2131427374;
 			
 			// aapt resource value: 0x7f0b002f
-			public const int primary_material_light = 2131427375;
+			public const int material_grey_300 = 2131427375;
 			
 			// aapt resource value: 0x7f0b0030
-			public const int primary_text_default_material_dark = 2131427376;
+			public const int material_grey_50 = 2131427376;
 			
 			// aapt resource value: 0x7f0b0031
-			public const int primary_text_default_material_light = 2131427377;
+			public const int material_grey_600 = 2131427377;
 			
 			// aapt resource value: 0x7f0b0032
-			public const int primary_text_disabled_material_dark = 2131427378;
+			public const int material_grey_800 = 2131427378;
 			
 			// aapt resource value: 0x7f0b0033
-			public const int primary_text_disabled_material_light = 2131427379;
+			public const int material_grey_850 = 2131427379;
 			
 			// aapt resource value: 0x7f0b0034
-			public const int ripple_material_dark = 2131427380;
+			public const int material_grey_900 = 2131427380;
+			
+			// aapt resource value: 0x7f0b000e
+			public const int notification_action_color_filter = 2131427342;
 			
 			// aapt resource value: 0x7f0b0035
-			public const int ripple_material_light = 2131427381;
+			public const int notification_icon_bg_color = 2131427381;
 			
 			// aapt resource value: 0x7f0b0036
-			public const int secondary_text_default_material_dark = 2131427382;
+			public const int notification_material_background_media_default_color = 2131427382;
 			
 			// aapt resource value: 0x7f0b0037
-			public const int secondary_text_default_material_light = 2131427383;
+			public const int primary_dark_material_dark = 2131427383;
 			
 			// aapt resource value: 0x7f0b0038
-			public const int secondary_text_disabled_material_dark = 2131427384;
+			public const int primary_dark_material_light = 2131427384;
 			
 			// aapt resource value: 0x7f0b0039
-			public const int secondary_text_disabled_material_light = 2131427385;
+			public const int primary_material_dark = 2131427385;
 			
 			// aapt resource value: 0x7f0b003a
-			public const int switch_thumb_disabled_material_dark = 2131427386;
+			public const int primary_material_light = 2131427386;
 			
 			// aapt resource value: 0x7f0b003b
-			public const int switch_thumb_disabled_material_light = 2131427387;
-			
-			// aapt resource value: 0x7f0b0052
-			public const int switch_thumb_material_dark = 2131427410;
-			
-			// aapt resource value: 0x7f0b0053
-			public const int switch_thumb_material_light = 2131427411;
+			public const int primary_text_default_material_dark = 2131427387;
 			
 			// aapt resource value: 0x7f0b003c
-			public const int switch_thumb_normal_material_dark = 2131427388;
+			public const int primary_text_default_material_light = 2131427388;
 			
 			// aapt resource value: 0x7f0b003d
-			public const int switch_thumb_normal_material_light = 2131427389;
+			public const int primary_text_disabled_material_dark = 2131427389;
+			
+			// aapt resource value: 0x7f0b003e
+			public const int primary_text_disabled_material_light = 2131427390;
+			
+			// aapt resource value: 0x7f0b003f
+			public const int ripple_material_dark = 2131427391;
+			
+			// aapt resource value: 0x7f0b0040
+			public const int ripple_material_light = 2131427392;
+			
+			// aapt resource value: 0x7f0b0041
+			public const int secondary_text_default_material_dark = 2131427393;
+			
+			// aapt resource value: 0x7f0b0042
+			public const int secondary_text_default_material_light = 2131427394;
+			
+			// aapt resource value: 0x7f0b0043
+			public const int secondary_text_disabled_material_dark = 2131427395;
+			
+			// aapt resource value: 0x7f0b0044
+			public const int secondary_text_disabled_material_light = 2131427396;
+			
+			// aapt resource value: 0x7f0b0045
+			public const int switch_thumb_disabled_material_dark = 2131427397;
+			
+			// aapt resource value: 0x7f0b0046
+			public const int switch_thumb_disabled_material_light = 2131427398;
+			
+			// aapt resource value: 0x7f0b005e
+			public const int switch_thumb_material_dark = 2131427422;
+			
+			// aapt resource value: 0x7f0b005f
+			public const int switch_thumb_material_light = 2131427423;
+			
+			// aapt resource value: 0x7f0b0047
+			public const int switch_thumb_normal_material_dark = 2131427399;
+			
+			// aapt resource value: 0x7f0b0048
+			public const int switch_thumb_normal_material_light = 2131427400;
 			
 			static Color()
 			{
@@ -2606,206 +2865,227 @@ namespace XForms.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f060019
-			public const int abc_action_bar_content_inset_material = 2131099673;
-			
-			// aapt resource value: 0x7f06000d
-			public const int abc_action_bar_default_height_material = 2131099661;
-			
-			// aapt resource value: 0x7f06001a
-			public const int abc_action_bar_default_padding_end_material = 2131099674;
-			
-			// aapt resource value: 0x7f06001b
-			public const int abc_action_bar_default_padding_start_material = 2131099675;
-			
-			// aapt resource value: 0x7f06001d
-			public const int abc_action_bar_icon_vertical_padding_material = 2131099677;
-			
-			// aapt resource value: 0x7f06001e
-			public const int abc_action_bar_overflow_padding_end_material = 2131099678;
-			
-			// aapt resource value: 0x7f06001f
-			public const int abc_action_bar_overflow_padding_start_material = 2131099679;
-			
-			// aapt resource value: 0x7f06000e
-			public const int abc_action_bar_progress_bar_size = 2131099662;
-			
-			// aapt resource value: 0x7f060020
-			public const int abc_action_bar_stacked_max_height = 2131099680;
-			
-			// aapt resource value: 0x7f060021
-			public const int abc_action_bar_stacked_tab_max_width = 2131099681;
-			
-			// aapt resource value: 0x7f060022
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099682;
-			
-			// aapt resource value: 0x7f060023
-			public const int abc_action_bar_subtitle_top_margin_material = 2131099683;
-			
-			// aapt resource value: 0x7f060024
-			public const int abc_action_button_min_height_material = 2131099684;
-			
-			// aapt resource value: 0x7f060025
-			public const int abc_action_button_min_width_material = 2131099685;
-			
-			// aapt resource value: 0x7f060026
-			public const int abc_action_button_min_width_overflow_material = 2131099686;
-			
-			// aapt resource value: 0x7f06000c
-			public const int abc_alert_dialog_button_bar_height = 2131099660;
-			
-			// aapt resource value: 0x7f060027
-			public const int abc_button_inset_horizontal_material = 2131099687;
-			
-			// aapt resource value: 0x7f060028
-			public const int abc_button_inset_vertical_material = 2131099688;
-			
-			// aapt resource value: 0x7f060029
-			public const int abc_button_padding_horizontal_material = 2131099689;
-			
-			// aapt resource value: 0x7f06002a
-			public const int abc_button_padding_vertical_material = 2131099690;
-			
-			// aapt resource value: 0x7f060011
-			public const int abc_config_prefDialogWidth = 2131099665;
-			
-			// aapt resource value: 0x7f06002b
-			public const int abc_control_corner_material = 2131099691;
-			
-			// aapt resource value: 0x7f06002c
-			public const int abc_control_inset_material = 2131099692;
-			
-			// aapt resource value: 0x7f06002d
-			public const int abc_control_padding_material = 2131099693;
-			
-			// aapt resource value: 0x7f060012
-			public const int abc_dialog_fixed_height_major = 2131099666;
-			
-			// aapt resource value: 0x7f060013
-			public const int abc_dialog_fixed_height_minor = 2131099667;
-			
-			// aapt resource value: 0x7f060014
-			public const int abc_dialog_fixed_width_major = 2131099668;
-			
-			// aapt resource value: 0x7f060015
-			public const int abc_dialog_fixed_width_minor = 2131099669;
-			
-			// aapt resource value: 0x7f06002e
-			public const int abc_dialog_list_padding_vertical_material = 2131099694;
-			
-			// aapt resource value: 0x7f060016
-			public const int abc_dialog_min_width_major = 2131099670;
-			
-			// aapt resource value: 0x7f060017
-			public const int abc_dialog_min_width_minor = 2131099671;
-			
-			// aapt resource value: 0x7f06002f
-			public const int abc_dialog_padding_material = 2131099695;
-			
-			// aapt resource value: 0x7f060030
-			public const int abc_dialog_padding_top_material = 2131099696;
-			
-			// aapt resource value: 0x7f060031
-			public const int abc_disabled_alpha_material_dark = 2131099697;
-			
-			// aapt resource value: 0x7f060032
-			public const int abc_disabled_alpha_material_light = 2131099698;
-			
-			// aapt resource value: 0x7f060033
-			public const int abc_dropdownitem_icon_width = 2131099699;
-			
-			// aapt resource value: 0x7f060034
-			public const int abc_dropdownitem_text_padding_left = 2131099700;
-			
 			// aapt resource value: 0x7f060035
-			public const int abc_dropdownitem_text_padding_right = 2131099701;
+			public const int abc_action_bar_content_inset_material = 2131099701;
 			
 			// aapt resource value: 0x7f060036
-			public const int abc_edit_text_inset_bottom_material = 2131099702;
+			public const int abc_action_bar_content_inset_with_nav = 2131099702;
+			
+			// aapt resource value: 0x7f06002a
+			public const int abc_action_bar_default_height_material = 2131099690;
 			
 			// aapt resource value: 0x7f060037
-			public const int abc_edit_text_inset_horizontal_material = 2131099703;
+			public const int abc_action_bar_default_padding_end_material = 2131099703;
 			
 			// aapt resource value: 0x7f060038
-			public const int abc_edit_text_inset_top_material = 2131099704;
-			
-			// aapt resource value: 0x7f060039
-			public const int abc_floating_window_z = 2131099705;
-			
-			// aapt resource value: 0x7f06003a
-			public const int abc_list_item_padding_horizontal_material = 2131099706;
-			
-			// aapt resource value: 0x7f06003b
-			public const int abc_panel_menu_list_width = 2131099707;
-			
-			// aapt resource value: 0x7f06003c
-			public const int abc_search_view_preferred_width = 2131099708;
-			
-			// aapt resource value: 0x7f060018
-			public const int abc_search_view_text_min_width = 2131099672;
-			
-			// aapt resource value: 0x7f06003d
-			public const int abc_seekbar_track_background_height_material = 2131099709;
+			public const int abc_action_bar_default_padding_start_material = 2131099704;
 			
 			// aapt resource value: 0x7f06003e
-			public const int abc_seekbar_track_progress_height_material = 2131099710;
+			public const int abc_action_bar_elevation_material = 2131099710;
 			
 			// aapt resource value: 0x7f06003f
-			public const int abc_select_dialog_padding_start_material = 2131099711;
-			
-			// aapt resource value: 0x7f06001c
-			public const int abc_switch_padding = 2131099676;
+			public const int abc_action_bar_icon_vertical_padding_material = 2131099711;
 			
 			// aapt resource value: 0x7f060040
-			public const int abc_text_size_body_1_material = 2131099712;
+			public const int abc_action_bar_overflow_padding_end_material = 2131099712;
 			
 			// aapt resource value: 0x7f060041
-			public const int abc_text_size_body_2_material = 2131099713;
+			public const int abc_action_bar_overflow_padding_start_material = 2131099713;
+			
+			// aapt resource value: 0x7f06002b
+			public const int abc_action_bar_progress_bar_size = 2131099691;
 			
 			// aapt resource value: 0x7f060042
-			public const int abc_text_size_button_material = 2131099714;
+			public const int abc_action_bar_stacked_max_height = 2131099714;
 			
 			// aapt resource value: 0x7f060043
-			public const int abc_text_size_caption_material = 2131099715;
+			public const int abc_action_bar_stacked_tab_max_width = 2131099715;
 			
 			// aapt resource value: 0x7f060044
-			public const int abc_text_size_display_1_material = 2131099716;
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099716;
 			
 			// aapt resource value: 0x7f060045
-			public const int abc_text_size_display_2_material = 2131099717;
+			public const int abc_action_bar_subtitle_top_margin_material = 2131099717;
 			
 			// aapt resource value: 0x7f060046
-			public const int abc_text_size_display_3_material = 2131099718;
+			public const int abc_action_button_min_height_material = 2131099718;
 			
 			// aapt resource value: 0x7f060047
-			public const int abc_text_size_display_4_material = 2131099719;
+			public const int abc_action_button_min_width_material = 2131099719;
 			
 			// aapt resource value: 0x7f060048
-			public const int abc_text_size_headline_material = 2131099720;
+			public const int abc_action_button_min_width_overflow_material = 2131099720;
+			
+			// aapt resource value: 0x7f060029
+			public const int abc_alert_dialog_button_bar_height = 2131099689;
 			
 			// aapt resource value: 0x7f060049
-			public const int abc_text_size_large_material = 2131099721;
+			public const int abc_button_inset_horizontal_material = 2131099721;
 			
 			// aapt resource value: 0x7f06004a
-			public const int abc_text_size_medium_material = 2131099722;
+			public const int abc_button_inset_vertical_material = 2131099722;
 			
 			// aapt resource value: 0x7f06004b
-			public const int abc_text_size_menu_material = 2131099723;
+			public const int abc_button_padding_horizontal_material = 2131099723;
 			
 			// aapt resource value: 0x7f06004c
-			public const int abc_text_size_small_material = 2131099724;
+			public const int abc_button_padding_vertical_material = 2131099724;
 			
 			// aapt resource value: 0x7f06004d
-			public const int abc_text_size_subhead_material = 2131099725;
+			public const int abc_cascading_menus_min_smallest_width = 2131099725;
 			
-			// aapt resource value: 0x7f06000f
-			public const int abc_text_size_subtitle_material_toolbar = 2131099663;
+			// aapt resource value: 0x7f06002e
+			public const int abc_config_prefDialogWidth = 2131099694;
 			
 			// aapt resource value: 0x7f06004e
-			public const int abc_text_size_title_material = 2131099726;
+			public const int abc_control_corner_material = 2131099726;
 			
-			// aapt resource value: 0x7f060010
-			public const int abc_text_size_title_material_toolbar = 2131099664;
+			// aapt resource value: 0x7f06004f
+			public const int abc_control_inset_material = 2131099727;
+			
+			// aapt resource value: 0x7f060050
+			public const int abc_control_padding_material = 2131099728;
+			
+			// aapt resource value: 0x7f06002f
+			public const int abc_dialog_fixed_height_major = 2131099695;
+			
+			// aapt resource value: 0x7f060030
+			public const int abc_dialog_fixed_height_minor = 2131099696;
+			
+			// aapt resource value: 0x7f060031
+			public const int abc_dialog_fixed_width_major = 2131099697;
+			
+			// aapt resource value: 0x7f060032
+			public const int abc_dialog_fixed_width_minor = 2131099698;
+			
+			// aapt resource value: 0x7f060051
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131099729;
+			
+			// aapt resource value: 0x7f060052
+			public const int abc_dialog_list_padding_top_no_title = 2131099730;
+			
+			// aapt resource value: 0x7f060033
+			public const int abc_dialog_min_width_major = 2131099699;
+			
+			// aapt resource value: 0x7f060034
+			public const int abc_dialog_min_width_minor = 2131099700;
+			
+			// aapt resource value: 0x7f060053
+			public const int abc_dialog_padding_material = 2131099731;
+			
+			// aapt resource value: 0x7f060054
+			public const int abc_dialog_padding_top_material = 2131099732;
+			
+			// aapt resource value: 0x7f060055
+			public const int abc_dialog_title_divider_material = 2131099733;
+			
+			// aapt resource value: 0x7f060056
+			public const int abc_disabled_alpha_material_dark = 2131099734;
+			
+			// aapt resource value: 0x7f060057
+			public const int abc_disabled_alpha_material_light = 2131099735;
+			
+			// aapt resource value: 0x7f060058
+			public const int abc_dropdownitem_icon_width = 2131099736;
+			
+			// aapt resource value: 0x7f060059
+			public const int abc_dropdownitem_text_padding_left = 2131099737;
+			
+			// aapt resource value: 0x7f06005a
+			public const int abc_dropdownitem_text_padding_right = 2131099738;
+			
+			// aapt resource value: 0x7f06005b
+			public const int abc_edit_text_inset_bottom_material = 2131099739;
+			
+			// aapt resource value: 0x7f06005c
+			public const int abc_edit_text_inset_horizontal_material = 2131099740;
+			
+			// aapt resource value: 0x7f06005d
+			public const int abc_edit_text_inset_top_material = 2131099741;
+			
+			// aapt resource value: 0x7f06005e
+			public const int abc_floating_window_z = 2131099742;
+			
+			// aapt resource value: 0x7f06005f
+			public const int abc_list_item_padding_horizontal_material = 2131099743;
+			
+			// aapt resource value: 0x7f060060
+			public const int abc_panel_menu_list_width = 2131099744;
+			
+			// aapt resource value: 0x7f060061
+			public const int abc_progress_bar_height_material = 2131099745;
+			
+			// aapt resource value: 0x7f060062
+			public const int abc_search_view_preferred_height = 2131099746;
+			
+			// aapt resource value: 0x7f060063
+			public const int abc_search_view_preferred_width = 2131099747;
+			
+			// aapt resource value: 0x7f060064
+			public const int abc_seekbar_track_background_height_material = 2131099748;
+			
+			// aapt resource value: 0x7f060065
+			public const int abc_seekbar_track_progress_height_material = 2131099749;
+			
+			// aapt resource value: 0x7f060066
+			public const int abc_select_dialog_padding_start_material = 2131099750;
+			
+			// aapt resource value: 0x7f06003a
+			public const int abc_switch_padding = 2131099706;
+			
+			// aapt resource value: 0x7f060067
+			public const int abc_text_size_body_1_material = 2131099751;
+			
+			// aapt resource value: 0x7f060068
+			public const int abc_text_size_body_2_material = 2131099752;
+			
+			// aapt resource value: 0x7f060069
+			public const int abc_text_size_button_material = 2131099753;
+			
+			// aapt resource value: 0x7f06006a
+			public const int abc_text_size_caption_material = 2131099754;
+			
+			// aapt resource value: 0x7f06006b
+			public const int abc_text_size_display_1_material = 2131099755;
+			
+			// aapt resource value: 0x7f06006c
+			public const int abc_text_size_display_2_material = 2131099756;
+			
+			// aapt resource value: 0x7f06006d
+			public const int abc_text_size_display_3_material = 2131099757;
+			
+			// aapt resource value: 0x7f06006e
+			public const int abc_text_size_display_4_material = 2131099758;
+			
+			// aapt resource value: 0x7f06006f
+			public const int abc_text_size_headline_material = 2131099759;
+			
+			// aapt resource value: 0x7f060070
+			public const int abc_text_size_large_material = 2131099760;
+			
+			// aapt resource value: 0x7f060071
+			public const int abc_text_size_medium_material = 2131099761;
+			
+			// aapt resource value: 0x7f060072
+			public const int abc_text_size_menu_header_material = 2131099762;
+			
+			// aapt resource value: 0x7f060073
+			public const int abc_text_size_menu_material = 2131099763;
+			
+			// aapt resource value: 0x7f060074
+			public const int abc_text_size_small_material = 2131099764;
+			
+			// aapt resource value: 0x7f060075
+			public const int abc_text_size_subhead_material = 2131099765;
+			
+			// aapt resource value: 0x7f06002c
+			public const int abc_text_size_subtitle_material_toolbar = 2131099692;
+			
+			// aapt resource value: 0x7f060076
+			public const int abc_text_size_title_material = 2131099766;
+			
+			// aapt resource value: 0x7f06002d
+			public const int abc_text_size_title_material_toolbar = 2131099693;
 			
 			// aapt resource value: 0x7f060009
 			public const int cardview_compat_inset_shadow = 2131099657;
@@ -2816,107 +3096,119 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f06000b
 			public const int cardview_default_radius = 2131099659;
 			
-			// aapt resource value: 0x7f06005f
-			public const int design_appbar_elevation = 2131099743;
+			// aapt resource value: 0x7f060014
+			public const int design_appbar_elevation = 2131099668;
 			
-			// aapt resource value: 0x7f060060
-			public const int design_bottom_sheet_modal_elevation = 2131099744;
+			// aapt resource value: 0x7f060015
+			public const int design_bottom_sheet_modal_elevation = 2131099669;
 			
-			// aapt resource value: 0x7f060061
-			public const int design_bottom_sheet_modal_peek_height = 2131099745;
+			// aapt resource value: 0x7f060016
+			public const int design_bottom_sheet_modal_peek_height = 2131099670;
 			
-			// aapt resource value: 0x7f060062
-			public const int design_fab_border_width = 2131099746;
+			// aapt resource value: 0x7f060017
+			public const int design_fab_border_width = 2131099671;
 			
-			// aapt resource value: 0x7f060063
-			public const int design_fab_elevation = 2131099747;
+			// aapt resource value: 0x7f060018
+			public const int design_fab_elevation = 2131099672;
 			
-			// aapt resource value: 0x7f060064
-			public const int design_fab_image_size = 2131099748;
+			// aapt resource value: 0x7f060019
+			public const int design_fab_image_size = 2131099673;
 			
-			// aapt resource value: 0x7f060065
-			public const int design_fab_size_mini = 2131099749;
+			// aapt resource value: 0x7f06001a
+			public const int design_fab_size_mini = 2131099674;
 			
-			// aapt resource value: 0x7f060066
-			public const int design_fab_size_normal = 2131099750;
+			// aapt resource value: 0x7f06001b
+			public const int design_fab_size_normal = 2131099675;
 			
-			// aapt resource value: 0x7f060067
-			public const int design_fab_translation_z_pressed = 2131099751;
+			// aapt resource value: 0x7f06001c
+			public const int design_fab_translation_z_pressed = 2131099676;
 			
-			// aapt resource value: 0x7f060068
-			public const int design_navigation_elevation = 2131099752;
+			// aapt resource value: 0x7f06001d
+			public const int design_navigation_elevation = 2131099677;
 			
-			// aapt resource value: 0x7f060069
-			public const int design_navigation_icon_padding = 2131099753;
+			// aapt resource value: 0x7f06001e
+			public const int design_navigation_icon_padding = 2131099678;
 			
-			// aapt resource value: 0x7f06006a
-			public const int design_navigation_icon_size = 2131099754;
+			// aapt resource value: 0x7f06001f
+			public const int design_navigation_icon_size = 2131099679;
 			
-			// aapt resource value: 0x7f060057
-			public const int design_navigation_max_width = 2131099735;
+			// aapt resource value: 0x7f06000c
+			public const int design_navigation_max_width = 2131099660;
 			
-			// aapt resource value: 0x7f06006b
-			public const int design_navigation_padding_bottom = 2131099755;
+			// aapt resource value: 0x7f060020
+			public const int design_navigation_padding_bottom = 2131099680;
 			
-			// aapt resource value: 0x7f06006c
-			public const int design_navigation_separator_vertical_padding = 2131099756;
+			// aapt resource value: 0x7f060021
+			public const int design_navigation_separator_vertical_padding = 2131099681;
 			
-			// aapt resource value: 0x7f060058
-			public const int design_snackbar_action_inline_max_width = 2131099736;
+			// aapt resource value: 0x7f06000d
+			public const int design_snackbar_action_inline_max_width = 2131099661;
 			
-			// aapt resource value: 0x7f060059
-			public const int design_snackbar_background_corner_radius = 2131099737;
+			// aapt resource value: 0x7f06000e
+			public const int design_snackbar_background_corner_radius = 2131099662;
 			
-			// aapt resource value: 0x7f06006d
-			public const int design_snackbar_elevation = 2131099757;
+			// aapt resource value: 0x7f060022
+			public const int design_snackbar_elevation = 2131099682;
 			
-			// aapt resource value: 0x7f06005a
-			public const int design_snackbar_extra_spacing_horizontal = 2131099738;
+			// aapt resource value: 0x7f06000f
+			public const int design_snackbar_extra_spacing_horizontal = 2131099663;
 			
-			// aapt resource value: 0x7f06005b
-			public const int design_snackbar_max_width = 2131099739;
+			// aapt resource value: 0x7f060010
+			public const int design_snackbar_max_width = 2131099664;
 			
-			// aapt resource value: 0x7f06005c
-			public const int design_snackbar_min_width = 2131099740;
+			// aapt resource value: 0x7f060011
+			public const int design_snackbar_min_width = 2131099665;
 			
-			// aapt resource value: 0x7f06006e
-			public const int design_snackbar_padding_horizontal = 2131099758;
+			// aapt resource value: 0x7f060023
+			public const int design_snackbar_padding_horizontal = 2131099683;
 			
-			// aapt resource value: 0x7f06006f
-			public const int design_snackbar_padding_vertical = 2131099759;
+			// aapt resource value: 0x7f060024
+			public const int design_snackbar_padding_vertical = 2131099684;
 			
-			// aapt resource value: 0x7f06005d
-			public const int design_snackbar_padding_vertical_2lines = 2131099741;
+			// aapt resource value: 0x7f060012
+			public const int design_snackbar_padding_vertical_2lines = 2131099666;
 			
-			// aapt resource value: 0x7f060070
-			public const int design_snackbar_text_size = 2131099760;
+			// aapt resource value: 0x7f060025
+			public const int design_snackbar_text_size = 2131099685;
 			
-			// aapt resource value: 0x7f060071
-			public const int design_tab_max_width = 2131099761;
+			// aapt resource value: 0x7f060026
+			public const int design_tab_max_width = 2131099686;
 			
-			// aapt resource value: 0x7f06005e
-			public const int design_tab_scrollable_min_width = 2131099742;
+			// aapt resource value: 0x7f060013
+			public const int design_tab_scrollable_min_width = 2131099667;
 			
-			// aapt resource value: 0x7f060072
-			public const int design_tab_text_size = 2131099762;
+			// aapt resource value: 0x7f060027
+			public const int design_tab_text_size = 2131099687;
 			
-			// aapt resource value: 0x7f060073
-			public const int design_tab_text_size_2line = 2131099763;
+			// aapt resource value: 0x7f060028
+			public const int design_tab_text_size_2line = 2131099688;
 			
-			// aapt resource value: 0x7f06004f
-			public const int disabled_alpha_material_dark = 2131099727;
+			// aapt resource value: 0x7f060077
+			public const int disabled_alpha_material_dark = 2131099767;
 			
-			// aapt resource value: 0x7f060050
-			public const int disabled_alpha_material_light = 2131099728;
+			// aapt resource value: 0x7f060078
+			public const int disabled_alpha_material_light = 2131099768;
 			
-			// aapt resource value: 0x7f060051
-			public const int highlight_alpha_material_colored = 2131099729;
+			// aapt resource value: 0x7f060079
+			public const int highlight_alpha_material_colored = 2131099769;
 			
-			// aapt resource value: 0x7f060052
-			public const int highlight_alpha_material_dark = 2131099730;
+			// aapt resource value: 0x7f06007a
+			public const int highlight_alpha_material_dark = 2131099770;
 			
-			// aapt resource value: 0x7f060053
-			public const int highlight_alpha_material_light = 2131099731;
+			// aapt resource value: 0x7f06007b
+			public const int highlight_alpha_material_light = 2131099771;
+			
+			// aapt resource value: 0x7f06007c
+			public const int hint_alpha_material_dark = 2131099772;
+			
+			// aapt resource value: 0x7f06007d
+			public const int hint_alpha_material_light = 2131099773;
+			
+			// aapt resource value: 0x7f06007e
+			public const int hint_pressed_alpha_material_dark = 2131099774;
+			
+			// aapt resource value: 0x7f06007f
+			public const int hint_pressed_alpha_material_light = 2131099775;
 			
 			// aapt resource value: 0x7f060000
 			public const int item_touch_helper_max_drag_scroll_per_frame = 2131099648;
@@ -2945,14 +3237,50 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f060007
 			public const int mr_dialog_fixed_width_minor = 2131099655;
 			
-			// aapt resource value: 0x7f060054
-			public const int notification_large_icon_height = 2131099732;
+			// aapt resource value: 0x7f060080
+			public const int notification_action_icon_size = 2131099776;
 			
-			// aapt resource value: 0x7f060055
-			public const int notification_large_icon_width = 2131099733;
+			// aapt resource value: 0x7f060081
+			public const int notification_action_text_size = 2131099777;
 			
-			// aapt resource value: 0x7f060056
-			public const int notification_subtext_size = 2131099734;
+			// aapt resource value: 0x7f060082
+			public const int notification_big_circle_margin = 2131099778;
+			
+			// aapt resource value: 0x7f06003b
+			public const int notification_content_margin_start = 2131099707;
+			
+			// aapt resource value: 0x7f060083
+			public const int notification_large_icon_height = 2131099779;
+			
+			// aapt resource value: 0x7f060084
+			public const int notification_large_icon_width = 2131099780;
+			
+			// aapt resource value: 0x7f06003c
+			public const int notification_main_column_padding_top = 2131099708;
+			
+			// aapt resource value: 0x7f06003d
+			public const int notification_media_narrow_margin = 2131099709;
+			
+			// aapt resource value: 0x7f060085
+			public const int notification_right_icon_size = 2131099781;
+			
+			// aapt resource value: 0x7f060039
+			public const int notification_right_side_padding_top = 2131099705;
+			
+			// aapt resource value: 0x7f060086
+			public const int notification_small_icon_background_padding = 2131099782;
+			
+			// aapt resource value: 0x7f060087
+			public const int notification_small_icon_size_as_large = 2131099783;
+			
+			// aapt resource value: 0x7f060088
+			public const int notification_subtext_size = 2131099784;
+			
+			// aapt resource value: 0x7f060089
+			public const int notification_top_pad = 2131099785;
+			
+			// aapt resource value: 0x7f06008a
+			public const int notification_top_pad_large_text = 2131099786;
 			
 			static Dimension()
 			{
@@ -3001,85 +3329,85 @@ namespace XForms.Droid
 			public const int abc_btn_radio_to_on_mtrl_015 = 2130837514;
 			
 			// aapt resource value: 0x7f02000b
-			public const int abc_btn_rating_star_off_mtrl_alpha = 2130837515;
+			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
 			
 			// aapt resource value: 0x7f02000c
-			public const int abc_btn_rating_star_on_mtrl_alpha = 2130837516;
+			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
 			
 			// aapt resource value: 0x7f02000d
-			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837517;
+			public const int abc_cab_background_internal_bg = 2130837517;
 			
 			// aapt resource value: 0x7f02000e
-			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837518;
+			public const int abc_cab_background_top_material = 2130837518;
 			
 			// aapt resource value: 0x7f02000f
-			public const int abc_cab_background_internal_bg = 2130837519;
+			public const int abc_cab_background_top_mtrl_alpha = 2130837519;
 			
 			// aapt resource value: 0x7f020010
-			public const int abc_cab_background_top_material = 2130837520;
+			public const int abc_control_background_material = 2130837520;
 			
 			// aapt resource value: 0x7f020011
-			public const int abc_cab_background_top_mtrl_alpha = 2130837521;
+			public const int abc_dialog_material_background = 2130837521;
 			
 			// aapt resource value: 0x7f020012
-			public const int abc_control_background_material = 2130837522;
+			public const int abc_edit_text_material = 2130837522;
 			
 			// aapt resource value: 0x7f020013
-			public const int abc_dialog_material_background_dark = 2130837523;
+			public const int abc_ic_ab_back_material = 2130837523;
 			
 			// aapt resource value: 0x7f020014
-			public const int abc_dialog_material_background_light = 2130837524;
+			public const int abc_ic_arrow_drop_right_black_24dp = 2130837524;
 			
 			// aapt resource value: 0x7f020015
-			public const int abc_edit_text_material = 2130837525;
+			public const int abc_ic_clear_material = 2130837525;
 			
 			// aapt resource value: 0x7f020016
-			public const int abc_ic_ab_back_mtrl_am_alpha = 2130837526;
+			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
 			
 			// aapt resource value: 0x7f020017
-			public const int abc_ic_clear_mtrl_alpha = 2130837527;
+			public const int abc_ic_go_search_api_material = 2130837527;
 			
 			// aapt resource value: 0x7f020018
-			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837528;
+			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
 			
 			// aapt resource value: 0x7f020019
-			public const int abc_ic_go_search_api_mtrl_alpha = 2130837529;
+			public const int abc_ic_menu_cut_mtrl_alpha = 2130837529;
 			
 			// aapt resource value: 0x7f02001a
-			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837530;
+			public const int abc_ic_menu_overflow_material = 2130837530;
 			
 			// aapt resource value: 0x7f02001b
-			public const int abc_ic_menu_cut_mtrl_alpha = 2130837531;
+			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
 			
 			// aapt resource value: 0x7f02001c
-			public const int abc_ic_menu_moreoverflow_mtrl_alpha = 2130837532;
+			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
 			
 			// aapt resource value: 0x7f02001d
-			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837533;
+			public const int abc_ic_menu_share_mtrl_alpha = 2130837533;
 			
 			// aapt resource value: 0x7f02001e
-			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837534;
+			public const int abc_ic_search_api_material = 2130837534;
 			
 			// aapt resource value: 0x7f02001f
-			public const int abc_ic_menu_share_mtrl_alpha = 2130837535;
+			public const int abc_ic_star_black_16dp = 2130837535;
 			
 			// aapt resource value: 0x7f020020
-			public const int abc_ic_search_api_mtrl_alpha = 2130837536;
+			public const int abc_ic_star_black_36dp = 2130837536;
 			
 			// aapt resource value: 0x7f020021
-			public const int abc_ic_star_black_16dp = 2130837537;
+			public const int abc_ic_star_black_48dp = 2130837537;
 			
 			// aapt resource value: 0x7f020022
-			public const int abc_ic_star_black_36dp = 2130837538;
+			public const int abc_ic_star_half_black_16dp = 2130837538;
 			
 			// aapt resource value: 0x7f020023
-			public const int abc_ic_star_half_black_16dp = 2130837539;
+			public const int abc_ic_star_half_black_36dp = 2130837539;
 			
 			// aapt resource value: 0x7f020024
-			public const int abc_ic_star_half_black_36dp = 2130837540;
+			public const int abc_ic_star_half_black_48dp = 2130837540;
 			
 			// aapt resource value: 0x7f020025
-			public const int abc_ic_voice_search_api_mtrl_alpha = 2130837541;
+			public const int abc_ic_voice_search_api_material = 2130837541;
 			
 			// aapt resource value: 0x7f020026
 			public const int abc_item_background_holo_dark = 2130837542;
@@ -3127,10 +3455,10 @@ namespace XForms.Droid
 			public const int abc_popup_background_mtrl_mult = 2130837556;
 			
 			// aapt resource value: 0x7f020035
-			public const int abc_ratingbar_full_material = 2130837557;
+			public const int abc_ratingbar_indicator_material = 2130837557;
 			
 			// aapt resource value: 0x7f020036
-			public const int abc_ratingbar_indicator_material = 2130837558;
+			public const int abc_ratingbar_material = 2130837558;
 			
 			// aapt resource value: 0x7f020037
 			public const int abc_ratingbar_small_material = 2130837559;
@@ -3154,304 +3482,361 @@ namespace XForms.Droid
 			public const int abc_seekbar_thumb_material = 2130837565;
 			
 			// aapt resource value: 0x7f02003e
-			public const int abc_seekbar_track_material = 2130837566;
+			public const int abc_seekbar_tick_mark_material = 2130837566;
 			
 			// aapt resource value: 0x7f02003f
-			public const int abc_spinner_mtrl_am_alpha = 2130837567;
+			public const int abc_seekbar_track_material = 2130837567;
 			
 			// aapt resource value: 0x7f020040
-			public const int abc_spinner_textfield_background_material = 2130837568;
+			public const int abc_spinner_mtrl_am_alpha = 2130837568;
 			
 			// aapt resource value: 0x7f020041
-			public const int abc_switch_thumb_material = 2130837569;
+			public const int abc_spinner_textfield_background_material = 2130837569;
 			
 			// aapt resource value: 0x7f020042
-			public const int abc_switch_track_mtrl_alpha = 2130837570;
+			public const int abc_switch_thumb_material = 2130837570;
 			
 			// aapt resource value: 0x7f020043
-			public const int abc_tab_indicator_material = 2130837571;
+			public const int abc_switch_track_mtrl_alpha = 2130837571;
 			
 			// aapt resource value: 0x7f020044
-			public const int abc_tab_indicator_mtrl_alpha = 2130837572;
+			public const int abc_tab_indicator_material = 2130837572;
 			
 			// aapt resource value: 0x7f020045
-			public const int abc_text_cursor_material = 2130837573;
+			public const int abc_tab_indicator_mtrl_alpha = 2130837573;
 			
 			// aapt resource value: 0x7f020046
-			public const int abc_textfield_activated_mtrl_alpha = 2130837574;
+			public const int abc_text_cursor_material = 2130837574;
 			
 			// aapt resource value: 0x7f020047
-			public const int abc_textfield_default_mtrl_alpha = 2130837575;
+			public const int abc_text_select_handle_left_mtrl_dark = 2130837575;
 			
 			// aapt resource value: 0x7f020048
-			public const int abc_textfield_search_activated_mtrl_alpha = 2130837576;
+			public const int abc_text_select_handle_left_mtrl_light = 2130837576;
 			
 			// aapt resource value: 0x7f020049
-			public const int abc_textfield_search_default_mtrl_alpha = 2130837577;
+			public const int abc_text_select_handle_middle_mtrl_dark = 2130837577;
 			
 			// aapt resource value: 0x7f02004a
-			public const int abc_textfield_search_material = 2130837578;
+			public const int abc_text_select_handle_middle_mtrl_light = 2130837578;
 			
 			// aapt resource value: 0x7f02004b
-			public const int design_fab_background = 2130837579;
+			public const int abc_text_select_handle_right_mtrl_dark = 2130837579;
 			
 			// aapt resource value: 0x7f02004c
-			public const int design_snackbar_background = 2130837580;
+			public const int abc_text_select_handle_right_mtrl_light = 2130837580;
 			
 			// aapt resource value: 0x7f02004d
-			public const int ic_audiotrack = 2130837581;
+			public const int abc_textfield_activated_mtrl_alpha = 2130837581;
 			
 			// aapt resource value: 0x7f02004e
-			public const int ic_audiotrack_light = 2130837582;
+			public const int abc_textfield_default_mtrl_alpha = 2130837582;
 			
 			// aapt resource value: 0x7f02004f
-			public const int ic_bluetooth_grey = 2130837583;
+			public const int abc_textfield_search_activated_mtrl_alpha = 2130837583;
 			
 			// aapt resource value: 0x7f020050
-			public const int ic_bluetooth_white = 2130837584;
+			public const int abc_textfield_search_default_mtrl_alpha = 2130837584;
 			
 			// aapt resource value: 0x7f020051
-			public const int ic_cast_dark = 2130837585;
+			public const int abc_textfield_search_material = 2130837585;
 			
 			// aapt resource value: 0x7f020052
-			public const int ic_cast_disabled_light = 2130837586;
+			public const int abc_vector_test = 2130837586;
 			
 			// aapt resource value: 0x7f020053
-			public const int ic_cast_grey = 2130837587;
+			public const int design_fab_background = 2130837587;
 			
 			// aapt resource value: 0x7f020054
-			public const int ic_cast_light = 2130837588;
+			public const int design_snackbar_background = 2130837588;
 			
 			// aapt resource value: 0x7f020055
-			public const int ic_cast_off_light = 2130837589;
+			public const int ic_audiotrack = 2130837589;
 			
 			// aapt resource value: 0x7f020056
-			public const int ic_cast_on_0_light = 2130837590;
+			public const int ic_audiotrack_light = 2130837590;
 			
 			// aapt resource value: 0x7f020057
-			public const int ic_cast_on_1_light = 2130837591;
+			public const int ic_bluetooth_grey = 2130837591;
 			
 			// aapt resource value: 0x7f020058
-			public const int ic_cast_on_2_light = 2130837592;
+			public const int ic_bluetooth_white = 2130837592;
 			
 			// aapt resource value: 0x7f020059
-			public const int ic_cast_on_light = 2130837593;
+			public const int ic_cast_dark = 2130837593;
 			
 			// aapt resource value: 0x7f02005a
-			public const int ic_cast_white = 2130837594;
+			public const int ic_cast_disabled_light = 2130837594;
 			
 			// aapt resource value: 0x7f02005b
-			public const int ic_close_dark = 2130837595;
+			public const int ic_cast_grey = 2130837595;
 			
 			// aapt resource value: 0x7f02005c
-			public const int ic_close_light = 2130837596;
+			public const int ic_cast_light = 2130837596;
 			
 			// aapt resource value: 0x7f02005d
-			public const int ic_collapse = 2130837597;
+			public const int ic_cast_off_light = 2130837597;
 			
 			// aapt resource value: 0x7f02005e
-			public const int ic_collapse_00000 = 2130837598;
+			public const int ic_cast_on_0_light = 2130837598;
 			
 			// aapt resource value: 0x7f02005f
-			public const int ic_collapse_00001 = 2130837599;
+			public const int ic_cast_on_1_light = 2130837599;
 			
 			// aapt resource value: 0x7f020060
-			public const int ic_collapse_00002 = 2130837600;
+			public const int ic_cast_on_2_light = 2130837600;
 			
 			// aapt resource value: 0x7f020061
-			public const int ic_collapse_00003 = 2130837601;
+			public const int ic_cast_on_light = 2130837601;
 			
 			// aapt resource value: 0x7f020062
-			public const int ic_collapse_00004 = 2130837602;
+			public const int ic_cast_white = 2130837602;
 			
 			// aapt resource value: 0x7f020063
-			public const int ic_collapse_00005 = 2130837603;
+			public const int ic_close_dark = 2130837603;
 			
 			// aapt resource value: 0x7f020064
-			public const int ic_collapse_00006 = 2130837604;
+			public const int ic_close_light = 2130837604;
 			
 			// aapt resource value: 0x7f020065
-			public const int ic_collapse_00007 = 2130837605;
+			public const int ic_collapse = 2130837605;
 			
 			// aapt resource value: 0x7f020066
-			public const int ic_collapse_00008 = 2130837606;
+			public const int ic_collapse_00000 = 2130837606;
 			
 			// aapt resource value: 0x7f020067
-			public const int ic_collapse_00009 = 2130837607;
+			public const int ic_collapse_00001 = 2130837607;
 			
 			// aapt resource value: 0x7f020068
-			public const int ic_collapse_00010 = 2130837608;
+			public const int ic_collapse_00002 = 2130837608;
 			
 			// aapt resource value: 0x7f020069
-			public const int ic_collapse_00011 = 2130837609;
+			public const int ic_collapse_00003 = 2130837609;
 			
 			// aapt resource value: 0x7f02006a
-			public const int ic_collapse_00012 = 2130837610;
+			public const int ic_collapse_00004 = 2130837610;
 			
 			// aapt resource value: 0x7f02006b
-			public const int ic_collapse_00013 = 2130837611;
+			public const int ic_collapse_00005 = 2130837611;
 			
 			// aapt resource value: 0x7f02006c
-			public const int ic_collapse_00014 = 2130837612;
+			public const int ic_collapse_00006 = 2130837612;
 			
 			// aapt resource value: 0x7f02006d
-			public const int ic_collapse_00015 = 2130837613;
+			public const int ic_collapse_00007 = 2130837613;
 			
 			// aapt resource value: 0x7f02006e
-			public const int ic_expand = 2130837614;
+			public const int ic_collapse_00008 = 2130837614;
 			
 			// aapt resource value: 0x7f02006f
-			public const int ic_expand_00000 = 2130837615;
+			public const int ic_collapse_00009 = 2130837615;
 			
 			// aapt resource value: 0x7f020070
-			public const int ic_expand_00001 = 2130837616;
+			public const int ic_collapse_00010 = 2130837616;
 			
 			// aapt resource value: 0x7f020071
-			public const int ic_expand_00002 = 2130837617;
+			public const int ic_collapse_00011 = 2130837617;
 			
 			// aapt resource value: 0x7f020072
-			public const int ic_expand_00003 = 2130837618;
+			public const int ic_collapse_00012 = 2130837618;
 			
 			// aapt resource value: 0x7f020073
-			public const int ic_expand_00004 = 2130837619;
+			public const int ic_collapse_00013 = 2130837619;
 			
 			// aapt resource value: 0x7f020074
-			public const int ic_expand_00005 = 2130837620;
+			public const int ic_collapse_00014 = 2130837620;
 			
 			// aapt resource value: 0x7f020075
-			public const int ic_expand_00006 = 2130837621;
+			public const int ic_collapse_00015 = 2130837621;
 			
 			// aapt resource value: 0x7f020076
-			public const int ic_expand_00007 = 2130837622;
+			public const int ic_expand = 2130837622;
 			
 			// aapt resource value: 0x7f020077
-			public const int ic_expand_00008 = 2130837623;
+			public const int ic_expand_00000 = 2130837623;
 			
 			// aapt resource value: 0x7f020078
-			public const int ic_expand_00009 = 2130837624;
+			public const int ic_expand_00001 = 2130837624;
 			
 			// aapt resource value: 0x7f020079
-			public const int ic_expand_00010 = 2130837625;
+			public const int ic_expand_00002 = 2130837625;
 			
 			// aapt resource value: 0x7f02007a
-			public const int ic_expand_00011 = 2130837626;
+			public const int ic_expand_00003 = 2130837626;
 			
 			// aapt resource value: 0x7f02007b
-			public const int ic_expand_00012 = 2130837627;
+			public const int ic_expand_00004 = 2130837627;
 			
 			// aapt resource value: 0x7f02007c
-			public const int ic_expand_00013 = 2130837628;
+			public const int ic_expand_00005 = 2130837628;
 			
 			// aapt resource value: 0x7f02007d
-			public const int ic_expand_00014 = 2130837629;
+			public const int ic_expand_00006 = 2130837629;
 			
 			// aapt resource value: 0x7f02007e
-			public const int ic_expand_00015 = 2130837630;
+			public const int ic_expand_00007 = 2130837630;
 			
 			// aapt resource value: 0x7f02007f
-			public const int ic_media_pause = 2130837631;
+			public const int ic_expand_00008 = 2130837631;
 			
 			// aapt resource value: 0x7f020080
-			public const int ic_media_play = 2130837632;
+			public const int ic_expand_00009 = 2130837632;
 			
 			// aapt resource value: 0x7f020081
-			public const int ic_media_route_disabled_mono_dark = 2130837633;
+			public const int ic_expand_00010 = 2130837633;
 			
 			// aapt resource value: 0x7f020082
-			public const int ic_media_route_off_mono_dark = 2130837634;
+			public const int ic_expand_00011 = 2130837634;
 			
 			// aapt resource value: 0x7f020083
-			public const int ic_media_route_on_0_mono_dark = 2130837635;
+			public const int ic_expand_00012 = 2130837635;
 			
 			// aapt resource value: 0x7f020084
-			public const int ic_media_route_on_1_mono_dark = 2130837636;
+			public const int ic_expand_00013 = 2130837636;
 			
 			// aapt resource value: 0x7f020085
-			public const int ic_media_route_on_2_mono_dark = 2130837637;
+			public const int ic_expand_00014 = 2130837637;
 			
 			// aapt resource value: 0x7f020086
-			public const int ic_media_route_on_mono_dark = 2130837638;
+			public const int ic_expand_00015 = 2130837638;
 			
 			// aapt resource value: 0x7f020087
-			public const int ic_pause_dark = 2130837639;
+			public const int ic_media_pause = 2130837639;
 			
 			// aapt resource value: 0x7f020088
-			public const int ic_pause_light = 2130837640;
+			public const int ic_media_play = 2130837640;
 			
 			// aapt resource value: 0x7f020089
-			public const int ic_play_dark = 2130837641;
+			public const int ic_media_route_disabled_mono_dark = 2130837641;
 			
 			// aapt resource value: 0x7f02008a
-			public const int ic_play_light = 2130837642;
+			public const int ic_media_route_off_mono_dark = 2130837642;
 			
 			// aapt resource value: 0x7f02008b
-			public const int ic_speaker_dark = 2130837643;
+			public const int ic_media_route_on_0_mono_dark = 2130837643;
 			
 			// aapt resource value: 0x7f02008c
-			public const int ic_speaker_group_dark = 2130837644;
+			public const int ic_media_route_on_1_mono_dark = 2130837644;
 			
 			// aapt resource value: 0x7f02008d
-			public const int ic_speaker_group_light = 2130837645;
+			public const int ic_media_route_on_2_mono_dark = 2130837645;
 			
 			// aapt resource value: 0x7f02008e
-			public const int ic_speaker_light = 2130837646;
+			public const int ic_media_route_on_mono_dark = 2130837646;
 			
 			// aapt resource value: 0x7f02008f
-			public const int ic_tv_dark = 2130837647;
+			public const int ic_pause_dark = 2130837647;
 			
 			// aapt resource value: 0x7f020090
-			public const int ic_tv_light = 2130837648;
+			public const int ic_pause_light = 2130837648;
 			
 			// aapt resource value: 0x7f020091
-			public const int icon = 2130837649;
+			public const int ic_play_dark = 2130837649;
 			
 			// aapt resource value: 0x7f020092
-			public const int mr_dialog_material_background_dark = 2130837650;
+			public const int ic_play_light = 2130837650;
 			
 			// aapt resource value: 0x7f020093
-			public const int mr_dialog_material_background_light = 2130837651;
+			public const int ic_speaker_dark = 2130837651;
 			
 			// aapt resource value: 0x7f020094
-			public const int mr_ic_audiotrack_light = 2130837652;
+			public const int ic_speaker_group_dark = 2130837652;
 			
 			// aapt resource value: 0x7f020095
-			public const int mr_ic_cast_dark = 2130837653;
+			public const int ic_speaker_group_light = 2130837653;
 			
 			// aapt resource value: 0x7f020096
-			public const int mr_ic_cast_light = 2130837654;
+			public const int ic_speaker_light = 2130837654;
 			
 			// aapt resource value: 0x7f020097
-			public const int mr_ic_close_dark = 2130837655;
+			public const int ic_tv_dark = 2130837655;
 			
 			// aapt resource value: 0x7f020098
-			public const int mr_ic_close_light = 2130837656;
+			public const int ic_tv_light = 2130837656;
 			
 			// aapt resource value: 0x7f020099
-			public const int mr_ic_media_route_connecting_mono_dark = 2130837657;
+			public const int icon = 2130837657;
 			
 			// aapt resource value: 0x7f02009a
-			public const int mr_ic_media_route_connecting_mono_light = 2130837658;
+			public const int mr_dialog_material_background_dark = 2130837658;
 			
 			// aapt resource value: 0x7f02009b
-			public const int mr_ic_media_route_mono_dark = 2130837659;
+			public const int mr_dialog_material_background_light = 2130837659;
 			
 			// aapt resource value: 0x7f02009c
-			public const int mr_ic_media_route_mono_light = 2130837660;
+			public const int mr_ic_audiotrack_light = 2130837660;
 			
 			// aapt resource value: 0x7f02009d
-			public const int mr_ic_pause_dark = 2130837661;
+			public const int mr_ic_cast_dark = 2130837661;
 			
 			// aapt resource value: 0x7f02009e
-			public const int mr_ic_pause_light = 2130837662;
+			public const int mr_ic_cast_light = 2130837662;
 			
 			// aapt resource value: 0x7f02009f
-			public const int mr_ic_play_dark = 2130837663;
+			public const int mr_ic_close_dark = 2130837663;
 			
 			// aapt resource value: 0x7f0200a0
-			public const int mr_ic_play_light = 2130837664;
+			public const int mr_ic_close_light = 2130837664;
 			
 			// aapt resource value: 0x7f0200a1
-			public const int notification_template_icon_bg = 2130837665;
+			public const int mr_ic_media_route_connecting_mono_dark = 2130837665;
+			
+			// aapt resource value: 0x7f0200a2
+			public const int mr_ic_media_route_connecting_mono_light = 2130837666;
+			
+			// aapt resource value: 0x7f0200a3
+			public const int mr_ic_media_route_mono_dark = 2130837667;
+			
+			// aapt resource value: 0x7f0200a4
+			public const int mr_ic_media_route_mono_light = 2130837668;
+			
+			// aapt resource value: 0x7f0200a5
+			public const int mr_ic_pause_dark = 2130837669;
+			
+			// aapt resource value: 0x7f0200a6
+			public const int mr_ic_pause_light = 2130837670;
+			
+			// aapt resource value: 0x7f0200a7
+			public const int mr_ic_play_dark = 2130837671;
+			
+			// aapt resource value: 0x7f0200a8
+			public const int mr_ic_play_light = 2130837672;
+			
+			// aapt resource value: 0x7f0200a9
+			public const int notification_action_background = 2130837673;
+			
+			// aapt resource value: 0x7f0200aa
+			public const int notification_bg = 2130837674;
+			
+			// aapt resource value: 0x7f0200ab
+			public const int notification_bg_low = 2130837675;
+			
+			// aapt resource value: 0x7f0200ac
+			public const int notification_bg_low_normal = 2130837676;
+			
+			// aapt resource value: 0x7f0200ad
+			public const int notification_bg_low_pressed = 2130837677;
+			
+			// aapt resource value: 0x7f0200ae
+			public const int notification_bg_normal = 2130837678;
+			
+			// aapt resource value: 0x7f0200af
+			public const int notification_bg_normal_pressed = 2130837679;
+			
+			// aapt resource value: 0x7f0200b0
+			public const int notification_icon_background = 2130837680;
+			
+			// aapt resource value: 0x7f0200b3
+			public const int notification_template_icon_bg = 2130837683;
+			
+			// aapt resource value: 0x7f0200b4
+			public const int notification_template_icon_low_bg = 2130837684;
+			
+			// aapt resource value: 0x7f0200b1
+			public const int notification_tile_bg = 2130837681;
+			
+			// aapt resource value: 0x7f0200b2
+			public const int notify_panel_notification_icon_bg = 2130837682;
 			
 			static Drawable()
 			{
@@ -3466,470 +3851,512 @@ namespace XForms.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f07008b
-			public const int action0 = 2131165323;
+			// aapt resource value: 0x7f070092
+			public const int action0 = 2131165330;
 			
-			// aapt resource value: 0x7f07005a
-			public const int action_bar = 2131165274;
-			
-			// aapt resource value: 0x7f070001
-			public const int action_bar_activity_content = 2131165185;
-			
-			// aapt resource value: 0x7f070059
-			public const int action_bar_container = 2131165273;
-			
-			// aapt resource value: 0x7f070055
-			public const int action_bar_root = 2131165269;
+			// aapt resource value: 0x7f07005e
+			public const int action_bar = 2131165278;
 			
 			// aapt resource value: 0x7f070002
-			public const int action_bar_spinner = 2131165186;
+			public const int action_bar_activity_content = 2131165186;
 			
-			// aapt resource value: 0x7f07003b
-			public const int action_bar_subtitle = 2131165243;
+			// aapt resource value: 0x7f07005d
+			public const int action_bar_container = 2131165277;
 			
-			// aapt resource value: 0x7f07003a
-			public const int action_bar_title = 2131165242;
-			
-			// aapt resource value: 0x7f07005b
-			public const int action_context_bar = 2131165275;
-			
-			// aapt resource value: 0x7f07008f
-			public const int action_divider = 2131165327;
+			// aapt resource value: 0x7f070059
+			public const int action_bar_root = 2131165273;
 			
 			// aapt resource value: 0x7f070003
-			public const int action_menu_divider = 2131165187;
-			
-			// aapt resource value: 0x7f070004
-			public const int action_menu_presenter = 2131165188;
-			
-			// aapt resource value: 0x7f070057
-			public const int action_mode_bar = 2131165271;
-			
-			// aapt resource value: 0x7f070056
-			public const int action_mode_bar_stub = 2131165270;
+			public const int action_bar_spinner = 2131165187;
 			
 			// aapt resource value: 0x7f07003c
-			public const int action_mode_close_button = 2131165244;
+			public const int action_bar_subtitle = 2131165244;
 			
-			// aapt resource value: 0x7f07003d
-			public const int activity_chooser_view_content = 2131165245;
+			// aapt resource value: 0x7f07003b
+			public const int action_bar_title = 2131165243;
 			
-			// aapt resource value: 0x7f07009a
-			public const int agentWebView = 2131165338;
+			// aapt resource value: 0x7f07008f
+			public const int action_container = 2131165327;
 			
-			// aapt resource value: 0x7f070049
-			public const int alertTitle = 2131165257;
-			
-			// aapt resource value: 0x7f07001e
-			public const int always = 2131165214;
-			
-			// aapt resource value: 0x7f07001b
-			public const int beginning = 2131165211;
-			
-			// aapt resource value: 0x7f07002a
-			public const int bottom = 2131165226;
-			
-			// aapt resource value: 0x7f070044
-			public const int buttonPanel = 2131165252;
-			
-			// aapt resource value: 0x7f07008c
-			public const int cancel_action = 2131165324;
-			
-			// aapt resource value: 0x7f07002b
-			public const int center = 2131165227;
-			
-			// aapt resource value: 0x7f07002c
-			public const int center_horizontal = 2131165228;
-			
-			// aapt resource value: 0x7f07002d
-			public const int center_vertical = 2131165229;
-			
-			// aapt resource value: 0x7f070052
-			public const int checkbox = 2131165266;
-			
-			// aapt resource value: 0x7f070092
-			public const int chronometer = 2131165330;
-			
-			// aapt resource value: 0x7f070033
-			public const int clip_horizontal = 2131165235;
-			
-			// aapt resource value: 0x7f070034
-			public const int clip_vertical = 2131165236;
-			
-			// aapt resource value: 0x7f07001f
-			public const int collapseActionView = 2131165215;
-			
-			// aapt resource value: 0x7f07004a
-			public const int contentPanel = 2131165258;
-			
-			// aapt resource value: 0x7f070050
-			public const int custom = 2131165264;
-			
-			// aapt resource value: 0x7f07004f
-			public const int customPanel = 2131165263;
-			
-			// aapt resource value: 0x7f070058
-			public const int decor_content_parent = 2131165272;
-			
-			// aapt resource value: 0x7f070040
-			public const int default_activity_button = 2131165248;
-			
-			// aapt resource value: 0x7f07006a
-			public const int design_bottom_sheet = 2131165290;
-			
-			// aapt resource value: 0x7f070071
-			public const int design_menu_item_action_area = 2131165297;
-			
-			// aapt resource value: 0x7f070070
-			public const int design_menu_item_action_area_stub = 2131165296;
-			
-			// aapt resource value: 0x7f07006f
-			public const int design_menu_item_text = 2131165295;
-			
-			// aapt resource value: 0x7f07006e
-			public const int design_navigation_view = 2131165294;
-			
-			// aapt resource value: 0x7f07000e
-			public const int disableHome = 2131165198;
-			
-			// aapt resource value: 0x7f07005c
-			public const int edit_query = 2131165276;
-			
-			// aapt resource value: 0x7f07001c
-			public const int end = 2131165212;
-			
-			// aapt resource value: 0x7f070097
-			public const int end_padder = 2131165335;
-			
-			// aapt resource value: 0x7f070023
-			public const int enterAlways = 2131165219;
-			
-			// aapt resource value: 0x7f070024
-			public const int enterAlwaysCollapsed = 2131165220;
-			
-			// aapt resource value: 0x7f070025
-			public const int exitUntilCollapsed = 2131165221;
-			
-			// aapt resource value: 0x7f07003e
-			public const int expand_activities_button = 2131165246;
-			
-			// aapt resource value: 0x7f070051
-			public const int expanded_menu = 2131165265;
-			
-			// aapt resource value: 0x7f070035
-			public const int fill = 2131165237;
-			
-			// aapt resource value: 0x7f070036
-			public const int fill_horizontal = 2131165238;
-			
-			// aapt resource value: 0x7f07002e
-			public const int fill_vertical = 2131165230;
-			
-			// aapt resource value: 0x7f070038
-			public const int @fixed = 2131165240;
-			
-			// aapt resource value: 0x7f070005
-			public const int home = 2131165189;
-			
-			// aapt resource value: 0x7f07000f
-			public const int homeAsUp = 2131165199;
-			
-			// aapt resource value: 0x7f070042
-			public const int icon = 2131165250;
-			
-			// aapt resource value: 0x7f070020
-			public const int ifRoom = 2131165216;
-			
-			// aapt resource value: 0x7f07003f
-			public const int image = 2131165247;
+			// aapt resource value: 0x7f07005f
+			public const int action_context_bar = 2131165279;
 			
 			// aapt resource value: 0x7f070096
-			public const int info = 2131165334;
+			public const int action_divider = 2131165334;
+			
+			// aapt resource value: 0x7f070090
+			public const int action_image = 2131165328;
+			
+			// aapt resource value: 0x7f070004
+			public const int action_menu_divider = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public const int action_menu_presenter = 2131165189;
+			
+			// aapt resource value: 0x7f07005b
+			public const int action_mode_bar = 2131165275;
+			
+			// aapt resource value: 0x7f07005a
+			public const int action_mode_bar_stub = 2131165274;
+			
+			// aapt resource value: 0x7f07003d
+			public const int action_mode_close_button = 2131165245;
+			
+			// aapt resource value: 0x7f070091
+			public const int action_text = 2131165329;
+			
+			// aapt resource value: 0x7f07009f
+			public const int actions = 2131165343;
+			
+			// aapt resource value: 0x7f07003e
+			public const int activity_chooser_view_content = 2131165246;
+			
+			// aapt resource value: 0x7f07002d
+			public const int add = 2131165229;
+			
+			// aapt resource value: 0x7f0700a8
+			public const int agentWebView = 2131165352;
+			
+			// aapt resource value: 0x7f070052
+			public const int alertTitle = 2131165266;
+			
+			// aapt resource value: 0x7f070036
+			public const int always = 2131165238;
+			
+			// aapt resource value: 0x7f070034
+			public const int beginning = 2131165236;
+			
+			// aapt resource value: 0x7f070013
+			public const int bottom = 2131165203;
+			
+			// aapt resource value: 0x7f070045
+			public const int buttonPanel = 2131165253;
+			
+			// aapt resource value: 0x7f070093
+			public const int cancel_action = 2131165331;
+			
+			// aapt resource value: 0x7f070014
+			public const int center = 2131165204;
+			
+			// aapt resource value: 0x7f070015
+			public const int center_horizontal = 2131165205;
+			
+			// aapt resource value: 0x7f070016
+			public const int center_vertical = 2131165206;
+			
+			// aapt resource value: 0x7f070055
+			public const int checkbox = 2131165269;
+			
+			// aapt resource value: 0x7f07009b
+			public const int chronometer = 2131165339;
+			
+			// aapt resource value: 0x7f07001d
+			public const int clip_horizontal = 2131165213;
+			
+			// aapt resource value: 0x7f07001e
+			public const int clip_vertical = 2131165214;
+			
+			// aapt resource value: 0x7f070037
+			public const int collapseActionView = 2131165239;
+			
+			// aapt resource value: 0x7f070048
+			public const int contentPanel = 2131165256;
+			
+			// aapt resource value: 0x7f07004f
+			public const int custom = 2131165263;
+			
+			// aapt resource value: 0x7f07004e
+			public const int customPanel = 2131165262;
+			
+			// aapt resource value: 0x7f07005c
+			public const int decor_content_parent = 2131165276;
+			
+			// aapt resource value: 0x7f070041
+			public const int default_activity_button = 2131165249;
+			
+			// aapt resource value: 0x7f07006e
+			public const int design_bottom_sheet = 2131165294;
+			
+			// aapt resource value: 0x7f070075
+			public const int design_menu_item_action_area = 2131165301;
+			
+			// aapt resource value: 0x7f070074
+			public const int design_menu_item_action_area_stub = 2131165300;
+			
+			// aapt resource value: 0x7f070073
+			public const int design_menu_item_text = 2131165299;
+			
+			// aapt resource value: 0x7f070072
+			public const int design_navigation_view = 2131165298;
+			
+			// aapt resource value: 0x7f070027
+			public const int disableHome = 2131165223;
+			
+			// aapt resource value: 0x7f070060
+			public const int edit_query = 2131165280;
+			
+			// aapt resource value: 0x7f070017
+			public const int end = 2131165207;
+			
+			// aapt resource value: 0x7f0700a5
+			public const int end_padder = 2131165349;
+			
+			// aapt resource value: 0x7f07000b
+			public const int enterAlways = 2131165195;
+			
+			// aapt resource value: 0x7f07000c
+			public const int enterAlwaysCollapsed = 2131165196;
+			
+			// aapt resource value: 0x7f07000d
+			public const int exitUntilCollapsed = 2131165197;
+			
+			// aapt resource value: 0x7f07003f
+			public const int expand_activities_button = 2131165247;
+			
+			// aapt resource value: 0x7f070054
+			public const int expanded_menu = 2131165268;
+			
+			// aapt resource value: 0x7f07001f
+			public const int fill = 2131165215;
+			
+			// aapt resource value: 0x7f070020
+			public const int fill_horizontal = 2131165216;
+			
+			// aapt resource value: 0x7f070018
+			public const int fill_vertical = 2131165208;
+			
+			// aapt resource value: 0x7f070023
+			public const int @fixed = 2131165219;
+			
+			// aapt resource value: 0x7f070006
+			public const int home = 2131165190;
+			
+			// aapt resource value: 0x7f070028
+			public const int homeAsUp = 2131165224;
+			
+			// aapt resource value: 0x7f070043
+			public const int icon = 2131165251;
+			
+			// aapt resource value: 0x7f0700a0
+			public const int icon_group = 2131165344;
+			
+			// aapt resource value: 0x7f070038
+			public const int ifRoom = 2131165240;
+			
+			// aapt resource value: 0x7f070040
+			public const int image = 2131165248;
+			
+			// aapt resource value: 0x7f07009c
+			public const int info = 2131165340;
 			
 			// aapt resource value: 0x7f070000
 			public const int item_touch_helper_previous_elevation = 2131165184;
 			
-			// aapt resource value: 0x7f07002f
-			public const int left = 2131165231;
+			// aapt resource value: 0x7f070019
+			public const int left = 2131165209;
 			
-			// aapt resource value: 0x7f070090
-			public const int line1 = 2131165328;
+			// aapt resource value: 0x7f0700a1
+			public const int line1 = 2131165345;
 			
-			// aapt resource value: 0x7f070094
-			public const int line3 = 2131165332;
+			// aapt resource value: 0x7f0700a3
+			public const int line3 = 2131165347;
 			
-			// aapt resource value: 0x7f07000b
-			public const int listMode = 2131165195;
+			// aapt resource value: 0x7f070025
+			public const int listMode = 2131165221;
 			
-			// aapt resource value: 0x7f070041
-			public const int list_item = 2131165249;
+			// aapt resource value: 0x7f070042
+			public const int list_item = 2131165250;
 			
-			// aapt resource value: 0x7f07008e
-			public const int media_actions = 2131165326;
+			// aapt resource value: 0x7f070095
+			public const int media_actions = 2131165333;
 			
-			// aapt resource value: 0x7f07001d
-			public const int middle = 2131165213;
-			
-			// aapt resource value: 0x7f070037
-			public const int mini = 2131165239;
-			
-			// aapt resource value: 0x7f07007d
-			public const int mr_art = 2131165309;
-			
-			// aapt resource value: 0x7f070072
-			public const int mr_chooser_list = 2131165298;
-			
-			// aapt resource value: 0x7f070075
-			public const int mr_chooser_route_desc = 2131165301;
-			
-			// aapt resource value: 0x7f070073
-			public const int mr_chooser_route_icon = 2131165299;
-			
-			// aapt resource value: 0x7f070074
-			public const int mr_chooser_route_name = 2131165300;
-			
-			// aapt resource value: 0x7f07007a
-			public const int mr_close = 2131165306;
-			
-			// aapt resource value: 0x7f070080
-			public const int mr_control_divider = 2131165312;
-			
-			// aapt resource value: 0x7f070086
-			public const int mr_control_play_pause = 2131165318;
-			
-			// aapt resource value: 0x7f070089
-			public const int mr_control_subtitle = 2131165321;
-			
-			// aapt resource value: 0x7f070088
-			public const int mr_control_title = 2131165320;
-			
-			// aapt resource value: 0x7f070087
-			public const int mr_control_title_container = 2131165319;
-			
-			// aapt resource value: 0x7f07007b
-			public const int mr_custom_control = 2131165307;
-			
-			// aapt resource value: 0x7f07007c
-			public const int mr_default_control = 2131165308;
-			
-			// aapt resource value: 0x7f070077
-			public const int mr_dialog_area = 2131165303;
-			
-			// aapt resource value: 0x7f070076
-			public const int mr_expandable_area = 2131165302;
-			
-			// aapt resource value: 0x7f07008a
-			public const int mr_group_expand_collapse = 2131165322;
-			
-			// aapt resource value: 0x7f07007e
-			public const int mr_media_main_control = 2131165310;
-			
-			// aapt resource value: 0x7f070079
-			public const int mr_name = 2131165305;
-			
-			// aapt resource value: 0x7f07007f
-			public const int mr_playback_control = 2131165311;
-			
-			// aapt resource value: 0x7f070078
-			public const int mr_title_bar = 2131165304;
-			
-			// aapt resource value: 0x7f070081
-			public const int mr_volume_control = 2131165313;
-			
-			// aapt resource value: 0x7f070082
-			public const int mr_volume_group_list = 2131165314;
-			
-			// aapt resource value: 0x7f070084
-			public const int mr_volume_item_icon = 2131165316;
-			
-			// aapt resource value: 0x7f070085
-			public const int mr_volume_slider = 2131165317;
-			
-			// aapt resource value: 0x7f070016
-			public const int multiply = 2131165206;
-			
-			// aapt resource value: 0x7f07006d
-			public const int navigation_header_container = 2131165293;
+			// aapt resource value: 0x7f070035
+			public const int middle = 2131165237;
 			
 			// aapt resource value: 0x7f070021
-			public const int never = 2131165217;
+			public const int mini = 2131165217;
+			
+			// aapt resource value: 0x7f070081
+			public const int mr_art = 2131165313;
+			
+			// aapt resource value: 0x7f070076
+			public const int mr_chooser_list = 2131165302;
+			
+			// aapt resource value: 0x7f070079
+			public const int mr_chooser_route_desc = 2131165305;
+			
+			// aapt resource value: 0x7f070077
+			public const int mr_chooser_route_icon = 2131165303;
+			
+			// aapt resource value: 0x7f070078
+			public const int mr_chooser_route_name = 2131165304;
+			
+			// aapt resource value: 0x7f07007e
+			public const int mr_close = 2131165310;
+			
+			// aapt resource value: 0x7f070084
+			public const int mr_control_divider = 2131165316;
+			
+			// aapt resource value: 0x7f07008a
+			public const int mr_control_play_pause = 2131165322;
+			
+			// aapt resource value: 0x7f07008d
+			public const int mr_control_subtitle = 2131165325;
+			
+			// aapt resource value: 0x7f07008c
+			public const int mr_control_title = 2131165324;
+			
+			// aapt resource value: 0x7f07008b
+			public const int mr_control_title_container = 2131165323;
+			
+			// aapt resource value: 0x7f07007f
+			public const int mr_custom_control = 2131165311;
+			
+			// aapt resource value: 0x7f070080
+			public const int mr_default_control = 2131165312;
+			
+			// aapt resource value: 0x7f07007b
+			public const int mr_dialog_area = 2131165307;
+			
+			// aapt resource value: 0x7f07007a
+			public const int mr_expandable_area = 2131165306;
+			
+			// aapt resource value: 0x7f07008e
+			public const int mr_group_expand_collapse = 2131165326;
+			
+			// aapt resource value: 0x7f070082
+			public const int mr_media_main_control = 2131165314;
+			
+			// aapt resource value: 0x7f07007d
+			public const int mr_name = 2131165309;
+			
+			// aapt resource value: 0x7f070083
+			public const int mr_playback_control = 2131165315;
+			
+			// aapt resource value: 0x7f07007c
+			public const int mr_title_bar = 2131165308;
+			
+			// aapt resource value: 0x7f070085
+			public const int mr_volume_control = 2131165317;
+			
+			// aapt resource value: 0x7f070086
+			public const int mr_volume_group_list = 2131165318;
+			
+			// aapt resource value: 0x7f070088
+			public const int mr_volume_item_icon = 2131165320;
+			
+			// aapt resource value: 0x7f070089
+			public const int mr_volume_slider = 2131165321;
+			
+			// aapt resource value: 0x7f07002e
+			public const int multiply = 2131165230;
+			
+			// aapt resource value: 0x7f070071
+			public const int navigation_header_container = 2131165297;
+			
+			// aapt resource value: 0x7f070039
+			public const int never = 2131165241;
 			
 			// aapt resource value: 0x7f070010
 			public const int none = 2131165200;
 			
-			// aapt resource value: 0x7f07000c
-			public const int normal = 2131165196;
+			// aapt resource value: 0x7f070022
+			public const int normal = 2131165218;
 			
-			// aapt resource value: 0x7f070028
-			public const int parallax = 2131165224;
-			
-			// aapt resource value: 0x7f070046
-			public const int parentPanel = 2131165254;
-			
-			// aapt resource value: 0x7f070029
-			public const int pin = 2131165225;
-			
-			// aapt resource value: 0x7f070006
-			public const int progress_circular = 2131165190;
-			
-			// aapt resource value: 0x7f070007
-			public const int progress_horizontal = 2131165191;
-			
-			// aapt resource value: 0x7f070054
-			public const int radio = 2131165268;
-			
-			// aapt resource value: 0x7f070030
-			public const int right = 2131165232;
-			
-			// aapt resource value: 0x7f070017
-			public const int screen = 2131165207;
-			
-			// aapt resource value: 0x7f070026
-			public const int scroll = 2131165222;
-			
-			// aapt resource value: 0x7f07004e
-			public const int scrollIndicatorDown = 2131165262;
-			
-			// aapt resource value: 0x7f07004b
-			public const int scrollIndicatorUp = 2131165259;
-			
-			// aapt resource value: 0x7f07004c
-			public const int scrollView = 2131165260;
-			
-			// aapt resource value: 0x7f070039
-			public const int scrollable = 2131165241;
-			
-			// aapt resource value: 0x7f07005e
-			public const int search_badge = 2131165278;
-			
-			// aapt resource value: 0x7f07005d
-			public const int search_bar = 2131165277;
-			
-			// aapt resource value: 0x7f07005f
-			public const int search_button = 2131165279;
-			
-			// aapt resource value: 0x7f070064
-			public const int search_close_btn = 2131165284;
-			
-			// aapt resource value: 0x7f070060
-			public const int search_edit_frame = 2131165280;
-			
-			// aapt resource value: 0x7f070066
-			public const int search_go_btn = 2131165286;
-			
-			// aapt resource value: 0x7f070061
-			public const int search_mag_icon = 2131165281;
-			
-			// aapt resource value: 0x7f070062
-			public const int search_plate = 2131165282;
-			
-			// aapt resource value: 0x7f070063
-			public const int search_src_text = 2131165283;
-			
-			// aapt resource value: 0x7f070067
-			public const int search_voice_btn = 2131165287;
-			
-			// aapt resource value: 0x7f070068
-			public const int select_dialog_listview = 2131165288;
-			
-			// aapt resource value: 0x7f070053
-			public const int shortcut = 2131165267;
-			
-			// aapt resource value: 0x7f070011
-			public const int showCustom = 2131165201;
-			
-			// aapt resource value: 0x7f070012
-			public const int showHome = 2131165202;
-			
-			// aapt resource value: 0x7f070013
-			public const int showTitle = 2131165203;
+			// aapt resource value: 0x7f07009e
+			public const int notification_background = 2131165342;
 			
 			// aapt resource value: 0x7f070098
-			public const int sliding_tabs = 2131165336;
+			public const int notification_main_column = 2131165336;
 			
-			// aapt resource value: 0x7f07006c
-			public const int snackbar_action = 2131165292;
+			// aapt resource value: 0x7f070097
+			public const int notification_main_column_container = 2131165335;
 			
-			// aapt resource value: 0x7f07006b
-			public const int snackbar_text = 2131165291;
-			
-			// aapt resource value: 0x7f070027
-			public const int snap = 2131165223;
-			
-			// aapt resource value: 0x7f070045
-			public const int spacer = 2131165253;
-			
-			// aapt resource value: 0x7f070008
-			public const int split_action_bar = 2131165192;
-			
-			// aapt resource value: 0x7f070018
-			public const int src_atop = 2131165208;
-			
-			// aapt resource value: 0x7f070019
-			public const int src_in = 2131165209;
-			
-			// aapt resource value: 0x7f07001a
-			public const int src_over = 2131165210;
-			
-			// aapt resource value: 0x7f070031
-			public const int start = 2131165233;
-			
-			// aapt resource value: 0x7f07008d
-			public const int status_bar_latest_event_content = 2131165325;
-			
-			// aapt resource value: 0x7f070065
-			public const int submit_area = 2131165285;
-			
-			// aapt resource value: 0x7f07000d
-			public const int tabMode = 2131165197;
-			
-			// aapt resource value: 0x7f070095
-			public const int text = 2131165333;
-			
-			// aapt resource value: 0x7f070093
-			public const int text2 = 2131165331;
-			
-			// aapt resource value: 0x7f07004d
-			public const int textSpacerNoButtons = 2131165261;
-			
-			// aapt resource value: 0x7f070091
-			public const int time = 2131165329;
-			
-			// aapt resource value: 0x7f070043
-			public const int title = 2131165251;
-			
-			// aapt resource value: 0x7f070048
-			public const int title_template = 2131165256;
-			
-			// aapt resource value: 0x7f070099
-			public const int toolbar = 2131165337;
-			
-			// aapt resource value: 0x7f070032
-			public const int top = 2131165234;
+			// aapt resource value: 0x7f070011
+			public const int parallax = 2131165201;
 			
 			// aapt resource value: 0x7f070047
-			public const int topPanel = 2131165255;
+			public const int parentPanel = 2131165255;
 			
-			// aapt resource value: 0x7f070069
-			public const int touch_outside = 2131165289;
+			// aapt resource value: 0x7f070012
+			public const int pin = 2131165202;
+			
+			// aapt resource value: 0x7f070007
+			public const int progress_circular = 2131165191;
+			
+			// aapt resource value: 0x7f070008
+			public const int progress_horizontal = 2131165192;
+			
+			// aapt resource value: 0x7f070057
+			public const int radio = 2131165271;
+			
+			// aapt resource value: 0x7f07001a
+			public const int right = 2131165210;
+			
+			// aapt resource value: 0x7f07009d
+			public const int right_icon = 2131165341;
+			
+			// aapt resource value: 0x7f070099
+			public const int right_side = 2131165337;
+			
+			// aapt resource value: 0x7f07002f
+			public const int screen = 2131165231;
+			
+			// aapt resource value: 0x7f07000e
+			public const int scroll = 2131165198;
+			
+			// aapt resource value: 0x7f07004d
+			public const int scrollIndicatorDown = 2131165261;
+			
+			// aapt resource value: 0x7f070049
+			public const int scrollIndicatorUp = 2131165257;
+			
+			// aapt resource value: 0x7f07004a
+			public const int scrollView = 2131165258;
+			
+			// aapt resource value: 0x7f070024
+			public const int scrollable = 2131165220;
+			
+			// aapt resource value: 0x7f070062
+			public const int search_badge = 2131165282;
+			
+			// aapt resource value: 0x7f070061
+			public const int search_bar = 2131165281;
+			
+			// aapt resource value: 0x7f070063
+			public const int search_button = 2131165283;
+			
+			// aapt resource value: 0x7f070068
+			public const int search_close_btn = 2131165288;
+			
+			// aapt resource value: 0x7f070064
+			public const int search_edit_frame = 2131165284;
+			
+			// aapt resource value: 0x7f07006a
+			public const int search_go_btn = 2131165290;
+			
+			// aapt resource value: 0x7f070065
+			public const int search_mag_icon = 2131165285;
+			
+			// aapt resource value: 0x7f070066
+			public const int search_plate = 2131165286;
+			
+			// aapt resource value: 0x7f070067
+			public const int search_src_text = 2131165287;
+			
+			// aapt resource value: 0x7f07006b
+			public const int search_voice_btn = 2131165291;
+			
+			// aapt resource value: 0x7f07006c
+			public const int select_dialog_listview = 2131165292;
+			
+			// aapt resource value: 0x7f070056
+			public const int shortcut = 2131165270;
+			
+			// aapt resource value: 0x7f070029
+			public const int showCustom = 2131165225;
+			
+			// aapt resource value: 0x7f07002a
+			public const int showHome = 2131165226;
+			
+			// aapt resource value: 0x7f07002b
+			public const int showTitle = 2131165227;
+			
+			// aapt resource value: 0x7f0700a6
+			public const int sliding_tabs = 2131165350;
+			
+			// aapt resource value: 0x7f070070
+			public const int snackbar_action = 2131165296;
+			
+			// aapt resource value: 0x7f07006f
+			public const int snackbar_text = 2131165295;
+			
+			// aapt resource value: 0x7f07000f
+			public const int snap = 2131165199;
+			
+			// aapt resource value: 0x7f070046
+			public const int spacer = 2131165254;
 			
 			// aapt resource value: 0x7f070009
-			public const int up = 2131165193;
+			public const int split_action_bar = 2131165193;
 			
-			// aapt resource value: 0x7f070014
-			public const int useLogo = 2131165204;
+			// aapt resource value: 0x7f070030
+			public const int src_atop = 2131165232;
+			
+			// aapt resource value: 0x7f070031
+			public const int src_in = 2131165233;
+			
+			// aapt resource value: 0x7f070032
+			public const int src_over = 2131165234;
+			
+			// aapt resource value: 0x7f07001b
+			public const int start = 2131165211;
+			
+			// aapt resource value: 0x7f070094
+			public const int status_bar_latest_event_content = 2131165332;
+			
+			// aapt resource value: 0x7f070058
+			public const int submenuarrow = 2131165272;
+			
+			// aapt resource value: 0x7f070069
+			public const int submit_area = 2131165289;
+			
+			// aapt resource value: 0x7f070026
+			public const int tabMode = 2131165222;
+			
+			// aapt resource value: 0x7f0700a4
+			public const int text = 2131165348;
+			
+			// aapt resource value: 0x7f0700a2
+			public const int text2 = 2131165346;
+			
+			// aapt resource value: 0x7f07004c
+			public const int textSpacerNoButtons = 2131165260;
+			
+			// aapt resource value: 0x7f07004b
+			public const int textSpacerNoTitle = 2131165259;
+			
+			// aapt resource value: 0x7f07009a
+			public const int time = 2131165338;
+			
+			// aapt resource value: 0x7f070044
+			public const int title = 2131165252;
+			
+			// aapt resource value: 0x7f070053
+			public const int titleDividerNoCustom = 2131165267;
+			
+			// aapt resource value: 0x7f070051
+			public const int title_template = 2131165265;
+			
+			// aapt resource value: 0x7f0700a7
+			public const int toolbar = 2131165351;
+			
+			// aapt resource value: 0x7f07001c
+			public const int top = 2131165212;
+			
+			// aapt resource value: 0x7f070050
+			public const int topPanel = 2131165264;
+			
+			// aapt resource value: 0x7f07006d
+			public const int touch_outside = 2131165293;
 			
 			// aapt resource value: 0x7f07000a
-			public const int view_offset_helper = 2131165194;
+			public const int up = 2131165194;
 			
-			// aapt resource value: 0x7f070083
-			public const int volume_item_container = 2131165315;
+			// aapt resource value: 0x7f07002c
+			public const int useLogo = 2131165228;
 			
-			// aapt resource value: 0x7f070022
-			public const int withText = 2131165218;
+			// aapt resource value: 0x7f070001
+			public const int view_offset_helper = 2131165185;
 			
-			// aapt resource value: 0x7f070015
-			public const int wrap_content = 2131165205;
+			// aapt resource value: 0x7f070087
+			public const int volume_item_container = 2131165319;
+			
+			// aapt resource value: 0x7f07003a
+			public const int withText = 2131165242;
+			
+			// aapt resource value: 0x7f070033
+			public const int wrap_content = 2131165235;
 			
 			static Id()
 			{
@@ -3944,23 +4371,20 @@ namespace XForms.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f090004
-			public const int abc_config_activityDefaultDur = 2131296260;
-			
 			// aapt resource value: 0x7f090005
-			public const int abc_config_activityShortDur = 2131296261;
-			
-			// aapt resource value: 0x7f090003
-			public const int abc_max_action_buttons = 2131296259;
-			
-			// aapt resource value: 0x7f090009
-			public const int bottom_sheet_slide_duration = 2131296265;
+			public const int abc_config_activityDefaultDur = 2131296261;
 			
 			// aapt resource value: 0x7f090006
-			public const int cancel_button_image_alpha = 2131296262;
+			public const int abc_config_activityShortDur = 2131296262;
 			
-			// aapt resource value: 0x7f090008
-			public const int design_snackbar_text_max_lines = 2131296264;
+			// aapt resource value: 0x7f090004
+			public const int bottom_sheet_slide_duration = 2131296260;
+			
+			// aapt resource value: 0x7f090007
+			public const int cancel_button_image_alpha = 2131296263;
+			
+			// aapt resource value: 0x7f090003
+			public const int design_snackbar_text_max_lines = 2131296259;
 			
 			// aapt resource value: 0x7f090000
 			public const int mr_controller_volume_group_list_animation_duration_ms = 2131296256;
@@ -3971,8 +4395,8 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f090002
 			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131296258;
 			
-			// aapt resource value: 0x7f090007
-			public const int status_bar_notification_info_maxnum = 2131296263;
+			// aapt resource value: 0x7f090008
+			public const int status_bar_notification_info_maxnum = 2131296264;
 			
 			static Integer()
 			{
@@ -4040,145 +4464,172 @@ namespace XForms.Droid
 			public const int abc_alert_dialog_material = 2130903050;
 			
 			// aapt resource value: 0x7f03000b
-			public const int abc_dialog_title_material = 2130903051;
+			public const int abc_alert_dialog_title_material = 2130903051;
 			
 			// aapt resource value: 0x7f03000c
-			public const int abc_expanded_menu_layout = 2130903052;
+			public const int abc_dialog_title_material = 2130903052;
 			
 			// aapt resource value: 0x7f03000d
-			public const int abc_list_menu_item_checkbox = 2130903053;
+			public const int abc_expanded_menu_layout = 2130903053;
 			
 			// aapt resource value: 0x7f03000e
-			public const int abc_list_menu_item_icon = 2130903054;
+			public const int abc_list_menu_item_checkbox = 2130903054;
 			
 			// aapt resource value: 0x7f03000f
-			public const int abc_list_menu_item_layout = 2130903055;
+			public const int abc_list_menu_item_icon = 2130903055;
 			
 			// aapt resource value: 0x7f030010
-			public const int abc_list_menu_item_radio = 2130903056;
+			public const int abc_list_menu_item_layout = 2130903056;
 			
 			// aapt resource value: 0x7f030011
-			public const int abc_popup_menu_item_layout = 2130903057;
+			public const int abc_list_menu_item_radio = 2130903057;
 			
 			// aapt resource value: 0x7f030012
-			public const int abc_screen_content_include = 2130903058;
+			public const int abc_popup_menu_header_item_layout = 2130903058;
 			
 			// aapt resource value: 0x7f030013
-			public const int abc_screen_simple = 2130903059;
+			public const int abc_popup_menu_item_layout = 2130903059;
 			
 			// aapt resource value: 0x7f030014
-			public const int abc_screen_simple_overlay_action_mode = 2130903060;
+			public const int abc_screen_content_include = 2130903060;
 			
 			// aapt resource value: 0x7f030015
-			public const int abc_screen_toolbar = 2130903061;
+			public const int abc_screen_simple = 2130903061;
 			
 			// aapt resource value: 0x7f030016
-			public const int abc_search_dropdown_item_icons_2line = 2130903062;
+			public const int abc_screen_simple_overlay_action_mode = 2130903062;
 			
 			// aapt resource value: 0x7f030017
-			public const int abc_search_view = 2130903063;
+			public const int abc_screen_toolbar = 2130903063;
 			
 			// aapt resource value: 0x7f030018
-			public const int abc_select_dialog_material = 2130903064;
+			public const int abc_search_dropdown_item_icons_2line = 2130903064;
 			
 			// aapt resource value: 0x7f030019
-			public const int design_bottom_sheet_dialog = 2130903065;
+			public const int abc_search_view = 2130903065;
 			
 			// aapt resource value: 0x7f03001a
-			public const int design_layout_snackbar = 2130903066;
+			public const int abc_select_dialog_material = 2130903066;
 			
 			// aapt resource value: 0x7f03001b
-			public const int design_layout_snackbar_include = 2130903067;
+			public const int design_bottom_sheet_dialog = 2130903067;
 			
 			// aapt resource value: 0x7f03001c
-			public const int design_layout_tab_icon = 2130903068;
+			public const int design_layout_snackbar = 2130903068;
 			
 			// aapt resource value: 0x7f03001d
-			public const int design_layout_tab_text = 2130903069;
+			public const int design_layout_snackbar_include = 2130903069;
 			
 			// aapt resource value: 0x7f03001e
-			public const int design_menu_item_action_area = 2130903070;
+			public const int design_layout_tab_icon = 2130903070;
 			
 			// aapt resource value: 0x7f03001f
-			public const int design_navigation_item = 2130903071;
+			public const int design_layout_tab_text = 2130903071;
 			
 			// aapt resource value: 0x7f030020
-			public const int design_navigation_item_header = 2130903072;
+			public const int design_menu_item_action_area = 2130903072;
 			
 			// aapt resource value: 0x7f030021
-			public const int design_navigation_item_separator = 2130903073;
+			public const int design_navigation_item = 2130903073;
 			
 			// aapt resource value: 0x7f030022
-			public const int design_navigation_item_subheader = 2130903074;
+			public const int design_navigation_item_header = 2130903074;
 			
 			// aapt resource value: 0x7f030023
-			public const int design_navigation_menu = 2130903075;
+			public const int design_navigation_item_separator = 2130903075;
 			
 			// aapt resource value: 0x7f030024
-			public const int design_navigation_menu_item = 2130903076;
+			public const int design_navigation_item_subheader = 2130903076;
 			
 			// aapt resource value: 0x7f030025
-			public const int mr_chooser_dialog = 2130903077;
+			public const int design_navigation_menu = 2130903077;
 			
 			// aapt resource value: 0x7f030026
-			public const int mr_chooser_list_item = 2130903078;
+			public const int design_navigation_menu_item = 2130903078;
 			
 			// aapt resource value: 0x7f030027
-			public const int mr_controller_material_dialog_b = 2130903079;
+			public const int mr_chooser_dialog = 2130903079;
 			
 			// aapt resource value: 0x7f030028
-			public const int mr_controller_volume_item = 2130903080;
+			public const int mr_chooser_list_item = 2130903080;
 			
 			// aapt resource value: 0x7f030029
-			public const int mr_playback_control = 2130903081;
+			public const int mr_controller_material_dialog_b = 2130903081;
 			
 			// aapt resource value: 0x7f03002a
-			public const int mr_volume_control = 2130903082;
+			public const int mr_controller_volume_item = 2130903082;
 			
 			// aapt resource value: 0x7f03002b
-			public const int notification_media_action = 2130903083;
+			public const int mr_playback_control = 2130903083;
 			
 			// aapt resource value: 0x7f03002c
-			public const int notification_media_cancel_action = 2130903084;
+			public const int mr_volume_control = 2130903084;
 			
 			// aapt resource value: 0x7f03002d
-			public const int notification_template_big_media = 2130903085;
+			public const int notification_action = 2130903085;
 			
 			// aapt resource value: 0x7f03002e
-			public const int notification_template_big_media_narrow = 2130903086;
+			public const int notification_action_tombstone = 2130903086;
 			
 			// aapt resource value: 0x7f03002f
-			public const int notification_template_lines = 2130903087;
+			public const int notification_media_action = 2130903087;
 			
 			// aapt resource value: 0x7f030030
-			public const int notification_template_media = 2130903088;
+			public const int notification_media_cancel_action = 2130903088;
 			
 			// aapt resource value: 0x7f030031
-			public const int notification_template_part_chronometer = 2130903089;
+			public const int notification_template_big_media = 2130903089;
 			
 			// aapt resource value: 0x7f030032
-			public const int notification_template_part_time = 2130903090;
+			public const int notification_template_big_media_custom = 2130903090;
 			
 			// aapt resource value: 0x7f030033
-			public const int select_dialog_item_material = 2130903091;
+			public const int notification_template_big_media_narrow = 2130903091;
 			
 			// aapt resource value: 0x7f030034
-			public const int select_dialog_multichoice_material = 2130903092;
+			public const int notification_template_big_media_narrow_custom = 2130903092;
 			
 			// aapt resource value: 0x7f030035
-			public const int select_dialog_singlechoice_material = 2130903093;
+			public const int notification_template_custom_big = 2130903093;
 			
 			// aapt resource value: 0x7f030036
-			public const int support_simple_spinner_dropdown_item = 2130903094;
+			public const int notification_template_icon_group = 2130903094;
 			
 			// aapt resource value: 0x7f030037
-			public const int Tabbar = 2130903095;
+			public const int notification_template_lines_media = 2130903095;
 			
 			// aapt resource value: 0x7f030038
-			public const int Toolbar = 2130903096;
+			public const int notification_template_media = 2130903096;
 			
 			// aapt resource value: 0x7f030039
-			public const int WebAuthenticationBroker = 2130903097;
+			public const int notification_template_media_custom = 2130903097;
+			
+			// aapt resource value: 0x7f03003a
+			public const int notification_template_part_chronometer = 2130903098;
+			
+			// aapt resource value: 0x7f03003b
+			public const int notification_template_part_time = 2130903099;
+			
+			// aapt resource value: 0x7f03003c
+			public const int select_dialog_item_material = 2130903100;
+			
+			// aapt resource value: 0x7f03003d
+			public const int select_dialog_multichoice_material = 2130903101;
+			
+			// aapt resource value: 0x7f03003e
+			public const int select_dialog_singlechoice_material = 2130903102;
+			
+			// aapt resource value: 0x7f03003f
+			public const int support_simple_spinner_dropdown_item = 2130903103;
+			
+			// aapt resource value: 0x7f030040
+			public const int Tabbar = 2130903104;
+			
+			// aapt resource value: 0x7f030041
+			public const int Toolbar = 2130903105;
+			
+			// aapt resource value: 0x7f030042
+			public const int WebAuthenticationBroker = 2130903106;
 			
 			static Layout()
 			{
@@ -4193,74 +4644,110 @@ namespace XForms.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f080026
-			public const int ApplicationName = 2131230758;
-			
-			// aapt resource value: 0x7f08000f
-			public const int abc_action_bar_home_description = 2131230735;
-			
-			// aapt resource value: 0x7f080010
-			public const int abc_action_bar_home_description_format = 2131230736;
-			
-			// aapt resource value: 0x7f080011
-			public const int abc_action_bar_home_subtitle_description_format = 2131230737;
+			// aapt resource value: 0x7f080033
+			public const int ApplicationName = 2131230771;
 			
 			// aapt resource value: 0x7f080012
-			public const int abc_action_bar_up_description = 2131230738;
+			public const int abc_action_bar_home_description = 2131230738;
 			
 			// aapt resource value: 0x7f080013
-			public const int abc_action_menu_overflow_description = 2131230739;
+			public const int abc_action_bar_home_description_format = 2131230739;
 			
 			// aapt resource value: 0x7f080014
-			public const int abc_action_mode_done = 2131230740;
+			public const int abc_action_bar_home_subtitle_description_format = 2131230740;
 			
 			// aapt resource value: 0x7f080015
-			public const int abc_activity_chooser_view_see_all = 2131230741;
+			public const int abc_action_bar_up_description = 2131230741;
 			
 			// aapt resource value: 0x7f080016
-			public const int abc_activitychooserview_choose_application = 2131230742;
+			public const int abc_action_menu_overflow_description = 2131230742;
 			
 			// aapt resource value: 0x7f080017
-			public const int abc_capital_off = 2131230743;
+			public const int abc_action_mode_done = 2131230743;
 			
 			// aapt resource value: 0x7f080018
-			public const int abc_capital_on = 2131230744;
+			public const int abc_activity_chooser_view_see_all = 2131230744;
 			
 			// aapt resource value: 0x7f080019
-			public const int abc_search_hint = 2131230745;
+			public const int abc_activitychooserview_choose_application = 2131230745;
 			
 			// aapt resource value: 0x7f08001a
-			public const int abc_searchview_description_clear = 2131230746;
+			public const int abc_capital_off = 2131230746;
 			
 			// aapt resource value: 0x7f08001b
-			public const int abc_searchview_description_query = 2131230747;
+			public const int abc_capital_on = 2131230747;
+			
+			// aapt resource value: 0x7f080027
+			public const int abc_font_family_body_1_material = 2131230759;
+			
+			// aapt resource value: 0x7f080028
+			public const int abc_font_family_body_2_material = 2131230760;
+			
+			// aapt resource value: 0x7f080029
+			public const int abc_font_family_button_material = 2131230761;
+			
+			// aapt resource value: 0x7f08002a
+			public const int abc_font_family_caption_material = 2131230762;
+			
+			// aapt resource value: 0x7f08002b
+			public const int abc_font_family_display_1_material = 2131230763;
+			
+			// aapt resource value: 0x7f08002c
+			public const int abc_font_family_display_2_material = 2131230764;
+			
+			// aapt resource value: 0x7f08002d
+			public const int abc_font_family_display_3_material = 2131230765;
+			
+			// aapt resource value: 0x7f08002e
+			public const int abc_font_family_display_4_material = 2131230766;
+			
+			// aapt resource value: 0x7f08002f
+			public const int abc_font_family_headline_material = 2131230767;
+			
+			// aapt resource value: 0x7f080030
+			public const int abc_font_family_menu_material = 2131230768;
+			
+			// aapt resource value: 0x7f080031
+			public const int abc_font_family_subhead_material = 2131230769;
+			
+			// aapt resource value: 0x7f080032
+			public const int abc_font_family_title_material = 2131230770;
 			
 			// aapt resource value: 0x7f08001c
-			public const int abc_searchview_description_search = 2131230748;
+			public const int abc_search_hint = 2131230748;
 			
 			// aapt resource value: 0x7f08001d
-			public const int abc_searchview_description_submit = 2131230749;
+			public const int abc_searchview_description_clear = 2131230749;
 			
 			// aapt resource value: 0x7f08001e
-			public const int abc_searchview_description_voice = 2131230750;
+			public const int abc_searchview_description_query = 2131230750;
 			
 			// aapt resource value: 0x7f08001f
-			public const int abc_shareactionprovider_share_with = 2131230751;
+			public const int abc_searchview_description_search = 2131230751;
 			
 			// aapt resource value: 0x7f080020
-			public const int abc_shareactionprovider_share_with_application = 2131230752;
+			public const int abc_searchview_description_submit = 2131230752;
 			
 			// aapt resource value: 0x7f080021
-			public const int abc_toolbar_collapse_description = 2131230753;
+			public const int abc_searchview_description_voice = 2131230753;
+			
+			// aapt resource value: 0x7f080022
+			public const int abc_shareactionprovider_share_with = 2131230754;
 			
 			// aapt resource value: 0x7f080023
-			public const int appbar_scrolling_view_behavior = 2131230755;
+			public const int abc_shareactionprovider_share_with_application = 2131230755;
 			
 			// aapt resource value: 0x7f080024
-			public const int bottom_sheet_behavior = 2131230756;
+			public const int abc_toolbar_collapse_description = 2131230756;
 			
-			// aapt resource value: 0x7f080025
-			public const int character_counter_pattern = 2131230757;
+			// aapt resource value: 0x7f08000f
+			public const int appbar_scrolling_view_behavior = 2131230735;
+			
+			// aapt resource value: 0x7f080010
+			public const int bottom_sheet_behavior = 2131230736;
+			
+			// aapt resource value: 0x7f080011
+			public const int character_counter_pattern = 2131230737;
 			
 			// aapt resource value: 0x7f080000
 			public const int mr_button_content_description = 2131230720;
@@ -4307,8 +4794,11 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f08000e
 			public const int mr_user_route_category_name = 2131230734;
 			
-			// aapt resource value: 0x7f080022
-			public const int status_bar_notification_info_overflow = 2131230754;
+			// aapt resource value: 0x7f080025
+			public const int search_menu_title = 2131230757;
+			
+			// aapt resource value: 0x7f080026
+			public const int status_bar_notification_info_overflow = 2131230758;
 			
 			static String()
 			{
@@ -4323,455 +4813,485 @@ namespace XForms.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0a00a1
-			public const int AlertDialog_AppCompat = 2131361953;
+			// aapt resource value: 0x7f0a00d1
+			public const int AlertDialog_AppCompat = 2131362001;
 			
-			// aapt resource value: 0x7f0a00a2
-			public const int AlertDialog_AppCompat_Light = 2131361954;
+			// aapt resource value: 0x7f0a00d2
+			public const int AlertDialog_AppCompat_Light = 2131362002;
 			
-			// aapt resource value: 0x7f0a00a3
-			public const int Animation_AppCompat_Dialog = 2131361955;
+			// aapt resource value: 0x7f0a00d3
+			public const int Animation_AppCompat_Dialog = 2131362003;
 			
-			// aapt resource value: 0x7f0a00a4
-			public const int Animation_AppCompat_DropDownUp = 2131361956;
+			// aapt resource value: 0x7f0a00d4
+			public const int Animation_AppCompat_DropDownUp = 2131362004;
 			
-			// aapt resource value: 0x7f0a015a
-			public const int Animation_Design_BottomSheetDialog = 2131362138;
+			// aapt resource value: 0x7f0a001c
+			public const int Animation_Design_BottomSheetDialog = 2131361820;
 			
-			// aapt resource value: 0x7f0a0174
-			public const int AppCompatDialogStyle = 2131362164;
+			// aapt resource value: 0x7f0a0193
+			public const int AppCompatDialogStyle = 2131362195;
 			
-			// aapt resource value: 0x7f0a00a5
-			public const int Base_AlertDialog_AppCompat = 2131361957;
+			// aapt resource value: 0x7f0a00d5
+			public const int Base_AlertDialog_AppCompat = 2131362005;
 			
-			// aapt resource value: 0x7f0a00a6
-			public const int Base_AlertDialog_AppCompat_Light = 2131361958;
+			// aapt resource value: 0x7f0a00d6
+			public const int Base_AlertDialog_AppCompat_Light = 2131362006;
 			
-			// aapt resource value: 0x7f0a00a7
-			public const int Base_Animation_AppCompat_Dialog = 2131361959;
+			// aapt resource value: 0x7f0a00d7
+			public const int Base_Animation_AppCompat_Dialog = 2131362007;
 			
-			// aapt resource value: 0x7f0a00a8
-			public const int Base_Animation_AppCompat_DropDownUp = 2131361960;
+			// aapt resource value: 0x7f0a00d8
+			public const int Base_Animation_AppCompat_DropDownUp = 2131362008;
 			
 			// aapt resource value: 0x7f0a0018
 			public const int Base_CardView = 2131361816;
 			
-			// aapt resource value: 0x7f0a00a9
-			public const int Base_DialogWindowTitle_AppCompat = 2131361961;
-			
-			// aapt resource value: 0x7f0a00aa
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131361962;
-			
-			// aapt resource value: 0x7f0a0051
-			public const int Base_TextAppearance_AppCompat = 2131361873;
-			
-			// aapt resource value: 0x7f0a0052
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131361874;
-			
-			// aapt resource value: 0x7f0a0053
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131361875;
-			
-			// aapt resource value: 0x7f0a003b
-			public const int Base_TextAppearance_AppCompat_Button = 2131361851;
-			
-			// aapt resource value: 0x7f0a0054
-			public const int Base_TextAppearance_AppCompat_Caption = 2131361876;
-			
-			// aapt resource value: 0x7f0a0055
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131361877;
-			
-			// aapt resource value: 0x7f0a0056
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131361878;
-			
-			// aapt resource value: 0x7f0a0057
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131361879;
-			
-			// aapt resource value: 0x7f0a0058
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131361880;
-			
-			// aapt resource value: 0x7f0a0059
-			public const int Base_TextAppearance_AppCompat_Headline = 2131361881;
-			
-			// aapt resource value: 0x7f0a0026
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131361830;
-			
-			// aapt resource value: 0x7f0a005a
-			public const int Base_TextAppearance_AppCompat_Large = 2131361882;
-			
-			// aapt resource value: 0x7f0a0027
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131361831;
-			
-			// aapt resource value: 0x7f0a005b
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131361883;
-			
-			// aapt resource value: 0x7f0a005c
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131361884;
-			
-			// aapt resource value: 0x7f0a005d
-			public const int Base_TextAppearance_AppCompat_Medium = 2131361885;
-			
-			// aapt resource value: 0x7f0a0028
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131361832;
-			
-			// aapt resource value: 0x7f0a005e
-			public const int Base_TextAppearance_AppCompat_Menu = 2131361886;
-			
-			// aapt resource value: 0x7f0a00ab
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131361963;
-			
-			// aapt resource value: 0x7f0a005f
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131361887;
-			
-			// aapt resource value: 0x7f0a0060
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131361888;
-			
-			// aapt resource value: 0x7f0a0061
-			public const int Base_TextAppearance_AppCompat_Small = 2131361889;
-			
-			// aapt resource value: 0x7f0a0029
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131361833;
-			
-			// aapt resource value: 0x7f0a0062
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131361890;
-			
-			// aapt resource value: 0x7f0a002a
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131361834;
-			
-			// aapt resource value: 0x7f0a0063
-			public const int Base_TextAppearance_AppCompat_Title = 2131361891;
-			
-			// aapt resource value: 0x7f0a002b
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131361835;
-			
-			// aapt resource value: 0x7f0a009a
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131361946;
-			
-			// aapt resource value: 0x7f0a0064
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131361892;
-			
-			// aapt resource value: 0x7f0a0065
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131361893;
-			
-			// aapt resource value: 0x7f0a0066
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131361894;
-			
-			// aapt resource value: 0x7f0a0067
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131361895;
-			
-			// aapt resource value: 0x7f0a0068
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131361896;
-			
-			// aapt resource value: 0x7f0a0069
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131361897;
-			
-			// aapt resource value: 0x7f0a006a
-			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131361898;
-			
-			// aapt resource value: 0x7f0a009b
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131361947;
-			
-			// aapt resource value: 0x7f0a00ac
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131361964;
-			
-			// aapt resource value: 0x7f0a006b
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131361899;
-			
-			// aapt resource value: 0x7f0a006c
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131361900;
-			
-			// aapt resource value: 0x7f0a006d
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131361901;
-			
-			// aapt resource value: 0x7f0a006e
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131361902;
-			
-			// aapt resource value: 0x7f0a00ad
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131361965;
-			
-			// aapt resource value: 0x7f0a006f
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131361903;
-			
-			// aapt resource value: 0x7f0a0070
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131361904;
-			
-			// aapt resource value: 0x7f0a0071
-			public const int Base_Theme_AppCompat = 2131361905;
-			
-			// aapt resource value: 0x7f0a00ae
-			public const int Base_Theme_AppCompat_CompactMenu = 2131361966;
-			
-			// aapt resource value: 0x7f0a002c
-			public const int Base_Theme_AppCompat_Dialog = 2131361836;
-			
-			// aapt resource value: 0x7f0a00af
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131361967;
-			
-			// aapt resource value: 0x7f0a00b0
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131361968;
-			
-			// aapt resource value: 0x7f0a00b1
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131361969;
-			
-			// aapt resource value: 0x7f0a001c
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131361820;
-			
-			// aapt resource value: 0x7f0a0072
-			public const int Base_Theme_AppCompat_Light = 2131361906;
-			
-			// aapt resource value: 0x7f0a00b2
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131361970;
-			
-			// aapt resource value: 0x7f0a002d
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131361837;
-			
-			// aapt resource value: 0x7f0a00b3
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131361971;
-			
-			// aapt resource value: 0x7f0a00b4
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131361972;
-			
-			// aapt resource value: 0x7f0a00b5
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131361973;
-			
-			// aapt resource value: 0x7f0a001d
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131361821;
-			
-			// aapt resource value: 0x7f0a00b6
-			public const int Base_ThemeOverlay_AppCompat = 2131361974;
-			
-			// aapt resource value: 0x7f0a00b7
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131361975;
-			
-			// aapt resource value: 0x7f0a00b8
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131361976;
-			
-			// aapt resource value: 0x7f0a00b9
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131361977;
-			
-			// aapt resource value: 0x7f0a00ba
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131361978;
-			
-			// aapt resource value: 0x7f0a002e
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131361838;
-			
-			// aapt resource value: 0x7f0a002f
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131361839;
-			
-			// aapt resource value: 0x7f0a0037
-			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131361847;
-			
-			// aapt resource value: 0x7f0a0038
-			public const int Base_V12_Widget_AppCompat_EditText = 2131361848;
+			// aapt resource value: 0x7f0a00d9
+			public const int Base_DialogWindowTitle_AppCompat = 2131362009;
+			
+			// aapt resource value: 0x7f0a00da
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131362010;
 			
 			// aapt resource value: 0x7f0a0073
-			public const int Base_V21_Theme_AppCompat = 2131361907;
+			public const int Base_TextAppearance_AppCompat = 2131361907;
 			
 			// aapt resource value: 0x7f0a0074
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131361908;
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131361908;
 			
 			// aapt resource value: 0x7f0a0075
-			public const int Base_V21_Theme_AppCompat_Light = 2131361909;
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131361909;
+			
+			// aapt resource value: 0x7f0a005b
+			public const int Base_TextAppearance_AppCompat_Button = 2131361883;
 			
 			// aapt resource value: 0x7f0a0076
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131361910;
-			
-			// aapt resource value: 0x7f0a0098
-			public const int Base_V22_Theme_AppCompat = 2131361944;
-			
-			// aapt resource value: 0x7f0a0099
-			public const int Base_V22_Theme_AppCompat_Light = 2131361945;
-			
-			// aapt resource value: 0x7f0a009c
-			public const int Base_V23_Theme_AppCompat = 2131361948;
-			
-			// aapt resource value: 0x7f0a009d
-			public const int Base_V23_Theme_AppCompat_Light = 2131361949;
-			
-			// aapt resource value: 0x7f0a00bb
-			public const int Base_V7_Theme_AppCompat = 2131361979;
-			
-			// aapt resource value: 0x7f0a00bc
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131361980;
-			
-			// aapt resource value: 0x7f0a00bd
-			public const int Base_V7_Theme_AppCompat_Light = 2131361981;
-			
-			// aapt resource value: 0x7f0a00be
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131361982;
-			
-			// aapt resource value: 0x7f0a00bf
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131361983;
-			
-			// aapt resource value: 0x7f0a00c0
-			public const int Base_V7_Widget_AppCompat_EditText = 2131361984;
-			
-			// aapt resource value: 0x7f0a00c1
-			public const int Base_Widget_AppCompat_ActionBar = 2131361985;
-			
-			// aapt resource value: 0x7f0a00c2
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131361986;
-			
-			// aapt resource value: 0x7f0a00c3
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131361987;
+			public const int Base_TextAppearance_AppCompat_Caption = 2131361910;
 			
 			// aapt resource value: 0x7f0a0077
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131361911;
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131361911;
 			
 			// aapt resource value: 0x7f0a0078
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131361912;
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131361912;
 			
 			// aapt resource value: 0x7f0a0079
-			public const int Base_Widget_AppCompat_ActionButton = 2131361913;
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131361913;
 			
 			// aapt resource value: 0x7f0a007a
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131361914;
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131361914;
 			
 			// aapt resource value: 0x7f0a007b
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131361915;
+			public const int Base_TextAppearance_AppCompat_Headline = 2131361915;
 			
-			// aapt resource value: 0x7f0a00c4
-			public const int Base_Widget_AppCompat_ActionMode = 2131361988;
-			
-			// aapt resource value: 0x7f0a00c5
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131361989;
-			
-			// aapt resource value: 0x7f0a0039
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131361849;
+			// aapt resource value: 0x7f0a003f
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131361855;
 			
 			// aapt resource value: 0x7f0a007c
-			public const int Base_Widget_AppCompat_Button = 2131361916;
+			public const int Base_TextAppearance_AppCompat_Large = 2131361916;
+			
+			// aapt resource value: 0x7f0a0040
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131361856;
 			
 			// aapt resource value: 0x7f0a007d
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131361917;
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131361917;
 			
 			// aapt resource value: 0x7f0a007e
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131361918;
-			
-			// aapt resource value: 0x7f0a00c6
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131361990;
-			
-			// aapt resource value: 0x7f0a009e
-			public const int Base_Widget_AppCompat_Button_Colored = 2131361950;
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131361918;
 			
 			// aapt resource value: 0x7f0a007f
-			public const int Base_Widget_AppCompat_Button_Small = 2131361919;
+			public const int Base_TextAppearance_AppCompat_Medium = 2131361919;
+			
+			// aapt resource value: 0x7f0a0041
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131361857;
 			
 			// aapt resource value: 0x7f0a0080
-			public const int Base_Widget_AppCompat_ButtonBar = 2131361920;
+			public const int Base_TextAppearance_AppCompat_Menu = 2131361920;
 			
-			// aapt resource value: 0x7f0a00c7
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131361991;
+			// aapt resource value: 0x7f0a00db
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131362011;
 			
 			// aapt resource value: 0x7f0a0081
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131361921;
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131361921;
 			
 			// aapt resource value: 0x7f0a0082
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131361922;
-			
-			// aapt resource value: 0x7f0a00c8
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131361992;
-			
-			// aapt resource value: 0x7f0a001b
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131361819;
-			
-			// aapt resource value: 0x7f0a00c9
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131361993;
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131361922;
 			
 			// aapt resource value: 0x7f0a0083
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131361923;
+			public const int Base_TextAppearance_AppCompat_Small = 2131361923;
 			
-			// aapt resource value: 0x7f0a003a
-			public const int Base_Widget_AppCompat_EditText = 2131361850;
+			// aapt resource value: 0x7f0a0042
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131361858;
 			
 			// aapt resource value: 0x7f0a0084
-			public const int Base_Widget_AppCompat_ImageButton = 2131361924;
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131361924;
 			
-			// aapt resource value: 0x7f0a00ca
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131361994;
-			
-			// aapt resource value: 0x7f0a00cb
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131361995;
-			
-			// aapt resource value: 0x7f0a00cc
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131361996;
+			// aapt resource value: 0x7f0a0043
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131361859;
 			
 			// aapt resource value: 0x7f0a0085
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131361925;
+			public const int Base_TextAppearance_AppCompat_Title = 2131361925;
+			
+			// aapt resource value: 0x7f0a0044
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131361860;
+			
+			// aapt resource value: 0x7f0a00c8
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131361992;
 			
 			// aapt resource value: 0x7f0a0086
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131361926;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131361926;
 			
 			// aapt resource value: 0x7f0a0087
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131361927;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131361927;
 			
 			// aapt resource value: 0x7f0a0088
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131361928;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131361928;
 			
 			// aapt resource value: 0x7f0a0089
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131361929;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131361929;
 			
 			// aapt resource value: 0x7f0a008a
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131361930;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131361930;
 			
 			// aapt resource value: 0x7f0a008b
-			public const int Base_Widget_AppCompat_ListView = 2131361931;
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131361931;
 			
 			// aapt resource value: 0x7f0a008c
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131361932;
-			
-			// aapt resource value: 0x7f0a008d
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131361933;
-			
-			// aapt resource value: 0x7f0a008e
-			public const int Base_Widget_AppCompat_PopupMenu = 2131361934;
-			
-			// aapt resource value: 0x7f0a008f
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131361935;
-			
-			// aapt resource value: 0x7f0a00cd
-			public const int Base_Widget_AppCompat_PopupWindow = 2131361997;
-			
-			// aapt resource value: 0x7f0a0030
-			public const int Base_Widget_AppCompat_ProgressBar = 2131361840;
-			
-			// aapt resource value: 0x7f0a0031
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131361841;
-			
-			// aapt resource value: 0x7f0a0090
-			public const int Base_Widget_AppCompat_RatingBar = 2131361936;
-			
-			// aapt resource value: 0x7f0a009f
-			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131361951;
-			
-			// aapt resource value: 0x7f0a00a0
-			public const int Base_Widget_AppCompat_RatingBar_Small = 2131361952;
-			
-			// aapt resource value: 0x7f0a00ce
-			public const int Base_Widget_AppCompat_SearchView = 2131361998;
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131361932;
 			
 			// aapt resource value: 0x7f0a00cf
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131361999;
-			
-			// aapt resource value: 0x7f0a0091
-			public const int Base_Widget_AppCompat_SeekBar = 2131361937;
-			
-			// aapt resource value: 0x7f0a0092
-			public const int Base_Widget_AppCompat_Spinner = 2131361938;
-			
-			// aapt resource value: 0x7f0a001e
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131361822;
-			
-			// aapt resource value: 0x7f0a0093
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131361939;
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131361999;
 			
 			// aapt resource value: 0x7f0a00d0
-			public const int Base_Widget_AppCompat_Toolbar = 2131362000;
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131362000;
+			
+			// aapt resource value: 0x7f0a00c9
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131361993;
+			
+			// aapt resource value: 0x7f0a00dc
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131362012;
+			
+			// aapt resource value: 0x7f0a008d
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131361933;
+			
+			// aapt resource value: 0x7f0a008e
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131361934;
+			
+			// aapt resource value: 0x7f0a008f
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131361935;
+			
+			// aapt resource value: 0x7f0a0090
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131361936;
+			
+			// aapt resource value: 0x7f0a0091
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131361937;
+			
+			// aapt resource value: 0x7f0a00dd
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131362013;
+			
+			// aapt resource value: 0x7f0a0092
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131361938;
+			
+			// aapt resource value: 0x7f0a0093
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131361939;
 			
 			// aapt resource value: 0x7f0a0094
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131361940;
+			public const int Base_Theme_AppCompat = 2131361940;
 			
-			// aapt resource value: 0x7f0a015b
-			public const int Base_Widget_Design_TabLayout = 2131362139;
+			// aapt resource value: 0x7f0a00de
+			public const int Base_Theme_AppCompat_CompactMenu = 2131362014;
+			
+			// aapt resource value: 0x7f0a0045
+			public const int Base_Theme_AppCompat_Dialog = 2131361861;
+			
+			// aapt resource value: 0x7f0a0046
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131361862;
+			
+			// aapt resource value: 0x7f0a00df
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131362015;
+			
+			// aapt resource value: 0x7f0a0047
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131361863;
+			
+			// aapt resource value: 0x7f0a0035
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131361845;
+			
+			// aapt resource value: 0x7f0a0095
+			public const int Base_Theme_AppCompat_Light = 2131361941;
+			
+			// aapt resource value: 0x7f0a00e0
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131362016;
+			
+			// aapt resource value: 0x7f0a0048
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131361864;
+			
+			// aapt resource value: 0x7f0a0049
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131361865;
+			
+			// aapt resource value: 0x7f0a00e1
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131362017;
+			
+			// aapt resource value: 0x7f0a004a
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131361866;
+			
+			// aapt resource value: 0x7f0a0036
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131361846;
+			
+			// aapt resource value: 0x7f0a00e2
+			public const int Base_ThemeOverlay_AppCompat = 2131362018;
+			
+			// aapt resource value: 0x7f0a00e3
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131362019;
+			
+			// aapt resource value: 0x7f0a00e4
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131362020;
+			
+			// aapt resource value: 0x7f0a00e5
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131362021;
+			
+			// aapt resource value: 0x7f0a004b
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131361867;
+			
+			// aapt resource value: 0x7f0a004c
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131361868;
+			
+			// aapt resource value: 0x7f0a00e6
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131362022;
+			
+			// aapt resource value: 0x7f0a004d
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131361869;
+			
+			// aapt resource value: 0x7f0a004e
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131361870;
+			
+			// aapt resource value: 0x7f0a004f
+			public const int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131361871;
+			
+			// aapt resource value: 0x7f0a0057
+			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131361879;
+			
+			// aapt resource value: 0x7f0a0058
+			public const int Base_V12_Widget_AppCompat_EditText = 2131361880;
+			
+			// aapt resource value: 0x7f0a0096
+			public const int Base_V21_Theme_AppCompat = 2131361942;
+			
+			// aapt resource value: 0x7f0a0097
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131361943;
+			
+			// aapt resource value: 0x7f0a0098
+			public const int Base_V21_Theme_AppCompat_Light = 2131361944;
+			
+			// aapt resource value: 0x7f0a0099
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131361945;
+			
+			// aapt resource value: 0x7f0a009a
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131361946;
+			
+			// aapt resource value: 0x7f0a00c6
+			public const int Base_V22_Theme_AppCompat = 2131361990;
+			
+			// aapt resource value: 0x7f0a00c7
+			public const int Base_V22_Theme_AppCompat_Light = 2131361991;
+			
+			// aapt resource value: 0x7f0a00ca
+			public const int Base_V23_Theme_AppCompat = 2131361994;
+			
+			// aapt resource value: 0x7f0a00cb
+			public const int Base_V23_Theme_AppCompat_Light = 2131361995;
+			
+			// aapt resource value: 0x7f0a00e7
+			public const int Base_V7_Theme_AppCompat = 2131362023;
+			
+			// aapt resource value: 0x7f0a00e8
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131362024;
+			
+			// aapt resource value: 0x7f0a00e9
+			public const int Base_V7_Theme_AppCompat_Light = 2131362025;
+			
+			// aapt resource value: 0x7f0a00ea
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131362026;
+			
+			// aapt resource value: 0x7f0a00eb
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131362027;
+			
+			// aapt resource value: 0x7f0a00ec
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131362028;
+			
+			// aapt resource value: 0x7f0a00ed
+			public const int Base_V7_Widget_AppCompat_EditText = 2131362029;
+			
+			// aapt resource value: 0x7f0a00ee
+			public const int Base_Widget_AppCompat_ActionBar = 2131362030;
+			
+			// aapt resource value: 0x7f0a00ef
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131362031;
+			
+			// aapt resource value: 0x7f0a00f0
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131362032;
+			
+			// aapt resource value: 0x7f0a009b
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131361947;
+			
+			// aapt resource value: 0x7f0a009c
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131361948;
+			
+			// aapt resource value: 0x7f0a009d
+			public const int Base_Widget_AppCompat_ActionButton = 2131361949;
+			
+			// aapt resource value: 0x7f0a009e
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131361950;
+			
+			// aapt resource value: 0x7f0a009f
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131361951;
+			
+			// aapt resource value: 0x7f0a00f1
+			public const int Base_Widget_AppCompat_ActionMode = 2131362033;
+			
+			// aapt resource value: 0x7f0a00f2
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131362034;
+			
+			// aapt resource value: 0x7f0a0059
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131361881;
+			
+			// aapt resource value: 0x7f0a00a0
+			public const int Base_Widget_AppCompat_Button = 2131361952;
+			
+			// aapt resource value: 0x7f0a00a1
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131361953;
+			
+			// aapt resource value: 0x7f0a00a2
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131361954;
+			
+			// aapt resource value: 0x7f0a00f3
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131362035;
+			
+			// aapt resource value: 0x7f0a00cc
+			public const int Base_Widget_AppCompat_Button_Colored = 2131361996;
+			
+			// aapt resource value: 0x7f0a00a3
+			public const int Base_Widget_AppCompat_Button_Small = 2131361955;
+			
+			// aapt resource value: 0x7f0a00a4
+			public const int Base_Widget_AppCompat_ButtonBar = 2131361956;
+			
+			// aapt resource value: 0x7f0a00f4
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131362036;
+			
+			// aapt resource value: 0x7f0a00a5
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131361957;
+			
+			// aapt resource value: 0x7f0a00a6
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131361958;
+			
+			// aapt resource value: 0x7f0a00f5
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131362037;
+			
+			// aapt resource value: 0x7f0a0034
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131361844;
+			
+			// aapt resource value: 0x7f0a00f6
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131362038;
+			
+			// aapt resource value: 0x7f0a00a7
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131361959;
+			
+			// aapt resource value: 0x7f0a005a
+			public const int Base_Widget_AppCompat_EditText = 2131361882;
+			
+			// aapt resource value: 0x7f0a00a8
+			public const int Base_Widget_AppCompat_ImageButton = 2131361960;
+			
+			// aapt resource value: 0x7f0a00f7
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131362039;
+			
+			// aapt resource value: 0x7f0a00f8
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131362040;
+			
+			// aapt resource value: 0x7f0a00f9
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131362041;
+			
+			// aapt resource value: 0x7f0a00a9
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131361961;
+			
+			// aapt resource value: 0x7f0a00aa
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131361962;
+			
+			// aapt resource value: 0x7f0a00ab
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131361963;
+			
+			// aapt resource value: 0x7f0a00ac
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131361964;
+			
+			// aapt resource value: 0x7f0a00ad
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131361965;
+			
+			// aapt resource value: 0x7f0a00fa
+			public const int Base_Widget_AppCompat_ListMenuView = 2131362042;
+			
+			// aapt resource value: 0x7f0a00ae
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131361966;
+			
+			// aapt resource value: 0x7f0a00af
+			public const int Base_Widget_AppCompat_ListView = 2131361967;
+			
+			// aapt resource value: 0x7f0a00b0
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131361968;
+			
+			// aapt resource value: 0x7f0a00b1
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131361969;
+			
+			// aapt resource value: 0x7f0a00b2
+			public const int Base_Widget_AppCompat_PopupMenu = 2131361970;
+			
+			// aapt resource value: 0x7f0a00b3
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131361971;
+			
+			// aapt resource value: 0x7f0a00fb
+			public const int Base_Widget_AppCompat_PopupWindow = 2131362043;
+			
+			// aapt resource value: 0x7f0a0050
+			public const int Base_Widget_AppCompat_ProgressBar = 2131361872;
+			
+			// aapt resource value: 0x7f0a0051
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131361873;
+			
+			// aapt resource value: 0x7f0a00b4
+			public const int Base_Widget_AppCompat_RatingBar = 2131361972;
+			
+			// aapt resource value: 0x7f0a00cd
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131361997;
+			
+			// aapt resource value: 0x7f0a00ce
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131361998;
+			
+			// aapt resource value: 0x7f0a00fc
+			public const int Base_Widget_AppCompat_SearchView = 2131362044;
+			
+			// aapt resource value: 0x7f0a00fd
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131362045;
+			
+			// aapt resource value: 0x7f0a00b5
+			public const int Base_Widget_AppCompat_SeekBar = 2131361973;
+			
+			// aapt resource value: 0x7f0a00fe
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131362046;
+			
+			// aapt resource value: 0x7f0a00b6
+			public const int Base_Widget_AppCompat_Spinner = 2131361974;
+			
+			// aapt resource value: 0x7f0a0037
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131361847;
+			
+			// aapt resource value: 0x7f0a00b7
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131361975;
+			
+			// aapt resource value: 0x7f0a00ff
+			public const int Base_Widget_AppCompat_Toolbar = 2131362047;
+			
+			// aapt resource value: 0x7f0a00b8
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131361976;
+			
+			// aapt resource value: 0x7f0a001d
+			public const int Base_Widget_Design_TabLayout = 2131361821;
 			
 			// aapt resource value: 0x7f0a0017
 			public const int CardView = 2131361815;
@@ -4782,341 +5302,386 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f0a001a
 			public const int CardView_Light = 2131361818;
 			
-			// aapt resource value: 0x7f0a0172
-			public const int MainTheme = 2131362162;
+			// aapt resource value: 0x7f0a0191
+			public const int MainTheme = 2131362193;
 			
-			// aapt resource value: 0x7f0a0173
-			public const int MainTheme_Base = 2131362163;
+			// aapt resource value: 0x7f0a0192
+			public const int MainTheme_Base = 2131362194;
 			
-			// aapt resource value: 0x7f0a0032
-			public const int Platform_AppCompat = 2131361842;
+			// aapt resource value: 0x7f0a0052
+			public const int Platform_AppCompat = 2131361874;
 			
-			// aapt resource value: 0x7f0a0033
-			public const int Platform_AppCompat_Light = 2131361843;
+			// aapt resource value: 0x7f0a0053
+			public const int Platform_AppCompat_Light = 2131361875;
 			
-			// aapt resource value: 0x7f0a0095
-			public const int Platform_ThemeOverlay_AppCompat = 2131361941;
+			// aapt resource value: 0x7f0a00b9
+			public const int Platform_ThemeOverlay_AppCompat = 2131361977;
 			
-			// aapt resource value: 0x7f0a0096
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131361942;
+			// aapt resource value: 0x7f0a00ba
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131361978;
 			
-			// aapt resource value: 0x7f0a0097
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131361943;
+			// aapt resource value: 0x7f0a00bb
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131361979;
 			
-			// aapt resource value: 0x7f0a0034
-			public const int Platform_V11_AppCompat = 2131361844;
+			// aapt resource value: 0x7f0a0054
+			public const int Platform_V11_AppCompat = 2131361876;
 			
-			// aapt resource value: 0x7f0a0035
-			public const int Platform_V11_AppCompat_Light = 2131361845;
+			// aapt resource value: 0x7f0a0055
+			public const int Platform_V11_AppCompat_Light = 2131361877;
 			
-			// aapt resource value: 0x7f0a003c
-			public const int Platform_V14_AppCompat = 2131361852;
+			// aapt resource value: 0x7f0a005c
+			public const int Platform_V14_AppCompat = 2131361884;
 			
-			// aapt resource value: 0x7f0a003d
-			public const int Platform_V14_AppCompat_Light = 2131361853;
+			// aapt resource value: 0x7f0a005d
+			public const int Platform_V14_AppCompat_Light = 2131361885;
 			
-			// aapt resource value: 0x7f0a0036
-			public const int Platform_Widget_AppCompat_Spinner = 2131361846;
+			// aapt resource value: 0x7f0a00bc
+			public const int Platform_V21_AppCompat = 2131361980;
 			
-			// aapt resource value: 0x7f0a0043
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131361859;
+			// aapt resource value: 0x7f0a00bd
+			public const int Platform_V21_AppCompat_Light = 2131361981;
 			
-			// aapt resource value: 0x7f0a0044
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131361860;
+			// aapt resource value: 0x7f0a0056
+			public const int Platform_Widget_AppCompat_Spinner = 2131361878;
 			
-			// aapt resource value: 0x7f0a0045
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131361861;
+			// aapt resource value: 0x7f0a0065
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131361893;
 			
-			// aapt resource value: 0x7f0a0046
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131361862;
+			// aapt resource value: 0x7f0a0066
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131361894;
 			
-			// aapt resource value: 0x7f0a0047
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131361863;
+			// aapt resource value: 0x7f0a0067
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131361895;
 			
-			// aapt resource value: 0x7f0a0048
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131361864;
+			// aapt resource value: 0x7f0a0068
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131361896;
 			
-			// aapt resource value: 0x7f0a0049
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131361865;
+			// aapt resource value: 0x7f0a0069
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131361897;
 			
-			// aapt resource value: 0x7f0a004a
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131361866;
+			// aapt resource value: 0x7f0a006a
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131361898;
 			
-			// aapt resource value: 0x7f0a004b
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131361867;
+			// aapt resource value: 0x7f0a006b
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131361899;
 			
-			// aapt resource value: 0x7f0a004c
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131361868;
+			// aapt resource value: 0x7f0a006c
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131361900;
 			
-			// aapt resource value: 0x7f0a004d
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131361869;
+			// aapt resource value: 0x7f0a006d
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131361901;
 			
-			// aapt resource value: 0x7f0a004e
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131361870;
+			// aapt resource value: 0x7f0a006e
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131361902;
 			
-			// aapt resource value: 0x7f0a004f
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131361871;
+			// aapt resource value: 0x7f0a006f
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131361903;
 			
-			// aapt resource value: 0x7f0a0050
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131361872;
+			// aapt resource value: 0x7f0a0070
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131361904;
 			
-			// aapt resource value: 0x7f0a00d1
-			public const int TextAppearance_AppCompat = 2131362001;
+			// aapt resource value: 0x7f0a0071
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131361905;
 			
-			// aapt resource value: 0x7f0a00d2
-			public const int TextAppearance_AppCompat_Body1 = 2131362002;
-			
-			// aapt resource value: 0x7f0a00d3
-			public const int TextAppearance_AppCompat_Body2 = 2131362003;
-			
-			// aapt resource value: 0x7f0a00d4
-			public const int TextAppearance_AppCompat_Button = 2131362004;
-			
-			// aapt resource value: 0x7f0a00d5
-			public const int TextAppearance_AppCompat_Caption = 2131362005;
-			
-			// aapt resource value: 0x7f0a00d6
-			public const int TextAppearance_AppCompat_Display1 = 2131362006;
-			
-			// aapt resource value: 0x7f0a00d7
-			public const int TextAppearance_AppCompat_Display2 = 2131362007;
-			
-			// aapt resource value: 0x7f0a00d8
-			public const int TextAppearance_AppCompat_Display3 = 2131362008;
-			
-			// aapt resource value: 0x7f0a00d9
-			public const int TextAppearance_AppCompat_Display4 = 2131362009;
-			
-			// aapt resource value: 0x7f0a00da
-			public const int TextAppearance_AppCompat_Headline = 2131362010;
-			
-			// aapt resource value: 0x7f0a00db
-			public const int TextAppearance_AppCompat_Inverse = 2131362011;
-			
-			// aapt resource value: 0x7f0a00dc
-			public const int TextAppearance_AppCompat_Large = 2131362012;
-			
-			// aapt resource value: 0x7f0a00dd
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131362013;
-			
-			// aapt resource value: 0x7f0a00de
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131362014;
-			
-			// aapt resource value: 0x7f0a00df
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131362015;
-			
-			// aapt resource value: 0x7f0a00e0
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131362016;
-			
-			// aapt resource value: 0x7f0a00e1
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131362017;
-			
-			// aapt resource value: 0x7f0a00e2
-			public const int TextAppearance_AppCompat_Medium = 2131362018;
-			
-			// aapt resource value: 0x7f0a00e3
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131362019;
-			
-			// aapt resource value: 0x7f0a00e4
-			public const int TextAppearance_AppCompat_Menu = 2131362020;
-			
-			// aapt resource value: 0x7f0a00e5
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131362021;
-			
-			// aapt resource value: 0x7f0a00e6
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131362022;
-			
-			// aapt resource value: 0x7f0a00e7
-			public const int TextAppearance_AppCompat_Small = 2131362023;
-			
-			// aapt resource value: 0x7f0a00e8
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131362024;
-			
-			// aapt resource value: 0x7f0a00e9
-			public const int TextAppearance_AppCompat_Subhead = 2131362025;
-			
-			// aapt resource value: 0x7f0a00ea
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131362026;
-			
-			// aapt resource value: 0x7f0a00eb
-			public const int TextAppearance_AppCompat_Title = 2131362027;
-			
-			// aapt resource value: 0x7f0a00ec
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131362028;
-			
-			// aapt resource value: 0x7f0a00ed
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131362029;
-			
-			// aapt resource value: 0x7f0a00ee
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131362030;
-			
-			// aapt resource value: 0x7f0a00ef
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131362031;
-			
-			// aapt resource value: 0x7f0a00f0
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131362032;
-			
-			// aapt resource value: 0x7f0a00f1
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131362033;
-			
-			// aapt resource value: 0x7f0a00f2
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131362034;
-			
-			// aapt resource value: 0x7f0a00f3
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131362035;
-			
-			// aapt resource value: 0x7f0a00f4
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131362036;
-			
-			// aapt resource value: 0x7f0a00f5
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131362037;
-			
-			// aapt resource value: 0x7f0a00f6
-			public const int TextAppearance_AppCompat_Widget_Button = 2131362038;
-			
-			// aapt resource value: 0x7f0a00f7
-			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131362039;
-			
-			// aapt resource value: 0x7f0a00f8
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131362040;
-			
-			// aapt resource value: 0x7f0a00f9
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131362041;
-			
-			// aapt resource value: 0x7f0a00fa
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131362042;
-			
-			// aapt resource value: 0x7f0a00fb
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131362043;
-			
-			// aapt resource value: 0x7f0a00fc
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131362044;
-			
-			// aapt resource value: 0x7f0a015c
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131362140;
-			
-			// aapt resource value: 0x7f0a015d
-			public const int TextAppearance_Design_Counter = 2131362141;
-			
-			// aapt resource value: 0x7f0a015e
-			public const int TextAppearance_Design_Counter_Overflow = 2131362142;
-			
-			// aapt resource value: 0x7f0a015f
-			public const int TextAppearance_Design_Error = 2131362143;
-			
-			// aapt resource value: 0x7f0a0160
-			public const int TextAppearance_Design_Hint = 2131362144;
-			
-			// aapt resource value: 0x7f0a0161
-			public const int TextAppearance_Design_Snackbar_Message = 2131362145;
-			
-			// aapt resource value: 0x7f0a0162
-			public const int TextAppearance_Design_Tab = 2131362146;
-			
-			// aapt resource value: 0x7f0a003e
-			public const int TextAppearance_StatusBar_EventContent = 2131361854;
-			
-			// aapt resource value: 0x7f0a003f
-			public const int TextAppearance_StatusBar_EventContent_Info = 2131361855;
-			
-			// aapt resource value: 0x7f0a0040
-			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131361856;
-			
-			// aapt resource value: 0x7f0a0041
-			public const int TextAppearance_StatusBar_EventContent_Time = 2131361857;
-			
-			// aapt resource value: 0x7f0a0042
-			public const int TextAppearance_StatusBar_EventContent_Title = 2131361858;
-			
-			// aapt resource value: 0x7f0a00fd
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131362045;
-			
-			// aapt resource value: 0x7f0a00fe
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131362046;
-			
-			// aapt resource value: 0x7f0a00ff
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131362047;
+			// aapt resource value: 0x7f0a0072
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131361906;
 			
 			// aapt resource value: 0x7f0a0100
-			public const int Theme_AppCompat = 2131362048;
+			public const int TextAppearance_AppCompat = 2131362048;
 			
 			// aapt resource value: 0x7f0a0101
-			public const int Theme_AppCompat_CompactMenu = 2131362049;
-			
-			// aapt resource value: 0x7f0a001f
-			public const int Theme_AppCompat_DayNight = 2131361823;
-			
-			// aapt resource value: 0x7f0a0020
-			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131361824;
-			
-			// aapt resource value: 0x7f0a0021
-			public const int Theme_AppCompat_DayNight_Dialog = 2131361825;
-			
-			// aapt resource value: 0x7f0a0022
-			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131361826;
-			
-			// aapt resource value: 0x7f0a0023
-			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131361827;
-			
-			// aapt resource value: 0x7f0a0024
-			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131361828;
-			
-			// aapt resource value: 0x7f0a0025
-			public const int Theme_AppCompat_DayNight_NoActionBar = 2131361829;
+			public const int TextAppearance_AppCompat_Body1 = 2131362049;
 			
 			// aapt resource value: 0x7f0a0102
-			public const int Theme_AppCompat_Dialog = 2131362050;
+			public const int TextAppearance_AppCompat_Body2 = 2131362050;
 			
 			// aapt resource value: 0x7f0a0103
-			public const int Theme_AppCompat_Dialog_Alert = 2131362051;
+			public const int TextAppearance_AppCompat_Button = 2131362051;
 			
 			// aapt resource value: 0x7f0a0104
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131362052;
+			public const int TextAppearance_AppCompat_Caption = 2131362052;
 			
 			// aapt resource value: 0x7f0a0105
-			public const int Theme_AppCompat_DialogWhenLarge = 2131362053;
+			public const int TextAppearance_AppCompat_Display1 = 2131362053;
 			
 			// aapt resource value: 0x7f0a0106
-			public const int Theme_AppCompat_Light = 2131362054;
+			public const int TextAppearance_AppCompat_Display2 = 2131362054;
 			
 			// aapt resource value: 0x7f0a0107
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131362055;
+			public const int TextAppearance_AppCompat_Display3 = 2131362055;
 			
 			// aapt resource value: 0x7f0a0108
-			public const int Theme_AppCompat_Light_Dialog = 2131362056;
+			public const int TextAppearance_AppCompat_Display4 = 2131362056;
 			
 			// aapt resource value: 0x7f0a0109
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131362057;
+			public const int TextAppearance_AppCompat_Headline = 2131362057;
 			
 			// aapt resource value: 0x7f0a010a
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131362058;
+			public const int TextAppearance_AppCompat_Inverse = 2131362058;
 			
 			// aapt resource value: 0x7f0a010b
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131362059;
+			public const int TextAppearance_AppCompat_Large = 2131362059;
 			
 			// aapt resource value: 0x7f0a010c
-			public const int Theme_AppCompat_Light_NoActionBar = 2131362060;
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131362060;
 			
 			// aapt resource value: 0x7f0a010d
-			public const int Theme_AppCompat_NoActionBar = 2131362061;
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131362061;
 			
-			// aapt resource value: 0x7f0a0163
-			public const int Theme_Design = 2131362147;
+			// aapt resource value: 0x7f0a010e
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131362062;
 			
-			// aapt resource value: 0x7f0a0164
-			public const int Theme_Design_BottomSheetDialog = 2131362148;
+			// aapt resource value: 0x7f0a010f
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131362063;
 			
-			// aapt resource value: 0x7f0a0165
-			public const int Theme_Design_Light = 2131362149;
+			// aapt resource value: 0x7f0a0110
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131362064;
 			
-			// aapt resource value: 0x7f0a0166
-			public const int Theme_Design_Light_BottomSheetDialog = 2131362150;
+			// aapt resource value: 0x7f0a0111
+			public const int TextAppearance_AppCompat_Medium = 2131362065;
 			
-			// aapt resource value: 0x7f0a0167
-			public const int Theme_Design_Light_NoActionBar = 2131362151;
+			// aapt resource value: 0x7f0a0112
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131362066;
 			
-			// aapt resource value: 0x7f0a0168
-			public const int Theme_Design_NoActionBar = 2131362152;
+			// aapt resource value: 0x7f0a0113
+			public const int TextAppearance_AppCompat_Menu = 2131362067;
+			
+			// aapt resource value: 0x7f0a005e
+			public const int TextAppearance_AppCompat_Notification = 2131361886;
+			
+			// aapt resource value: 0x7f0a00be
+			public const int TextAppearance_AppCompat_Notification_Info = 2131361982;
+			
+			// aapt resource value: 0x7f0a00bf
+			public const int TextAppearance_AppCompat_Notification_Info_Media = 2131361983;
+			
+			// aapt resource value: 0x7f0a0114
+			public const int TextAppearance_AppCompat_Notification_Line2 = 2131362068;
+			
+			// aapt resource value: 0x7f0a0115
+			public const int TextAppearance_AppCompat_Notification_Line2_Media = 2131362069;
+			
+			// aapt resource value: 0x7f0a00c0
+			public const int TextAppearance_AppCompat_Notification_Media = 2131361984;
+			
+			// aapt resource value: 0x7f0a00c1
+			public const int TextAppearance_AppCompat_Notification_Time = 2131361985;
+			
+			// aapt resource value: 0x7f0a00c2
+			public const int TextAppearance_AppCompat_Notification_Time_Media = 2131361986;
+			
+			// aapt resource value: 0x7f0a005f
+			public const int TextAppearance_AppCompat_Notification_Title = 2131361887;
+			
+			// aapt resource value: 0x7f0a00c3
+			public const int TextAppearance_AppCompat_Notification_Title_Media = 2131361987;
+			
+			// aapt resource value: 0x7f0a0116
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131362070;
+			
+			// aapt resource value: 0x7f0a0117
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131362071;
+			
+			// aapt resource value: 0x7f0a0118
+			public const int TextAppearance_AppCompat_Small = 2131362072;
+			
+			// aapt resource value: 0x7f0a0119
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131362073;
+			
+			// aapt resource value: 0x7f0a011a
+			public const int TextAppearance_AppCompat_Subhead = 2131362074;
+			
+			// aapt resource value: 0x7f0a011b
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131362075;
+			
+			// aapt resource value: 0x7f0a011c
+			public const int TextAppearance_AppCompat_Title = 2131362076;
+			
+			// aapt resource value: 0x7f0a011d
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131362077;
+			
+			// aapt resource value: 0x7f0a011e
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131362078;
+			
+			// aapt resource value: 0x7f0a011f
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131362079;
+			
+			// aapt resource value: 0x7f0a0120
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131362080;
+			
+			// aapt resource value: 0x7f0a0121
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131362081;
+			
+			// aapt resource value: 0x7f0a0122
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131362082;
+			
+			// aapt resource value: 0x7f0a0123
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131362083;
+			
+			// aapt resource value: 0x7f0a0124
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131362084;
+			
+			// aapt resource value: 0x7f0a0125
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131362085;
+			
+			// aapt resource value: 0x7f0a0126
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131362086;
+			
+			// aapt resource value: 0x7f0a0127
+			public const int TextAppearance_AppCompat_Widget_Button = 2131362087;
+			
+			// aapt resource value: 0x7f0a0128
+			public const int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131362088;
+			
+			// aapt resource value: 0x7f0a0129
+			public const int TextAppearance_AppCompat_Widget_Button_Colored = 2131362089;
+			
+			// aapt resource value: 0x7f0a012a
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131362090;
+			
+			// aapt resource value: 0x7f0a012b
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131362091;
+			
+			// aapt resource value: 0x7f0a012c
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131362092;
+			
+			// aapt resource value: 0x7f0a012d
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131362093;
+			
+			// aapt resource value: 0x7f0a012e
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131362094;
+			
+			// aapt resource value: 0x7f0a012f
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131362095;
+			
+			// aapt resource value: 0x7f0a0130
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131362096;
+			
+			// aapt resource value: 0x7f0a001e
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131361822;
+			
+			// aapt resource value: 0x7f0a001f
+			public const int TextAppearance_Design_Counter = 2131361823;
+			
+			// aapt resource value: 0x7f0a0020
+			public const int TextAppearance_Design_Counter_Overflow = 2131361824;
+			
+			// aapt resource value: 0x7f0a0021
+			public const int TextAppearance_Design_Error = 2131361825;
+			
+			// aapt resource value: 0x7f0a0022
+			public const int TextAppearance_Design_Hint = 2131361826;
+			
+			// aapt resource value: 0x7f0a0023
+			public const int TextAppearance_Design_Snackbar_Message = 2131361827;
+			
+			// aapt resource value: 0x7f0a0024
+			public const int TextAppearance_Design_Tab = 2131361828;
+			
+			// aapt resource value: 0x7f0a0060
+			public const int TextAppearance_StatusBar_EventContent = 2131361888;
+			
+			// aapt resource value: 0x7f0a0061
+			public const int TextAppearance_StatusBar_EventContent_Info = 2131361889;
+			
+			// aapt resource value: 0x7f0a0062
+			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131361890;
+			
+			// aapt resource value: 0x7f0a0063
+			public const int TextAppearance_StatusBar_EventContent_Time = 2131361891;
+			
+			// aapt resource value: 0x7f0a0064
+			public const int TextAppearance_StatusBar_EventContent_Title = 2131361892;
+			
+			// aapt resource value: 0x7f0a0131
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131362097;
+			
+			// aapt resource value: 0x7f0a0132
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131362098;
+			
+			// aapt resource value: 0x7f0a0133
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131362099;
+			
+			// aapt resource value: 0x7f0a0134
+			public const int Theme_AppCompat = 2131362100;
+			
+			// aapt resource value: 0x7f0a0135
+			public const int Theme_AppCompat_CompactMenu = 2131362101;
+			
+			// aapt resource value: 0x7f0a0038
+			public const int Theme_AppCompat_DayNight = 2131361848;
+			
+			// aapt resource value: 0x7f0a0039
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131361849;
+			
+			// aapt resource value: 0x7f0a003a
+			public const int Theme_AppCompat_DayNight_Dialog = 2131361850;
+			
+			// aapt resource value: 0x7f0a003b
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131361851;
+			
+			// aapt resource value: 0x7f0a003c
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131361852;
+			
+			// aapt resource value: 0x7f0a003d
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131361853;
+			
+			// aapt resource value: 0x7f0a003e
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131361854;
+			
+			// aapt resource value: 0x7f0a0136
+			public const int Theme_AppCompat_Dialog = 2131362102;
+			
+			// aapt resource value: 0x7f0a0137
+			public const int Theme_AppCompat_Dialog_Alert = 2131362103;
+			
+			// aapt resource value: 0x7f0a0138
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131362104;
+			
+			// aapt resource value: 0x7f0a0139
+			public const int Theme_AppCompat_DialogWhenLarge = 2131362105;
+			
+			// aapt resource value: 0x7f0a013a
+			public const int Theme_AppCompat_Light = 2131362106;
+			
+			// aapt resource value: 0x7f0a013b
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131362107;
+			
+			// aapt resource value: 0x7f0a013c
+			public const int Theme_AppCompat_Light_Dialog = 2131362108;
+			
+			// aapt resource value: 0x7f0a013d
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131362109;
+			
+			// aapt resource value: 0x7f0a013e
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131362110;
+			
+			// aapt resource value: 0x7f0a013f
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131362111;
+			
+			// aapt resource value: 0x7f0a0140
+			public const int Theme_AppCompat_Light_NoActionBar = 2131362112;
+			
+			// aapt resource value: 0x7f0a0141
+			public const int Theme_AppCompat_NoActionBar = 2131362113;
+			
+			// aapt resource value: 0x7f0a0025
+			public const int Theme_Design = 2131361829;
+			
+			// aapt resource value: 0x7f0a0026
+			public const int Theme_Design_BottomSheetDialog = 2131361830;
+			
+			// aapt resource value: 0x7f0a0027
+			public const int Theme_Design_Light = 2131361831;
+			
+			// aapt resource value: 0x7f0a0028
+			public const int Theme_Design_Light_BottomSheetDialog = 2131361832;
+			
+			// aapt resource value: 0x7f0a0029
+			public const int Theme_Design_Light_NoActionBar = 2131361833;
+			
+			// aapt resource value: 0x7f0a002a
+			public const int Theme_Design_NoActionBar = 2131361834;
 			
 			// aapt resource value: 0x7f0a0000
 			public const int Theme_MediaRouter = 2131361792;
@@ -5130,260 +5695,278 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f0a0003
 			public const int Theme_MediaRouter_LightControlPanel = 2131361795;
 			
-			// aapt resource value: 0x7f0a010e
-			public const int ThemeOverlay_AppCompat = 2131362062;
-			
-			// aapt resource value: 0x7f0a010f
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131362063;
-			
-			// aapt resource value: 0x7f0a0110
-			public const int ThemeOverlay_AppCompat_Dark = 2131362064;
-			
-			// aapt resource value: 0x7f0a0111
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131362065;
-			
-			// aapt resource value: 0x7f0a0112
-			public const int ThemeOverlay_AppCompat_Light = 2131362066;
-			
-			// aapt resource value: 0x7f0a0113
-			public const int Widget_AppCompat_ActionBar = 2131362067;
-			
-			// aapt resource value: 0x7f0a0114
-			public const int Widget_AppCompat_ActionBar_Solid = 2131362068;
-			
-			// aapt resource value: 0x7f0a0115
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131362069;
-			
-			// aapt resource value: 0x7f0a0116
-			public const int Widget_AppCompat_ActionBar_TabText = 2131362070;
-			
-			// aapt resource value: 0x7f0a0117
-			public const int Widget_AppCompat_ActionBar_TabView = 2131362071;
-			
-			// aapt resource value: 0x7f0a0118
-			public const int Widget_AppCompat_ActionButton = 2131362072;
-			
-			// aapt resource value: 0x7f0a0119
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131362073;
-			
-			// aapt resource value: 0x7f0a011a
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131362074;
-			
-			// aapt resource value: 0x7f0a011b
-			public const int Widget_AppCompat_ActionMode = 2131362075;
-			
-			// aapt resource value: 0x7f0a011c
-			public const int Widget_AppCompat_ActivityChooserView = 2131362076;
-			
-			// aapt resource value: 0x7f0a011d
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131362077;
-			
-			// aapt resource value: 0x7f0a011e
-			public const int Widget_AppCompat_Button = 2131362078;
-			
-			// aapt resource value: 0x7f0a011f
-			public const int Widget_AppCompat_Button_Borderless = 2131362079;
-			
-			// aapt resource value: 0x7f0a0120
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131362080;
-			
-			// aapt resource value: 0x7f0a0121
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131362081;
-			
-			// aapt resource value: 0x7f0a0122
-			public const int Widget_AppCompat_Button_Colored = 2131362082;
-			
-			// aapt resource value: 0x7f0a0123
-			public const int Widget_AppCompat_Button_Small = 2131362083;
-			
-			// aapt resource value: 0x7f0a0124
-			public const int Widget_AppCompat_ButtonBar = 2131362084;
-			
-			// aapt resource value: 0x7f0a0125
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131362085;
-			
-			// aapt resource value: 0x7f0a0126
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131362086;
-			
-			// aapt resource value: 0x7f0a0127
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131362087;
-			
-			// aapt resource value: 0x7f0a0128
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131362088;
-			
-			// aapt resource value: 0x7f0a0129
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131362089;
-			
-			// aapt resource value: 0x7f0a012a
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131362090;
-			
-			// aapt resource value: 0x7f0a012b
-			public const int Widget_AppCompat_EditText = 2131362091;
-			
-			// aapt resource value: 0x7f0a012c
-			public const int Widget_AppCompat_ImageButton = 2131362092;
-			
-			// aapt resource value: 0x7f0a012d
-			public const int Widget_AppCompat_Light_ActionBar = 2131362093;
-			
-			// aapt resource value: 0x7f0a012e
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131362094;
-			
-			// aapt resource value: 0x7f0a012f
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131362095;
-			
-			// aapt resource value: 0x7f0a0130
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131362096;
-			
-			// aapt resource value: 0x7f0a0131
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131362097;
-			
-			// aapt resource value: 0x7f0a0132
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131362098;
-			
-			// aapt resource value: 0x7f0a0133
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131362099;
-			
-			// aapt resource value: 0x7f0a0134
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131362100;
-			
-			// aapt resource value: 0x7f0a0135
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131362101;
-			
-			// aapt resource value: 0x7f0a0136
-			public const int Widget_AppCompat_Light_ActionButton = 2131362102;
-			
-			// aapt resource value: 0x7f0a0137
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131362103;
-			
-			// aapt resource value: 0x7f0a0138
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131362104;
-			
-			// aapt resource value: 0x7f0a0139
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131362105;
-			
-			// aapt resource value: 0x7f0a013a
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131362106;
-			
-			// aapt resource value: 0x7f0a013b
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131362107;
-			
-			// aapt resource value: 0x7f0a013c
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131362108;
-			
-			// aapt resource value: 0x7f0a013d
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131362109;
-			
-			// aapt resource value: 0x7f0a013e
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131362110;
-			
-			// aapt resource value: 0x7f0a013f
-			public const int Widget_AppCompat_Light_PopupMenu = 2131362111;
-			
-			// aapt resource value: 0x7f0a0140
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131362112;
-			
-			// aapt resource value: 0x7f0a0141
-			public const int Widget_AppCompat_Light_SearchView = 2131362113;
-			
 			// aapt resource value: 0x7f0a0142
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131362114;
+			public const int ThemeOverlay_AppCompat = 2131362114;
 			
 			// aapt resource value: 0x7f0a0143
-			public const int Widget_AppCompat_ListPopupWindow = 2131362115;
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131362115;
 			
 			// aapt resource value: 0x7f0a0144
-			public const int Widget_AppCompat_ListView = 2131362116;
+			public const int ThemeOverlay_AppCompat_Dark = 2131362116;
 			
 			// aapt resource value: 0x7f0a0145
-			public const int Widget_AppCompat_ListView_DropDown = 2131362117;
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131362117;
 			
 			// aapt resource value: 0x7f0a0146
-			public const int Widget_AppCompat_ListView_Menu = 2131362118;
+			public const int ThemeOverlay_AppCompat_Dialog = 2131362118;
 			
 			// aapt resource value: 0x7f0a0147
-			public const int Widget_AppCompat_PopupMenu = 2131362119;
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131362119;
 			
 			// aapt resource value: 0x7f0a0148
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131362120;
+			public const int ThemeOverlay_AppCompat_Light = 2131362120;
 			
 			// aapt resource value: 0x7f0a0149
-			public const int Widget_AppCompat_PopupWindow = 2131362121;
+			public const int Widget_AppCompat_ActionBar = 2131362121;
 			
 			// aapt resource value: 0x7f0a014a
-			public const int Widget_AppCompat_ProgressBar = 2131362122;
+			public const int Widget_AppCompat_ActionBar_Solid = 2131362122;
 			
 			// aapt resource value: 0x7f0a014b
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131362123;
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131362123;
 			
 			// aapt resource value: 0x7f0a014c
-			public const int Widget_AppCompat_RatingBar = 2131362124;
+			public const int Widget_AppCompat_ActionBar_TabText = 2131362124;
 			
 			// aapt resource value: 0x7f0a014d
-			public const int Widget_AppCompat_RatingBar_Indicator = 2131362125;
+			public const int Widget_AppCompat_ActionBar_TabView = 2131362125;
 			
 			// aapt resource value: 0x7f0a014e
-			public const int Widget_AppCompat_RatingBar_Small = 2131362126;
+			public const int Widget_AppCompat_ActionButton = 2131362126;
 			
 			// aapt resource value: 0x7f0a014f
-			public const int Widget_AppCompat_SearchView = 2131362127;
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131362127;
 			
 			// aapt resource value: 0x7f0a0150
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131362128;
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131362128;
 			
 			// aapt resource value: 0x7f0a0151
-			public const int Widget_AppCompat_SeekBar = 2131362129;
+			public const int Widget_AppCompat_ActionMode = 2131362129;
 			
 			// aapt resource value: 0x7f0a0152
-			public const int Widget_AppCompat_Spinner = 2131362130;
+			public const int Widget_AppCompat_ActivityChooserView = 2131362130;
 			
 			// aapt resource value: 0x7f0a0153
-			public const int Widget_AppCompat_Spinner_DropDown = 2131362131;
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131362131;
 			
 			// aapt resource value: 0x7f0a0154
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131362132;
+			public const int Widget_AppCompat_Button = 2131362132;
 			
 			// aapt resource value: 0x7f0a0155
-			public const int Widget_AppCompat_Spinner_Underlined = 2131362133;
+			public const int Widget_AppCompat_Button_Borderless = 2131362133;
 			
 			// aapt resource value: 0x7f0a0156
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131362134;
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131362134;
 			
 			// aapt resource value: 0x7f0a0157
-			public const int Widget_AppCompat_Toolbar = 2131362135;
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131362135;
 			
 			// aapt resource value: 0x7f0a0158
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131362136;
-			
-			// aapt resource value: 0x7f0a0169
-			public const int Widget_Design_AppBarLayout = 2131362153;
-			
-			// aapt resource value: 0x7f0a016a
-			public const int Widget_Design_BottomSheet_Modal = 2131362154;
-			
-			// aapt resource value: 0x7f0a016b
-			public const int Widget_Design_CollapsingToolbar = 2131362155;
-			
-			// aapt resource value: 0x7f0a016c
-			public const int Widget_Design_CoordinatorLayout = 2131362156;
-			
-			// aapt resource value: 0x7f0a016d
-			public const int Widget_Design_FloatingActionButton = 2131362157;
-			
-			// aapt resource value: 0x7f0a016e
-			public const int Widget_Design_NavigationView = 2131362158;
-			
-			// aapt resource value: 0x7f0a016f
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131362159;
-			
-			// aapt resource value: 0x7f0a0170
-			public const int Widget_Design_Snackbar = 2131362160;
+			public const int Widget_AppCompat_Button_Colored = 2131362136;
 			
 			// aapt resource value: 0x7f0a0159
-			public const int Widget_Design_TabLayout = 2131362137;
+			public const int Widget_AppCompat_Button_Small = 2131362137;
+			
+			// aapt resource value: 0x7f0a015a
+			public const int Widget_AppCompat_ButtonBar = 2131362138;
+			
+			// aapt resource value: 0x7f0a015b
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131362139;
+			
+			// aapt resource value: 0x7f0a015c
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131362140;
+			
+			// aapt resource value: 0x7f0a015d
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131362141;
+			
+			// aapt resource value: 0x7f0a015e
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131362142;
+			
+			// aapt resource value: 0x7f0a015f
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131362143;
+			
+			// aapt resource value: 0x7f0a0160
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131362144;
+			
+			// aapt resource value: 0x7f0a0161
+			public const int Widget_AppCompat_EditText = 2131362145;
+			
+			// aapt resource value: 0x7f0a0162
+			public const int Widget_AppCompat_ImageButton = 2131362146;
+			
+			// aapt resource value: 0x7f0a0163
+			public const int Widget_AppCompat_Light_ActionBar = 2131362147;
+			
+			// aapt resource value: 0x7f0a0164
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131362148;
+			
+			// aapt resource value: 0x7f0a0165
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131362149;
+			
+			// aapt resource value: 0x7f0a0166
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131362150;
+			
+			// aapt resource value: 0x7f0a0167
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131362151;
+			
+			// aapt resource value: 0x7f0a0168
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131362152;
+			
+			// aapt resource value: 0x7f0a0169
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131362153;
+			
+			// aapt resource value: 0x7f0a016a
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131362154;
+			
+			// aapt resource value: 0x7f0a016b
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131362155;
+			
+			// aapt resource value: 0x7f0a016c
+			public const int Widget_AppCompat_Light_ActionButton = 2131362156;
+			
+			// aapt resource value: 0x7f0a016d
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131362157;
+			
+			// aapt resource value: 0x7f0a016e
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131362158;
+			
+			// aapt resource value: 0x7f0a016f
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131362159;
+			
+			// aapt resource value: 0x7f0a0170
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131362160;
 			
 			// aapt resource value: 0x7f0a0171
-			public const int Widget_Design_TextInputLayout = 2131362161;
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131362161;
+			
+			// aapt resource value: 0x7f0a0172
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131362162;
+			
+			// aapt resource value: 0x7f0a0173
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131362163;
+			
+			// aapt resource value: 0x7f0a0174
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131362164;
+			
+			// aapt resource value: 0x7f0a0175
+			public const int Widget_AppCompat_Light_PopupMenu = 2131362165;
+			
+			// aapt resource value: 0x7f0a0176
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131362166;
+			
+			// aapt resource value: 0x7f0a0177
+			public const int Widget_AppCompat_Light_SearchView = 2131362167;
+			
+			// aapt resource value: 0x7f0a0178
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131362168;
+			
+			// aapt resource value: 0x7f0a0179
+			public const int Widget_AppCompat_ListMenuView = 2131362169;
+			
+			// aapt resource value: 0x7f0a017a
+			public const int Widget_AppCompat_ListPopupWindow = 2131362170;
+			
+			// aapt resource value: 0x7f0a017b
+			public const int Widget_AppCompat_ListView = 2131362171;
+			
+			// aapt resource value: 0x7f0a017c
+			public const int Widget_AppCompat_ListView_DropDown = 2131362172;
+			
+			// aapt resource value: 0x7f0a017d
+			public const int Widget_AppCompat_ListView_Menu = 2131362173;
+			
+			// aapt resource value: 0x7f0a00c4
+			public const int Widget_AppCompat_NotificationActionContainer = 2131361988;
+			
+			// aapt resource value: 0x7f0a00c5
+			public const int Widget_AppCompat_NotificationActionText = 2131361989;
+			
+			// aapt resource value: 0x7f0a017e
+			public const int Widget_AppCompat_PopupMenu = 2131362174;
+			
+			// aapt resource value: 0x7f0a017f
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131362175;
+			
+			// aapt resource value: 0x7f0a0180
+			public const int Widget_AppCompat_PopupWindow = 2131362176;
+			
+			// aapt resource value: 0x7f0a0181
+			public const int Widget_AppCompat_ProgressBar = 2131362177;
+			
+			// aapt resource value: 0x7f0a0182
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131362178;
+			
+			// aapt resource value: 0x7f0a0183
+			public const int Widget_AppCompat_RatingBar = 2131362179;
+			
+			// aapt resource value: 0x7f0a0184
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131362180;
+			
+			// aapt resource value: 0x7f0a0185
+			public const int Widget_AppCompat_RatingBar_Small = 2131362181;
+			
+			// aapt resource value: 0x7f0a0186
+			public const int Widget_AppCompat_SearchView = 2131362182;
+			
+			// aapt resource value: 0x7f0a0187
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131362183;
+			
+			// aapt resource value: 0x7f0a0188
+			public const int Widget_AppCompat_SeekBar = 2131362184;
+			
+			// aapt resource value: 0x7f0a0189
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131362185;
+			
+			// aapt resource value: 0x7f0a018a
+			public const int Widget_AppCompat_Spinner = 2131362186;
+			
+			// aapt resource value: 0x7f0a018b
+			public const int Widget_AppCompat_Spinner_DropDown = 2131362187;
+			
+			// aapt resource value: 0x7f0a018c
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131362188;
+			
+			// aapt resource value: 0x7f0a018d
+			public const int Widget_AppCompat_Spinner_Underlined = 2131362189;
+			
+			// aapt resource value: 0x7f0a018e
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131362190;
+			
+			// aapt resource value: 0x7f0a018f
+			public const int Widget_AppCompat_Toolbar = 2131362191;
+			
+			// aapt resource value: 0x7f0a0190
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131362192;
+			
+			// aapt resource value: 0x7f0a002b
+			public const int Widget_Design_AppBarLayout = 2131361835;
+			
+			// aapt resource value: 0x7f0a002c
+			public const int Widget_Design_BottomSheet_Modal = 2131361836;
+			
+			// aapt resource value: 0x7f0a002d
+			public const int Widget_Design_CollapsingToolbar = 2131361837;
+			
+			// aapt resource value: 0x7f0a002e
+			public const int Widget_Design_CoordinatorLayout = 2131361838;
+			
+			// aapt resource value: 0x7f0a002f
+			public const int Widget_Design_FloatingActionButton = 2131361839;
+			
+			// aapt resource value: 0x7f0a0030
+			public const int Widget_Design_NavigationView = 2131361840;
+			
+			// aapt resource value: 0x7f0a0031
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131361841;
+			
+			// aapt resource value: 0x7f0a0032
+			public const int Widget_Design_Snackbar = 2131361842;
+			
+			// aapt resource value: 0x7f0a001b
+			public const int Widget_Design_TabLayout = 2131361819;
+			
+			// aapt resource value: 0x7f0a0033
+			public const int Widget_Design_TextInputLayout = 2131361843;
 			
 			// aapt resource value: 0x7f0a0004
 			public const int Widget_MediaRouter_ChooserText = 2131361796;
@@ -5456,33 +6039,35 @@ namespace XForms.Droid
 		{
 			
 			public static int[] ActionBar = new int[] {
-					2130772007,
-					2130772009,
-					2130772010,
-					2130772011,
-					2130772012,
-					2130772013,
-					2130772014,
-					2130772015,
-					2130772016,
-					2130772017,
-					2130772018,
-					2130772019,
-					2130772020,
-					2130772021,
-					2130772022,
-					2130772023,
-					2130772024,
-					2130772025,
-					2130772026,
-					2130772027,
-					2130772028,
-					2130772029,
-					2130772030,
-					2130772031,
-					2130772032,
-					2130772033,
-					2130772090};
+					2130772076,
+					2130772078,
+					2130772079,
+					2130772080,
+					2130772081,
+					2130772082,
+					2130772083,
+					2130772084,
+					2130772085,
+					2130772086,
+					2130772087,
+					2130772088,
+					2130772089,
+					2130772090,
+					2130772091,
+					2130772092,
+					2130772093,
+					2130772094,
+					2130772095,
+					2130772096,
+					2130772097,
+					2130772098,
+					2130772099,
+					2130772100,
+					2130772101,
+					2130772102,
+					2130772103,
+					2130772104,
+					2130772166};
 			
 			// aapt resource value: 10
 			public const int ActionBar_background = 10;
@@ -5496,6 +6081,9 @@ namespace XForms.Droid
 			// aapt resource value: 21
 			public const int ActionBar_contentInsetEnd = 21;
 			
+			// aapt resource value: 25
+			public const int ActionBar_contentInsetEndWithActions = 25;
+			
 			// aapt resource value: 22
 			public const int ActionBar_contentInsetLeft = 22;
 			
@@ -5504,6 +6092,9 @@ namespace XForms.Droid
 			
 			// aapt resource value: 20
 			public const int ActionBar_contentInsetStart = 20;
+			
+			// aapt resource value: 24
+			public const int ActionBar_contentInsetStartWithNavigation = 24;
 			
 			// aapt resource value: 13
 			public const int ActionBar_customNavigationLayout = 13;
@@ -5514,8 +6105,8 @@ namespace XForms.Droid
 			// aapt resource value: 9
 			public const int ActionBar_divider = 9;
 			
-			// aapt resource value: 24
-			public const int ActionBar_elevation = 24;
+			// aapt resource value: 26
+			public const int ActionBar_elevation = 26;
 			
 			// aapt resource value: 0
 			public const int ActionBar_height = 0;
@@ -5523,8 +6114,8 @@ namespace XForms.Droid
 			// aapt resource value: 19
 			public const int ActionBar_hideOnContentScroll = 19;
 			
-			// aapt resource value: 26
-			public const int ActionBar_homeAsUpIndicator = 26;
+			// aapt resource value: 28
+			public const int ActionBar_homeAsUpIndicator = 28;
 			
 			// aapt resource value: 14
 			public const int ActionBar_homeLayout = 14;
@@ -5544,8 +6135,8 @@ namespace XForms.Droid
 			// aapt resource value: 2
 			public const int ActionBar_navigationMode = 2;
 			
-			// aapt resource value: 25
-			public const int ActionBar_popupTheme = 25;
+			// aapt resource value: 27
+			public const int ActionBar_popupTheme = 27;
 			
 			// aapt resource value: 17
 			public const int ActionBar_progressBarPadding = 17;
@@ -5580,12 +6171,12 @@ namespace XForms.Droid
 			public static int[] ActionMenuView;
 			
 			public static int[] ActionMode = new int[] {
-					2130772007,
-					2130772013,
-					2130772014,
-					2130772018,
-					2130772020,
-					2130772034};
+					2130772076,
+					2130772082,
+					2130772083,
+					2130772087,
+					2130772089,
+					2130772105};
 			
 			// aapt resource value: 3
 			public const int ActionMode_background = 3;
@@ -5606,8 +6197,8 @@ namespace XForms.Droid
 			public const int ActionMode_titleTextStyle = 1;
 			
 			public static int[] ActivityChooserView = new int[] {
-					2130772035,
-					2130772036};
+					2130772106,
+					2130772107};
 			
 			// aapt resource value: 1
 			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
@@ -5617,11 +6208,12 @@ namespace XForms.Droid
 			
 			public static int[] AlertDialog = new int[] {
 					16842994,
-					2130772037,
-					2130772038,
-					2130772039,
-					2130772040,
-					2130772041};
+					2130772108,
+					2130772109,
+					2130772110,
+					2130772111,
+					2130772112,
+					2130772113};
 			
 			// aapt resource value: 0
 			public const int AlertDialog_android_layout = 0;
@@ -5638,26 +6230,29 @@ namespace XForms.Droid
 			// aapt resource value: 3
 			public const int AlertDialog_multiChoiceItemLayout = 3;
 			
+			// aapt resource value: 6
+			public const int AlertDialog_showTitle = 6;
+			
 			// aapt resource value: 4
 			public const int AlertDialog_singleChoiceItemLayout = 4;
 			
 			public static int[] AppBarLayout = new int[] {
 					16842964,
-					2130772032,
-					2130772215};
+					2130772006,
+					2130772103};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_android_background = 0;
 			
-			// aapt resource value: 1
-			public const int AppBarLayout_elevation = 1;
-			
 			// aapt resource value: 2
-			public const int AppBarLayout_expanded = 2;
+			public const int AppBarLayout_elevation = 2;
+			
+			// aapt resource value: 1
+			public const int AppBarLayout_expanded = 1;
 			
 			public static int[] AppBarLayout_LayoutParams = new int[] {
-					2130772216,
-					2130772217};
+					2130772007,
+					2130772008};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_LayoutParams_layout_scrollFlags = 0;
@@ -5667,7 +6262,7 @@ namespace XForms.Droid
 			
 			public static int[] AppCompatImageView = new int[] {
 					16843033,
-					2130772042};
+					2130772114};
 			
 			// aapt resource value: 0
 			public const int AppCompatImageView_android_src = 0;
@@ -5675,9 +6270,57 @@ namespace XForms.Droid
 			// aapt resource value: 1
 			public const int AppCompatImageView_srcCompat = 1;
 			
+			public static int[] AppCompatSeekBar = new int[] {
+					16843074,
+					2130772115,
+					2130772116,
+					2130772117};
+			
+			// aapt resource value: 0
+			public const int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public const int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			public static int[] AppCompatTextHelper = new int[] {
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public const int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public const int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public const int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public const int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public const int AppCompatTextHelper_android_textAppearance = 0;
+			
 			public static int[] AppCompatTextView = new int[] {
 					16842804,
-					2130772043};
+					2130772118};
 			
 			// aapt resource value: 0
 			public const int AppCompatTextView_android_textAppearance = 0;
@@ -5688,81 +6331,6 @@ namespace XForms.Droid
 			public static int[] AppCompatTheme = new int[] {
 					16842839,
 					16842926,
-					2130772044,
-					2130772045,
-					2130772046,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050,
-					2130772051,
-					2130772052,
-					2130772053,
-					2130772054,
-					2130772055,
-					2130772056,
-					2130772057,
-					2130772058,
-					2130772059,
-					2130772060,
-					2130772061,
-					2130772062,
-					2130772063,
-					2130772064,
-					2130772065,
-					2130772066,
-					2130772067,
-					2130772068,
-					2130772069,
-					2130772070,
-					2130772071,
-					2130772072,
-					2130772073,
-					2130772074,
-					2130772075,
-					2130772076,
-					2130772077,
-					2130772078,
-					2130772079,
-					2130772080,
-					2130772081,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772086,
-					2130772087,
-					2130772088,
-					2130772089,
-					2130772090,
-					2130772091,
-					2130772092,
-					2130772093,
-					2130772094,
-					2130772095,
-					2130772096,
-					2130772097,
-					2130772098,
-					2130772099,
-					2130772100,
-					2130772101,
-					2130772102,
-					2130772103,
-					2130772104,
-					2130772105,
-					2130772106,
-					2130772107,
-					2130772108,
-					2130772109,
-					2130772110,
-					2130772111,
-					2130772112,
-					2130772113,
-					2130772114,
-					2130772115,
-					2130772116,
-					2130772117,
-					2130772118,
 					2130772119,
 					2130772120,
 					2130772121,
@@ -5797,7 +6365,85 @@ namespace XForms.Droid
 					2130772150,
 					2130772151,
 					2130772152,
-					2130772153};
+					2130772153,
+					2130772154,
+					2130772155,
+					2130772156,
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164,
+					2130772165,
+					2130772166,
+					2130772167,
+					2130772168,
+					2130772169,
+					2130772170,
+					2130772171,
+					2130772172,
+					2130772173,
+					2130772174,
+					2130772175,
+					2130772176,
+					2130772177,
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182,
+					2130772183,
+					2130772184,
+					2130772185,
+					2130772186,
+					2130772187,
+					2130772188,
+					2130772189,
+					2130772190,
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194,
+					2130772195,
+					2130772196,
+					2130772197,
+					2130772198,
+					2130772199,
+					2130772200,
+					2130772201,
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209,
+					2130772210,
+					2130772211,
+					2130772212,
+					2130772213,
+					2130772214,
+					2130772215,
+					2130772216,
+					2130772217,
+					2130772218,
+					2130772219,
+					2130772220,
+					2130772221,
+					2130772222,
+					2130772223,
+					2130772224,
+					2130772225,
+					2130772226,
+					2130772227,
+					2130772228,
+					2130772229,
+					2130772230,
+					2130772231};
 			
 			// aapt resource value: 23
 			public const int AppCompatTheme_actionBarDivider = 23;
@@ -5832,11 +6478,11 @@ namespace XForms.Droid
 			// aapt resource value: 21
 			public const int AppCompatTheme_actionBarWidgetTheme = 21;
 			
-			// aapt resource value: 49
-			public const int AppCompatTheme_actionButtonStyle = 49;
+			// aapt resource value: 50
+			public const int AppCompatTheme_actionButtonStyle = 50;
 			
-			// aapt resource value: 45
-			public const int AppCompatTheme_actionDropDownStyle = 45;
+			// aapt resource value: 46
+			public const int AppCompatTheme_actionDropDownStyle = 46;
 			
 			// aapt resource value: 25
 			public const int AppCompatTheme_actionMenuTextAppearance = 25;
@@ -5889,20 +6535,20 @@ namespace XForms.Droid
 			// aapt resource value: 16
 			public const int AppCompatTheme_actionOverflowMenuStyle = 16;
 			
-			// aapt resource value: 57
-			public const int AppCompatTheme_activityChooserViewStyle = 57;
-			
-			// aapt resource value: 92
-			public const int AppCompatTheme_alertDialogButtonGroupStyle = 92;
-			
-			// aapt resource value: 93
-			public const int AppCompatTheme_alertDialogCenterButtons = 93;
-			
-			// aapt resource value: 91
-			public const int AppCompatTheme_alertDialogStyle = 91;
+			// aapt resource value: 58
+			public const int AppCompatTheme_activityChooserViewStyle = 58;
 			
 			// aapt resource value: 94
-			public const int AppCompatTheme_alertDialogTheme = 94;
+			public const int AppCompatTheme_alertDialogButtonGroupStyle = 94;
+			
+			// aapt resource value: 95
+			public const int AppCompatTheme_alertDialogCenterButtons = 95;
+			
+			// aapt resource value: 93
+			public const int AppCompatTheme_alertDialogStyle = 93;
+			
+			// aapt resource value: 96
+			public const int AppCompatTheme_alertDialogTheme = 96;
 			
 			// aapt resource value: 1
 			public const int AppCompatTheme_android_windowAnimationStyle = 1;
@@ -5910,200 +6556,209 @@ namespace XForms.Droid
 			// aapt resource value: 0
 			public const int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: 99
-			public const int AppCompatTheme_autoCompleteTextViewStyle = 99;
-			
-			// aapt resource value: 54
-			public const int AppCompatTheme_borderlessButtonStyle = 54;
-			
-			// aapt resource value: 51
-			public const int AppCompatTheme_buttonBarButtonStyle = 51;
-			
-			// aapt resource value: 97
-			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 97;
-			
-			// aapt resource value: 98
-			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 98;
-			
-			// aapt resource value: 96
-			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 96;
-			
-			// aapt resource value: 50
-			public const int AppCompatTheme_buttonBarStyle = 50;
-			
-			// aapt resource value: 100
-			public const int AppCompatTheme_buttonStyle = 100;
-			
 			// aapt resource value: 101
-			public const int AppCompatTheme_buttonStyleSmall = 101;
-			
-			// aapt resource value: 102
-			public const int AppCompatTheme_checkboxStyle = 102;
-			
-			// aapt resource value: 103
-			public const int AppCompatTheme_checkedTextViewStyle = 103;
-			
-			// aapt resource value: 84
-			public const int AppCompatTheme_colorAccent = 84;
-			
-			// aapt resource value: 88
-			public const int AppCompatTheme_colorButtonNormal = 88;
-			
-			// aapt resource value: 86
-			public const int AppCompatTheme_colorControlActivated = 86;
-			
-			// aapt resource value: 87
-			public const int AppCompatTheme_colorControlHighlight = 87;
-			
-			// aapt resource value: 85
-			public const int AppCompatTheme_colorControlNormal = 85;
-			
-			// aapt resource value: 82
-			public const int AppCompatTheme_colorPrimary = 82;
-			
-			// aapt resource value: 83
-			public const int AppCompatTheme_colorPrimaryDark = 83;
-			
-			// aapt resource value: 89
-			public const int AppCompatTheme_colorSwitchThumbNormal = 89;
-			
-			// aapt resource value: 90
-			public const int AppCompatTheme_controlBackground = 90;
-			
-			// aapt resource value: 43
-			public const int AppCompatTheme_dialogPreferredPadding = 43;
-			
-			// aapt resource value: 42
-			public const int AppCompatTheme_dialogTheme = 42;
-			
-			// aapt resource value: 56
-			public const int AppCompatTheme_dividerHorizontal = 56;
+			public const int AppCompatTheme_autoCompleteTextViewStyle = 101;
 			
 			// aapt resource value: 55
-			public const int AppCompatTheme_dividerVertical = 55;
-			
-			// aapt resource value: 74
-			public const int AppCompatTheme_dropDownListViewStyle = 74;
-			
-			// aapt resource value: 46
-			public const int AppCompatTheme_dropdownListPreferredItemHeight = 46;
-			
-			// aapt resource value: 63
-			public const int AppCompatTheme_editTextBackground = 63;
-			
-			// aapt resource value: 62
-			public const int AppCompatTheme_editTextColor = 62;
-			
-			// aapt resource value: 104
-			public const int AppCompatTheme_editTextStyle = 104;
-			
-			// aapt resource value: 48
-			public const int AppCompatTheme_homeAsUpIndicator = 48;
-			
-			// aapt resource value: 64
-			public const int AppCompatTheme_imageButtonStyle = 64;
-			
-			// aapt resource value: 81
-			public const int AppCompatTheme_listChoiceBackgroundIndicator = 81;
-			
-			// aapt resource value: 44
-			public const int AppCompatTheme_listDividerAlertDialog = 44;
-			
-			// aapt resource value: 75
-			public const int AppCompatTheme_listPopupWindowStyle = 75;
-			
-			// aapt resource value: 69
-			public const int AppCompatTheme_listPreferredItemHeight = 69;
-			
-			// aapt resource value: 71
-			public const int AppCompatTheme_listPreferredItemHeightLarge = 71;
-			
-			// aapt resource value: 70
-			public const int AppCompatTheme_listPreferredItemHeightSmall = 70;
-			
-			// aapt resource value: 72
-			public const int AppCompatTheme_listPreferredItemPaddingLeft = 72;
-			
-			// aapt resource value: 73
-			public const int AppCompatTheme_listPreferredItemPaddingRight = 73;
-			
-			// aapt resource value: 78
-			public const int AppCompatTheme_panelBackground = 78;
-			
-			// aapt resource value: 80
-			public const int AppCompatTheme_panelMenuListTheme = 80;
-			
-			// aapt resource value: 79
-			public const int AppCompatTheme_panelMenuListWidth = 79;
-			
-			// aapt resource value: 60
-			public const int AppCompatTheme_popupMenuStyle = 60;
-			
-			// aapt resource value: 61
-			public const int AppCompatTheme_popupWindowStyle = 61;
-			
-			// aapt resource value: 105
-			public const int AppCompatTheme_radioButtonStyle = 105;
-			
-			// aapt resource value: 106
-			public const int AppCompatTheme_ratingBarStyle = 106;
-			
-			// aapt resource value: 107
-			public const int AppCompatTheme_ratingBarStyleIndicator = 107;
-			
-			// aapt resource value: 108
-			public const int AppCompatTheme_ratingBarStyleSmall = 108;
-			
-			// aapt resource value: 68
-			public const int AppCompatTheme_searchViewStyle = 68;
-			
-			// aapt resource value: 109
-			public const int AppCompatTheme_seekBarStyle = 109;
+			public const int AppCompatTheme_borderlessButtonStyle = 55;
 			
 			// aapt resource value: 52
-			public const int AppCompatTheme_selectableItemBackground = 52;
+			public const int AppCompatTheme_buttonBarButtonStyle = 52;
 			
-			// aapt resource value: 53
-			public const int AppCompatTheme_selectableItemBackgroundBorderless = 53;
+			// aapt resource value: 99
+			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 99;
+			
+			// aapt resource value: 100
+			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 100;
+			
+			// aapt resource value: 98
+			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 98;
+			
+			// aapt resource value: 51
+			public const int AppCompatTheme_buttonBarStyle = 51;
+			
+			// aapt resource value: 102
+			public const int AppCompatTheme_buttonStyle = 102;
+			
+			// aapt resource value: 103
+			public const int AppCompatTheme_buttonStyleSmall = 103;
+			
+			// aapt resource value: 104
+			public const int AppCompatTheme_checkboxStyle = 104;
+			
+			// aapt resource value: 105
+			public const int AppCompatTheme_checkedTextViewStyle = 105;
+			
+			// aapt resource value: 85
+			public const int AppCompatTheme_colorAccent = 85;
+			
+			// aapt resource value: 92
+			public const int AppCompatTheme_colorBackgroundFloating = 92;
+			
+			// aapt resource value: 89
+			public const int AppCompatTheme_colorButtonNormal = 89;
+			
+			// aapt resource value: 87
+			public const int AppCompatTheme_colorControlActivated = 87;
+			
+			// aapt resource value: 88
+			public const int AppCompatTheme_colorControlHighlight = 88;
+			
+			// aapt resource value: 86
+			public const int AppCompatTheme_colorControlNormal = 86;
+			
+			// aapt resource value: 83
+			public const int AppCompatTheme_colorPrimary = 83;
+			
+			// aapt resource value: 84
+			public const int AppCompatTheme_colorPrimaryDark = 84;
+			
+			// aapt resource value: 90
+			public const int AppCompatTheme_colorSwitchThumbNormal = 90;
+			
+			// aapt resource value: 91
+			public const int AppCompatTheme_controlBackground = 91;
+			
+			// aapt resource value: 44
+			public const int AppCompatTheme_dialogPreferredPadding = 44;
+			
+			// aapt resource value: 43
+			public const int AppCompatTheme_dialogTheme = 43;
+			
+			// aapt resource value: 57
+			public const int AppCompatTheme_dividerHorizontal = 57;
+			
+			// aapt resource value: 56
+			public const int AppCompatTheme_dividerVertical = 56;
+			
+			// aapt resource value: 75
+			public const int AppCompatTheme_dropDownListViewStyle = 75;
 			
 			// aapt resource value: 47
-			public const int AppCompatTheme_spinnerDropDownItemStyle = 47;
+			public const int AppCompatTheme_dropdownListPreferredItemHeight = 47;
+			
+			// aapt resource value: 64
+			public const int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 63
+			public const int AppCompatTheme_editTextColor = 63;
+			
+			// aapt resource value: 106
+			public const int AppCompatTheme_editTextStyle = 106;
+			
+			// aapt resource value: 49
+			public const int AppCompatTheme_homeAsUpIndicator = 49;
+			
+			// aapt resource value: 65
+			public const int AppCompatTheme_imageButtonStyle = 65;
+			
+			// aapt resource value: 82
+			public const int AppCompatTheme_listChoiceBackgroundIndicator = 82;
+			
+			// aapt resource value: 45
+			public const int AppCompatTheme_listDividerAlertDialog = 45;
+			
+			// aapt resource value: 114
+			public const int AppCompatTheme_listMenuViewStyle = 114;
+			
+			// aapt resource value: 76
+			public const int AppCompatTheme_listPopupWindowStyle = 76;
+			
+			// aapt resource value: 70
+			public const int AppCompatTheme_listPreferredItemHeight = 70;
+			
+			// aapt resource value: 72
+			public const int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			
+			// aapt resource value: 71
+			public const int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			
+			// aapt resource value: 73
+			public const int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			
+			// aapt resource value: 74
+			public const int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			
+			// aapt resource value: 79
+			public const int AppCompatTheme_panelBackground = 79;
+			
+			// aapt resource value: 81
+			public const int AppCompatTheme_panelMenuListTheme = 81;
+			
+			// aapt resource value: 80
+			public const int AppCompatTheme_panelMenuListWidth = 80;
+			
+			// aapt resource value: 61
+			public const int AppCompatTheme_popupMenuStyle = 61;
+			
+			// aapt resource value: 62
+			public const int AppCompatTheme_popupWindowStyle = 62;
+			
+			// aapt resource value: 107
+			public const int AppCompatTheme_radioButtonStyle = 107;
+			
+			// aapt resource value: 108
+			public const int AppCompatTheme_ratingBarStyle = 108;
+			
+			// aapt resource value: 109
+			public const int AppCompatTheme_ratingBarStyleIndicator = 109;
 			
 			// aapt resource value: 110
-			public const int AppCompatTheme_spinnerStyle = 110;
+			public const int AppCompatTheme_ratingBarStyleSmall = 110;
+			
+			// aapt resource value: 69
+			public const int AppCompatTheme_searchViewStyle = 69;
 			
 			// aapt resource value: 111
-			public const int AppCompatTheme_switchStyle = 111;
+			public const int AppCompatTheme_seekBarStyle = 111;
+			
+			// aapt resource value: 53
+			public const int AppCompatTheme_selectableItemBackground = 53;
+			
+			// aapt resource value: 54
+			public const int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			
+			// aapt resource value: 48
+			public const int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			
+			// aapt resource value: 112
+			public const int AppCompatTheme_spinnerStyle = 112;
+			
+			// aapt resource value: 113
+			public const int AppCompatTheme_switchStyle = 113;
 			
 			// aapt resource value: 40
 			public const int AppCompatTheme_textAppearanceLargePopupMenu = 40;
 			
-			// aapt resource value: 76
-			public const int AppCompatTheme_textAppearanceListItem = 76;
-			
 			// aapt resource value: 77
-			public const int AppCompatTheme_textAppearanceListItemSmall = 77;
+			public const int AppCompatTheme_textAppearanceListItem = 77;
+			
+			// aapt resource value: 78
+			public const int AppCompatTheme_textAppearanceListItemSmall = 78;
+			
+			// aapt resource value: 42
+			public const int AppCompatTheme_textAppearancePopupMenuHeader = 42;
+			
+			// aapt resource value: 67
+			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
 			
 			// aapt resource value: 66
-			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 66;
-			
-			// aapt resource value: 65
-			public const int AppCompatTheme_textAppearanceSearchResultTitle = 65;
+			public const int AppCompatTheme_textAppearanceSearchResultTitle = 66;
 			
 			// aapt resource value: 41
 			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
 			
-			// aapt resource value: 95
-			public const int AppCompatTheme_textColorAlertDialogListItem = 95;
+			// aapt resource value: 97
+			public const int AppCompatTheme_textColorAlertDialogListItem = 97;
 			
-			// aapt resource value: 67
-			public const int AppCompatTheme_textColorSearchUrl = 67;
+			// aapt resource value: 68
+			public const int AppCompatTheme_textColorSearchUrl = 68;
+			
+			// aapt resource value: 60
+			public const int AppCompatTheme_toolbarNavigationButtonStyle = 60;
 			
 			// aapt resource value: 59
-			public const int AppCompatTheme_toolbarNavigationButtonStyle = 59;
-			
-			// aapt resource value: 58
-			public const int AppCompatTheme_toolbarStyle = 58;
+			public const int AppCompatTheme_toolbarStyle = 59;
 			
 			// aapt resource value: 2
 			public const int AppCompatTheme_windowActionBar = 2;
@@ -6136,8 +6791,8 @@ namespace XForms.Droid
 			public const int AppCompatTheme_windowNoTitle = 3;
 			
 			public static int[] BottomSheetBehavior_Params = new int[] {
-					2130772218,
-					2130772219};
+					2130772009,
+					2130772010};
 			
 			// aapt resource value: 1
 			public const int BottomSheetBehavior_Params_behavior_hideable = 1;
@@ -6146,7 +6801,7 @@ namespace XForms.Droid
 			public const int BottomSheetBehavior_Params_behavior_peekHeight = 0;
 			
 			public static int[] ButtonBarLayout = new int[] {
-					2130772154};
+					2130772232};
 			
 			// aapt resource value: 0
 			public const int ButtonBarLayout_allowStacking = 0;
@@ -6206,8 +6861,8 @@ namespace XForms.Droid
 			public const int CardView_contentPaddingTop = 11;
 			
 			public static int[] CollapsingAppBarLayout_LayoutParams = new int[] {
-					2130772220,
-					2130772221};
+					2130772011,
+					2130772012};
 			
 			// aapt resource value: 0
 			public const int CollapsingAppBarLayout_LayoutParams_layout_collapseMode = 0;
@@ -6216,67 +6871,81 @@ namespace XForms.Droid
 			public const int CollapsingAppBarLayout_LayoutParams_layout_collapseParallaxMultiplier = 1;
 			
 			public static int[] CollapsingToolbarLayout = new int[] {
-					2130772009,
-					2130772222,
-					2130772223,
-					2130772224,
-					2130772225,
-					2130772226,
-					2130772227,
-					2130772228,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233,
-					2130772234};
-			
-			// aapt resource value: 11
-			public const int CollapsingToolbarLayout_collapsedTitleGravity = 11;
-			
-			// aapt resource value: 7
-			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
-			
-			// aapt resource value: 8
-			public const int CollapsingToolbarLayout_contentScrim = 8;
-			
-			// aapt resource value: 12
-			public const int CollapsingToolbarLayout_expandedTitleGravity = 12;
-			
-			// aapt resource value: 1
-			public const int CollapsingToolbarLayout_expandedTitleMargin = 1;
-			
-			// aapt resource value: 5
-			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
-			
-			// aapt resource value: 4
-			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 4;
-			
-			// aapt resource value: 2
-			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 2;
-			
-			// aapt resource value: 3
-			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 3;
-			
-			// aapt resource value: 6
-			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
-			
-			// aapt resource value: 9
-			public const int CollapsingToolbarLayout_statusBarScrim = 9;
-			
-			// aapt resource value: 0
-			public const int CollapsingToolbarLayout_title = 0;
-			
-			// aapt resource value: 13
-			public const int CollapsingToolbarLayout_titleEnabled = 13;
+					2130772013,
+					2130772014,
+					2130772015,
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772025,
+					2130772078};
 			
 			// aapt resource value: 10
-			public const int CollapsingToolbarLayout_toolbarId = 10;
+			public const int CollapsingToolbarLayout_collapsedTitleGravity = 10;
+			
+			// aapt resource value: 6
+			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 6;
+			
+			// aapt resource value: 7
+			public const int CollapsingToolbarLayout_contentScrim = 7;
+			
+			// aapt resource value: 11
+			public const int CollapsingToolbarLayout_expandedTitleGravity = 11;
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_expandedTitleMargin = 0;
+			
+			// aapt resource value: 4
+			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 4;
+			
+			// aapt resource value: 3
+			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 3;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 1;
+			
+			// aapt resource value: 2
+			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 2;
+			
+			// aapt resource value: 5
+			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 5;
+			
+			// aapt resource value: 8
+			public const int CollapsingToolbarLayout_statusBarScrim = 8;
+			
+			// aapt resource value: 13
+			public const int CollapsingToolbarLayout_title = 13;
+			
+			// aapt resource value: 12
+			public const int CollapsingToolbarLayout_titleEnabled = 12;
+			
+			// aapt resource value: 9
+			public const int CollapsingToolbarLayout_toolbarId = 9;
+			
+			public static int[] ColorStateListItem = new int[] {
+					16843173,
+					16843551,
+					2130772233};
+			
+			// aapt resource value: 2
+			public const int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public const int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public const int ColorStateListItem_android_color = 0;
 			
 			public static int[] CompoundButton = new int[] {
 					16843015,
-					2130772155,
-					2130772156};
+					2130772234,
+					2130772235};
 			
 			// aapt resource value: 0
 			public const int CompoundButton_android_button = 0;
@@ -6288,8 +6957,8 @@ namespace XForms.Droid
 			public const int CompoundButton_buttonTintMode = 2;
 			
 			public static int[] CoordinatorLayout = new int[] {
-					2130772235,
-					2130772236};
+					2130772026,
+					2130772027};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_keylines = 0;
@@ -6299,10 +6968,10 @@ namespace XForms.Droid
 			
 			public static int[] CoordinatorLayout_LayoutParams = new int[] {
 					16842931,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240};
+					2130772028,
+					2130772029,
+					2130772030,
+					2130772031};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_LayoutParams_android_layout_gravity = 0;
@@ -6320,9 +6989,9 @@ namespace XForms.Droid
 			public const int CoordinatorLayout_LayoutParams_layout_keyline = 3;
 			
 			public static int[] DesignTheme = new int[] {
-					2130772241,
-					2130772242,
-					2130772243};
+					2130772032,
+					2130772033,
+					2130772034};
 			
 			// aapt resource value: 0
 			public const int DesignTheme_bottomSheetDialogTheme = 0;
@@ -6334,14 +7003,14 @@ namespace XForms.Droid
 			public const int DesignTheme_textColorError = 2;
 			
 			public static int[] DrawerArrowToggle = new int[] {
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164};
+					2130772236,
+					2130772237,
+					2130772238,
+					2130772239,
+					2130772240,
+					2130772241,
+					2130772242,
+					2130772243};
 			
 			// aapt resource value: 4
 			public const int DrawerArrowToggle_arrowHeadLength = 4;
@@ -6368,43 +7037,43 @@ namespace XForms.Droid
 			public const int DrawerArrowToggle_thickness = 7;
 			
 			public static int[] FloatingActionButton = new int[] {
-					2130772032,
-					2130772213,
-					2130772214,
-					2130772244,
-					2130772245,
-					2130772246,
-					2130772247,
-					2130772248};
-			
-			// aapt resource value: 1
-			public const int FloatingActionButton_backgroundTint = 1;
-			
-			// aapt resource value: 2
-			public const int FloatingActionButton_backgroundTintMode = 2;
+					2130772035,
+					2130772036,
+					2130772037,
+					2130772038,
+					2130772039,
+					2130772103,
+					2130772301,
+					2130772302};
 			
 			// aapt resource value: 6
-			public const int FloatingActionButton_borderWidth = 6;
-			
-			// aapt resource value: 0
-			public const int FloatingActionButton_elevation = 0;
-			
-			// aapt resource value: 4
-			public const int FloatingActionButton_fabSize = 4;
-			
-			// aapt resource value: 5
-			public const int FloatingActionButton_pressedTranslationZ = 5;
-			
-			// aapt resource value: 3
-			public const int FloatingActionButton_rippleColor = 3;
+			public const int FloatingActionButton_backgroundTint = 6;
 			
 			// aapt resource value: 7
-			public const int FloatingActionButton_useCompatPadding = 7;
+			public const int FloatingActionButton_backgroundTintMode = 7;
+			
+			// aapt resource value: 3
+			public const int FloatingActionButton_borderWidth = 3;
+			
+			// aapt resource value: 5
+			public const int FloatingActionButton_elevation = 5;
+			
+			// aapt resource value: 1
+			public const int FloatingActionButton_fabSize = 1;
+			
+			// aapt resource value: 2
+			public const int FloatingActionButton_pressedTranslationZ = 2;
+			
+			// aapt resource value: 0
+			public const int FloatingActionButton_rippleColor = 0;
+			
+			// aapt resource value: 4
+			public const int FloatingActionButton_useCompatPadding = 4;
 			
 			public static int[] ForegroundLinearLayout = new int[] {
 					16843017,
 					16843264,
-					2130772249};
+					2130772040};
 			
 			// aapt resource value: 0
 			public const int ForegroundLinearLayout_android_foreground = 0;
@@ -6421,10 +7090,10 @@ namespace XForms.Droid
 					16843046,
 					16843047,
 					16843048,
-					2130772017,
-					2130772165,
-					2130772166,
-					2130772167};
+					2130772086,
+					2130772244,
+					2130772245,
+					2130772246};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -6535,10 +7204,10 @@ namespace XForms.Droid
 					16843236,
 					16843237,
 					16843375,
-					2130772168,
-					2130772169,
-					2130772170,
-					2130772171};
+					2130772247,
+					2130772248,
+					2130772249,
+					2130772250};
 			
 			// aapt resource value: 14
 			public const int MenuItem_actionLayout = 14;
@@ -6599,7 +7268,8 @@ namespace XForms.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130772172};
+					2130772251,
+					2130772252};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -6625,17 +7295,20 @@ namespace XForms.Droid
 			// aapt resource value: 7
 			public const int MenuView_preserveIconSpacing = 7;
 			
+			// aapt resource value: 8
+			public const int MenuView_subMenuArrow = 8;
+			
 			public static int[] NavigationView = new int[] {
 					16842964,
 					16842973,
 					16843039,
-					2130772032,
-					2130772250,
-					2130772251,
-					2130772252,
-					2130772253,
-					2130772254,
-					2130772255};
+					2130772041,
+					2130772042,
+					2130772043,
+					2130772044,
+					2130772045,
+					2130772046,
+					2130772103};
 			
 			// aapt resource value: 0
 			public const int NavigationView_android_background = 0;
@@ -6646,42 +7319,56 @@ namespace XForms.Droid
 			// aapt resource value: 2
 			public const int NavigationView_android_maxWidth = 2;
 			
-			// aapt resource value: 3
-			public const int NavigationView_elevation = 3;
-			
 			// aapt resource value: 9
-			public const int NavigationView_headerLayout = 9;
-			
-			// aapt resource value: 7
-			public const int NavigationView_itemBackground = 7;
-			
-			// aapt resource value: 5
-			public const int NavigationView_itemIconTint = 5;
+			public const int NavigationView_elevation = 9;
 			
 			// aapt resource value: 8
-			public const int NavigationView_itemTextAppearance = 8;
+			public const int NavigationView_headerLayout = 8;
 			
 			// aapt resource value: 6
-			public const int NavigationView_itemTextColor = 6;
+			public const int NavigationView_itemBackground = 6;
 			
 			// aapt resource value: 4
-			public const int NavigationView_menu = 4;
+			public const int NavigationView_itemIconTint = 4;
+			
+			// aapt resource value: 7
+			public const int NavigationView_itemTextAppearance = 7;
+			
+			// aapt resource value: 5
+			public const int NavigationView_itemTextColor = 5;
+			
+			// aapt resource value: 3
+			public const int NavigationView_menu = 3;
 			
 			public static int[] PopupWindow = new int[] {
 					16843126,
-					2130772173};
+					16843465,
+					2130772253};
+			
+			// aapt resource value: 1
+			public const int PopupWindow_android_popupAnimationStyle = 1;
 			
 			// aapt resource value: 0
 			public const int PopupWindow_android_popupBackground = 0;
 			
-			// aapt resource value: 1
-			public const int PopupWindow_overlapAnchor = 1;
+			// aapt resource value: 2
+			public const int PopupWindow_overlapAnchor = 2;
 			
 			public static int[] PopupWindowBackgroundState = new int[] {
-					2130772174};
+					2130772254};
 			
 			// aapt resource value: 0
 			public const int PopupWindowBackgroundState_state_above_anchor = 0;
+			
+			public static int[] RecycleListView = new int[] {
+					2130772255,
+					2130772256};
+			
+			// aapt resource value: 0
+			public const int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public const int RecycleListView_paddingTopNoTitle = 1;
 			
 			public static int[] RecyclerView = new int[] {
 					16842948,
@@ -6706,13 +7393,13 @@ namespace XForms.Droid
 			public const int RecyclerView_stackFromEnd = 4;
 			
 			public static int[] ScrimInsetsFrameLayout = new int[] {
-					2130772256};
+					2130772047};
 			
 			// aapt resource value: 0
 			public const int ScrimInsetsFrameLayout_insetForeground = 0;
 			
 			public static int[] ScrollingViewBehavior_Params = new int[] {
-					2130772257};
+					2130772048};
 			
 			// aapt resource value: 0
 			public const int ScrollingViewBehavior_Params_behavior_overlapTop = 0;
@@ -6722,19 +7409,19 @@ namespace XForms.Droid
 					16843039,
 					16843296,
 					16843364,
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182,
-					2130772183,
-					2130772184,
-					2130772185,
-					2130772186,
-					2130772187};
+					2130772257,
+					2130772258,
+					2130772259,
+					2130772260,
+					2130772261,
+					2130772262,
+					2130772263,
+					2130772264,
+					2130772265,
+					2130772266,
+					2130772267,
+					2130772268,
+					2130772269};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -6789,24 +7476,24 @@ namespace XForms.Droid
 			
 			public static int[] SnackbarLayout = new int[] {
 					16843039,
-					2130772032,
-					2130772258};
+					2130772049,
+					2130772103};
 			
 			// aapt resource value: 0
 			public const int SnackbarLayout_android_maxWidth = 0;
 			
-			// aapt resource value: 1
-			public const int SnackbarLayout_elevation = 1;
-			
 			// aapt resource value: 2
-			public const int SnackbarLayout_maxActionInlineWidth = 2;
+			public const int SnackbarLayout_elevation = 2;
+			
+			// aapt resource value: 1
+			public const int SnackbarLayout_maxActionInlineWidth = 1;
 			
 			public static int[] Spinner = new int[] {
 					16842930,
 					16843126,
 					16843131,
 					16843362,
-					2130772033};
+					2130772104};
 			
 			// aapt resource value: 3
 			public const int Spinner_android_dropDownWidth = 3;
@@ -6827,13 +7514,17 @@ namespace XForms.Droid
 					16843044,
 					16843045,
 					16843074,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194};
+					2130772270,
+					2130772271,
+					2130772272,
+					2130772273,
+					2130772274,
+					2130772275,
+					2130772276,
+					2130772277,
+					2130772278,
+					2130772279,
+					2130772280};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -6844,26 +7535,38 @@ namespace XForms.Droid
 			// aapt resource value: 2
 			public const int SwitchCompat_android_thumb = 2;
 			
+			// aapt resource value: 13
+			public const int SwitchCompat_showText = 13;
+			
+			// aapt resource value: 12
+			public const int SwitchCompat_splitTrack = 12;
+			
+			// aapt resource value: 10
+			public const int SwitchCompat_switchMinWidth = 10;
+			
+			// aapt resource value: 11
+			public const int SwitchCompat_switchPadding = 11;
+			
 			// aapt resource value: 9
-			public const int SwitchCompat_showText = 9;
+			public const int SwitchCompat_switchTextAppearance = 9;
 			
 			// aapt resource value: 8
-			public const int SwitchCompat_splitTrack = 8;
-			
-			// aapt resource value: 6
-			public const int SwitchCompat_switchMinWidth = 6;
-			
-			// aapt resource value: 7
-			public const int SwitchCompat_switchPadding = 7;
-			
-			// aapt resource value: 5
-			public const int SwitchCompat_switchTextAppearance = 5;
-			
-			// aapt resource value: 4
-			public const int SwitchCompat_thumbTextPadding = 4;
+			public const int SwitchCompat_thumbTextPadding = 8;
 			
 			// aapt resource value: 3
-			public const int SwitchCompat_track = 3;
+			public const int SwitchCompat_thumbTint = 3;
+			
+			// aapt resource value: 4
+			public const int SwitchCompat_thumbTintMode = 4;
+			
+			// aapt resource value: 5
+			public const int SwitchCompat_track = 5;
+			
+			// aapt resource value: 6
+			public const int SwitchCompat_trackTint = 6;
+			
+			// aapt resource value: 7
+			public const int SwitchCompat_trackTintMode = 7;
 			
 			public static int[] TabItem = new int[] {
 					16842754,
@@ -6880,22 +7583,22 @@ namespace XForms.Droid
 			public const int TabItem_android_text = 2;
 			
 			public static int[] TabLayout = new int[] {
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263,
-					2130772264,
-					2130772265,
-					2130772266,
-					2130772267,
-					2130772268,
-					2130772269,
-					2130772270,
-					2130772271,
-					2130772272,
-					2130772273,
-					2130772274};
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053,
+					2130772054,
+					2130772055,
+					2130772056,
+					2130772057,
+					2130772058,
+					2130772059,
+					2130772060,
+					2130772061,
+					2130772062,
+					2130772063,
+					2130772064,
+					2130772065};
 			
 			// aapt resource value: 3
 			public const int TabLayout_tabBackground = 3;
@@ -6950,26 +7653,30 @@ namespace XForms.Droid
 					16842902,
 					16842903,
 					16842904,
+					16842906,
 					16843105,
 					16843106,
 					16843107,
 					16843108,
-					2130772043};
-			
-			// aapt resource value: 4
-			public const int TextAppearance_android_shadowColor = 4;
+					2130772118};
 			
 			// aapt resource value: 5
-			public const int TextAppearance_android_shadowDx = 5;
+			public const int TextAppearance_android_shadowColor = 5;
 			
 			// aapt resource value: 6
-			public const int TextAppearance_android_shadowDy = 6;
+			public const int TextAppearance_android_shadowDx = 6;
 			
 			// aapt resource value: 7
-			public const int TextAppearance_android_shadowRadius = 7;
+			public const int TextAppearance_android_shadowDy = 7;
+			
+			// aapt resource value: 8
+			public const int TextAppearance_android_shadowRadius = 8;
 			
 			// aapt resource value: 3
 			public const int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public const int TextAppearance_android_textColorHint = 4;
 			
 			// aapt resource value: 0
 			public const int TextAppearance_android_textSize = 0;
@@ -6980,21 +7687,21 @@ namespace XForms.Droid
 			// aapt resource value: 1
 			public const int TextAppearance_android_typeface = 1;
 			
-			// aapt resource value: 8
-			public const int TextAppearance_textAllCaps = 8;
+			// aapt resource value: 9
+			public const int TextAppearance_textAllCaps = 9;
 			
 			public static int[] TextInputLayout = new int[] {
 					16842906,
 					16843088,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278,
-					2130772279,
-					2130772280,
-					2130772281,
-					2130772282,
-					2130772283};
+					2130772066,
+					2130772067,
+					2130772068,
+					2130772069,
+					2130772070,
+					2130772071,
+					2130772072,
+					2130772073,
+					2130772074};
 			
 			// aapt resource value: 1
 			public const int TextInputLayout_android_hint = 1;
@@ -7032,29 +7739,33 @@ namespace XForms.Droid
 			public static int[] Toolbar = new int[] {
 					16842927,
 					16843072,
-					2130772009,
-					2130772012,
-					2130772016,
-					2130772028,
-					2130772029,
-					2130772030,
-					2130772031,
-					2130772033,
-					2130772195,
-					2130772196,
-					2130772197,
-					2130772198,
-					2130772199,
-					2130772200,
-					2130772201,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207,
-					2130772208,
-					2130772209};
+					2130772078,
+					2130772081,
+					2130772085,
+					2130772097,
+					2130772098,
+					2130772099,
+					2130772100,
+					2130772101,
+					2130772102,
+					2130772104,
+					2130772281,
+					2130772282,
+					2130772283,
+					2130772284,
+					2130772285,
+					2130772286,
+					2130772287,
+					2130772288,
+					2130772289,
+					2130772290,
+					2130772291,
+					2130772292,
+					2130772293,
+					2130772294,
+					2130772295,
+					2130772296,
+					2130772297};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -7062,14 +7773,20 @@ namespace XForms.Droid
 			// aapt resource value: 1
 			public const int Toolbar_android_minHeight = 1;
 			
-			// aapt resource value: 19
-			public const int Toolbar_collapseContentDescription = 19;
+			// aapt resource value: 21
+			public const int Toolbar_buttonGravity = 21;
 			
-			// aapt resource value: 18
-			public const int Toolbar_collapseIcon = 18;
+			// aapt resource value: 23
+			public const int Toolbar_collapseContentDescription = 23;
+			
+			// aapt resource value: 22
+			public const int Toolbar_collapseIcon = 22;
 			
 			// aapt resource value: 6
 			public const int Toolbar_contentInsetEnd = 6;
+			
+			// aapt resource value: 10
+			public const int Toolbar_contentInsetEndWithActions = 10;
 			
 			// aapt resource value: 7
 			public const int Toolbar_contentInsetLeft = 7;
@@ -7080,63 +7797,69 @@ namespace XForms.Droid
 			// aapt resource value: 5
 			public const int Toolbar_contentInsetStart = 5;
 			
+			// aapt resource value: 9
+			public const int Toolbar_contentInsetStartWithNavigation = 9;
+			
 			// aapt resource value: 4
 			public const int Toolbar_logo = 4;
 			
-			// aapt resource value: 22
-			public const int Toolbar_logoDescription = 22;
-			
-			// aapt resource value: 17
-			public const int Toolbar_maxButtonHeight = 17;
-			
-			// aapt resource value: 21
-			public const int Toolbar_navigationContentDescription = 21;
+			// aapt resource value: 26
+			public const int Toolbar_logoDescription = 26;
 			
 			// aapt resource value: 20
-			public const int Toolbar_navigationIcon = 20;
+			public const int Toolbar_maxButtonHeight = 20;
 			
-			// aapt resource value: 9
-			public const int Toolbar_popupTheme = 9;
+			// aapt resource value: 25
+			public const int Toolbar_navigationContentDescription = 25;
+			
+			// aapt resource value: 24
+			public const int Toolbar_navigationIcon = 24;
+			
+			// aapt resource value: 11
+			public const int Toolbar_popupTheme = 11;
 			
 			// aapt resource value: 3
 			public const int Toolbar_subtitle = 3;
 			
-			// aapt resource value: 11
-			public const int Toolbar_subtitleTextAppearance = 11;
+			// aapt resource value: 13
+			public const int Toolbar_subtitleTextAppearance = 13;
 			
-			// aapt resource value: 24
-			public const int Toolbar_subtitleTextColor = 24;
+			// aapt resource value: 28
+			public const int Toolbar_subtitleTextColor = 28;
 			
 			// aapt resource value: 2
 			public const int Toolbar_title = 2;
 			
-			// aapt resource value: 16
-			public const int Toolbar_titleMarginBottom = 16;
-			
 			// aapt resource value: 14
-			public const int Toolbar_titleMarginEnd = 14;
+			public const int Toolbar_titleMargin = 14;
 			
-			// aapt resource value: 13
-			public const int Toolbar_titleMarginStart = 13;
+			// aapt resource value: 18
+			public const int Toolbar_titleMarginBottom = 18;
+			
+			// aapt resource value: 16
+			public const int Toolbar_titleMarginEnd = 16;
 			
 			// aapt resource value: 15
-			public const int Toolbar_titleMarginTop = 15;
+			public const int Toolbar_titleMarginStart = 15;
+			
+			// aapt resource value: 17
+			public const int Toolbar_titleMarginTop = 17;
+			
+			// aapt resource value: 19
+			public const int Toolbar_titleMargins = 19;
 			
 			// aapt resource value: 12
-			public const int Toolbar_titleMargins = 12;
+			public const int Toolbar_titleTextAppearance = 12;
 			
-			// aapt resource value: 10
-			public const int Toolbar_titleTextAppearance = 10;
-			
-			// aapt resource value: 23
-			public const int Toolbar_titleTextColor = 23;
+			// aapt resource value: 27
+			public const int Toolbar_titleTextColor = 27;
 			
 			public static int[] View = new int[] {
 					16842752,
 					16842970,
-					2130772210,
-					2130772211,
-					2130772212};
+					2130772298,
+					2130772299,
+					2130772300};
 			
 			// aapt resource value: 1
 			public const int View_android_focusable = 1;
@@ -7155,8 +7878,8 @@ namespace XForms.Droid
 			
 			public static int[] ViewBackgroundHelper = new int[] {
 					16842964,
-					2130772213,
-					2130772214};
+					2130772301,
+					2130772302};
 			
 			// aapt resource value: 0
 			public const int ViewBackgroundHelper_android_background = 0;

--- a/tests/dev apps/XForms/XForms.Android/XForms.Android.csproj
+++ b/tests/dev apps/XForms/XForms.Android/XForms.Android.csproj
@@ -98,15 +98,6 @@
     <PackageReference Include="StrongNamer">
       <Version>0.0.6</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs">
-      <Version>25.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>25.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>25.3.1</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>2.3.4.247</Version>
     </PackageReference>

--- a/tests/dev apps/XForms/XForms.Android/XForms.Android.csproj
+++ b/tests/dev apps/XForms/XForms.Android/XForms.Android.csproj
@@ -98,9 +98,6 @@
     <PackageReference Include="StrongNamer">
       <Version>0.0.6</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>2.3.4.247</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj">

--- a/tests/dev apps/XForms/XForms.Android/XForms.Android.csproj
+++ b/tests/dev apps/XForms/XForms.Android/XForms.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidStoreUncompressedFileExtensions />
     <MandroidI18n />
@@ -96,7 +96,19 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="StrongNamer">
-      <Version>0.0.3</Version>
+      <Version>0.0.6</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs">
+      <Version>25.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v4">
+      <Version>25.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+      <Version>25.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms">
+      <Version>2.3.4.247</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/dev apps/XForms/XForms.UWP/project.json
+++ b/tests/dev apps/XForms/XForms.UWP/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.0",
-    "StrongNamer": "0.0.3"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.3",
+    "StrongNamer": "0.0.6",
+    "Xamarin.Forms": "2.3.4.247"
   },
   "frameworks": {
     "uap10.0": {}

--- a/tests/dev apps/XForms/XForms.UWP/project.json
+++ b/tests/dev apps/XForms/XForms.UWP/project.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.3.3",
     "StrongNamer": "0.0.6",
-    "Xamarin.Forms": "2.3.4.247"
   },
   "frameworks": {
     "uap10.0": {}

--- a/tests/dev apps/XForms/XForms.iOS/XForms.iOS.csproj
+++ b/tests/dev apps/XForms/XForms.iOS/XForms.iOS.csproj
@@ -122,7 +122,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="StrongNamer">
-      <Version>0.0.3</Version>
+      <Version>0.0.6</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms">
+      <Version>2.3.4.247</Version>
     </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/tests/dev apps/XForms/XForms.iOS/XForms.iOS.csproj
+++ b/tests/dev apps/XForms/XForms.iOS/XForms.iOS.csproj
@@ -124,9 +124,6 @@
     <PackageReference Include="StrongNamer">
       <Version>0.0.6</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>2.3.4.247</Version>
-    </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />

--- a/tests/dev apps/XForms/XForms/XForms.csproj
+++ b/tests/dev apps/XForms/XForms/XForms.csproj
@@ -45,8 +45,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StrongNamer" Version="0.0.3" />
-    <PackageReference Include="Xamarin.Forms" Version="2.3.4.231" />
+    <PackageReference Include="StrongNamer" Version="0.0.6" />
+    <PackageReference Include="Xamarin.Forms" Version="2.3.4.247" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />


### PR DESCRIPTION
Bug(#443) The current version (25.3.1) of Xamarin android support libraries is not being used by MSAL so I updated the NuGet packages within MSAL to use these new libraries. 