### PR TITLE
Add support for WIthClaims

### DIFF
--- a/src/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -92,6 +92,20 @@ namespace Microsoft.Identity.Client.ApiConfig
             return (T)this;
         }
 
+
+        /// <summary>
+        /// Sets claims in the query. Use when the AAD admin has enabled conditional access. Acquiring the token normally will result in a
+        /// <see cref="MsalServiceException"/> with the <see cref="MsalServiceException.Claims"/> property set. Retry the 
+        /// token acquisition, and use this value in the <see cref="WithClaims(string)"/> method. See https://aka.ms/msal-exceptions for details
+        /// </summary>
+        /// <param name="claims">A string with one or multiple claims.</param>
+        /// <returns>The builder to chain .With methods</returns>
+        public T WithClaims(string claims)
+        {
+            CommonParameters.Claims = claims;
+            return (T)this;
+        }
+
         // This exists for back compat with old-style API.  Once we deprecate it, we can remove this.
         internal T WithExtraQueryParameters(string extraQueryParameters)
         {

--- a/src/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     {
         public ApiEvent.ApiIds ApiId { get; set; } = ApiEvent.ApiIds.None;
         public IEnumerable<string> Scopes { get; set; }
-        public Dictionary<string, string> ExtraQueryParameters { get; set; }
+        public IDictionary<string, string> ExtraQueryParameters { get; set; }
+        public string Claims { get; set; }
         public AuthorityInfo AuthorityOverride { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -28,12 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http;
-using Microsoft.Identity.Client.PlatformsCommon.Factories;
-using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.AppConfig
 {
@@ -56,6 +51,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// or setting the Agent.
         /// </summary>
         /// <param name="httpClientFactory">HTTP client factory</param>
+        /// <remarks>MSAL does not guarantee that it will not modify the HttpClient, for example by adding new headers.</remarks>
         /// <returns>The builder to chain the .With methods</returns>
         public T WithHttpClientFactory(IMsalHttpClientFactory httpClientFactory)
         {
@@ -88,9 +84,9 @@ namespace Microsoft.Identity.Client.AppConfig
         /// <exception cref="InvalidOperationException"/> is thrown if the loggingCallback
         /// was already set on the application builder
         public T WithLogging(
-            LogCallback loggingCallback, 
-            LogLevel? logLevel = null, 
-            bool? enablePiiLogging = null, 
+            LogCallback loggingCallback,
+            LogLevel? logLevel = null,
+            bool? enablePiiLogging = null,
             bool? enableDefaultPlatformLogging = null)
         {
             if (Config.LoggingCallback != null)
@@ -102,6 +98,19 @@ namespace Microsoft.Identity.Client.AppConfig
             Config.LogLevel = logLevel ?? Config.LogLevel;
             Config.EnablePiiLogging = enablePiiLogging ?? Config.EnablePiiLogging;
             Config.IsDefaultPlatformLoggingEnabled = enableDefaultPlatformLogging ?? Config.IsDefaultPlatformLoggingEnabled;
+            return (T)this;
+        }
+
+        /// <summary>
+        /// Use when the AAD admin has enabled conditional access. Acquiring the token normally will result in a
+        /// <see cref="MsalServiceException"/> with the <see cref="MsalServiceException.Claims"/> property set. Retry the 
+        /// token acquisition, and use this value in the <see cref="WithClaims(string)"/> method. See https://aka.ms/msal-exceptions for details
+        /// </summary>
+        /// <param name="claims">A string with one or multiple claims.</param>
+        /// <returns>The builder to chain .With methods</returns>
+        public T WithClaims(string claims)
+        {
+            Config.Claims = claims;
             return (T)this;
         }
 
@@ -126,7 +135,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// <seealso cref="WithLogging(LogCallback, LogLevel?, bool?, bool?)"/>
         public T WithDebugLoggingCallback(
             LogLevel logLevel = LogLevel.Info,
-            bool enablePiiLogging = false, 
+            bool enablePiiLogging = false,
             bool withDefaultPlatformLoggingEnabled = false)
         {
             WithLogging(
@@ -148,7 +157,7 @@ namespace Microsoft.Identity.Client.AppConfig
 
         public T WithTelemetry(TelemetryCallback telemetryCallback)
         {
-            if (Config.TelemetryCallback  != null)
+            if (Config.TelemetryCallback != null)
             {
                 throw new InvalidOperationException(CoreErrorMessages.TelemetryCallbackAlreadySet);
             }
@@ -213,8 +222,8 @@ namespace Microsoft.Identity.Client.AppConfig
             WithComponent(applicationOptions.Component);
 
             WithLogging(
-                null, 
-                applicationOptions.LogLevel, 
+                null,
+                applicationOptions.LogLevel,
                 applicationOptions.EnablePiiLogging,
                 applicationOptions.IsDefaultPlatformLoggingEnabled);
 
@@ -246,7 +255,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// as a string of segments of the form <c>key=value</c> separated by an ampersand character.
         /// The parameter can be null.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithExtraQueryParameters(Dictionary<string, string> extraQueryParameters)
+        public T WithExtraQueryParameters(IDictionary<string, string> extraQueryParameters)
         {
             Config.ExtraQueryParameters = extraQueryParameters ?? new Dictionary<string, string>();
             return (T)this;

--- a/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -102,9 +102,9 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// Use when the AAD admin has enabled conditional access. Acquiring the token normally will result in a
-        /// <see cref="MsalServiceException"/> with the <see cref="MsalServiceException.Claims"/> property set. Retry the 
-        /// token acquisition, and use this value in the <see cref="WithClaims(string)"/> method. See https://aka.ms/msal-exceptions for details
+        /// Use when the tenant admin has enabled conditional access. Acquiring a token, either in your app or in a downstream API, 
+        /// could result in a <see cref="MsalServiceException"/> with the <see cref="MsalServiceException.Claims"/> property set. Retry the 
+        /// token acquisition, and use this value in the <see cref="WithClaims(string)"/> method. See https://aka.ms/msal-exceptions for details.
         /// </summary>
         /// <param name="claims">A string with one or multiple claims.</param>
         /// <returns>The builder to chain .With methods</returns>

--- a/src/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -54,16 +54,18 @@ namespace Microsoft.Identity.Client.AppConfig
         public TelemetryCallback TelemetryCallback { get; internal set; }
         public LogCallback LoggingCallback { get; internal set; }
         public string Component { get; internal set; }
-        public Dictionary<string, string> ExtraQueryParameters { get; internal set; } = new Dictionary<string, string>();
+        public string Claims { get; internal set; }
+        public IDictionary<string, string> ExtraQueryParameters { get; internal set; } = new Dictionary<string, string>();
 
         internal ILegacyCachePersistence UserTokenLegacyCachePersistenceForTest { get; set; }
         internal ILegacyCachePersistence AppTokenLegacyCachePersistenceForTest { get; set; }
 
 #if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide confidential client on mobile platforms
+
         public ClientCredential ClientCredential { get; internal set; }
         public string ClientSecret { get; internal set; }
         public X509Certificate2 Certificate { get; internal set; }
-#endif
+#endif 
 
         /// <summary>
         /// Should _not_ go in the interface, only for builder usage while determining authorities with ApplicationOptions

--- a/src/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
@@ -75,7 +75,11 @@ namespace Microsoft.Identity.Client.AppConfig
 
         /// <summary>
         /// </summary>
-        Dictionary<string, string> ExtraQueryParameters { get; }
+        IDictionary<string, string> ExtraQueryParameters { get; }
+
+        /// <summary>
+        /// </summary>
+        string Claims { get; }
 
 #if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide confidential client on mobile platforms
         /// <summary>

--- a/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             // Set application wide query parameters.
             ExtraQueryParameters = serviceBundle.Config.ExtraQueryParameters ?? new Dictionary<string, string>();
+            Claims = serviceBundle.Config.Claims;
 
             // Copy in call-specific query parameters.
             if (commonParameters.ExtraQueryParameters != null)
@@ -84,7 +85,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
         public SortedSet<string> Scope { get; set; }
         public string ClientId { get; set; }
         public Uri RedirectUri { get; set; }
-        public Dictionary<string, string> ExtraQueryParameters { get; set; }
+        public IDictionary<string, string> ExtraQueryParameters { get; }
+        public string Claims { get; }
 
         #region TODO REMOVE FROM HERE AND USE FROM SPECIFIC REQUEST PARAMETERS
         // TODO: ideally, these can come from the particular request instance and not be in RequestBase since it's not valid for all requests.

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         }
 
         private static void CheckForDuplicateQueryParameters(
-            Dictionary<string, string> queryParamsDictionary, 
+            IDictionary<string, string> queryParamsDictionary, 
             IDictionary<string, string> requestParameters)
         {
             foreach (KeyValuePair<string, string> kvp in queryParamsDictionary)

--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     AuthenticationRequestParameters.Endpoints,
                     AuthenticationRequestParameters.SendX5C);
 
-                foreach (KeyValuePair<string, string> entry in ccBodyParameters)
+                foreach (var entry in ccBodyParameters)
                 {
                     client.AddBodyParameter(entry.Key, entry.Value);
                 }
@@ -341,7 +341,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             client.AddQueryParameter(OAuth2Parameter.Claims, AuthenticationRequestParameters.Claims);
 
-            foreach (KeyValuePair<string, string> kvp in additionalBodyParameters)
+            foreach (var kvp in additionalBodyParameters)
             {
                 client.AddBodyParameter(kvp.Key, kvp.Value);
             }

--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -25,20 +25,20 @@
 //
 //------------------------------------------------------------------------------
 
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Cache;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Exceptions;
+using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.TelemetryCore;
+using Microsoft.Identity.Client.Utils;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client.ApiConfig.Parameters;
-using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Cache;
-using Microsoft.Identity.Client.Exceptions;
-using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.TelemetryCore;
-using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             LogRequestStarted(AuthenticationRequestParameters);
             string accountId = AuthenticationRequestParameters.Account?.HomeAccountId?.Identifier;
-            var apiEvent = InitializeApiEvent(accountId);
+            ApiEvent apiEvent = InitializeApiEvent(accountId);
 
             using (ServiceBundle.TelemetryManager.CreateTelemetryHelper(
                 AuthenticationRequestParameters.RequestContext.TelemetryRequestId,
@@ -135,7 +135,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 try
                 {
-                    var authenticationResult = await ExecuteAsync(cancellationToken).ConfigureAwait(false);
+                    AuthenticationResult authenticationResult = await ExecuteAsync(cancellationToken).ConfigureAwait(false);
                     LogReturnedToken(authenticationResult);
 
                     apiEvent.TenantId = authenticationResult.TenantId;
@@ -165,7 +165,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         private ApiEvent InitializeApiEvent(string accountId)
         {
             AuthenticationRequestParameters.RequestContext.TelemetryRequestId = ServiceBundle.TelemetryManager.GenerateNewRequestId();
-            var apiEvent = new ApiEvent(AuthenticationRequestParameters.RequestContext.Logger, ServiceBundle.PlatformProxy.CryptographyManager)
+            ApiEvent apiEvent = new ApiEvent(AuthenticationRequestParameters.RequestContext.Logger, ServiceBundle.PlatformProxy.CryptographyManager)
             {
                 ApiId = AuthenticationRequestParameters.ApiId,
                 AccountId = accountId ?? "",
@@ -210,7 +210,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 AuthenticationRequestParameters.RequestContext.Logger.Info("Saving Token Response to cache..");
 
-                var tuple = TokenCache.SaveAccessAndRefreshToken(AuthenticationRequestParameters, msalTokenResponse);
+                Tuple<MsalAccessTokenCacheItem, MsalIdTokenCacheItem> tuple = TokenCache.SaveAccessAndRefreshToken(AuthenticationRequestParameters, msalTokenResponse);
                 return new AuthenticationResult(tuple.Item1, tuple.Item2);
             }
             else
@@ -218,20 +218,20 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return new AuthenticationResult(
                     new MsalAccessTokenCacheItem(
                         AuthenticationRequestParameters.AuthorityInfo.Host,
-                        AuthenticationRequestParameters.ClientId, 
+                        AuthenticationRequestParameters.ClientId,
                         msalTokenResponse,
                         idToken?.TenantId),
                     new MsalIdTokenCacheItem(
                         AuthenticationRequestParameters.AuthorityInfo.Host,
-                        AuthenticationRequestParameters.ClientId, 
-                        msalTokenResponse, 
+                        AuthenticationRequestParameters.ClientId,
+                        msalTokenResponse,
                         idToken?.TenantId));
             }
         }
 
         private static string GetTenantUpdatedCanonicalAuthority(string authority, string replacementTenantId)
         {
-            var authUri = new Uri(authority);
+            Uri authUri = new Uri(authority);
             string[] pathSegments = authUri.AbsolutePath.Substring(1).Split(
                 new[]
                 {
@@ -309,7 +309,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         protected async Task<MsalTokenResponse> SendTokenRequestAsync(
             string tokenEndpoint,
-            IDictionary<string, string> additionalBodyParameters, 
+            IDictionary<string, string> additionalBodyParameters,
             CancellationToken cancellationToken)
         {
             OAuth2Client client = new OAuth2Client(ServiceBundle.DefaultLogger, ServiceBundle.HttpManager, ServiceBundle.TelemetryManager);
@@ -321,7 +321,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 #if DESKTOP || NETSTANDARD1_3 || NET_CORE
             if (AuthenticationRequestParameters.ClientCredential != null)
             {
-                var ccBodyParameters = ClientCredentialHelper.CreateClientCredentialBodyParameters(
+                Dictionary<string, string> ccBodyParameters = ClientCredentialHelper.CreateClientCredentialBodyParameters(
                     AuthenticationRequestParameters.RequestContext.Logger,
                     ServiceBundle.PlatformProxy.CryptographyManager,
                     AuthenticationRequestParameters.ClientCredential,
@@ -329,7 +329,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     AuthenticationRequestParameters.Endpoints,
                     AuthenticationRequestParameters.SendX5C);
 
-                foreach (var entry in ccBodyParameters)
+                foreach (KeyValuePair<string, string> entry in ccBodyParameters)
                 {
                     client.AddBodyParameter(entry.Key, entry.Value);
                 }
@@ -339,7 +339,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             client.AddBodyParameter(OAuth2Parameter.Scope,
                 GetDecoratedScope(AuthenticationRequestParameters.Scope).AsSingleString());
 
-            foreach (var kvp in additionalBodyParameters)
+            client.AddQueryParameter(OAuth2Parameter.Claims, AuthenticationRequestParameters.Claims);
+
+            foreach (KeyValuePair<string, string> kvp in additionalBodyParameters)
             {
                 client.AddBodyParameter(kvp.Key, kvp.Value);
             }

--- a/src/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -25,6 +25,12 @@
 //
 // ------------------------------------------------------------------------------
 
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Exceptions;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.TelemetryCore;
+using Microsoft.Identity.Client.Utils;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -32,12 +38,6 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Exceptions;
-using Microsoft.Identity.Client.Http;
-using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Client.TelemetryCore;
-using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.OAuth2
 {
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Client.OAuth2
 
         public void AddQueryParameter(string key, string value)
         {
-            if (!String.IsNullOrWhiteSpace(key) && !String.IsNullOrWhiteSpace(value))
+            if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
             {
                 _queryParameters[key] = value;
             }
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Client.OAuth2
             }
 
             HttpResponse response = null;
-            var endpointUri = CreateFullEndpointUri(endPoint);
+            Uri endpointUri = CreateFullEndpointUri(endPoint);
             var httpEvent = new HttpEvent()
             {
                 HttpPath = endpointUri,
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Client.OAuth2
                         throw MsalExceptionFactory.GetServiceException(
                             CoreErrorCodes.NonParsableOAuthError,
                             CoreErrorMessages.NonParsableOAuthError,
-                            response, 
+                            response,
                             e);
                     }
                 }
@@ -184,7 +184,7 @@ namespace Microsoft.Identity.Client.OAuth2
                     throw MsalExceptionFactory.GetServiceException(
                         CoreErrorCodes.InvalidGrantError,
                         msalTokenResponse.ErrorDescription,
-                        response, 
+                        response,
                         isUiRequiredException: true);
                 }
 

--- a/src/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -58,7 +58,10 @@ namespace Microsoft.Identity.Client.OAuth2
 
         public void AddQueryParameter(string key, string value)
         {
-            _queryParameters[key] = value;
+            if (!String.IsNullOrWhiteSpace(key) && !String.IsNullOrWhiteSpace(value))
+            {
+                _queryParameters[key] = value;
+            }
         }
 
         public void AddBodyParameter(string key, string value)

--- a/src/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
+++ b/src/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Identity.Client.OAuth2
 
         public const string Prompt = "prompt"; // prompt is not standard oauth2 parameter
         public const string ClientInfo = "client_info"; // restrict_to_hint is not standard oauth2 parameter
+
+        public const string Claims = "claims"; // claims is not a standard oauth2 paramter
     }
 
     internal static class OAuth2GrantType

--- a/src/Microsoft.Identity.Client/Utils/UriBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Client/Utils/UriBuilderExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client.Utils
             }
         }
 
-        public static void AppendQueryParameters(this UriBuilder builder, Dictionary<string, string> queryParams)
+        public static void AppendQueryParameters(this UriBuilder builder, IDictionary<string, string> queryParams)
         {
             var list = new List<string>();
             foreach (var kvp in queryParams)

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
@@ -65,12 +65,14 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             SortedSet<string> scopes, 
             ITokenCacheInternal tokenCache = null, 
             IAccount account = null,
-            Dictionary<string, string> extraQueryParameters = null)
+            IDictionary<string, string> extraQueryParameters = null, 
+            string claims = null)
         {
             var commonParameters = new AcquireTokenCommonParameters
             {
                 Scopes = scopes ?? MsalTestConstants.Scope,
-                ExtraQueryParameters = extraQueryParameters ?? new Dictionary<string, string>()
+                ExtraQueryParameters = extraQueryParameters ?? new Dictionary<string, string>(),
+                Claims = claims
             };
 
             return new AuthenticationRequestParameters(

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                         "provided url ({0}) does not contain query parameters, as expected",
                         uri.AbsolutePath));
                 IDictionary<string, string> inputQp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', false, null);
+                Assert.AreEqual(ExpectedQueryParams.Count, inputQp.Count, "Different number of query params`");
                 foreach (string key in ExpectedQueryParams.Keys)
                 {
                     Assert.IsTrue(
@@ -96,19 +97,6 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                             "expected QP ({0}) not found in the url ({1})",
                             key,
                             uri.AbsolutePath));
-                    Assert.AreEqual(ExpectedQueryParams[key], inputQp[key]);
-                }
-            }
-
-
-            // Match QP passed in for validation.
-            if (ExpectedQueryParams != null)
-            {
-                Assert.IsFalse(string.IsNullOrEmpty(uri.Query));
-                IDictionary<string, string> inputQp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', false, null);
-                foreach (string key in ExpectedQueryParams.Keys)
-                {
-                    Assert.IsTrue(inputQp.ContainsKey(key));
                     Assert.AreEqual(ExpectedQueryParams[key], inputQp[key]);
                 }
             }

--- a/tests/Microsoft.Identity.Test.Common/Mocks/MockWebUI.cs
+++ b/tests/Microsoft.Identity.Test.Common/Mocks/MockWebUI.cs
@@ -52,20 +52,25 @@ namespace Microsoft.Identity.Test.Common.Mocks
 
         public bool AddStateInAuthorizationResult { get; set; }
 
-        public RequestContext RequestContext { get; set; }
+        public string ExpectedEnvironment { get; set; }
 
-        public string Environment { get; set; }
+        public Uri ActualAuthorizationUri { get; private set; }
 
-        public async Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, RequestContext requestContext)
+        public async Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri, 
+            RequestContext requestContext)
         {
+            ActualAuthorizationUri = authorizationUri;
+
             if (ExceptionToThrow != null)
             {
                 throw ExceptionToThrow;
             }
 
-            if (Environment != null)
+            if (ExpectedEnvironment != null)
             {
-                Assert.AreEqual(Environment, authorizationUri.Host);
+                Assert.AreEqual(ExpectedEnvironment, authorizationUri.Host);
             }
 
             IDictionary<string, string> inputQp = CoreHelpers.ParseKeyValueList(authorizationUri.Query.Substring(1), '&', true, null);

--- a/tests/Microsoft.Identity.Test.Common/Mocks/MsalMockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Mocks/MsalMockHelpers.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Test.Common.Mocks
             {
                 QueryParamsToValidate = queryParamsToValidate,
                 MockResult = authorizationResult,
-                Environment = environment
+                ExpectedEnvironment = environment
             };
 
             ConfigureMockWebUI(platformProxy, webUi);

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -77,15 +77,16 @@ namespace Microsoft.Identity.Test.Unit
         public const string DefaultAccessToken = "DefaultAccessToken";
         public const string DefaultClientAssertion = "DefaultClientAssertion";
         public const string RawClientId = "eyJ1aWQiOiJteS11aWQiLCJ1dGlkIjoibXktdXRpZCJ9";
-        public const string XClientSku =  "x-client-SKU";
+        public const string XClientSku = "x-client-SKU";
         public const string XClientVer = "x-client-Ver";
         public const TokenSubjectType TokenSubjectTypeUser = 0;
 
-        public static readonly IDictionary<string, string> ExtraQueryParams = new Dictionary<string, string>()
+        public static readonly IDictionary<string, string> ExtraQueryParams 
+            = new Dictionary<string, string>()
             {
-                        {"extra", "qp" },
-                        {"key1", "value1%20with%20encoded%20space"},
-                        {"key2", "value2"}
+                {"extra", "qp" },
+                {"key1", "value1%20with%20encoded%20space"},
+                {"key2", "value2"}
             };
 
         public enum AuthorityType { B2C };

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string UniqueId = "unique_id";
         public const string IdentityProvider = "my-idp";
         public const string Name = "First Last";
+        public const string Claims = "claim1claim2";
         public const string DisplayableId = "displayable@id.com";
         public const string RedirectUri = "urn:ietf:wg:oauth:2.0:oob";
         public const string ClientSecret = "client_secret";
@@ -79,6 +80,14 @@ namespace Microsoft.Identity.Test.Unit
         public const string XClientSku =  "x-client-SKU";
         public const string XClientVer = "x-client-Ver";
         public const TokenSubjectType TokenSubjectTypeUser = 0;
+
+        public static readonly IDictionary<string, string> ExtraQueryParams = new Dictionary<string, string>()
+            {
+                        {"extra", "qp" },
+                        {"key1", "value1%20with%20encoded%20space"},
+                        {"key2", "value2"}
+            };
+
         public enum AuthorityType { B2C };
         public static string[] ProdEnvAliases = new string[] {
                                 "login.microsoftonline.com",

--- a/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/Harnesses/AbstractBuilderHarness.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/Harnesses/AbstractBuilderHarness.cs
@@ -26,6 +26,7 @@
 // ------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.Utils;
@@ -51,7 +52,9 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests.Harnesses
             CoreAssert.AreScopesEqual(
                 (expectedScopes ?? MsalTestConstants.Scope).AsSingleString(),
                 CommonParametersReceived.Scopes.AsSingleString());
-            CollectionAssert.AreEqual(expectedExtraQueryParameters, CommonParametersReceived.ExtraQueryParameters);
+            CollectionAssert.AreEqual(
+                expectedExtraQueryParameters, 
+                CommonParametersReceived.ExtraQueryParameters.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/Harnesses/AbstractBuilderHarness.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/Harnesses/AbstractBuilderHarness.cs
@@ -49,12 +49,14 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests.Harnesses
 
             Assert.AreEqual(expectedApiId, CommonParametersReceived.ApiId);
             Assert.AreEqual(expectedAuthorityOverride, CommonParametersReceived.AuthorityOverride);
+
             CoreAssert.AreScopesEqual(
                 (expectedScopes ?? MsalTestConstants.Scope).AsSingleString(),
                 CommonParametersReceived.Scopes.AsSingleString());
+
             CollectionAssert.AreEqual(
                 expectedExtraQueryParameters, 
-                CommonParametersReceived.ExtraQueryParameters.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+                CommonParametersReceived.ExtraQueryParameters?.ToList());
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security;
@@ -37,6 +38,7 @@ using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Exceptions;
 using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Test.Common;
@@ -156,20 +158,22 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 });
         }
 
-        private void AddMockHandlerAadSuccess(MockHttpManager httpManager, string authority)
+        private MockHttpMessageHandler AddMockHandlerAadSuccess(MockHttpManager httpManager, string authority)
         {
-            httpManager.AddMockHandler(
-                new MockHttpMessageHandler
-                {
-                    ExpectedUrl = authority + "oauth2/v2.0/token",
-                    ExpectedMethod = HttpMethod.Post,
-                    ExpectedPostData = new Dictionary<string, string>
+            var handler = new MockHttpMessageHandler
+            {
+                ExpectedUrl = authority + "oauth2/v2.0/token",
+                ExpectedMethod = HttpMethod.Post,
+                ExpectedPostData = new Dictionary<string, string>
                     {
                         {"grant_type", "urn:ietf:params:oauth:grant-type:saml1_1-bearer"},
                         {"scope", "openid offline_access profile r1/scope1 r1/scope2"}
                     },
-                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
-                });
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+            };
+            httpManager.AddMockHandler(handler);
+
+            return handler;
         }
 
         internal MockHttpMessageHandler AddMockResponseForFederatedAccounts(MockHttpManager httpManager)
@@ -278,6 +282,10 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
         public async Task AcquireTokenByIntegratedWindowsAuthTestAsync()
         {
+            IDictionary<string, string> extraQueryParamsAndClaims =
+                MsalTestConstants.ExtraQueryParams.ToDictionary(e => e.Key, e => e.Value);
+            extraQueryParamsAndClaims.Add(OAuth2Parameter.Claims, MsalTestConstants.Claims);
+
             using (var httpManager = new MockHttpManager())
             {
                 httpManager.AddInstanceDiscoveryMockHandler();
@@ -286,11 +294,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 MockHttpMessageHandler realmDiscoveryHandler = AddMockHandlerDefaultUserRealmDiscovery(httpManager);
                 AddMockHandlerMex(httpManager);
                 AddMockHandlerWsTrustWindowsTransport(httpManager);
-                AddMockHandlerAadSuccess(httpManager, MsalTestConstants.AuthorityCommonTenant);
+                var tokenRequestHandler = AddMockHandlerAadSuccess(httpManager, MsalTestConstants.AuthorityCommonTenant);
+                tokenRequestHandler.ExpectedQueryParams = extraQueryParamsAndClaims;
 
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
+                                                        .WithClaims(MsalTestConstants.Claims)
+                                                        .WithExtraQueryParameters(MsalTestConstants.ExtraQueryParams)
                                                         .BuildConcrete();
 
                 var result = await app

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -25,6 +25,14 @@
 //
 // ------------------------------------------------------------------------------
 
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Exceptions;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -33,20 +41,6 @@ using System.Net;
 using System.Net.Http;
 using System.Security;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.AppConfig;
-using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Exceptions;
-using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.TelemetryCore;
-using Microsoft.Identity.Client.UI;
-using Microsoft.Identity.Test.Common;
-using Microsoft.Identity.Test.Common.Core.Helpers;
-using Microsoft.Identity.Test.Common.Core.Mocks;
-using Microsoft.Identity.Test.Common.Mocks;
-using Microsoft.Identity.Test.Unit.PublicApiTests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
@@ -294,8 +288,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 MockHttpMessageHandler realmDiscoveryHandler = AddMockHandlerDefaultUserRealmDiscovery(httpManager);
                 AddMockHandlerMex(httpManager);
                 AddMockHandlerWsTrustWindowsTransport(httpManager);
-                var tokenRequestHandler = AddMockHandlerAadSuccess(httpManager, MsalTestConstants.AuthorityCommonTenant);
-                tokenRequestHandler.ExpectedQueryParams = extraQueryParamsAndClaims;
+                var mockTokenRequestHttpHandler = AddMockHandlerAadSuccess(httpManager, MsalTestConstants.AuthorityCommonTenant);
+                mockTokenRequestHttpHandler.ExpectedQueryParams = extraQueryParamsAndClaims;
 
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
@@ -25,29 +25,27 @@
 //
 // ------------------------------------------------------------------------------
 
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Cache;
+using Microsoft.Identity.Client.Exceptions;
+using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.Internal.Requests;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.TelemetryCore;
+using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Common.Mocks;
+using Microsoft.Identity.Test.Unit.PublicApiTests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.ApiConfig.Parameters;
-using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Exceptions;
-using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.Internal.Requests;
-using Microsoft.Identity.Client.Cache;
-using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.TelemetryCore;
-using Microsoft.Identity.Client.UI;
-using Microsoft.Identity.Client.Utils;
-using Microsoft.Identity.Test.Common.Core.Mocks;
-using Microsoft.Identity.Test.Common.Mocks;
-using Microsoft.Identity.Test.Unit.PublicApiTests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Identity.Test.Common;
 
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
@@ -62,63 +60,59 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
         [TestMethod]
         [TestCategory("InteractiveRequestTests")]
-        public void SliceParametersTest()
+        public async Task WithExtraQueryParamsAndClaimsAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
-            {
-                var cache = new TokenCache(harness.ServiceBundle);
+        
+            IDictionary<string, string> extraQueryParamsAndClaims =
+                MsalTestConstants.ExtraQueryParams.ToDictionary(e => e.Key, e => e.Value);
+            extraQueryParamsAndClaims.Add(OAuth2Parameter.Claims, MsalTestConstants.Claims);
 
-                var ui = new MockWebUI()
+            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
+            {
+                TokenCache cache = new TokenCache(harness.ServiceBundle);
+
+                MockWebUI ui = new MockWebUI()
                 {
                     MockResult = new AuthorizationResult(
                         AuthorizationStatus.Success,
                         MsalTestConstants.AuthorityHomeTenant + "?code=some-code"),
-                    QueryParamsToValidate = new Dictionary<string, string>()
-                    {
-                        {"key1", "value1%20with%20encoded%20space"},
-                        {"key2", "value2"}
-                    }
+                    QueryParamsToValidate = MsalTestConstants.ExtraQueryParams
                 };
 
                 MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
 
-                harness.HttpManager.AddMockHandler(
-                    new MockHttpMessageHandler
-                    {
-                        ExpectedMethod = HttpMethod.Post,
-                        ExpectedQueryParams = new Dictionary<string, string>()
-                        {
-                            {"key1", "value1%20with%20encoded%20space"},
-                            {"key2", "value2"}
-                        },
-                        ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
-                    });
-
-                var parameters = harness.CreateAuthenticationRequestParameters(
-                    MsalTestConstants.AuthorityHomeTenant, MsalTestConstants.Scope, cache, extraQueryParameters: new Dictionary<string, string>
+                MockHttpMessageHandler tokenResponseHandler = new MockHttpMessageHandler
                 {
-                    { "extra", "qp" },
-                    // Slice Parameters
-                    { "key1", "value1%20with%20encoded%20space" },
-                    { "key2", "value2" }
-                });
+                    ExpectedMethod = HttpMethod.Post,
+                    ExpectedQueryParams = extraQueryParamsAndClaims,
+                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                };
+                harness.HttpManager.AddMockHandler(tokenResponseHandler);
+
+                AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
+                    MsalTestConstants.AuthorityHomeTenant,
+                    MsalTestConstants.Scope,
+                    cache,
+                    extraQueryParameters: MsalTestConstants.ExtraQueryParams,
+                    claims: MsalTestConstants.Claims);
+
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = MsalTestConstants.DisplayableId;
-                var interactiveParameters = new AcquireTokenInteractiveParameters
+
+                AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters
                 {
                     Prompt = Prompt.SelectAccount,
                     ExtraScopesToConsent = MsalTestConstants.ScopeForAnotherResource.ToArray(),
                 };
 
-                var request = new InteractiveRequest(
+                InteractiveRequest request = new InteractiveRequest(
                     harness.ServiceBundle,
                     parameters,
                     interactiveParameters,
                     ui);
 
-                Task<AuthenticationResult> task = request.RunAsync(CancellationToken.None);
-                task.Wait();
-                var result = task.Result;
+                AuthenticationResult result = await request.RunAsync(CancellationToken.None).ConfigureAwait(false);
+
                 Assert.IsNotNull(result);
                 Assert.AreEqual(1, ((ITokenCacheInternal)cache).Accessor.RefreshTokenCount);
                 Assert.AreEqual(1, ((ITokenCacheInternal)cache).Accessor.AccessTokenCount);
@@ -132,11 +126,11 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             MyReceiver myReceiver = new MyReceiver();
 
-            using (var harness = new MockHttpAndServiceBundle(telemetryCallback: myReceiver.HandleTelemetryEvents))
+            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle(telemetryCallback: myReceiver.HandleTelemetryEvents))
             {
-                var cache = new TokenCache(harness.ServiceBundle);
+                TokenCache cache = new TokenCache(harness.ServiceBundle);
 
-                var atItem = new MsalAccessTokenCacheItem(
+                MsalAccessTokenCacheItem atItem = new MsalAccessTokenCacheItem(
                     MsalTestConstants.ProductionPrefNetworkEnvironment,
                     MsalTestConstants.ClientId,
                     "Bearer",
@@ -151,18 +145,18 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 atItem.Secret = atKey;
                 ((ITokenCacheInternal)cache).Accessor.SaveAccessToken(atItem);
 
-                var ui = new MockWebUI()
+                MockWebUI ui = new MockWebUI()
                 {
                     MockResult = new AuthorizationResult(
                         AuthorizationStatus.Success,
                         MsalTestConstants.AuthorityHomeTenant + "?code=some-code")
                 };
-                                
+
                 MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(MsalTestConstants.AuthorityHomeTenant);
 
-                var parameters = harness.CreateAuthenticationRequestParameters(
+                AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityHomeTenant,
                     MsalTestConstants.Scope,
                     cache,
@@ -172,13 +166,13 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     });
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = MsalTestConstants.DisplayableId;
-                var interactiveParameters = new AcquireTokenInteractiveParameters
+                AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters
                 {
                     Prompt = Prompt.SelectAccount,
                     ExtraScopesToConsent = MsalTestConstants.ScopeForAnotherResource.ToArray(),
                 };
 
-                var request = new InteractiveRequest(
+                InteractiveRequest request = new InteractiveRequest(
                     harness.ServiceBundle,
                     parameters,
                     interactiveParameters,
@@ -186,7 +180,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 Task<AuthenticationResult> task = request.RunAsync(CancellationToken.None);
                 task.Wait();
-                var result = task.Result;
+                AuthenticationResult result = task.Result;
                 Assert.IsNotNull(result);
                 Assert.AreEqual(1, ((ITokenCacheInternal)cache).Accessor.RefreshTokenCount);
                 Assert.AreEqual(2, ((ITokenCacheInternal)cache).Accessor.AccessTokenCount);
@@ -216,9 +210,9 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             try
             {
-                using (var harness = new MockHttpAndServiceBundle())
+                using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
                 {
-                    var parameters = harness.CreateAuthenticationRequestParameters(
+                    AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                         MsalTestConstants.AuthorityHomeTenant,
                         MsalTestConstants.Scope,
                         null,
@@ -228,7 +222,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         });
                     parameters.RedirectUri = new Uri("some://uri#fragment=not-so-good");
                     parameters.LoginHint = MsalTestConstants.DisplayableId;
-                    var interactiveParameters = new AcquireTokenInteractiveParameters
+                    AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters
                     {
                         Prompt = Prompt.ForceLogin,
                         ExtraScopesToConsent = MsalTestConstants.ScopeForAnotherResource.ToArray(),
@@ -253,7 +247,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void OAuthClient_FailsWithServiceExceptionWhenItCannotParseJsonResponse()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
             {
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
@@ -262,19 +256,19 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         ResponseMessage = MockHelpers.CreateTooManyRequestsNonJsonResponse() // returns a non json response
                     });
 
-                var parameters = harness.CreateAuthenticationRequestParameters(
+                AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityHomeTenant,
                     MsalTestConstants.Scope,
                     null);
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = MsalTestConstants.DisplayableId;
-                var interactiveParameters = new AcquireTokenInteractiveParameters
+                AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters
                 {
                     Prompt = Prompt.SelectAccount,
                     ExtraScopesToConsent = MsalTestConstants.ScopeForAnotherResource.ToArray(),
                 };
 
-                var request = new InteractiveRequest(
+                InteractiveRequest request = new InteractiveRequest(
                     harness.ServiceBundle,
                     parameters,
                     interactiveParameters,
@@ -288,7 +282,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 }
                 catch (Exception exc)
                 {
-                    var serverEx = exc.InnerException as MsalServiceException;
+                    MsalServiceException serverEx = exc.InnerException as MsalServiceException;
                     Assert.IsNotNull(serverEx);
                     Assert.AreEqual(429, serverEx.StatusCode);
                     Assert.AreEqual(MockHelpers.TooManyRequestsContent, serverEx.ResponseBody);
@@ -302,7 +296,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void OAuthClient_FailsWithServiceExceptionWhenItCanParseJsonResponse()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
             {
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
@@ -311,19 +305,19 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         ResponseMessage = MockHelpers.CreateTooManyRequestsJsonResponse() // returns a non json response
                     });
 
-                var parameters = harness.CreateAuthenticationRequestParameters(
+                AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityHomeTenant,
                     MsalTestConstants.Scope,
                     null);
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = MsalTestConstants.DisplayableId;
-                var interactiveParameters = new AcquireTokenInteractiveParameters
+                AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters
                 {
                     Prompt = Prompt.SelectAccount,
                     ExtraScopesToConsent = MsalTestConstants.ScopeForAnotherResource.ToArray(),
                 };
 
-                var request = new InteractiveRequest(
+                InteractiveRequest request = new InteractiveRequest(
                     harness.ServiceBundle,
                     parameters,
                     interactiveParameters,
@@ -336,7 +330,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 }
                 catch (Exception exc)
                 {
-                    var serverEx = exc.InnerException as MsalServiceException;
+                    MsalServiceException serverEx = exc.InnerException as MsalServiceException;
                     Assert.IsNotNull(serverEx);
                     Assert.AreEqual(429, serverEx.StatusCode);
                     Assert.AreEqual(MockHelpers.TestRetryAfterDuration, serverEx.Headers.RetryAfter.Delta);
@@ -349,33 +343,33 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void VerifyAuthorizationResultTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
             {
-                var authority = Authority.CreateAuthority(harness.ServiceBundle, MsalTestConstants.AuthorityHomeTenant);
+                Authority authority = Authority.CreateAuthority(harness.ServiceBundle, MsalTestConstants.AuthorityHomeTenant);
 
                 MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
 
-                var webUi = new MockWebUI()
+                MockWebUI webUi = new MockWebUI()
                 {
                     MockResult = new AuthorizationResult(
                         AuthorizationStatus.ErrorHttp,
                         MsalTestConstants.AuthorityHomeTenant + "?error=" + OAuth2Error.LoginRequired)
                 };
 
-                var parameters = harness.CreateAuthenticationRequestParameters(
+                AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityHomeTenant,
                     MsalTestConstants.Scope,
                     null,
-                    extraQueryParameters: new Dictionary<string, string> {{ "extra", "qp" }});
+                    extraQueryParameters: new Dictionary<string, string> { { "extra", "qp" } });
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = MsalTestConstants.DisplayableId;
-                var interactiveParameters = new AcquireTokenInteractiveParameters
+                AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters
                 {
                     Prompt = Prompt.ForceLogin,
                     ExtraScopesToConsent = MsalTestConstants.ScopeForAnotherResource.ToArray(),
                 };
 
-                var request = new InteractiveRequest(
+                InteractiveRequest request = new InteractiveRequest(
                     harness.ServiceBundle,
                     parameters,
                     interactiveParameters,
@@ -425,25 +419,25 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void DuplicateQueryParameterErrorTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 harness.HttpManager.AddMockHandlerForTenantEndpointDiscovery(MsalTestConstants.AuthorityHomeTenant);
 
-                var parameters = harness.CreateAuthenticationRequestParameters(
+                AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityHomeTenant,
                     MsalTestConstants.Scope,
                     null,
-                    extraQueryParameters: new Dictionary<string, string> {{ "extra", "qp" }, {"prompt", "login"}});
+                    extraQueryParameters: new Dictionary<string, string> { { "extra", "qp" }, { "prompt", "login" } });
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = MsalTestConstants.DisplayableId;
-                var interactiveParameters = new AcquireTokenInteractiveParameters
+                AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters
                 {
                     Prompt = Prompt.ForceLogin,
                     ExtraScopesToConsent = MsalTestConstants.ScopeForAnotherResource.ToArray(),
                 };
 
-                var request = new InteractiveRequest(
+                InteractiveRequest request = new InteractiveRequest(
                     harness.ServiceBundle,
                     parameters,
                     interactiveParameters,

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,6 +39,7 @@ using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Internal.Requests;
+using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common;
@@ -82,10 +84,18 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("SilentRequestTests")]
         public void ExpiredTokenRefreshFlowTest()
         {
+            IDictionary<string, string> extraQueryParamsAndClaims =
+               MsalTestConstants.ExtraQueryParams.ToDictionary(e => e.Key, e => e.Value);
+            extraQueryParamsAndClaims.Add(OAuth2Parameter.Claims, MsalTestConstants.Claims);
+
             using (var harness = new MockHttpTestHarness(MsalTestConstants.AuthorityHomeTenant))
             {
                 _tokenCacheHelper.PopulateCache(harness.Cache.Accessor);
-                var parameters = harness.CreateRequestParams(harness.Cache, null);
+                var parameters = harness.CreateRequestParams(
+                    harness.Cache, 
+                    null, 
+                    MsalTestConstants.ExtraQueryParams, 
+                    MsalTestConstants.Claims);
                 var silentParameters = new AcquireTokenSilentParameters();
 
                 // set access tokens as expired
@@ -105,7 +115,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     new MockHttpMessageHandler()
                     {
                         ExpectedMethod = HttpMethod.Post,
-                        ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                        ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                        ExpectedQueryParams = extraQueryParamsAndClaims
                     });
 
                 var request = new SilentRequest(harness.ServiceBundle, parameters, silentParameters);
@@ -207,11 +218,17 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 _mockHttpAndServiceBundle.Dispose();
             }
 
-            public AuthenticationRequestParameters CreateRequestParams(ITokenCacheInternal cache, SortedSet<string> scopes)
+            public AuthenticationRequestParameters CreateRequestParams(
+                ITokenCacheInternal cache, 
+                SortedSet<string> scopes, 
+                IDictionary<string, string> extraQueryParams = null, 
+                string claims = null)
             {
                 var commonParameters = new AcquireTokenCommonParameters
                 {
                     Scopes = scopes ?? MsalTestConstants.Scope,
+                    ExtraQueryParameters = extraQueryParams,
+                    Claims = claims
                 };
 
                 var parameters = new AuthenticationRequestParameters(
@@ -222,6 +239,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     RequestContext.CreateForTest(ServiceBundle))
                 {
                     Account = new Account(MsalTestConstants.UserIdentifier, MsalTestConstants.DisplayableId, null),
+                   
                 };
                 return parameters;
             }


### PR DESCRIPTION
As discussed with @jmprieur , WithClaims behaves similarly to setting ExtraQueryParameters to claims="...". I discovered that neither ExtraQueryParameters nor Claims are respected in Device Code Flow. I will follow up with a separate PR to address this.