### PR TITLE
Address issues w/Chrome disabled on android device: 

### DIFF
--- a/src/Microsoft.Identity.Client/MsalClientException.cs
+++ b/src/Microsoft.Identity.Client/MsalClientException.cs
@@ -97,6 +97,12 @@ namespace Microsoft.Identity.Client
         public const string ChromeNotInstalledError = "chrome_not_installed";
 
         /// <summary>
+        /// Indicates that chrome is installed on the device but disabled. The sdk uses chrome custom tab for
+        /// authorize request if applicable or fall back to chrome browser.
+        /// </summary>
+        public const string ChromeDisabledError = "chrome_disabled";
+
+        /// <summary>
         /// The intent to launch AuthenticationActivity is not resolvable by the OS or the intent.
         /// </summary>
         public const string UnresolvableIntentError = "unresolvable_intent";

--- a/src/Microsoft.Identity.Client/Platforms/Android/AuthenticationActivity.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/AuthenticationActivity.cs
@@ -136,7 +136,15 @@ namespace Microsoft.Identity.Client
                 browserIntent.SetData(Uri.Parse(_requestUrl));
                 browserIntent.SetPackage(chromePackage);
                 browserIntent.AddCategory(Intent.CategoryBrowsable);
-                StartActivity(browserIntent);
+                try
+                {
+                    StartActivity(browserIntent);
+                }
+                catch (ActivityNotFoundException ex)
+                {
+                    throw new MsalClientException(MsalClientException.ChromeDisabledError,
+                        "Chrome is disabled on the device, cannot proceed with authentication " + ex.Message);
+                }
             }
             else
             {

--- a/tests/dev apps/XForms/XForms.Android/MainActivity.cs
+++ b/tests/dev apps/XForms/XForms.Android/MainActivity.cs
@@ -46,9 +46,7 @@ namespace XForms.Droid
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
-#pragma warning disable CS0618
             App.UIParent = new UIParent(this);
-#pragma warning restore CS0618
         }
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)

--- a/tests/dev apps/XForms/XForms.Android/MainActivity.cs
+++ b/tests/dev apps/XForms/XForms.Android/MainActivity.cs
@@ -47,7 +47,7 @@ namespace XForms.Droid
             global::Xamarin.Forms.Forms.Init(this, bundle);
             LoadApplication(new App());
 #pragma warning disable CS0618
-            App.UIParent = new UIParent(Xamarin.Forms.Forms.Context as Activity);
+            App.UIParent = new UIParent(this);
 #pragma warning restore CS0618
         }
 


### PR DESCRIPTION
- add try/catch block for StartActivity() to catch when Chrome packag…e is installed on device but Chrome is disabled
- add MsalClientException for Chrome disabled
- address Forms.Context is obsolete warning in XForms.Droid app

#567 
