### PR TITLE
Add support for source link

### DIFF
--- a/src/MSAL.Common.props
+++ b/src/MSAL.Common.props
@@ -1,8 +1,6 @@
 <Project>
 
   <PropertyGroup>
-
-    <DebugType>full</DebugType>
     <!-- The MSAL.snk has both private and public keys -->
     <DelaySign>false</DelaySign>
   </PropertyGroup>
@@ -29,6 +27,12 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Company>Microsoft Corporation</Company>
     <Product>Microsoft Authentication Library</Product>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -200,4 +204,8 @@
     <None Update="$(PathToMsalSources)\Platforms\net45\SilentWindowsFormsAuthenticationDialog.cs" SubType="Form" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This will allow developers to debug into MSAL, as long as they use VS 15.7+ 

It will do 2 things: 

1. Generate a snupkg package that contains the pdb files (one for each platform). We will need to upload this to NuGet 
2. Add a manifest containing urls to source files in the nuget package (You can use NuGet package explorer to see this manifest)