### PR TITLE
change how we set the keychaingroup

### DIFF
--- a/src/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
@@ -72,6 +72,9 @@ namespace Microsoft.Identity.Client.Cache
 
 #if iOS
         void SetKeychainSecurityGroup(string keychainSecurityGroup);
+
+        // Will remove in v3.
+        void SetIOSKeychainSecurityGroup(string keychainSecurityGroup);
 #endif
 
         void Clear();

--- a/src/Microsoft.Identity.Client/Features/PublicClientWithTokenCache/TokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Features/PublicClientWithTokenCache/TokenCacheAccessor.cs
@@ -23,6 +23,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Concurrent;
@@ -184,6 +185,12 @@ namespace Microsoft.Identity.Client
         }
 
         public void SetKeychainSecurityGroup(string keychainSecurityGroup)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", false)]
+        public void SetIOSKeychainSecurityGroup(string keychainSecurityGroup)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -43,11 +43,12 @@ namespace Microsoft.Identity.Client
 #if iOS
         /// <summary>
         /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
-        /// If you provide this key, you MUST add the capability to your Application Entitlement.
+        /// If you use this property, you MUST add the capability to your Application Entitlement.
+        /// In this property, the value should not contain the TeamId prefix, MSAL will resolve the TeamId at runtime.
         /// For more details, please see https://aka.ms/msal-net-sharing-cache-on-ios
         /// </summary>
         /// <remarks>This API may change in future release.</remarks>
-        string KeychainSecurityGroup {get;set;}
+        string iOSKeychainSecurityGroup { get; set; }
 #endif
 
 #if WINDOWS_APP

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -49,6 +49,14 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <remarks>This API may change in future release.</remarks>
         string iOSKeychainSecurityGroup { get; set; }
+
+        /// <summary>
+        /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
+        /// If you use this property, you MUST add the capability to your Application Entitlement.
+        /// When using this property, the value must contain the TeamId prefix, which is why this will be obsolete in future releases.
+        /// </summary>
+        /// <remarks>This API will be removed in MSAL v3.x. See https://aka.ms/msal-net-ios-keychain-security-group for details</remarks>
+        string KeychainSecurityGroup { get; set; }
 #endif
 
 #if WINDOWS_APP

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -56,6 +57,7 @@ namespace Microsoft.Identity.Client
         /// When using this property, the value must contain the TeamId prefix, which is why this will be obsolete in future releases.
         /// </summary>
         /// <remarks>This API will be removed in MSAL v3.x. See https://aka.ms/msal-net-ios-keychain-security-group for details</remarks>
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", false)]
         string KeychainSecurityGroup { get; set; }
 #endif
 

--- a/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -174,5 +174,36 @@ namespace Microsoft.Identity.Client
         }
 #pragma warning restore 1998
 #endif
+
+#if iOS
+        /// <summary>
+        /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
+        /// If you use this property, you MUST add the capability to your Application Entitlement.
+        /// When using this property, the value must contain the TeamId prefix, which is why this is now obsolete.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", true)]
+        public string KeychainSecurityGroup { get { throw new NotImplementedException(); } }
+#endif
+    }
+
+    /// <Summary>
+    /// Interface defining common API methods and properties.
+    /// For details see https://aka.ms/msal-net-client-applications
+    /// </Summary>
+    public partial interface IPublicApplicationBase
+    {
+#if iOS
+        /// <summary>
+        /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
+        /// If you use this property, you MUST add the capability to your Application Entitlement.
+        /// When using this property, the value must contain the TeamId prefix, which is why this is now obsolete.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", true)]
+        string KeychainSecurityGroup { get; }
+#endif
     }
 }

--- a/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -174,36 +174,5 @@ namespace Microsoft.Identity.Client
         }
 #pragma warning restore 1998
 #endif
-
-#if iOS
-        /// <summary>
-        /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
-        /// If you use this property, you MUST add the capability to your Application Entitlement.
-        /// When using this property, the value must contain the TeamId prefix, which is why this is now obsolete.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", true)]
-        public string KeychainSecurityGroup { get { throw new NotImplementedException(); } }
-#endif
-    }
-
-    /// <Summary>
-    /// Interface defining common API methods and properties.
-    /// For details see https://aka.ms/msal-net-client-applications
-    /// </Summary>
-    public partial interface IPublicApplicationBase
-    {
-#if iOS
-        /// <summary>
-        /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
-        /// If you use this property, you MUST add the capability to your Application Entitlement.
-        /// When using this property, the value must contain the TeamId prefix, which is why this is now obsolete.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", true)]
-        string KeychainSecurityGroup { get; }
-#endif
     }
 }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         }
 
         // Will remove in v3.
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", false)]
         public void SetIOSKeychainSecurityGroup(string keychainSecurityGroup)
         {
             if (keychainSecurityGroup == null)

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -83,6 +83,19 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             }
         }
 
+        // Will remove in v3.
+        public void SetIOSKeychainSecurityGroup(string keychainSecurityGroup)
+        {
+            if (keychainSecurityGroup == null)
+            {
+                keychainGroup = GetBundleId();
+            }
+            else
+            {
+                keychainGroup = keychainSecurityGroup;
+            }
+        }
+
         private string GetTeamId()
         {
             var queryRecord = new SecRecord(SecKind.GenericPassword)

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             }
             else
             {
-                keychainGroup = keychainSecurityGroup;
+                keychainGroup = GetTeamId() + '.' + keychainSecurityGroup;
             }
         }
 

--- a/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -124,11 +124,12 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
-        /// If you provide this key, you MUST add the capability to your Application Entitlement.
+        /// If you use this property, you MUST add the capability to your Application Entitlement.
+        /// In this property, the value should not contain the TeamId prefix, MSAL will resolve the TeamId at runtime.
         /// For more details, please see https://aka.ms/msal-net-sharing-cache-on-ios
         /// </summary>
         /// <remarks>This API may change in future release.</remarks>
-        public string KeychainSecurityGroup
+        public string iOSKeychainSecurityGroup
         {
             get
             {

--- a/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -161,7 +161,8 @@ namespace Microsoft.Identity.Client
             {
                 keychainSecurityGroup = value;
                 UserTokenCache.TokenCacheAccessor.SetIOSKeychainSecurityGroup(value);
-                UserTokenCache.LegacyCachePersistence.SetKeychainSecurityGroup(value);
+                (UserTokenCache.LegacyCachePersistence as iOSLegacyCachePersistence)
+                    .SetKeychainSecurityGroup(value);
             }
         }
 #endif

--- a/src/Microsoft.Identity.Client/TelemetryCore/TelemetryTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/TelemetryCore/TelemetryTokenCacheAccessor.cs
@@ -49,6 +49,12 @@ namespace Microsoft.Identity.Client.TelemetryCore
         {
             _tokenCacheAccessor.SetKeychainSecurityGroup(keychainSecurityGroup);
         }
+
+        // Will remove in v3.
+        public void SetIOSKeychainSecurityGroup(string keychainSecurityGroup)
+        {
+            _tokenCacheAccessor.SetIOSKeychainSecurityGroup(keychainSecurityGroup);
+        }
 #endif
 
         // The content of this class has to be placed outside of its base class TokenCacheAccessor,

--- a/tests/devapps/XForms/XForms.iOS/AppDelegate.cs
+++ b/tests/devapps/XForms/XForms.iOS/AppDelegate.cs
@@ -56,6 +56,8 @@ namespace XForms.iOS
             // Default system browser
             App.UIParent = new UIParent();
 
+            //App.MsalPublicClient.iOSKeychainSecurityGroup = "com.microsoft.adalcache";
+
             // To activate embedded webview, remove '//' below
             //App.UIParent = new UIParent(true);
             return base.FinishedLaunching(app, options);


### PR DESCRIPTION
Saw this issue in [SO](https://stackoverflow.com/questions/53829119/xamarin-with-msal-cannot-save-access-token-as-keychain-access-groups-changed-dur) 

We force devs to provide a teamId, which will change between dogfood and development, so we should resolve teamId and ask for the actual keychain group. This is what native iOS does.

Tested w/iOS device by setting and not setting keychain group