### PR TITLE
Remove logging from iOS TokenCacheAccesssor as requestContext is null…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+1.1.4-preview
+=============
+Hot fix of null pointer in iOS TokenCacheAccessor(#570)
+
 1.1.3-preview
 =============
 This release contains updates to Xamarin.Android.Support v27.0.2 and MonoAndroid8.1 (#553 #520).

--- a/src/Microsoft.Identity.Client/Platforms/iOS/TokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/TokenCacheAccessor.cs
@@ -165,17 +165,6 @@ namespace Microsoft.Identity.Client
 
             var result = SecKeyChain.Add(CreateRecord(key, value, service));
 
-            if (result == SecStatusCode.Param)
-            {
-                _requestContext.Logger.Warning("Failed to remove cache record from iOS Keychain. SecStatusCode: Param. Ensure that your project contains an Entitlements.plist.");
-                _requestContext.Logger.WarningPii("Failed to remove cache record from iOS Keychain. SecStatusCode: Param. Ensure that your project contains an Entitlements.plist.");
-            }
-            else if (result != SecStatusCode.Success)
-            {
-                _requestContext.Logger.Warning("Failed to add cache record to iOS Keychain. SecStatusCode: " + result.ToString());
-                _requestContext.Logger.WarningPii("Failed to add cache record to iOS Keychain. SecStatusCode: " + result.ToString());
-            }
-
             return result;
         }
 
@@ -201,19 +190,7 @@ namespace Microsoft.Identity.Client
                 Label = key
             };
 
-            var result = SecKeyChain.Remove(record);
-
-            if (result == SecStatusCode.Param)
-            {
-                _requestContext.Logger.Warning("Failed to remove cache record from iOS Keychain. SecStatusCode: Param. Ensure that your project contains an Entitlements.plist file.");
-                _requestContext.Logger.WarningPii("Failed to remove cache record from iOS Keychain. SecStatusCode: Param. Ensure that your project contains an Entitlements.plist file.");
-            }
-            else if (result != SecStatusCode.Success )
-            {
-                _requestContext.Logger.Warning("Failed to remove cache record from iOS Keychain. SecStatusCode: " + result.ToString());
-                _requestContext.Logger.WarningPii("Failed to remove cache record from iOS Keychain. SecStatusCode: " + result.ToString());
-            }
-            return result;
+            return SecKeyChain.Remove(record);
         }
 
         private void RemoveAll(string service)
@@ -229,18 +206,7 @@ namespace Microsoft.Identity.Client
             {
                 foreach (var record in records)
                 {
-                    var result = SecKeyChain.Remove(record);
-
-                    if (result == SecStatusCode.Param)
-                    {
-                        _requestContext.Logger.Warning("Failed to remove cache record from iOS Keychain. SecStatusCode: Param. Ensure that your project contains an Entitlements.plist file.");
-                        _requestContext.Logger.WarningPii("Failed to remove cache record from iOS Keychain. SecStatusCode: Param. Ensure that your project contains an Entitlements.plist file.");
-                    }
-                    else if (result != SecStatusCode.Success)
-                    {
-                        _requestContext.Logger.Warning("Failed to remove cache record from iOS Keychain. SecStatusCode: " + result.ToString());
-                        _requestContext.Logger.WarningPii("Failed to remove cache record from iOS Keychain. SecStatusCode: " + result.ToString());
-                    }
+                    SecKeyChain.Remove(record);
                 }
             }
         }


### PR DESCRIPTION
… and resulting in a null reference exception.

#570 

**Tested w/iOS simulator on iOS 11.3**