### PR TITLE
browsertab fix

### DIFF
--- a/src/Microsoft.Identity.Client/Platforms/Android/BrowserTabActivity.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/BrowserTabActivity.cs
@@ -31,7 +31,7 @@ using Android.Content;
 using Android.OS;
 using Microsoft.Identity.Client.Platforms.Android.SystemWebview;
 
-namespace Microsoft.Identity.Client.Platforms.Android
+namespace Microsoft.Identity.Client
 {
     /// <summary>
     /// BrowserTabActivity to get the redirect with code from authorize endpoint. Intent filter has to be declared in the
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
     /// uri (redirect_uri has to be unique across apps), the os will fire an intent with the redirect,
     /// and the BrowserTabActivity will be launched.
     /// </summary>
-    [Activity(Name = "microsoft.identity.client.BrowserTabActivity")]
+    //[Activity(Name = "microsoft.identity.client.BrowserTabActivity")]
     [CLSCompliant(false)]
     public class BrowserTabActivity : Activity
     {

--- a/src/Microsoft.Identity.Client/Platforms/Android/BrowserTabActivity.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/BrowserTabActivity.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Identity.Client.Platforms.Android
 {
     /// <summary>
     /// BrowserTabActivity to get the redirect with code from authorize endpoint. Intent filter has to be declared in the
-    /// manifest for this activity. When chrome custom tab is launched, and we're redirected back with the redirect
+    /// android manifest for this activity. When chrome custom tab is launched, and we're redirected back with the redirect
     /// uri (redirect_uri has to be unique across apps), the os will fire an intent with the redirect,
     /// and the BrowserTabActivity will be launched.
     /// </summary>
-    //[Activity(Name = "microsoft.identity.client.BrowserTabActivity")]
+    [Activity(Name = "microsoft.identity.client.BrowserTabActivity")]
     [CLSCompliant(false)]
     public class BrowserTabActivity : Activity
     {


### PR DESCRIPTION
BrowserTabActivity is used w/system browser so we know were to return the redirect. This also has to be declared in the android manifest.

With the changes to MSAL restructuring, the namespace has changed to `Microsoft.Identity.Client.Platforms.Android.BrowserTabActivity`
In order to not make this a breaking change, changing the namespace back to Microsoft.identity.client
`<activity android:name="microsoft.identity.client.BrowserTabActivity">`

PS. I'll update the wiki was well. I don't see this documented anywhere 
cc: @jmprieur 