### PR TITLE
updating Xamarin.Android customTabs and support compat versions to 25…

### DIFF
--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -152,6 +152,8 @@
     <None Update="Platforms\net45\WindowsFormsWebAuthenticationDialogBase.cs" SubType="Form" />
     <None Update="Platforms\net45\SilentWindowsFormsAuthenticationDialog.cs" SubType="Form" />
   </ItemGroup>
+  
+  <!-- CustomTabs and AppCompat must reference the same version -->
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid7'">
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
       <Version>25.4.0.2</Version>

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -154,10 +154,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid7'">
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
-      <Version>25.3.1</Version>
+      <Version>25.4.0.2</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>25.3.1</Version>
+      <Version>25.4.0.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
….4.02 for issue #520 Currently NuGet does not have a way to determine, when hitting an incompatibility with Xamarin Android versioning, if a higher level version would solve all constraints and solve dependencies automatically. We have suggested to customers to manually change their csproj files, but this is not ideal. Oren suggested that, as a short term fix, MSAL should always reference latest CustomTabs version. We also need to reference same Xamarin.Android.Support.Compat version as well. 