### PR TITLE
Adding XML comment to the public API

### DIFF
--- a/src/Microsoft.Identity.Client/AppConfig/AadAuthorityAudience.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AadAuthorityAudience.cs
@@ -45,10 +45,12 @@ namespace Microsoft.Identity.Client.AppConfig
     */
 
     /// <summary>
+    /// Specifies what Microsoft accounts can be signed-in in a given application.
     /// </summary>
     public enum AadAuthorityAudience
     {
         /// <summary>
+        /// The sign-in audience was not specified
         /// </summary>
         None,
 
@@ -58,22 +60,25 @@ namespace Microsoft.Identity.Client.AppConfig
         Default,
 
         /// <summary>
+        /// Users with a Microsoft work or school account in my organization’s Azure AD tenant (i.e. single tenant).
         /// Maps to https://[instance]/[tenantId]
         /// </summary>
         AzureAdSpecificDirectoryOnly,
 
         /// <summary>
-        ///     Maps to https://[instance]/common/
+        /// Users with a personal Microsoft account, or a work or school account in any organization’s Azure AD tenant
+        /// Maps to https://[instance]/common/
         /// </summary>
         AzureAdAndPersonalMicrosoftAccount,
 
         /// <summary>
-        ///     Maps to https://[instance]/organizations/
+        /// Users with a Microsoft work or school account in any organization’s Azure AD tenant (i.e. multi-tenant).
+        /// Maps to https://[instance]/organizations/
         /// </summary>
         AzureAdOnly,
 
         /// <summary>
-        ///     Maps to https://[instance]/consumers/
+        /// Users with a personal Microsoft account. Maps to https://[instance]/consumers/
         /// </summary>
         MicrosoftAccountOnly
     }

--- a/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -46,9 +46,12 @@ namespace Microsoft.Identity.Client.AppConfig
         internal ApplicationConfiguration Config { get; }
 
         /// <summary>
+        /// Uses a specific <see cref="IMsalHttpClientFactory"/> to communicate
+        /// with the IdP. This enable advanced scenarios such as setting a proxy,
+        /// or setting the Agent.
         /// </summary>
-        /// <param name="httpClientFactory"></param>
-        /// <returns></returns>
+        /// <param name="httpClientFactory">HTTP client factory</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithHttpClientFactory(IMsalHttpClientFactory httpClientFactory)
         {
             Config.HttpClientFactory = httpClientFactory;
@@ -62,8 +65,11 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the logging callback. For details see https://aka.ms/msal-net-logging
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The builder to chain the .With methods</returns>
+        /// <exception cref="InvalidOperationException"/> is thrown if the loggingCallback
+        /// was already set on the application builder
         public T WithLoggingCallback(LogCallback loggingCallback)
         {
             if (Config.LoggingCallback != null)
@@ -76,8 +82,14 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the Debug logging callback to a default debug methods which displays
+        /// the level of the message and the message. For details see https://aka.ms/msal-net-logging
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The builder to chain the .With methods</returns>
+        /// <exception cref="InvalidOperationException"/> is thrown if the loggingCallback
+        /// was already set on the application builder by calling <see cref="WithLoggingCallback(LogCallback)"/>
+        /// <seealso cref="WithLoggingCallback(LogCallback)"/>
+        /// <seealso cref="WithLoggingLevel(LogLevel)"/>
         public T WithDebugLoggingCallback()
         {
             if (Config.LoggingCallback != null)
@@ -90,8 +102,14 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the telemetry callback. For details see https://aka.ms/msal-net-telemetry
         /// </summary>
-        /// <returns></returns>
+        /// <param name="telemetryCallback">Delegate to the callback sending the telemetry
+        /// elaborated by the library to the telemetry endpoint of choice</param>
+        /// <returns>The builder to chain the .With methods</returns>
+        /// <exception cref="InvalidOperationException"/> is thrown if the the method was already 
+        /// called on the application builder.
+
         public T WithTelemetryCallback(TelemetryCallback telemetryCallback)
         {
             if (Config.TelemetryCallback  != null)
@@ -104,9 +122,11 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the Client ID of the application
         /// </summary>
-        /// <param name="clientId"></param>
-        /// <returns></returns>
+        /// <param name="clientId">Client ID (also known as <i>Application ID</i>) of the application as registered in the
+        ///  application registration portal (https://aka.ms/msal-net-register-app)</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithClientId(string clientId)
         {
             Config.ClientId = clientId;
@@ -114,9 +134,13 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the redirect URI of the application. See https://aka.ms/msal-net-application-configuration
         /// </summary>
-        /// <param name="redirectUri"></param>
-        /// <returns></returns>
+        /// <param name="redirectUri">URL where the STS will call back the application with the security token.
+        /// This parameter is not required for desktop or UWP applications (as a default is used).
+        /// It's not required for mobile applications that don't use a broker
+        /// It is required for Web Apps</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithRedirectUri(string redirectUri)
         {
             Config.RedirectUri = GetValueIfNotEmpty(Config.RedirectUri, redirectUri);
@@ -124,9 +148,15 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the Tenant Id of the organization from which the application will let
+        /// users sign-in. This is classically a GUID or a domain name. See https://aka.ms/msal-net-application-configuration.
+        /// Although this is also possible to set <paramref name="tenantId"/> to <c>common</c>, 
+        /// <c>organizations</c>, and <c>consumers</c>, it's rather recommended to use one of the
+        /// overrides of <see cref="AddKnownAadAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
         /// </summary>
-        /// <param name="tenantId"></param>
-        /// <returns></returns>
+        /// <param name="tenantId">tenant ID of the Azure AD tenant
+        /// or a domain associated with this Azure AD tenant, in order to sign-in user of a specific organization only</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithTenantId(string tenantId)
         {
             Config.TenantId = GetValueIfNotEmpty(Config.TenantId, tenantId);
@@ -134,9 +164,14 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Enables/disable logging of Personally Identifiable Information. See https://aka.ms/msal-net-logging
         /// </summary>
-        /// <param name="enablePiiLogging"></param>
-        /// <returns></returns>
+        /// <param name="enablePiiLogging">Boolean used to enable/disable logging of 
+        /// Personally Identifiable data (PII) data. 
+        /// PII logs are never written to default outputs like Console, Logcat or NSLog
+        /// Default is set to <c>false</c>, which ensures that your application is compliant with GDPR. 
+        /// You can set it to <c>true</c> for advanced debugging requiring PII</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithEnablePiiLogging(bool enablePiiLogging)
         {
             Config.EnablePiiLogging = enablePiiLogging;
@@ -144,9 +179,13 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Enables you to configure the level of logging you want. See https://aka.ms/msal-net-logging
+        /// The default value is <see cref="LogLevel.Info"/>.
+        /// Setting it to <see cref="LogLevel.Error"/> will only get errors
+        /// Setting it to <see cref="LogLevel.Warning"/> will get errors and warning, etc..
         /// </summary>
-        /// <param name="logLevel"></param>
-        /// <returns></returns>
+        /// <param name="logLevel">Desired level of logging</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithLoggingLevel(LogLevel logLevel)
         {
             Config.LogLevel = logLevel;
@@ -154,9 +193,13 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Flag to enable/disable logging to platform defaults. See https://aka.ms/msal-net-logging
+        /// In Desktop/UWP, Event Tracing is used. In iOS, NSLog is used.
+        /// In android, logcat is used. The default value is <c>false</c>
         /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns></returns>
+        /// <param name="enabled">Boolean telling if default logging is
+        /// enabled or not</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithDefaultPlatformLoggingEnabled(bool enabled)
         {
             Config.IsDefaultPlatformLoggingEnabled = enabled;
@@ -164,9 +207,11 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets application options, which can, for instance have been read. See https://aka.ms/msal-net-application-configuration.
+        /// from configuration files.
         /// </summary>
-        /// <param name="applicationOptions"></param>
-        /// <returns></returns>
+        /// <param name="applicationOptions">Application options</param>
+        /// <returns>The builder to chain the .With methods</returns>
         protected T WithOptions(ApplicationOptions applicationOptions)
         {
             WithClientId(applicationOptions.ClientId);
@@ -186,9 +231,13 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the identifier of the software component (libraries/SDK) consuming MSAL.NET.
+        /// This will allow for disambiguation between MSAL usage by the app vs MSAL usage 
+        /// by component libraries. You can, for instance set it to the name of your application.
+        /// This is used in telemetry.
         /// </summary>
-        /// <param name="component"></param>
-        /// <returns></returns>
+        /// <param name="component">identifier of the software component (libraries/SDK) consuming MSAL.NET</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithComponent(string component)
         {
             Config.Component = GetValueIfNotEmpty(Config.Component, component);
@@ -196,9 +245,13 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets a custom query parameters named slice= that may be sent to the STS for dogfood testing 
+        /// or debugging. 
+        /// Unless requested otherwise by Microsoft support, you should not set this parameter as it may have adverse effect on the application.
+        /// This property is also concatenated to the <c>extraQueryParameter</c> parameters of token acquisition operations.
         /// </summary>
-        /// <param name="sliceParameters"></param>
-        /// <returns></returns>
+        /// <param name="sliceParameters">name of the slice on which the application will run</param>
+        /// <returns>The builder to chain the .With methods</returns>
         public T WithSliceParameters(string sliceParameters)
         {
             Config.SliceParameters = GetValueIfNotEmpty(Config.SliceParameters, sliceParameters);
@@ -317,10 +370,16 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Adds a known authority to the application from its Uri. See https://aka.ms/msal-net-application-configuration.
+        /// This constructor is mainly used for scenarios where the authority is not a standard Azure AD authority,
+        /// nor an ADFS authority, nor an Azure AD B2C authority. For Azure AD, even in national and sovereign clouds, prefer
+        /// using other overrides such as <see cref="AddKnownAadAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
         /// </summary>
-        /// <param name="authorityUri"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="authorityUri">Uri of the authority</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority</remarks>
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAuthority(Uri authorityUri, bool isDefaultAuthority)
         {
             Config.AddAuthorityInfo(AuthorityInfo.FromAuthorityUri(authorityUri.ToString(), isDefaultAuthority));
@@ -328,12 +387,15 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Adds a known Azure AD authority to the application to sign-in users from a single
+        /// organization (single tenant application) specified by its tenant ID. See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="cloudInstanceUri"></param>
-        /// <param name="tenantId"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="cloudInstanceUri">Azure Cloud instance</param>
+        /// <param name="tenantId">Guid of the tenant from which to sign-in users</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority</remarks>
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAadAuthority(
             Uri cloudInstanceUri,
             Guid tenantId,
@@ -344,12 +406,20 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Adds a known Azure AD authority to the application to sign-in users from a single
+        /// organization (single tenant application) described by its domain name. See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="cloudInstanceUri"></param>
-        /// <param name="tenant"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="cloudInstanceUri">Uri to the Azure Cloud instance (for instance
+        /// <c>https://login.microsoftonline.com)</c></param>
+        /// <param name="tenant">domain name associated with the tenant from which to sign-in users</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// <paramref name="tenant"/> can also contain the string representation of a GUID (tenantId),
+        /// or even <c>common</c>, <c>organizations</c> or <c>consumers</c> but in this case
+        /// it's recommended to use another override (<see cref="AddKnownAadAuthority(AzureCloudInstance, Guid, bool)"/>
+        /// and <see cref="AddKnownAadAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/></remarks>
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAadAuthority(
             Uri cloudInstanceUri,
             string tenant,
@@ -365,12 +435,17 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Adds a known Azure AD authority to the application to sign-in users from a single
+        /// organization (single tenant application) described by its cloud instance and its tenant ID.
+        /// See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="azureCloudInstance"></param>
-        /// <param name="tenantId"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="azureCloudInstance">Instance of Azure Cloud (for instance Azure 
+        /// worldwide cloud, Azure German Cloud, US government ...)</param>
+        /// <param name="tenantId">Tenant Id of the tenant from which to sign-in users</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAadAuthority(
             AzureCloudInstance azureCloudInstance,
             Guid tenantId,
@@ -382,12 +457,18 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Adds a known Azure AD authority to the application to sign-in users from a single
+        /// organization (single tenant application) described by its cloud instance and its domain
+        /// name or tenant ID. See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="azureCloudInstance"></param>
-        /// <param name="tenant">Domain name or guid</param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="azureCloudInstance">Instance of Azure Cloud (for instance Azure 
+        /// worldwide cloud, Azure German Cloud, US government ...)</param>
+        /// <param name="tenant">Domain name associated with the Azure AD tenant from which 
+        /// to sign-in users. This can also be a guid</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAadAuthority(
             AzureCloudInstance azureCloudInstance,
             string tenant,
@@ -404,12 +485,18 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Adds a known Azure AD authority to the application to sign-in users specifying 
+        /// the cloud instance and the sign-in audience. See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="azureCloudInstance"></param>
-        /// <param name="authorityAudience"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="azureCloudInstance">Instance of Azure Cloud (for instance Azure 
+        /// worldwide cloud, Azure German Cloud, US government ...)</param>
+        /// <param name="authorityAudience">Sign-in audience (one AAD organization, 
+        /// any work and school accounts, or any work and school accounts and Microsoft personal
+        /// accounts</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAadAuthority(AzureCloudInstance azureCloudInstance, AadAuthorityAudience authorityAudience, bool isDefaultAuthority = false)
         {
             string authorityUri = GetAuthorityUri(azureCloudInstance, authorityAudience);
@@ -418,11 +505,17 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Adds a known Azure AD authority to the application to sign-in users specifying 
+        /// the sign-in audience (the cloud being the Azure public cloud). See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="authorityAudience"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="authorityAudience">Sign-in audience (one AAD organization, 
+        /// any work and school accounts, or any work and school accounts and Microsoft personal
+        /// accounts</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// <returns>The builder to chain the .With methods</returns>
+
         public T AddKnownAadAuthority(AadAuthorityAudience authorityAudience, bool isDefaultAuthority = false)
         {
             string authorityUri = GetAuthorityUri(AzureCloudInstance.AzurePublic, authorityAudience);
@@ -431,10 +524,23 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Adds a known Azure AD authority to the application to sign-in users specifying 
+        /// the full authority Uri. See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="authorityUri"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="authorityUri">URL of the security token service (STS) from which MSAL.NET will acquire the tokens.
+        ///  Usual authorities endpoints for the Azure public Cloud are:
+        ///  <list type="bullet">
+        ///  <item><description><c>https://login.microsoftonline.com/tenant/</c> where <c>tenant</c> is the tenant ID of the Azure AD tenant
+        ///  or a domain associated with this Azure AD tenant, in order to sign-in users of a specific organization only</description></item>
+        ///  <item><description><c>https://login.microsoftonline.com/common/</c> to sign-in users with any work and school accounts or Microsoft personal account</description></item>
+        ///  <item><description><c>https://login.microsoftonline.com/organizations/</c> to sign-in users with any work and school accounts</description></item>
+        ///  <item><description><c>https://login.microsoftonline.com/consumers/</c> to sign-in users with only personal Microsoft accounts (live)</description></item>
+        ///  </list>
+        ///  Note that this setting needs to be consistent with what is declared in the application registration portal</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAadAuthority(string authorityUri, bool isDefaultAuthority = false)
         {
             Config.AddAuthorityInfo(new AuthorityInfo(AuthorityType.Aad, authorityUri, isDefaultAuthority));
@@ -496,11 +602,15 @@ namespace Microsoft.Identity.Client.AppConfig
             }
         }
 
-        /// <summary>
+        /// <summary>   
+        /// Adds a known Authority corresponding to an ADFS server. See https://aka.ms/msal-net-adfs
         /// </summary>
-        /// <param name="authorityUri"></param>
-        /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="authorityUri">Authority URL for an ADFS server</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// MSAL.NET will only support ADFS 2019
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownAdfsAuthority(string authorityUri, bool isDefaultAuthority)
         {
             Config.AddAuthorityInfo(new AuthorityInfo(AuthorityType.Adfs, authorityUri, isDefaultAuthority));
@@ -508,10 +618,17 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Adds a know authority corresponding to an Azure AD B2C policy. 
+        /// See https://aka.ms/msal-net-b2c-specificities
         /// </summary>
-        /// <param name="authorityUri"></param>
+        /// <param name="authorityUri">Azure AD B2C authority, including the B2C policy (for instance
+        /// <c>"https://fabrikamb2c.b2clogin.com/tfp/{Tenant}/{policy}</c></param>)
         /// <param name="isDefaultAuthority"></param>
-        /// <returns></returns>
+        /// <param name="authorityUri">Authority URL for an ADFS server</param>
+        /// <param name="isDefaultAuthority">Boolean telling if this is the default authority
+        /// for the application</param>
+        /// <remarks>You can add several authorities, but only one can be the default authority.
+        /// <returns>The builder to chain the .With methods</returns>
         public T AddKnownB2CAuthority(string authorityUri, bool isDefaultAuthority)
         {
             Config.AddAuthorityInfo(new AuthorityInfo(AuthorityType.B2C, authorityUri, isDefaultAuthority));

--- a/src/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
@@ -28,48 +28,86 @@
 namespace Microsoft.Identity.Client.AppConfig
 {
     /// <summary>
-    ///     Options object with string values loadable from JSON configuration (as in an asp.net configuration scenario)
+    /// Options object with string values loadable from a configuration file 
+    /// (for instance a JSon file as in an asp.net configuration scenario)
+    /// See https://aka.ms/msal-net-application-configuration
     /// </summary>
     public abstract class ApplicationOptions
     {
         /// <summary>
+        /// Client ID (also known as App ID) of the application as registered in the
+        /// application registration portal (https://aka.ms/msal-net-register-app)
         /// </summary>
         public string ClientId { get; set; }
 
         /// <summary>
-        /// Can be domain, can be guid tenant, can be meta-tenant (e.g. consumers).
+        /// Tenant from which the application will allow users to sign it. This can be:
+        /// a domain associated with a tenant, a guid (tenant id), or a meta-tenant (e.g. consumers).
+        /// This property is mutually exclusive with <see cref="AadAuthorityAudience"/>
         /// </summary>
+        /// <remarks>The name of the property was chosen o ensure compatibility with AzureAdOptions 
+        /// in ASP.NET Core configuration files (even the semantics would be tenant)</remarks>
         public string TenantId { get; set; }
 
         /// <summary>
-        /// Mutually exclusive with TenantId...
+        /// Sign-in audience. This property is mutually exclusive with TenantId...
         /// </summary>
         public AadAuthorityAudience AadAuthorityAudience { get; set; } = AadAuthorityAudience.None;
 
         /// <summary>
-        /// For compat with AzureAdOptions...
+        /// STS instance (for instance https://login.microsoftonline.com for the Azure public cloud). 
+        /// The name was chosen to ensure compatibility with AzureAdOptions in ASP.NET Core.
+        /// This property is mutually exclusive with <see cref="AzureCloudInstance"/>
         /// </summary>
         public string Instance { get; set; }
 
         /// <summary>
-        /// Mutually exclusive with Instance, allows users to use the enum instead of the explicit url.
+        /// Specific instance in the case of Azure Active Directory. 
+        /// This property is mutually exclusive with <see cref="Instance"/>. 
+        /// It allows users to use the enum instead of the explicit url.
         /// </summary>
         public AzureCloudInstance AzureCloudInstance { get; set; } = AzureCloudInstance.None;
 
         /// <summary>
+        /// The redirect URI (also known as Reply URI or Reply URL), is the URI at which Azure AD will contact back the application with the tokens.
+        /// This redirect URI needs to be registered in the app registration (https://aka.ms/msal-net-register-app).
+        /// In MSAL.NET, <see cref="T:IPublicClientApplication"/> define the following default RedirectUri values:
+        /// <list type="bullet">
+        /// <item><description><c>urn:ietf:wg:oauth:2.0:oob</c> for desktop (.NET Framework and .NET Core) applications</description></item>
+        /// <item><description><c>msal{ClientId}</c> for Xamarin iOS and Xamarin Android without broker (as this will be used by the system web browser by default on these
+        /// platforms to call back the application)
+        /// </description></item>
+        /// </list>
+        /// These default URIs could change in the future.
+        /// In <see cref="Microsoft.Identity.Client.IConfidentialClientApplication"/>, this can be the URL of the Web application / Web API.
+        /// </summary>
+        /// <remarks>This is especially important when you deploy an application that you have initially tested locally;
+        /// you then need to add the reply URL of the deployed application in the application registration portal</remarks>
+
         /// </summary>
         public string RedirectUri { get; set; }
 
         /// <summary>
+        /// Enables you to configure the level of logging you want. The default value is <see cref="LogLevel.Info"/>. Setting it to <see cref="LogLevel.Error"/> will only get errors
+        /// Setting it to <see cref="LogLevel.Warning"/> will get errors and warning, etc..
+        /// See https://aka.ms/msal-net-logging
         /// </summary>
         public LogLevel LogLevel { get; set; }
 
         /// <summary>
+        /// Flag to enable/disable logging of Personally Identifiable data (PII) data. 
+        /// PII logs are never written to default outputs like Console, Logcat or NSLog
+        /// Default is set to <c>false</c>, which ensures that your application is compliant with GDPR. You can set
+        /// it to <c>true</c> for advanced debugging requiring PII. See https://aka.ms/msal-net-logging
         /// </summary>
+        /// <seealso cref="IsDefaultPlatformLoggingEnabled"/>
         public bool EnablePiiLogging { get; set; }
 
         /// <summary>
+        /// Flag to enable/disable logging to platform defaults. In Desktop/UWP, Event Tracing is used. In iOS, NSLog is used.
+        /// In android, logcat is used. The default value is <c>false</c>. See https://aka.ms/msal-net-logging
         /// </summary>
+        /// <seealso cref="EnablePiiLogging"/>
         public bool IsDefaultPlatformLoggingEnabled { get; set; }
 
         /// <summary>
@@ -78,6 +116,8 @@ namespace Microsoft.Identity.Client.AppConfig
         public string SliceParameters { get; set; }
 
         /// <summary>
+        /// Identifier of the component (libraries/SDK) consuming MSAL.NET.
+        /// This will allow for disambiguation between MSAL usage by the app vs MSAL usage by component libraries.
         ///     TODO: do we have a better / more descriptive name for this?
         /// </summary>
         public string Component { get; set; }

--- a/src/Microsoft.Identity.Client/AppConfig/AzureCloud.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AzureCloud.cs
@@ -32,27 +32,27 @@ namespace Microsoft.Identity.Client.AppConfig
     public enum AzureCloudInstance
     {
         /// <summary>
-        ///     Communicates that the AzureCloudInstance is not specified.
+        /// Value communicating that the AzureCloudInstance is not specified.
         /// </summary>
         None,
    
         /// <summary>
-        ///     Maps to https://login.microsoftonline.com
+        /// Microsoft Azure public cloud. Maps to https://login.microsoftonline.com
         /// </summary>
         AzurePublic,
 
         /// <summary>
-        ///     Maps to https://login.chinacloudapi.cn
+        /// Microsoft Chineses national cloud. Maps to https://login.chinacloudapi.cn
         /// </summary>
         AzureChina,
 
         /// <summary>
-        ///     Maps to https://login.microsoftonline.de
+        /// Microsoft German national cloud. Maps to https://login.microsoftonline.de
         /// </summary>
         AzureGermany,
 
         /// <summary>
-        ///     Maps to https://login.microsoftonline.us
+        /// Us Government cloud. Maps to https://login.microsoftonline.us
         /// </summary>
         AzureUsGovernment,
     };

--- a/src/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -43,9 +43,12 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Constructor of a ConfidentialClientApplicationBuilder from application configuration options
+        /// . See https://aka.ms/msal-net-application-configuration
         /// </summary>
-        /// <param name="options"></param>
-        /// <returns></returns>
+        /// <param name="options">Public client applications configuration options</param>
+        /// <returns>A <see cref="ConfidentialClientApplicationBuilder"/> from which to set more
+        /// parameters, and to create a public client application instance</returns>
         public static ConfidentialClientApplicationBuilder CreateWithApplicationOptions(
             ConfidentialClientApplicationOptions options)
         {
@@ -55,9 +58,13 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Creates a ConfidentialClientApplicationBuilder from a clientID. 
+        /// See https://aka.ms/msal-net-application-configuration
         /// </summary>
-        /// <param name="clientId"></param>
-        /// <returns></returns>
+        /// <param name="clientId">Client ID (also known as App ID) of the application as registered in the
+        /// application registration portal (https://aka.ms/msal-net-register-app)/.</param>
+        /// <returns>A <see cref="ConfidentialClientApplicationBuilder"/> from which to set more
+        /// parameters, and to create a public client application instance</returns>
         public static ConfidentialClientApplicationBuilder Create(string clientId)
         {
             var config = new ApplicationConfiguration();
@@ -65,8 +72,11 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the Application token cache. This cache is used in client credential flows
+        /// (<see cref="IConfidentialClientApplication.AcquireTokenForClientAsync(System.Collections.Generic.IEnumerable{string})"/>
+        /// and its override
         /// </summary>
-        /// <param name="tokenCache"></param>
+        /// <param name="tokenCache">Application token cache</param>
         /// <returns></returns>
         [Obsolete("You can access the AppTokenCache using the AppTokenCache property on the created IConfidentialClientApplication")]
         public ConfidentialClientApplicationBuilder WithAppTokenCache(TokenCache tokenCache)
@@ -75,8 +85,10 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Sets the user token cache. In a confidential client application, you should ensure that there is
+        /// one cache per user.
         /// </summary>
-        /// <param name="tokenCache"></param>
+        /// <param name="tokenCache">User token cache</param>
         /// <returns></returns>
         [Obsolete("You can access the UserTokenCache using the UserTokenCache property on the created IConfidentialClientApplication")]
         public ConfidentialClientApplicationBuilder WithUserTokenCache(TokenCache tokenCache)
@@ -85,9 +97,9 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Sets the certificate associated with the application
         /// </summary>
-        /// <param name="certificate"></param>
+        /// <param name="certificate">The X509 certificate used as credentials to prove the identity of the application to Azure AD.</param>
         /// <returns></returns>
         public ConfidentialClientApplicationBuilder WithX509Certificate2(X509Certificate2 certificate)
         {
@@ -96,9 +108,10 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// 
+        /// Sets the application secret
         /// </summary>
-        /// <param name="clientSecret"></param>
+        /// <param name="clientSecret">Secret string previously shared with AAD at application registration to prove the identity
+        /// of the application (the client) requesting the tokens</param>
         /// <returns></returns>
         public ConfidentialClientApplicationBuilder WithClientSecret(string clientSecret)
         {
@@ -156,6 +169,8 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Builds the ConfidentialClientApplication from the parameters set
+        /// in the builder
         /// </summary>
         /// <returns></returns>
         public IConfidentialClientApplication Build()

--- a/src/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationOptions.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationOptions.cs
@@ -28,10 +28,15 @@
 namespace Microsoft.Identity.Client.AppConfig
 {
     /// <summary>
+    /// Configuration options for a confidential client application 
+    /// (Web app / Web API / daemon app). See https://aka.ms/msal-net/application-configuration
     /// </summary>
     public class ConfidentialClientApplicationOptions : ApplicationOptions
     {
         /// <summary>
+        /// Client secret for the confidential client application. This secret (application password)
+        /// is provided by the application registration portal, or provided to Azure AD during the
+        /// application registration with PowerShell AzureAD, PowerShell AzureRM, or Azure CLI.
         /// </summary>
         public string ClientSecret { get; set; }
     }

--- a/src/Microsoft.Identity.Client/AppConfig/IMsalHttpClientFactory.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/IMsalHttpClientFactory.cs
@@ -30,12 +30,15 @@ using System.Net.Http;
 namespace Microsoft.Identity.Client.AppConfig
 {
     /// <summary>
+    /// Http Client Factory
     /// </summary>
     public interface IMsalHttpClientFactory
     {
         /// <summary>
+        /// Method returning an Http client that will be used to
+        /// communicate with Azure AD
         /// </summary>
-        /// <returns></returns>
+        /// <returns>An Http client</returns>
         HttpClient GetHttpClient();
     }
 }

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -41,9 +41,12 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Creates a PublicClientApplicationBuilder from public client application
+        /// configuration options. See https://aka.ms/msal-net-application-configuration
         /// </summary>
-        /// <param name="options"></param>
-        /// <returns></returns>
+        /// <param name="options">Public client applications configuration options</param>
+        /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
+        /// parameters, and to create a public client application instance</returns>
         public static PublicClientApplicationBuilder CreateWithApplicationOptions(PublicClientApplicationOptions options)
         {
             var config = new ApplicationConfiguration();
@@ -51,8 +54,13 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
+        /// Creates a PublicClientApplicationBuilder from a clientID. 
+        /// See https://aka.ms/msal-net-application-configuration
         /// </summary>
-        /// <param name="clientId"></param>
+        /// <param name="clientId">Client ID (also known as App ID) of the application as registered in the
+        /// application registration portal (https://aka.ms/msal-net-register-app)/.</param>
+        /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
+        /// parameters, and to create a public client application instance</returns>
         public static PublicClientApplicationBuilder Create(string clientId)
         {
             var config = new ApplicationConfiguration();

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationOptions.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationOptions.cs
@@ -28,6 +28,8 @@
 namespace Microsoft.Identity.Client.AppConfig
 {
     /// <summary>
+    /// Configuration options for a public client application (desktop/mobile app).
+    /// See https://aka.ms/msal-net/application-configuration
     /// </summary>
     public class PublicClientApplicationOptions : ApplicationOptions
     {


### PR DESCRIPTION
First cut of XML comment on the public API for App configuration.

@MarkZuber ; should I add comments to `IAppConfig`: I'm not sure I fully understand how it can be seen by developers.