### PR TITLE
High CPU under load fix

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Http/HttpClientFactory.cs
+++ b/src/Microsoft.Identity.Client/Internal/Http/HttpClientFactory.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Microsoft.Identity.Client.Internal.Http
 {
@@ -43,6 +44,9 @@ namespace Microsoft.Identity.Client.Internal.Http
             {
                 MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
             };
+
+            httpClient.DefaultRequestHeaders.Accept.Clear();
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return httpClient;
         }

--- a/src/Microsoft.Identity.Client/Internal/Http/HttpRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Http/HttpRequest.cs
@@ -31,7 +31,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client.Internal.Http
@@ -137,8 +136,6 @@ namespace Microsoft.Identity.Client.Internal.Http
             Dictionary<string, string> bodyParameters, HttpMethod method)
         {
             HttpClient client = HttpClientFactory.GetHttpClient();
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             using (HttpRequestMessage requestMessage = CreateRequestMessage(endpoint, headers))
             {

--- a/tests/Test.MSAL.NET.Unit/HttpTests/HttpClientFactoryTests.cs
+++ b/tests/Test.MSAL.NET.Unit/HttpTests/HttpClientFactoryTests.cs
@@ -26,10 +26,12 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.Text;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Internal.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -46,6 +48,15 @@ namespace Test.MSAL.NET.Unit.HttpTests
         {
             HttpClientFactory.ReturnHttpClientForMocks = false;
             Assert.AreEqual(1024 * 1024, HttpClientFactory.GetHttpClient().MaxResponseContentBufferSize);
+        }
+
+        [TestMethod]
+        [TestCategory("HttpClientFactoryTests")]
+        public void GetHttpClient_DefaultHeadersSetToJson()
+        {
+            var client = HttpClientFactory.GetHttpClient();
+            Assert.IsNotNull(client.DefaultRequestHeaders.Accept);
+            Assert.IsTrue(client.DefaultRequestHeaders.Accept.Any<MediaTypeWithQualityHeaderValue>(x => x.MediaType == "application/json"));
         }
     }
 }


### PR DESCRIPTION
The default headers should only be changed once so I moved the change to the factory. Otherwise, the following problem occurs under load: https://blogs.msdn.microsoft.com/tess/2009/12/21/high-cpu-in-net-app-using-a-static-generic-dictionary/