### PR TITLE
add install_dependencies.ps1 for installing chromedriver

### DIFF
--- a/build/install_dependencies.ps1
+++ b/build/install_dependencies.ps1
@@ -1,0 +1,41 @@
+#requires -version 4.0
+#requires –runasadministrator
+
+function Test-ChocolateyPackageInstalled {
+  Param (
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Package
+  )
+  
+  Process {
+    $pkgResult = choco list --local-only --id-only --limit-output --exact $Package
+    
+    return (-Not ([string]::IsNullOrEmpty($pkgResult)))
+  }
+}
+
+function Test-IsChocolateyInstalled {
+  $ChocoInstalled = $false
+  if (Get-Command choco.exe -ErrorAction SilentlyContinue) {
+      $ChocoInstalled = $true
+  }
+  
+  return $ChocoInstalled
+}
+   
+
+
+if (-Not (Test-IsChocolateyInstalled)) {
+  Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+}
+
+$ChocoPackages = 'chromedriver'
+
+ForEach ($PackageName in $ChocoPackages) {
+  if (-Not (Test-ChocolateyPackageInstalled($PackageName))) {
+    choco install $PackageName -y
+  }
+}
+
+choco upgrade all -y --limit-output


### PR DESCRIPTION
Adding a powershell script to install chocolatey (if it doesn't already exist) and install the chromedriver.  We can use this for other dependencies as well in the future (including the ability to install VS Community with the appropriate packages, install OS dependencies, install certificates, etc.