### PR TITLE
CLA site updated

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -5,7 +5,7 @@ through the process.
 
 ### CONTRIBUTOR LICENSE AGREEMENT
 
-Please visit [https://cla.msopentech.com/](https://cla.msopentech.com/) and sign the Contributor License
+Please visit [https://cla.opensource.microsoft.com/](https://cla.opensource.microsoft.com/) and sign the Contributor License
 Agreement.  You only need to do that once. We can not look at your code until you've submitted this request.
 
 


### PR DESCRIPTION
Seems MS has updated the CLA signing site for contributions.
The original URL is no longer active and no redirect is issued...