### PR TITLE
add iOSKeychainSecurityGroup property for handling TeamID()

### DIFF
--- a/src/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
@@ -71,6 +71,9 @@ namespace Microsoft.Identity.Client.Cache
         ICollection<string> GetAllAccountsAsString();
 
 #if iOS
+        void SetiOSKeychainSecurityGroup(string keychainSecurityGroup);
+        
+        // Will remove in v3.
         void SetKeychainSecurityGroup(string keychainSecurityGroup);
 #endif
 

--- a/src/Microsoft.Identity.Client/Features/PublicClientWithTokenCache/TokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Features/PublicClientWithTokenCache/TokenCacheAccessor.cs
@@ -23,6 +23,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections.Concurrent;
@@ -183,6 +184,12 @@ namespace Microsoft.Identity.Client
                    AccountCacheDictionary.Values.ToList());
         }
 
+        public void SetiOSKeychainSecurityGroup(string keychainSecurityGroup)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", false)]
         public void SetKeychainSecurityGroup(string keychainSecurityGroup)
         {
             throw new System.NotImplementedException();

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -43,11 +44,21 @@ namespace Microsoft.Identity.Client
 #if iOS
         /// <summary>
         /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
-        /// If you provide this key, you MUST add the capability to your Application Entitlement.
+        /// If you use this property, you MUST add the capability to your Application Entitlement.
+        /// In this property, the value should not contain the TeamId prefix, MSAL will resolve the TeamId at runtime.
         /// For more details, please see https://aka.ms/msal-net-sharing-cache-on-ios
         /// </summary>
         /// <remarks>This API may change in future release.</remarks>
-        string KeychainSecurityGroup {get;set;}
+        string iOSKeychainSecurityGroup { get; set; }
+
+        /// <summary>
+        /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
+        /// If you use this property, you MUST add the capability to your Application Entitlement.
+        /// When using this property, the value must contain the TeamId prefix, which is why this will be obsolete in future releases.
+        /// </summary>
+        /// <remarks>This API will be removed in MSAL v3.x. See https://aka.ms/msal-net-ios-keychain-security-group for details</remarks>
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", false)]
+        string KeychainSecurityGroup { get; set; }
 #endif
 
 #if WINDOWS_APP

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -71,6 +71,19 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             return NSBundle.MainBundle.BundleIdentifier;
         }
 
+        public void SetiOSKeychainSecurityGroup(string keychainSecurityGroup)
+        {
+            if (keychainSecurityGroup == null)
+            {
+                keychainGroup = GetBundleId();
+            }
+            else
+            {
+                keychainGroup = GetTeamId() + '.' + keychainSecurityGroup;
+            }
+        }
+
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", false)]
         public void SetKeychainSecurityGroup(string keychainSecurityGroup)
         {
             if (keychainSecurityGroup == null)

--- a/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Consutructor of the application. It will use https://login.microsoftonline.com/common as the default authority.
+        /// Constructor of the application. It will use https://login.microsoftonline.com/common as the default authority.
         /// </summary>
         /// <param name="clientId">Client ID (also known as App ID) of the application as registered in the
         /// application registration portal (https://aka.ms/msal-net-register-app)/. REQUIRED</param>
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Consutructor of the application.
+        /// Constructor of the application.
         /// </summary>
         /// <param name="clientId">Client ID (also named Application ID) of the application as registered in the
         /// application registration portal (https://aka.ms/msal-net-register-app)/. REQUIRED</param>
@@ -122,12 +122,24 @@ namespace Microsoft.Identity.Client
 #if iOS
         private string keychainSecurityGroup;
 
-        /// <summary>
-        /// Xamarin iOS specific property enabling the application to share the token cache with other applications sharing the same keychain security group.
-        /// If you provide this key, you MUST add the capability to your Application Entitlement.
-        /// For more details, please see https://aka.ms/msal-net-sharing-cache-on-ios
-        /// </summary>
-        /// <remarks>This API may change in future release.</remarks>
+        /// <inheritdoc />
+        public string iOSKeychainSecurityGroup
+        {
+            get
+            {
+                return keychainSecurityGroup;
+            }
+            set
+            {
+                keychainSecurityGroup = value;
+                UserTokenCache.TokenCacheAccessor.SetiOSKeychainSecurityGroup(value);
+                (UserTokenCache.LegacyCachePersistence as iOSLegacyCachePersistence)
+                    .SetKeychainSecurityGroup(value);
+            }
+        }
+
+        /// <inheritdoc />
+        [Obsolete("Use iOSKeychainSecurityGroup instead (See https://aka.ms/msal-net-ios-keychain-security-group)", false)]
         public string KeychainSecurityGroup
         {
             get

--- a/src/Microsoft.Identity.Client/TelemetryCore/TelemetryTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/TelemetryCore/TelemetryTokenCacheAccessor.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Identity.Client.TelemetryCore
         }
 
 #if iOS
+        public void SetiOSKeychainSecurityGroup(string keychainSecurityGroup)
+        {
+            _tokenCacheAccessor.SetiOSKeychainSecurityGroup(keychainSecurityGroup);
+        }
+
+        // Will remove in v3.
         public void SetKeychainSecurityGroup(string keychainSecurityGroup)
         {
             _tokenCacheAccessor.SetKeychainSecurityGroup(keychainSecurityGroup);

--- a/tests/devapps/XForms/XForms.iOS/AppDelegate.cs
+++ b/tests/devapps/XForms/XForms.iOS/AppDelegate.cs
@@ -56,6 +56,8 @@ namespace XForms.iOS
             // Default system browser
             App.UIParent = new UIParent();
 
+            //App.MsalPublicClient.iOSKeychainSecurityGroup = "com.microsoft.adalcache";
+
             // To activate embedded webview, remove '//' below
             //App.UIParent = new UIParent(true);
             return base.FinishedLaunching(app, options);


### PR DESCRIPTION
Make obsolete KeychainSecurityGroup property

closing this [PR](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/742) but have address comments here. was easier to open a new one.