### PR TITLE
Jennyf/universal view

### DIFF
--- a/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
                 viewController.InvokeOnMainThread(() =>
                 {
                     var navigationController =
-                        new AuthenticationAgentUINavigationController(authorizationUri.AbsoluteUri,
+                        new MsalAuthenticationAgentUINavigationController(authorizationUri.AbsoluteUri,
                             redirectUri.OriginalString, CallbackMethod, CoreUIParent.PreferredStatusBarStyle)
                         {
                             ModalPresentationStyle = CoreUIParent.ModalPresentationStyle,

--- a/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/MsalAuthenticationAgentUINavigationController.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/MsalAuthenticationAgentUINavigationController.cs
@@ -30,15 +30,15 @@ using UIKit;
 
 namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
 {
-    [Foundation.Register("UniversalView")]
-    internal class UniversalView : UIView
+    [Foundation.Register("MsalUniversalView")]
+    internal class MsalUniversalView : UIView
     {
-        public UniversalView()
+        public MsalUniversalView()
         {
             Initialize();
         }
 
-        public UniversalView(CGRect bounds)
+        public MsalUniversalView(CGRect bounds)
             : base(bounds)
         {
             Initialize();
@@ -50,17 +50,17 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
         }
     }
 
-    [Foundation.Register("AuthenticationAgentUINavigationController")]
-    internal class AuthenticationAgentUINavigationController : UINavigationController
+    [Foundation.Register("MsalAuthenticationAgentUINavigationController")]
+    internal class MsalAuthenticationAgentUINavigationController : UINavigationController
     {
         private readonly string url;
         private readonly string callback;
 
-        private readonly AuthenticationAgentUIViewController.ReturnCodeCallback callbackMethod;
+        private readonly MsalAuthenticationAgentUIViewController.ReturnCodeCallback callbackMethod;
 
         private readonly UIStatusBarStyle preferredStatusBarStyle;
 
-        public AuthenticationAgentUINavigationController(string url, string callback, AuthenticationAgentUIViewController.ReturnCodeCallback callbackMethod, UIStatusBarStyle preferredStatusBarStyle)
+        public MsalAuthenticationAgentUINavigationController(string url, string callback, MsalAuthenticationAgentUIViewController.ReturnCodeCallback callbackMethod, UIStatusBarStyle preferredStatusBarStyle)
         {
             this.url = url;
             this.callback = callback;
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
             base.ViewDidLoad();
 
             // Perform any additional setup after loading the view
-            this.PushViewController(new AuthenticationAgentUIViewController(this.url, this.callback, this.callbackMethod), true);
+            this.PushViewController(new MsalAuthenticationAgentUIViewController(this.url, this.callback, this.callbackMethod), true);
         }
 
         public override UIStatusBarStyle PreferredStatusBarStyle()

--- a/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/MsalAuthenticationAgentUIViewController.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/MsalAuthenticationAgentUIViewController.cs
@@ -35,8 +35,8 @@ using WebKit;
 
 namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
 {
-    [Foundation.Register("AuthenticationAgentUIViewController")]
-    internal class AuthenticationAgentUIViewController : UIViewController
+    [Foundation.Register("MsalAuthenticationAgentUIViewController")]
+    internal class MsalAuthenticationAgentUIViewController : UIViewController
     {
         private readonly string url;
         public readonly string callback;
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
 
         public delegate void ReturnCodeCallback(AuthorizationResult result);
 
-        public AuthenticationAgentUIViewController(string url, string callback, ReturnCodeCallback callbackMethod)
+        public MsalAuthenticationAgentUIViewController(string url, string callback, ReturnCodeCallback callbackMethod)
         {
             this.url = url;
             this.callback = callback;

--- a/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
     internal class WKWebNavigationDelegate : WKNavigationDelegate
     {
         private const string AboutBlankUri = "about:blank";
-        private AuthenticationAgentUIViewController AuthenticationAgentUIViewController = null;
+        private MsalAuthenticationAgentUIViewController AuthenticationAgentUIViewController = null;
 
-        public WKWebNavigationDelegate(AuthenticationAgentUIViewController AuthUIViewController)
+        public WKWebNavigationDelegate(MsalAuthenticationAgentUIViewController AuthUIViewController)
         {
             AuthenticationAgentUIViewController = AuthUIViewController;
             return;
@@ -118,9 +118,9 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
 
         internal class WKWebViewUIDelegate : WKUIDelegate
         {
-            private readonly AuthenticationAgentUIViewController _controller = null;
+            private readonly MsalAuthenticationAgentUIViewController _controller = null;
 
-            public WKWebViewUIDelegate(AuthenticationAgentUIViewController c)
+            public WKWebViewUIDelegate(MsalAuthenticationAgentUIViewController c)
             {
                 _controller = c;
                 return;


### PR DESCRIPTION
Customer using both Adal v4 and Msal v2 in an iOS app, is running into an issue w/iOS UIViewControllers being registered with the same names in both libraries after we did the split.

Here is one of the errors: 
```Could not register the assembly 'Microsoft.IdentityModel.Clients.ActiveDirectory': error MT4118: Cannot register two managed types ('Microsoft.Identity.Core.UI.EmbeddedWebview.AuthenticationAgentUIViewController, Microsoft.IdentityModel.Clients.ActiveDirectory' and 'Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview.AuthenticationAgentUIViewController, Microsoft.Identity.Client') with the same native name ('AuthenticationAgentUIViewController')```

I ran this by the iOS team a couple weeks ago, and they suggested we just change the registered name and the class names (prefix them w/MSAL). We could go the other route and change ADAL and leave MSAL as-is. 

The customer sent me a test app to use and I was able to verify this fixes the issue. I am waiting to get confirmation from them (they are in Europe). 
