### PR TITLE
add sdk flag to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,5 @@
 {
+  "sdk": { "version": "2.1.502" }
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "1.6.61"
   }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-  "sdk": { "version": "2.1.502" }
+  "sdk": { "version": "2.1.502" },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "1.6.61"
   }


### PR DESCRIPTION
Adding an "sdk" property to our global.json to lock us to 2.1.502 since I (and possibly others) need to run later versions of .NET sdk (3.0 preview) and that interferes with the build of this product since dotnet defaults to the latest sdk installed by default.