### PR TITLE
Integrate Nerdbank NuGet versioning

### DIFF
--- a/LibsNoSamples.sln
+++ b/LibsNoSamples.sln
@@ -9,8 +9,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{5D231979
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{48CF4D7C-5E2E-4C4A-BDD2-8F2A06AAE3F6}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
 		src\MSAL.Common.props = src\MSAL.Common.props
+		src\MSAL.Frameworks.props = src\MSAL.Frameworks.props
 		build\SolutionWideAnalyzerConfig.ruleset = build\SolutionWideAnalyzerConfig.ruleset
+		src\version.json = src\version.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Identity.Test.Unit.netcore", "tests\Microsoft.Identity.Test.Unit.netcore\Microsoft.Identity.Test.Unit.netcore.csproj", "{AF0E7BEC-90A3-46B4-AEDC-4162D7873AE8}"

--- a/src/MSAL.Common.props
+++ b/src/MSAL.Common.props
@@ -1,17 +1,12 @@
 <Project>
 
   <PropertyGroup>
-
     <DebugType>full</DebugType>
     <!-- The MSAL.snk has both private and public keys -->
     <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet and AssemblyInfo metadata">
-    <!--This should be passed from the VSTS build-->
-    <MsalClientSemVer Condition="'$(MsalClientSemVer)' == ''">1.0.0-localbuild</MsalClientSemVer>
-    <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
-    <Version>$(MsalClientSemVer)</Version>
 
     <!-- Copyright needs to be in the form of © not (c) to be compliant -->
     <Title>Microsoft Authentication Library for .NET</Title>
@@ -28,7 +23,10 @@
     <PackageTags>Microsoft Authentication Library MSA MSAL B2C Azure Active Directory AAD Identity Authentication .NET Windows Store Xamarin iOS Android</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Company>Microsoft Corporation</Company>
-    <Product>Microsoft Authentication Library</Product>
+    <Product>Microsoft Authentication Library ($(TargetFramework))</Product>
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -72,9 +70,9 @@
     <DefineConstants>$(DefineConstants);PORTABLE;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_SERIALIZATION;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DYNAMIC;HAVE_EXPRESSIONS;HAVE_FSHARP_TYPES;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_BINDER;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_OBSOLETE_FORMATTER_ASSEMBLY_STYLE;HAVE_XML_DOCUMENT;HAVE_CONCURRENT_DICTIONARY;HAVE_ICONVERTIBLE;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Include all files so that VS sees them, exclude platform specific ones from compilation">
     <!-- This None is here so the conditionally included files show up in the Solution Explorer -->
-    <None Include="$(PathToMsalSources)\**\*.cs;$(PathToMsalSources)\**\*.xml;$(PathToMsalSources)\**\*.axml"
+    <None Include="$(PathToMsalSources)\**\*.cs;$(PathToMsalSources)\**\*.xml;$(PathToMsalSources)\**\*.axml;$(PathToMsalSources)\**\*.json"
           Exclude="$(PathToMsalSources)\obj\**\*.*;$(PathToMsalSources)\bin\**\*.*" />
     <!-- Manually include the cs files -->
     <Compile Include="$(PathToMsalSources)\**\*.cs" Exclude="$(PathToMsalSources)\obj\**\*.*" />
@@ -107,7 +105,6 @@
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetCore)' ">
 
     <Compile Include="$(PathToMsalSources)\Features\Cache\**\*.cs" LinkBase="Core\Features\Cache" />
@@ -198,6 +195,10 @@
     <None Update="$(PathToMsalSources)\Platforms\net45\WinFormWebAuthenticationDialog.cs" SubType="Form" />
     <None Update="$(PathToMsalSources)\Platforms\net45\WindowsFormsWebAuthenticationDialogBase.cs" SubType="Form" />
     <None Update="$(PathToMsalSources)\Platforms\net45\SilentWindowsFormsAuthenticationDialog.cs" SubType="Form" />
+  </ItemGroup>
+ 
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/version.json
+++ b/src/version.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.7-preview", 
+  "assemblyVersion": {
+    "precision": "revision"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
+  ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  }
+}

--- a/src/version.json
+++ b/src/version.json
@@ -9,5 +9,10 @@
   ],
   "nugetPackageVersion": {
     "semVer": 2
+  },
+   "cloudBuild": {
+    "buildNumber": {   // use version as build number
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
A few notes about how this changes the way we do versioning: 

1. We no longer control the patch number of our version (i.e. the z from x.y.z). Instead, z is calculated automatically as the git height (number of commits from HEAD). This ensures alphabetical order

2. Builds from master will be versioned as "2.7.34-preview", "2.7.89-preview" etc. Builds from other branches will be versioned as "2.7.13-ab2d56a", i.e. they will include both the height and the git commit id (this will allow us to still release private nuget packages from non-master branches)

3. Nightly builds are from master and will be versioned as 2.7.34-preview. Release builds will need to remove the preview tag, by editing version.json, to obtain 2.7.35 (we can do it at the same time we push the release notes)

This is based on @sangonzal 's original PR  https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/720, but with a few changes: allow nerdbank to use the patch number as height and make sure both msal and msal.ref are versioned.