### PR TITLE
fix path to msal common props in sln files

### DIFF
--- a/LibsAndSamples.sln
+++ b/LibsAndSamples.sln
@@ -47,7 +47,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UWP", "tests\devapps\UWP\UW
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{E19B0572-BBD7-424E-81D5-E59E6884EB3A}"
 	ProjectSection(SolutionItems) = preProject
-		msal\src\MSAL.Common.props = msal\src\MSAL.Common.props
+		src\MSAL.Common.props = src\MSAL.Common.props
 		build\SolutionWideAnalyzerConfig.ruleset = build\SolutionWideAnalyzerConfig.ruleset
 	EndProjectSection
 EndProject

--- a/LibsNoSamples.sln
+++ b/LibsNoSamples.sln
@@ -9,7 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{5D231979
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{48CF4D7C-5E2E-4C4A-BDD2-8F2A06AAE3F6}"
 	ProjectSection(SolutionItems) = preProject
-		msal\src\MSAL.Common.props = msal\src\MSAL.Common.props
+		src\MSAL.Common.props = src\MSAL.Common.props
 		build\SolutionWideAnalyzerConfig.ruleset = build\SolutionWideAnalyzerConfig.ruleset
 	EndProjectSection
 EndProject


### PR DESCRIPTION
this doesn't impact the release, but these files were not referenced properly in the solution directory layout so they weren't openable within VS.