### PR TITLE
Make this work on Unix with the Xamarin.Mac Full profile and Mono

### DIFF
--- a/src/Microsoft.Identity.Client/Platforms/net45/PlatformInformation.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/PlatformInformation.cs
@@ -37,8 +37,24 @@ namespace Microsoft.Identity.Client
 {
     internal class PlatformInformation : PlatformInformationBase
     {
+	bool isWindows;
+	internal static bool IsWindows {
+            get {
+                switch (Environment.OSVersion.Platform) {
+                    case PlatformID.Win32S:
+                    case PlatformID.Win32Windows:
+                    case PlatformID.Win32NT:
+                    case PlatformID.WinCE:
+                        return true;
+                    default:
+                        return false;
+		}
+            }
+        }
+
         public PlatformInformation(RequestContext requestContext) :base(requestContext)
         {
+	    isWindows = IsWindows;
         }
 
         public override string GetProductName()
@@ -54,7 +70,10 @@ namespace Microsoft.Identity.Client
 
         public override string GetProcessorArchitecture()
         {
-            return NativeMethods.GetProcessorArchitecture(RequestContext);
+	        if (isWindows)
+                return NativeMethods.GetProcessorArchitecture(RequestContext);
+			else
+                return null;
         }
 
         public override string GetOperatingSystem()
@@ -85,6 +104,9 @@ namespace Microsoft.Identity.Client
 
         public override bool IsDomainJoined()
         {
+            if (!isWindows)
+                return false;
+            
             bool returnValue = false;
             try
             {


### PR DESCRIPTION
Without this change, the code attempts to P/Invoke Win32 APIs on Unix causing a stackoverflow as the logging facility is triggered and in turn, calls the platform identification code to report the platform and so on.