### PR TITLE
Change AuthenticationContinuationHelper namespace

### DIFF
--- a/src/Microsoft.Identity.Client/Platforms/Android/AuthenticationContinuationHelper.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/AuthenticationContinuationHelper.cs
@@ -31,10 +31,11 @@ using Android.App;
 using Android.Content;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Android;
 using Microsoft.Identity.Client.Platforms.Android.SystemWebview;
 using Microsoft.Identity.Client.UI;
 
-namespace Microsoft.Identity.Client.Platforms.Android
+namespace Microsoft.Identity.Client
 {
     /// <summary>
     /// Static class that consumes the response from the Authentication flow and continues token acquisition. This class should be called in OnActivityResult() of the activity doing authentication.

--- a/src/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -27,8 +27,9 @@
 
 using System;
 using Foundation;
+using Microsoft.Identity.Client.Platforms.iOS;
 
-namespace Microsoft.Identity.Client.Platforms.iOS
+namespace Microsoft.Identity.Client
 {
     /// <summary>
     /// Static class that consumes the response from the Authentication flow and continues token acquisition. This class should be called in ApplicationDelegate whenever app loads/reloads.


### PR DESCRIPTION
This represents a breaking change to 2.6.1, and it fixes a breaking change we accidentally introduced in 2.6.0.