### PR TITLE
send client info headers to userrealm endpoint

### DIFF
--- a/src/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Client.Http
 
         public async Task<HttpResponse> SendGetAsync(
             Uri endpoint,
-            Dictionary<string, string> headers,
+            IDictionary<string, string> headers,
             RequestContext requestContext)
         {
             return await ExecuteWithRetryAsync(endpoint, headers, null, HttpMethod.Get, requestContext).ConfigureAwait(false);

--- a/src/Microsoft.Identity.Client/Http/IHttpManager.cs
+++ b/src/Microsoft.Identity.Client/Http/IHttpManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Client.Http
 
         Task<HttpResponse> SendGetAsync(
             Uri endpoint,
-            Dictionary<string, string> headers,
+            IDictionary<string, string> headers,
             RequestContext requestContext);
 
         Task<IHttpWebResponse> SendPostForceResponseAsync(

--- a/src/Microsoft.Identity.Client/WsTrust/IWsTrustWebRequestManager.cs
+++ b/src/Microsoft.Identity.Client/WsTrust/IWsTrustWebRequestManager.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 

--- a/src/Microsoft.Identity.Client/WsTrust/IWsTrustWebRequestManager.cs
+++ b/src/Microsoft.Identity.Client/WsTrust/IWsTrustWebRequestManager.cs
@@ -25,7 +25,6 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 

--- a/src/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -139,12 +139,12 @@ namespace Microsoft.Identity.Client.WsTrust
         {
             requestContext.Logger.Info("Sending request to userrealm endpoint.");
 
-            var uri = new UriBuilder(userRealmUriPrefix + userName + "?api-version=1.0").Uri;
+             var uri = new UriBuilder(userRealmUriPrefix + userName + "?api-version=1.0").Uri;
 
-            var httpResponse = await _httpManager.SendGetAsync(uri, null, requestContext).ConfigureAwait(false);
+            var httpResponse = await _httpManager.SendGetAsync(uri, MsalIdHelper.GetMsalIdParameters(requestContext.Logger), requestContext).ConfigureAwait(false);
             return httpResponse.StatusCode == System.Net.HttpStatusCode.OK 
                 ? JsonHelper.DeserializeFromJson<UserRealmDiscoveryResponse>(httpResponse.Body) 
                 : null;
         }
-    }
+    } 
 }

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -310,8 +310,8 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         {
             return new MockHttpMessageHandler()
             {
-                Url = url,
-                Method = HttpMethod.Get,
+                ExpectedUrl = url,
+                ExpectedMethod = HttpMethod.Get,
                 ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(content)

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler()
                 {
-                    Url = authority + "oauth2/v2.0/token",
-                    Method = HttpMethod.Post,
-                    PostData = bodyParameters,
-                    QueryParams = queryParameters,
+                    ExpectedUrl = authority + "oauth2/v2.0/token",
+                    ExpectedMethod = HttpMethod.Post,
+                    ExpectedPostData = bodyParameters,
+                    ExpectedQueryParams = queryParameters,
                     ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
                 });
         }
@@ -71,9 +71,9 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler()
                 {
-                    Method = HttpMethod.Get,
-                    PostData = bodyParameters,
-                    QueryParams = queryParameters,
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedPostData = bodyParameters,
+                    ExpectedQueryParams = queryParameters,
                     ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
                 });
         }
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler()
                 {
-                    Method = httpMethod,
+                    ExpectedMethod = httpMethod,
                     ResponseMessage = MockHelpers.CreateResiliencyMessage(httpStatusCode)
                 });
         }
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler()
                 {
-                    Method = httpMethod,
+                    ExpectedMethod = httpMethod,
                     ResponseMessage = MockHelpers.CreateRequestTimeoutResponseMessage(),
                     ExceptionToThrow = new TaskCanceledException("request timed out")
                 });
@@ -107,8 +107,8 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler
                 {
-                    Url = authority + "v2.0/.well-known/openid-configuration",
-                    Method = HttpMethod.Get,
+                    ExpectedUrl = authority + "v2.0/.well-known/openid-configuration",
+                    ExpectedMethod = HttpMethod.Get,
                     ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(authority, qp)
                 });
         }
@@ -118,8 +118,8 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler()
                 {
-                    Url = url,
-                    Method = httpMethod,
+                    ExpectedUrl = url,
+                    ExpectedMethod = httpMethod,
                     ResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
                     {
                         Content = new StringContent("Not found")
@@ -132,7 +132,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler()
                 {
-                    Method = HttpMethod.Post,
+                    ExpectedMethod = HttpMethod.Post,
                     ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage()
                 });
         }
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             httpManager.AddMockHandler(
                 new MockHttpMessageHandler
                 {
-                    Method = HttpMethod.Get,
+                    ExpectedMethod = HttpMethod.Get,
                     ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new StringContent("Foo")

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
@@ -41,27 +41,33 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
     internal class MockHttpMessageHandler : HttpMessageHandler
     {
         public HttpResponseMessage ResponseMessage { get; set; }
-        public string Url { get; set; }
-        public IDictionary<string, string> QueryParams { get; set; }
-        public IDictionary<string, string> PostData { get; set; }
-        public IDictionary<string, object> PostDataObject { get; set; }
-        public IDictionary<string, string> Headers { get; set; }
-        public HttpMethod Method { get; set; }
+        public string ExpectedUrl { get; set; }
+        public IDictionary<string, string> ExpectedQueryParams { get; set; }
+        public IDictionary<string, string> ExpectedPostData { get; set; }
+        public IDictionary<string, object> ExpectedPostDataObject { get; set; }
+        public HttpMethod ExpectedMethod { get; set; }
         public Exception ExceptionToThrow { get; set; }
         public Action<HttpRequestMessage> AdditionalRequestValidation { get; set; }
 
+        /// <summary>
+        /// Once the http message is executed, this property holds the request message
+        /// </summary>
+        public HttpRequestMessage ActualRequestMessge { get; private set; }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            ActualRequestMessge = request;
+
             if (ExceptionToThrow != null)
             {
                 throw ExceptionToThrow;
             }
 
             var uri = request.RequestUri;
-            if (!string.IsNullOrEmpty(Url))
+            if (!string.IsNullOrEmpty(ExpectedUrl))
             {
                 Assert.AreEqual(
-                    Url,
+                    ExpectedUrl,
                     uri.AbsoluteUri.Split(
                         new[]
                         {
@@ -69,10 +75,10 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                         })[0]);
             }
 
-            Assert.AreEqual(Method, request.Method);
+            Assert.AreEqual(ExpectedMethod, request.Method);
 
             // Match QP passed in for validation. 
-            if (QueryParams != null)
+            if (ExpectedQueryParams != null)
             {
                 Assert.IsFalse(
                     string.IsNullOrEmpty(uri.Query),
@@ -81,7 +87,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                         "provided url ({0}) does not contain query parameters, as expected",
                         uri.AbsolutePath));
                 IDictionary<string, string> inputQp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', false, null);
-                foreach (string key in QueryParams.Keys)
+                foreach (string key in ExpectedQueryParams.Keys)
                 {
                     Assert.IsTrue(
                         inputQp.ContainsKey(key),
@@ -90,37 +96,38 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                             "expected QP ({0}) not found in the url ({1})",
                             key,
                             uri.AbsolutePath));
-                    Assert.AreEqual(QueryParams[key], inputQp[key]);
+                    Assert.AreEqual(ExpectedQueryParams[key], inputQp[key]);
                 }
             }
 
+
             // Match QP passed in for validation.
-            if (QueryParams != null)
+            if (ExpectedQueryParams != null)
             {
                 Assert.IsFalse(string.IsNullOrEmpty(uri.Query));
                 IDictionary<string, string> inputQp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', false, null);
-                foreach (string key in QueryParams.Keys)
+                foreach (string key in ExpectedQueryParams.Keys)
                 {
                     Assert.IsTrue(inputQp.ContainsKey(key));
-                    Assert.AreEqual(QueryParams[key], inputQp[key]);
+                    Assert.AreEqual(ExpectedQueryParams[key], inputQp[key]);
                 }
             }
 
-            if (PostData != null)
+            if (ExpectedPostData != null)
             {
                 string postData = request.Content.ReadAsStringAsync().Result;
                 Dictionary<string, string> requestPostDataPairs = CoreHelpers.ParseKeyValueList(postData, '&', true, null);
 
-                foreach (string key in PostData.Keys)
+                foreach (string key in ExpectedPostData.Keys)
                 {
                     Assert.IsTrue(requestPostDataPairs.ContainsKey(key));
                     if (key.Equals(OAuth2Parameter.Scope, StringComparison.OrdinalIgnoreCase))
                     {
-                        CoreAssert.AreScopesEqual(PostData[key], requestPostDataPairs[key]);
+                        CoreAssert.AreScopesEqual(ExpectedPostData[key], requestPostDataPairs[key]);
                     }
                     else
                     {
-                        Assert.AreEqual(PostData[key], requestPostDataPairs[key]);
+                        Assert.AreEqual(ExpectedPostData[key], requestPostDataPairs[key]);
                     }
                 }
             }

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string DefaultAccessToken = "DefaultAccessToken";
         public const string DefaultClientAssertion = "DefaultClientAssertion";
         public const string RawClientId = "eyJ1aWQiOiJteS11aWQiLCJ1dGlkIjoibXktdXRpZCJ9";
+        public const string XClientSku =  "x-client-SKU";
+        public const string XClientVer = "x-client-Ver";
         public const TokenSubjectType TokenSubjectTypeUser = 0;
         public enum AuthorityType { B2C };
         public static string[] ProdEnvAliases = new string[] {

--- a/tests/Microsoft.Identity.Test.Unit.net45/AuthorityAliasesTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/AuthorityAliasesTests.cs
@@ -83,9 +83,9 @@ namespace Microsoft.Identity.Test.Unit
                 // mock for openId config request
                 httpManager.AddMockHandler(new MockHttpMessageHandler
                 {
-                    Url = string.Format(CultureInfo.InvariantCulture, "https://{0}/common/v2.0/.well-known/openid-configuration",
+                    ExpectedUrl = string.Format(CultureInfo.InvariantCulture, "https://{0}/common/v2.0/.well-known/openid-configuration",
                         MsalTestConstants.ProductionPrefNetworkEnvironment),
-                    Method = HttpMethod.Get,
+                    ExpectedMethod = HttpMethod.Get,
                     ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(MsalTestConstants.AuthorityHomeTenant)
                 });
 
@@ -98,9 +98,9 @@ namespace Microsoft.Identity.Test.Unit
                 // mock token request
                 httpManager.AddMockHandler(new MockHttpMessageHandler
                 {
-                    Url = string.Format(CultureInfo.InvariantCulture, "https://{0}/home/oauth2/v2.0/token",
+                    ExpectedUrl = string.Format(CultureInfo.InvariantCulture, "https://{0}/home/oauth2/v2.0/token",
                         MsalTestConstants.ProductionPrefNetworkEnvironment),
-                    Method = HttpMethod.Post,
+                    ExpectedMethod = HttpMethod.Post,
                     ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
                 });
 
@@ -124,9 +124,9 @@ namespace Microsoft.Identity.Test.Unit
                 // mock for openId config request for tenant specific authority
                 httpManager.AddMockHandler(new MockHttpMessageHandler
                 {
-                    Url = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/v2.0/.well-known/openid-configuration",
+                    ExpectedUrl = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/v2.0/.well-known/openid-configuration",
                         MsalTestConstants.ProductionPrefNetworkEnvironment, MsalTestConstants.Utid),
-                    Method = HttpMethod.Get,
+                    ExpectedMethod = HttpMethod.Get,
                     ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(MsalTestConstants.AuthorityUtidTenant)
                 });
 
@@ -137,10 +137,10 @@ namespace Microsoft.Identity.Test.Unit
 
                     httpManager.AddMockHandler(new MockHttpMessageHandler()
                     {
-                        Url = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/oauth2/v2.0/token",
+                        ExpectedUrl = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/oauth2/v2.0/token",
                             MsalTestConstants.ProductionPrefNetworkEnvironment, MsalTestConstants.Utid),
-                        Method = HttpMethod.Post,
-                        PostData = new Dictionary<string, string>()
+                        ExpectedMethod = HttpMethod.Post,
+                        ExpectedPostData = new Dictionary<string, string>()
                     {
                         {"grant_type", "refresh_token"}
                     },

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheFormatTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheFormatTests.cs
@@ -207,12 +207,12 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 //add mock response for tenant endpoint discovery
                 harness.HttpManager.AddMockHandler(new MockHttpMessageHandler
                 {
-                    Method = HttpMethod.Get,
+                    ExpectedMethod = HttpMethod.Get,
                     ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(MsalTestConstants.AuthorityHomeTenant)
                 });
                 harness.HttpManager.AddMockHandler(new MockHttpMessageHandler
                 {
-                    Method = HttpMethod.Post,
+                    ExpectedMethod = HttpMethod.Post,
                     ResponseMessage = MockHelpers.CreateSuccessResponseMessage(TokenResponse)
                 });
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheTests.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
-                        PostData = new Dictionary<string, string>()
+                        ExpectedMethod = HttpMethod.Post,
+                        ExpectedPostData = new Dictionary<string, string>()
                         {
                             {"grant_type", "refresh_token"}
                         },

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -60,9 +60,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://login.microsoftonline.com/common/discovery/instance",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.microsoftonline.com/common/discovery/instance",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.1"},
                             {
@@ -78,8 +78,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://login.microsoftonline.in/mytenant.com/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.microsoftonline.in/mytenant.com/.well-known/openid-configuration",
                         ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
                            File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("OpenidConfiguration.json")))
                     });
@@ -115,8 +115,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://login.microsoftonline.in/mytenant.com/v2.0/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.microsoftonline.in/mytenant.com/v2.0/.well-known/openid-configuration",
                         ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
                            File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("OpenidConfiguration.json")))
                     });
@@ -151,9 +151,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://login.microsoftonline.com/common/discovery/instance",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.microsoftonline.com/common/discovery/instance",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.1"},
                             {
@@ -202,9 +202,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://login.windows.net/common/discovery/instance",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.windows.net/common/discovery/instance",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.0"},
                             {"authorization_endpoint", "https://login.microsoft0nline.com/mytenant.com/oauth2/v2.0/authorize"},
@@ -242,8 +242,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://login.microsoftonline.in/mytenant.com/v2.0/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.microsoftonline.in/mytenant.com/v2.0/.well-known/openid-configuration",
                         ResponseMessage =
                             MockHelpers.CreateSuccessResponseMessage(
                                 File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("OpenidConfiguration-MissingFields.json")))

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AdfsAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AdfsAuthorityTests.cs
@@ -73,9 +73,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.0"}
                         },
@@ -88,9 +88,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"resource", "https://fs.contoso.com"},
                             {"rel", "http://schemas.microsoft.com/rel/trusted-realm"}
@@ -102,8 +102,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
                         ResponseMessage =
                             MockHelpers.CreateSuccessResponseMessage(
                                 ResourceHelper.GetTestResourceRelativePath(File.ReadAllText("OpenidConfiguration-OnPremise.json")))
@@ -148,9 +148,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.0"}
                         },
@@ -161,9 +161,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://enterpriseregistration.windows.net/fabrikam.com/enrollmentserver/contract",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://enterpriseregistration.windows.net/fabrikam.com/enrollmentserver/contract",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.0"}
                         },
@@ -176,9 +176,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"resource", "https://fs.contoso.com"},
                             {"rel", "http://schemas.microsoft.com/rel/trusted-realm"}
@@ -190,8 +190,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
                         ResponseMessage =
                             MockHelpers.CreateSuccessResponseMessage(
                                 ResourceHelper.GetTestResourceRelativePath(File.ReadAllText("OpenidConfiguration-OnPremise.json")))
@@ -223,8 +223,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
                         ResponseMessage =
                             MockHelpers.CreateSuccessResponseMessage(
                                 ResourceHelper.GetTestResourceRelativePath(File.ReadAllText("OpenidConfiguration-OnPremise.json")))
@@ -255,9 +255,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.0"}
                         },
@@ -270,9 +270,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"resource", "https://fs.contoso.com"},
                             {"rel", "http://schemas.microsoft.com/rel/trusted-realm"}
@@ -310,9 +310,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.0"}
                         },
@@ -325,9 +325,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.fabrikam.com/adfs/.well-known/webfinger",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"resource", "https://fs.contoso.com"},
                             {"rel", "http://schemas.microsoft.com/rel/trusted-realm"}
@@ -364,9 +364,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
-                        QueryParams = new Dictionary<string, string>
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://enterpriseregistration.fabrikam.com/enrollmentserver/contract",
+                        ExpectedQueryParams = new Dictionary<string, string>
                         {
                             {"api-version", "1.0"}
                         },
@@ -404,8 +404,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://fs.contoso.com/adfs/.well-known/openid-configuration",
                         ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
                             ResourceHelper.GetTestResourceRelativePath(File.ReadAllText("OpenidConfiguration-MissingFields-OnPremise.json")))
                     });

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/B2cAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/B2cAuthorityTests.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://mytenant.com.b2clogin.com/tfp/mytenant.com/my-policy/v2.0/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://mytenant.com.b2clogin.com/tfp/mytenant.com/my-policy/v2.0/.well-known/openid-configuration",
                         ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
                            File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("OpenidConfiguration-B2CLogin.json")))
                     });
@@ -127,8 +127,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
-                        Url = "https://login.microsoftonline.com/tfp/mytenant.com/my-policy/v2.0/.well-known/openid-configuration",
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.microsoftonline.com/tfp/mytenant.com/my-policy/v2.0/.well-known/openid-configuration",
                         ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
                            File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("OpenidConfiguration-B2C.json")))
                     });

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustEndpointTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustEndpointTests.cs
@@ -27,7 +27,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.WsTrust;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustEndpointTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustEndpointTests.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.WsTrust;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -145,10 +146,10 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
                 "<wsa:messageID>urn:uuid:b052e0d8-349c-4d73-9ddb-0782043a440e</wsa:messageID>" +
                 "<wsa:ReplyTo><wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>" +
                 "</wsa:ReplyTo><wsa:To s:mustUnderstand=\"1\">https://windowsorusernamepasswordendpointurl/</wsa:To>" +
-                "<wsse:Security s:mustUnderstand=\"1\" xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">" + 
-                "<wsu:Timestamp wsu:Id=\"MSATimeStamp\"><wsu:Created>2018-10-02T10:15:30.068Z</wsu:Created>" + 
-                "<wsu:Expires>2018-10-02T10:25:30.068Z</wsu:Expires></wsu:Timestamp>" + 
-                "<wsse:UsernameToken wsu:Id=\"UnPwSecTok13-d9d9bd71-1cfd-4dbf-8d9d-0bc5cfdbbe72\">" + 
+                "<wsse:Security s:mustUnderstand=\"1\" xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">" +
+                "<wsu:Timestamp wsu:Id=\"MSATimeStamp\"><wsu:Created>2018-10-02T10:15:30.068Z</wsu:Created>" +
+                "<wsu:Expires>2018-10-02T10:25:30.068Z</wsu:Expires></wsu:Timestamp>" +
+                "<wsse:UsernameToken wsu:Id=\"UnPwSecTok13-d9d9bd71-1cfd-4dbf-8d9d-0bc5cfdbbe72\">" +
                 "<wsse:Username>the_username</wsse:Username><wsse:Password>the_password</wsse:Password></wsse:UsernameToken></wsse:Security>" +
                 "</s:Header><s:Body><wst:RequestSecurityToken xmlns:wst=\"http://docs.oasis-open.org/ws-sx/ws-trust/200512\">" +
                 "<wsp:AppliesTo xmlns:wsp=\"http://schemas.xmlsoap.org/ws/2004/09/policy\"><wsa:EndpointReference>" +

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Url = wsTrustAddress,
-                        Method = HttpMethod.Post,
+                        ExpectedUrl = wsTrustAddress,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new StringContent(

--- a/tests/Microsoft.Identity.Test.Unit.net45/JsonWebTokenTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/JsonWebTokenTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Test.Unit
 
         private readonly MockHttpMessageHandler X5CMockHandler = new MockHttpMessageHandler()
         {
-            Method = HttpMethod.Post,
+            ExpectedMethod = HttpMethod.Post,
             ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                 MsalTestConstants.Scope.AsSingleString(),
                 MockHelpers.CreateIdToken(MsalTestConstants.UniqueId, MsalTestConstants.DisplayableId),

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -427,7 +427,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
+                        ExpectedMethod = HttpMethod.Get,
                         ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
                             File.ReadAllText(
                                 ResourceHelper.GetTestResourceRelativePath(@"OpenidConfiguration-QueryParams-B2C.json")))
@@ -625,7 +625,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage =
                             MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage(TokenRetrievedFromNetCall)
                     });

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             "some-scope1 some-scope2",
                             MockHelpers.CreateIdToken(MsalTestConstants.UniqueId, MsalTestConstants.DisplayableId),
@@ -359,7 +359,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.Scope.ToString(),
                             MockHelpers.CreateIdToken(
@@ -427,7 +427,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.Scope.AsSingleString(),
                             MockHelpers.CreateIdToken(MsalTestConstants.UniqueId, MsalTestConstants.DisplayableId),
@@ -495,7 +495,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.Scope.AsSingleString(),
                             MockHelpers.CreateIdToken(MsalTestConstants.UniqueId, MsalTestConstants.DisplayableId),
@@ -744,7 +744,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -825,7 +825,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -868,7 +868,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -896,7 +896,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -924,7 +924,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -951,7 +951,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -996,7 +996,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -1022,7 +1022,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -1050,7 +1050,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(
                             MsalTestConstants.UniqueId,
                             MsalTestConstants.DisplayableId,
@@ -1094,7 +1094,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateInvalidGrantTokenResponseMessage()
                     });
                 try

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/DeviceCodeRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/DeviceCodeRequestTests.cs
@@ -266,8 +266,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             harness.HttpManager.AddMockHandler(
                 new MockHttpMessageHandler
                 {
-                    Method = HttpMethod.Post,
-                    PostData = new Dictionary<string, string>()
+                    ExpectedMethod = HttpMethod.Post,
+                    ExpectedPostData = new Dictionary<string, string>()
                     {
                         {OAuth2Parameter.ClientId, MsalTestConstants.ClientId},
                         {OAuth2Parameter.Scope, expectedScopes.AsSingleString()}
@@ -280,8 +280,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
-                        Url = "https://login.microsoftonline.com/home/oauth2/v2.0/token",
+                        ExpectedMethod = HttpMethod.Post,
+                        ExpectedUrl = "https://login.microsoftonline.com/home/oauth2/v2.0/token",
                         ResponseMessage = MockHelpers.CreateFailureMessage(
                             HttpStatusCode.Forbidden,
                             "{\"error\":\"authorization_pending\"," +
@@ -300,8 +300,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
-                        PostData = new Dictionary<string, string>()
+                        ExpectedMethod = HttpMethod.Post,
+                        ExpectedPostData = new Dictionary<string, string>()
                         {
                             {OAuth2Parameter.ClientId, MsalTestConstants.ClientId},
                             {OAuth2Parameter.Scope, expectedScopes.AsSingleString()}

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -302,8 +302,12 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.IsNotNull(result.Account);
                 Assert.AreEqual(MsalTestConstants.DisplayableId, result.Account.Username);
                 Assert.IsNotNull(realmDiscoveryHandler.ActualRequestMessge.Headers);
-                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), "x-client-SKU");
-                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), "x-client-Ver");
+                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), MsalTestConstants.XClientSku,
+                    "Client info header should contain " + MsalTestConstants.XClientSku,
+                    StringComparison.OrdinalIgnoreCase);
+                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), MsalTestConstants.XClientVer,
+                    "Client info header should contain " + MsalTestConstants.XClientVer,
+                    StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -334,8 +338,12 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.IsNotNull(result.Account);
                 Assert.AreEqual(MsalTestConstants.User.Username, result.Account.Username);
                 Assert.IsNotNull(realmDiscoveryHandler.ActualRequestMessge.Headers);
-                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), "x-client-SKU");
-                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), "x-client-Ver");
+                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), MsalTestConstants.XClientSku,
+                    "Client info header should contain " + MsalTestConstants.XClientSku,
+                    StringComparison.OrdinalIgnoreCase);
+                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessge.Headers.ToString(), MsalTestConstants.XClientVer,
+                    "Client info header should contain " + MsalTestConstants.XClientVer,
+                    StringComparison.OrdinalIgnoreCase);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
@@ -85,8 +85,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Post,
-                        QueryParams = new Dictionary<string, string>()
+                        ExpectedMethod = HttpMethod.Post,
+                        ExpectedQueryParams = new Dictionary<string, string>()
                         {
                             {"key1", "value1%20with%20encoded%20space"},
                             {"key2", "value2"}
@@ -258,7 +258,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
+                        ExpectedMethod = HttpMethod.Get,
                         ResponseMessage = MockHelpers.CreateTooManyRequestsNonJsonResponse() // returns a non json response
                     });
 
@@ -307,7 +307,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {
-                        Method = HttpMethod.Get,
+                        ExpectedMethod = HttpMethod.Get,
                         ResponseMessage = MockHelpers.CreateTooManyRequestsJsonResponse() // returns a non json response
                     });
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler()
                     {
-                        Method = HttpMethod.Post,
+                        ExpectedMethod = HttpMethod.Post,
                         ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
                     });
 


### PR DESCRIPTION
[#820](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/820)