### PR TITLE
Sagonzal/telemetry fix

### DIFF
--- a/src/Microsoft.Identity.Client/Core/ServiceBundle.cs
+++ b/src/Microsoft.Identity.Client/Core/ServiceBundle.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Client.Core
             bool shouldClearCaches = false)
         {
             HttpManager = httpManager ?? new HttpManager(httpClientFactory);
-            TelemetryManager = new TelemetryManager(telemetryReceiver);
+            TelemetryManager = new TelemetryManager(telemetryReceiver ?? Telemetry.GetInstance());
             ValidatedAuthoritiesCache = validatedAuthoritiesCache ?? new ValidatedAuthoritiesCache(shouldClearCaches);
             AadInstanceDiscovery = aadInstanceDiscovery ?? new AadInstanceDiscovery(HttpManager, TelemetryManager, shouldClearCaches);
             WsTrustWebRequestManager = wsTrustWebRequestManager ?? new WsTrustWebRequestManager(HttpManager);

--- a/src/Microsoft.Identity.Client/Telemetry.cs
+++ b/src/Microsoft.Identity.Client/Telemetry.cs
@@ -79,6 +79,14 @@ namespace Microsoft.Identity.Client
             _receiver = r;
         }
 
+        /// <summary>
+        ///     Checks if a delegate has been registered as a receiver
+        /// </summary>
+        public bool HasRegisteredReceiver()
+        {
+            return _receiver != null;
+        }
+
         void ITelemetryReceiver.HandleTelemetryEvents(List<Dictionary<string, string>> events)
         {
             _receiver?.Invoke(events);

--- a/src/Microsoft.Identity.Client/TelemetryCore/TelemetryManager.cs
+++ b/src/Microsoft.Identity.Client/TelemetryCore/TelemetryManager.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
             {
                 lock (_lockObj)
                 {
-                    return _telemetryReceiver;
+                    return _telemetryReceiver ?? Telemetry.GetInstance();
                 }
             }
             set
@@ -113,7 +113,8 @@ namespace Microsoft.Identity.Client.TelemetryCore
         {
             lock (_lockObj)
             {
-                return _telemetryReceiver != null;
+                return _telemetryReceiver != null ||
+                    Telemetry.GetInstance().HasRegisteredReceiver();
             }
         }
 


### PR DESCRIPTION
When registering a telemetry receiver via Telemetry.GetInstance().RegisterReceiver(), the receiver in TelemetryManager is never set, and therefore the client never gets the callback. 

Proposed fix: If _telemetryReceiver in TelemetryManager is null, default to the Telemetry static.