### PR TITLE
fix net45 instead of net452

### DIFF
--- a/src/MSAL.Frameworks.props
+++ b/src/MSAL.Frameworks.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFrameworkNetDesktop>net452</TargetFrameworkNetDesktop>
+        <TargetFrameworkNetDesktop>net45</TargetFrameworkNetDesktop>
         <TargetFrameworkNetStandard>netstandard1.3</TargetFrameworkNetStandard>
         <TargetFrameworkNetCore>netcoreapp1.0</TargetFrameworkNetCore>
         <TargetFrameworkUap>uap10.0</TargetFrameworkUap>

--- a/src/Microsoft.Identity.Client/Features/ConfidentialClient/JsonWebToken.cs
+++ b/src/Microsoft.Identity.Client/Features/ConfidentialClient/JsonWebToken.cs
@@ -216,10 +216,10 @@ namespace Microsoft.Identity.Client.Internal.Jwt
                     return;
                 }
 
-#if NET45
+#if NETSTANDARD1_3
+                X509CertificatePublicCertValue = Convert.ToBase64String(credential.Certificate.RawData);
+#elif DESKTOP
                 X509CertificatePublicCertValue = Convert.ToBase64String(credential.Certificate.GetRawCertData());
-#elif NETSTANDARD1_3
-                    X509CertificatePublicCertValue = Convert.ToBase64String(credential.Certificate.RawData);
 #endif
             }
 


### PR DESCRIPTION
We will also want to eventually fix this in JsonWebToken, since any desktop framework besides NET45 will break this.

#if NET45
                X509CertificatePublicCertValue = Convert.ToBase64String(credential.Certificate.GetRawCertData());
#elif NETSTANDARD1_3
                    X509CertificatePublicCertValue = Convert.ToBase64String(credential.Certificate.RawData);
#endif