### PR TITLE
Renaming WithAadAuthority to WithAuthority

### DIFF
--- a/src/Microsoft.Identity.Client/@Diagrams/ApplicationBuilders.cd
+++ b/src/Microsoft.Identity.Client/@Diagrams/ApplicationBuilders.cd
@@ -1,49 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
   <Class Name="Microsoft.Identity.Client.AppConfig.ConfidentialClientApplicationBuilder">
-    <Position X="9.25" Y="6.75" Width="7.25" />
+    <Position X="9.25" Y="6.25" Width="7.25" />
     <Members>
       <Method Name="BuildConcrete" Hidden="true" />
-      <Method Name="BuildConfiguration" Hidden="true" />
       <Method Name="ConfidentialClientApplicationBuilder" Hidden="true" />
+      <Method Name="Validate" Hidden="true" />
       <Method Name="WithClientCredential" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>AAAAAAAYAEAgBAAAAAAAAAAAAACAgEAAAEAEAAAAAAA=</HashCode>
+      <HashCode>AAAAAAAAAACgBAgAAAAAAAAAAACAgEAAAEAAAAAAAAA=</HashCode>
       <FileName>AppConfig\ConfidentialClientApplicationBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.AppConfig.AbstractApplicationBuilder&lt;T&gt;">
-    <Position X="5" Y="0.5" Width="8.75" />
+    <Position X="5" Y="0.5" Width="10.5" />
     <Members>
       <Method Name="AbstractApplicationBuilder" Hidden="true" />
       <Method Name="BuildConfiguration" Hidden="true" />
       <Property Name="Config" Hidden="true" />
-      <Method Name="DetermineDefaultAuthorityType" Hidden="true" />
-      <Method Name="GetAadAuthorityAudienceValue" Hidden="true" />
-      <Method Name="GetAuthorityUri" Hidden="true" />
-      <Method Name="GetCloudUrl" Hidden="true" />
       <Method Name="GetDefaultAuthorityAudience" Hidden="true" />
       <Method Name="GetDefaultAuthorityInstance" Hidden="true" />
       <Method Name="GetValueIfNotEmpty" Hidden="true" />
       <Method Name="TryAddDefaultAuthority" Hidden="true" />
+      <Method Name="Validate" Hidden="true" />
       <Method Name="WithHttpManager" Hidden="true" />
       <Method Name="WithOptions" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>gYQDAAAItiQQAAAAAAAAAAABCAAIAhAAAABAJFAgAAA=</HashCode>
+      <HashCode>AAQDAAAIEiCAAgAAAAAAAAACCAAIAhAAAABARAIgAAQ=</HashCode>
       <FileName>AppConfig\AbstractApplicationBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.AppConfig.PublicClientApplicationBuilder">
-    <Position X="2.5" Y="6.75" Width="6.5" />
+    <Position X="2.5" Y="6.25" Width="6.5" />
     <Members>
       <Method Name="BuildConcrete" Hidden="true" />
       <Method Name="PublicClientApplicationBuilder" Hidden="true" />
+      <Method Name="Validate" Hidden="true" />
+      <Method Name="WithBroker" Hidden="true" />
       <Method Name="WithUserTokenLegacyCachePersistenceForTest" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAgAAAAAAAAAAAAGAAAgEAAAEAAAAAAAAA=</HashCode>
+      <HashCode>AQAAAAAAAACgAAAAAAAAAAAAEAAAgEAAAEAAAAAAAAA=</HashCode>
       <FileName>AppConfig\PublicClientApplicationBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>

--- a/src/Microsoft.Identity.Client/@Diagrams/AppsWithBuilders.cd
+++ b/src/Microsoft.Identity.Client/@Diagrams/AppsWithBuilders.cd
@@ -19,7 +19,7 @@
       <Property Name="UserTokenCacheInternal" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>AAAABSCAAEAAAAIChBgQBAEAABBAAAAAECJAAEAAEEA=</HashCode>
+      <HashCode>AAAABSCEAEAAAAICjBgQBAEAABBAAAAAECJAAEAAEEA=</HashCode>
       <FileName>MigrationAid\MigrationAid.cs</FileName>
     </TypeIdentifier>
     <ShowAsAssociation>
@@ -28,14 +28,13 @@
     <Lollipop Position="0.2" />
   </Class>
   <Class Name="Microsoft.Identity.Client.PublicClientApplication">
-    <Position X="0.5" Y="4.75" Width="10.25" />
+    <Position X="0.5" Y="5.5" Width="10.25" />
     <Members>
       <Method Name="AcquireTokenAsync" Hidden="true" />
       <Method Name="AcquireTokenByIntegratedWindowsAuthAsync" Hidden="true" />
       <Method Name="AcquireTokenByUsernamePasswordAsync" Hidden="true" />
       <Method Name="AcquireTokenWithDeviceCodeAsync" Hidden="true" />
       <Method Name="CreateWebAuthenticationDialog" Hidden="true" />
-      <Method Name="CreateWebAuthenticationDialogEx" Hidden="true" />
       <Method Name="GetParentObjectFromUiParent" Hidden="true" />
       <Method Name="GuardIWANetCore" Hidden="true" />
       <Method Name="GuardMobilePlatforms" Hidden="true" />
@@ -48,20 +47,20 @@
     </Members>
     <InheritanceLine Type="Microsoft.Identity.Client.ClientApplicationBase" FixedToPoint="true">
       <Path>
-        <Point X="5" Y="3.911" />
-        <Point X="5" Y="4.375" />
-        <Point X="3.312" Y="4.375" />
-        <Point X="3.312" Y="4.75" />
+        <Point X="5" Y="4.488" />
+        <Point X="5" Y="5.125" />
+        <Point X="3.375" Y="5.125" />
+        <Point X="3.375" Y="5.5" />
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAEAEAQAEAAAAAQQyAAQCAAAAAAgBAAgAAEAAEA=</HashCode>
+      <HashCode>AAAAAAEAEAQAAAAAAAQQyAAQCAAAAAAgBAAgCAEAAEA=</HashCode>
       <FileName>MigrationAid\MigrationAid.cs</FileName>
     </TypeIdentifier>
     <Lollipop Position="0.2" />
   </Class>
   <Class Name="Microsoft.Identity.Client.ConfidentialClientApplication">
-    <Position X="1.75" Y="7.5" Width="12.5" />
+    <Position X="2.25" Y="8.75" Width="12.5" />
     <Members>
       <Method Name="AcquireTokenByAuthorizationCodeAsync" Hidden="true" />
       <Method Name="AcquireTokenForClientAsync" Hidden="true" />
@@ -70,7 +69,6 @@
       <Property Name="ClientCredential" Hidden="true" />
       <Method Name="ConfidentialClientApplication" Hidden="true" />
       <Method Name="CreateRequestParameters" Hidden="true" />
-      <Method Name="GetAuthorizationRequestUrlAsync" Hidden="true" />
       <Method Name="GuardMobileFrameworks" Hidden="true" />
       <Method Name="IByRefreshToken.AcquireTokenByRefreshToken" Hidden="true" />
       <Method Name="IByRefreshToken.AcquireTokenByRefreshTokenAsync" Hidden="true" />
@@ -81,14 +79,14 @@
     </Members>
     <InheritanceLine Type="Microsoft.Identity.Client.ClientApplicationBase" FixedToPoint="true">
       <Path>
-        <Point X="5" Y="3.911" />
-        <Point X="5" Y="4.375" />
-        <Point X="11" Y="4.375" />
-        <Point X="11" Y="7.5" />
+        <Point X="5" Y="4.488" />
+        <Point X="5" Y="5.125" />
+        <Point X="11.125" Y="5.125" />
+        <Point X="11.125" Y="8.75" />
       </Path>
     </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAFAAFAEQQDAAAiCAAKAFAAAAAAACAACAACAAAAAA=</HashCode>
+      <HashCode>AAAAFAABAEQQDAAAgCAACAFAAAAAAACAACAACAAABAA=</HashCode>
       <FileName>ConfidentialClientApplication.cs</FileName>
     </TypeIdentifier>
     <ShowAsAssociation>
@@ -99,7 +97,7 @@
   <Interface Name="Microsoft.Identity.Client.ITokenCache">
     <Position X="11.5" Y="0.75" Width="3.75" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAAAABAAAAAAGBAAAABAAAAiAAAAAA=</HashCode>
+      <HashCode>AAAAAAAAAAAAAAAAAABAAAABAGBAIAABAAAAiAAAAAA=</HashCode>
       <FileName>ITokenCache.cs</FileName>
     </TypeIdentifier>
   </Interface>

--- a/src/Microsoft.Identity.Client/@Diagrams/TokenRequestBuilders.cd
+++ b/src/Microsoft.Identity.Client/@Diagrams/TokenRequestBuilders.cd
@@ -1,193 +1,188 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
   <Class Name="Microsoft.Identity.Client.ApiConfig.AbstractAcquireTokenParameterBuilder&lt;T&gt;">
-    <Position X="6.5" Y="0.75" Width="5" />
+    <Position X="9" Y="0.5" Width="8.25" />
     <Members>
-      <Property Name="Parameters" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
+      <Property Name="CommonParameters" Hidden="true" />
       <Method Name="Validate" Hidden="true" />
+      <Method Name="ValidateAndCalculateApiId" Hidden="true" />
       <Method Name="WithExtraQueryParameters" Hidden="true" />
+      <Method Name="WithScopes" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>IAAEAAAAAACAAAgAAAAAAAAAAIAAgAAAAIAAQAAAAEA=</HashCode>
+      <HashCode>AAAAAAAAAACAAAAAAAAAAAACAAAAgDAAAAAAYAIAAEQ=</HashCode>
       <FileName>ApiConfig\AbstractAcquireTokenParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Microsoft.Identity.Client.ApiConfig.AbstractCcaAcquireTokenParameterBuilder&lt;T&gt;" Collapsed="true">
-    <Position X="19.5" Y="3" Width="2.75" />
+  <Class Name="Microsoft.Identity.Client.ApiConfig.AbstractConfidentialClientAcquireTokenParameterBuilder&lt;T&gt;" Collapsed="true">
+    <Position X="24.75" Y="5.5" Width="2.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA=</HashCode>
-      <FileName>ApiConfig\AbstractCcaAcquireTokenParameterBuilder.cs</FileName>
+      <FileName>ApiConfig\AbstractConfidentialClientAcquireTokenParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AbstractClientAppBaseAcquireTokenParameterBuilder&lt;T&gt;" Collapsed="true">
-    <Position X="2.25" Y="3.75" Width="3.5" />
-    <Members>
-      <Method Name="AbstractClientAppBaseAcquireTokenParameterBuilder" Hidden="true" />
-      <Property Name="ClientApplicationBase" Hidden="true" />
-      <Method Name="ExecuteAsync" Hidden="true" />
-    </Members>
+    <Position X="2.25" Y="5.5" Width="3.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA=</HashCode>
       <FileName>ApiConfig\AbstractClientAppBaseAcquireTokenParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Microsoft.Identity.Client.ApiConfig.AbstractPcaAcquireTokenParameterBuilder&lt;T&gt;" Collapsed="true">
-    <Position X="7" Y="3.75" Width="3.75" />
+  <Class Name="Microsoft.Identity.Client.ApiConfig.AbstractPublicClientAcquireTokenParameterBuilder&lt;T&gt;" Collapsed="true">
+    <Position X="13.25" Y="5.5" Width="3.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAEA=</HashCode>
-      <FileName>ApiConfig\AbstractPcaAcquireTokenParameterBuilder.cs</FileName>
+      <FileName>ApiConfig\AbstractPublicClientAcquireTokenParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenByAuthorizationCodeParameterBuilder" Collapsed="true">
-    <Position X="17.5" Y="5" Width="3.5" />
-    <InheritanceLine Type="Microsoft.Identity.Client.ApiConfig.AbstractCcaAcquireTokenParameterBuilder&lt;T&gt;" ManuallyRouted="true">
-      <Path>
-        <Point X="20.875" Y="3.691" />
-        <Point X="20.875" Y="4.639" />
-        <Point X="19.25" Y="4.639" />
-        <Point X="19.25" Y="5" />
-      </Path>
-    </InheritanceLine>
+  <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenByAuthorizationCodeParameterBuilder">
+    <Position X="22" Y="7" Width="3.5" />
+    <Members>
+      <Method Name="AcquireTokenByAuthorizationCodeParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
+      <Method Name="Create" Hidden="true" />
+      <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
+      <Method Name="Validate" Hidden="true" />
+      <Method Name="WithAuthorizationCode" Hidden="true" />
+    </Members>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAACAAIAAAAAAAAAAAAAAAEAAAAAAAAAAAEA=</HashCode>
+      <HashCode>AAAAAAAAAACAAIAAAAAAAAAAAAAAAEAAAIAAIAAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenByAuthorizationCodeParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenForClientParameterBuilder">
-    <Position X="18.25" Y="6" Width="5" />
+    <Position X="23.5" Y="8.75" Width="5" />
     <Members>
       <Method Name="AcquireTokenForClientParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
     </Members>
-    <InheritanceLine Type="Microsoft.Identity.Client.ApiConfig.AbstractCcaAcquireTokenParameterBuilder&lt;T&gt;" ManuallyRouted="true" FixedToPoint="true">
-      <Path>
-        <Point X="20.875" Y="3.691" />
-        <Point X="20.875" Y="4.656" />
-        <Point X="21.188" Y="4.656" />
-        <Point X="21.188" Y="6" />
-      </Path>
-    </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAIAgAAAEA=</HashCode>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAIAIIgAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenForClientParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenOnBehalfOfParameterBuilder">
-    <Position X="23.5" Y="5.25" Width="4.5" />
+    <Position X="26.25" Y="7" Width="4.5" />
     <Members>
+      <Method Name="AcquireTokenOnBehalfOfParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
       <Method Name="WithUserAssertion" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAAAAAAACAAAAAAAEAAAAAAAgAAAEA=</HashCode>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAACAAAAAAAEAAAIAAIgAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenOnBehalfOfParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.GetAuthorizationRequestUrlParameterBuilder">
-    <Position X="24.25" Y="7.25" Width="5.5" />
+    <Position X="4.5" Y="7" Width="5.5" />
     <Members>
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Method Name="GetAuthorizationRequestUrlParameterBuilder" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
     </Members>
-    <InheritanceLine Type="Microsoft.Identity.Client.ApiConfig.AbstractCcaAcquireTokenParameterBuilder&lt;T&gt;" FixedToPoint="true">
-      <Path>
-        <Point X="20.875" Y="3.691" />
-        <Point X="20.875" Y="4.066" />
-        <Point X="28.188" Y="4.066" />
-        <Point X="28.188" Y="7.25" />
-      </Path>
-    </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAEAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAEA=</HashCode>
+      <HashCode>IAAAAAAAEAAAAAgAAAAAAAAAAIAAAEAAAIAAIAAAAEA=</HashCode>
       <FileName>ApiConfig\GetAuthorizationRequestUrlParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenByRefreshTokenParameterBuilder">
-    <Position X="0.75" Y="7.25" Width="6" />
+    <Position X="0.5" Y="7" Width="3.25" />
     <Members>
+      <Method Name="AcquireTokenByRefreshTokenParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
       <Method Name="WithRefreshToken" Hidden="true" />
     </Members>
-    <InheritanceLine Type="Microsoft.Identity.Client.ApiConfig.AbstractClientAppBaseAcquireTokenParameterBuilder&lt;T&gt;" FixedToPoint="true">
-      <Path>
-        <Point X="4" Y="4.441" />
-        <Point X="4" Y="4.816" />
-        <Point X="6.188" Y="4.816" />
-        <Point X="6.188" Y="7.25" />
-      </Path>
-    </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>gAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAEA=</HashCode>
+      <HashCode>gAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAIAAIAAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenByRefreshTokenParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenSilentParameterBuilder">
-    <Position X="0.5" Y="5.25" Width="5.25" />
+    <Position X="1.75" Y="9.25" Width="5.25" />
     <Members>
+      <Method Name="AcquireTokenSilentParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
       <Method Name="Validate" Hidden="true" />
     </Members>
+    <InheritanceLine Type="Microsoft.Identity.Client.ApiConfig.AbstractClientAppBaseAcquireTokenParameterBuilder&lt;T&gt;" FixedToPoint="true">
+      <Path>
+        <Point X="4" Y="6.191" />
+        <Point X="4" Y="6.625" />
+        <Point X="4.188" Y="6.625" />
+        <Point X="4.188" Y="9.25" />
+      </Path>
+    </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAACAAAAAAAAAAAAAAAAAAEAAAAAIAAAAAEA=</HashCode>
+      <HashCode>IAAAAAAAAACAAAAAAAAAAAAAAIAAAEAAAIAIIAAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenSilentParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenInteractiveParameterBuilder">
-    <Position X="7" Y="5.25" Width="4" />
+    <Position X="10.5" Y="7" Width="4" />
     <Members>
       <Field Name="_ownerWindow" Hidden="true" />
       <Method Name="AcquireTokenInteractiveParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
       <Method Name="Validate" Hidden="true" />
       <Method Name="WithParent" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>AAAAAAIAAACAAAQAAAAAAAAAEAAAAEAAAAAAAgAAAEA=</HashCode>
+      <HashCode>IAQAAAIAAACAAAgAAAAAAAAAEIAAAEAAAIAAIgAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenInteractiveParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenWithDeviceCodeParameterBuilder">
-    <Position X="7.5" Y="7" Width="5.75" />
+    <Position X="12" Y="9.25" Width="5.75" />
     <Members>
       <Method Name="AcquireTokenWithDeviceCodeParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
       <Method Name="Validate" Hidden="true" />
     </Members>
-    <InheritanceLine Type="Microsoft.Identity.Client.ApiConfig.AbstractPcaAcquireTokenParameterBuilder&lt;T&gt;" FixedToPoint="true">
-      <Path>
-        <Point X="8.875" Y="4.441" />
-        <Point X="8.875" Y="4.875" />
-        <Point X="11.525" Y="4.875" />
-        <Point X="11.525" Y="7" />
-      </Path>
-    </InheritanceLine>
     <TypeIdentifier>
-      <HashCode>AAAAAAAgAACAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAEA=</HashCode>
+      <HashCode>AAAAAAAgAACAAAAAAAAAAAAAAAAAAEAAAIAAIAAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenWithDeviceCodeParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenByIntegratedWindowsAuthParameterBuilder">
-    <Position X="13.5" Y="6.5" Width="4" />
+    <Position X="17.25" Y="8" Width="4" />
     <Members>
       <Method Name="AcquireTokenByIntegratedWindowsAuthParameterBuilder" Hidden="true" />
+      <Method Name="CalculateApiEventId" Hidden="true" />
       <Method Name="Create" Hidden="true" />
       <Method Name="ExecuteAsync" Hidden="true" />
+      <Property Name="Parameters" Hidden="true" />
     </Members>
     <TypeIdentifier>
-      <HashCode>AAAAABAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAEA=</HashCode>
+      <HashCode>AAAAABAAAAAAAAAAAAAAAAAAAAAAAEAAAIAAIAAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenByIntegratedWindowsAuthParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Microsoft.Identity.Client.ApiConfig.AcquireTokenByUsernamePasswordParameterBuilder" Collapsed="true">
-    <Position X="12.25" Y="5.25" Width="3.5" />
+    <Position X="15.5" Y="7" Width="3.5" />
     <TypeIdentifier>
-      <HashCode>AAIAABAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAEA=</HashCode>
+      <HashCode>AAIAABAAAAAAAAAAAAAAAAAAAAAAAEAAAIAAIAAAAEA=</HashCode>
       <FileName>ApiConfig\AcquireTokenByUsernamePasswordParameterBuilder.cs</FileName>
     </TypeIdentifier>
   </Class>

--- a/src/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -116,9 +116,12 @@ namespace Microsoft.Identity.Client.ApiConfig
         /// Specific authority for which the token is requested. Passing a different value than configured
         /// at the application constructor narrows down the selection to a specific tenant.
         /// This does not change the configured value in the application. This is specific
-        /// to applications managing several accounts (like a mail client with several mailboxes)
+        /// to applications managing several accounts (like a mail client with several mailboxes).
+        /// See https://aka.ms/msal-net-application-configuration
         /// </summary>
-        /// <param name="authorityUri">Uri for the authority</param>
+        /// <param name="authorityUri">Uri for the authority. In the case when the authority URI is 
+        /// a known Azure AD URI, this setting needs to be consistent with what is declared in 
+        /// the application registration portal</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
         public T WithAuthority(string authorityUri, bool validateAuthority = true)
@@ -135,7 +138,7 @@ namespace Microsoft.Identity.Client.ApiConfig
         /// <param name="tenantId">Guid of the tenant from which to sign-in users</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             string cloudInstanceUri,
             Guid tenantId,
             bool validateAuthority = true)
@@ -155,11 +158,11 @@ namespace Microsoft.Identity.Client.ApiConfig
         /// <remarks>
         /// <paramref name="tenant"/> can also contain the string representation of a GUID (tenantId),
         /// or even <c>common</c>, <c>organizations</c> or <c>consumers</c> but in this case
-        /// it's recommended to use another override (<see cref="WithAadAuthority(AzureCloudInstance, Guid, bool)"/>
-        /// and <see cref="WithAadAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
+        /// it's recommended to use another override (<see cref="WithAuthority(AzureCloudInstance, Guid, bool)"/>
+        /// and <see cref="WithAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
         /// </remarks>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             string cloudInstanceUri,
             string tenant,
             bool validateAuthority = true)
@@ -178,7 +181,7 @@ namespace Microsoft.Identity.Client.ApiConfig
         /// <param name="tenantId">Tenant Id of the tenant from which to sign-in users</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             AzureCloudInstance azureCloudInstance,
             Guid tenantId,
             bool validateAuthority = true)
@@ -198,7 +201,7 @@ namespace Microsoft.Identity.Client.ApiConfig
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// to sign-in users. This can also be a guid</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             AzureCloudInstance azureCloudInstance,
             string tenant,
             bool validateAuthority = true)
@@ -218,7 +221,7 @@ namespace Microsoft.Identity.Client.ApiConfig
         /// accounts</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(AzureCloudInstance azureCloudInstance, AadAuthorityAudience authorityAudience, bool validateAuthority = true)
+        public T WithAuthority(AzureCloudInstance azureCloudInstance, AadAuthorityAudience authorityAudience, bool validateAuthority = true)
         {
             CommonParameters.AuthorityOverride = AuthorityInfo.FromAadAuthority(azureCloudInstance, authorityAudience, validateAuthority);
             return (T)this;
@@ -233,31 +236,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         /// accounts</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(AadAuthorityAudience authorityAudience, bool validateAuthority = true)
+        public T WithAuthority(AadAuthorityAudience authorityAudience, bool validateAuthority = true)
         {
             CommonParameters.AuthorityOverride = AuthorityInfo.FromAadAuthority(authorityAudience, validateAuthority);
-            return (T)this;
-        }
-
-        /// <summary>
-        /// Adds a known Azure AD authority to the application to sign-in users specifying
-        /// the full authority Uri. See https://aka.ms/msal-net-application-configuration.
-        /// </summary>
-        /// <param name="authorityUri">URL of the security token service (STS) from which MSAL.NET will acquire the tokens.
-        ///  Usual authorities endpoints for the Azure public Cloud are:
-        ///  <list type="bullet">
-        ///  <item><description><c>https://login.microsoftonline.com/tenant/</c> where <c>tenant</c> is the tenant ID of the Azure AD tenant
-        ///  or a domain associated with this Azure AD tenant, in order to sign-in users of a specific organization only</description></item>
-        ///  <item><description><c>https://login.microsoftonline.com/common/</c> to sign-in users with any work and school accounts or Microsoft personal account</description></item>
-        ///  <item><description><c>https://login.microsoftonline.com/organizations/</c> to sign-in users with any work and school accounts</description></item>
-        ///  <item><description><c>https://login.microsoftonline.com/consumers/</c> to sign-in users with only personal Microsoft accounts (live)</description></item>
-        ///  </list>
-        ///  Note that this setting needs to be consistent with what is declared in the application registration portal</param>
-        /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
-        /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(string authorityUri, bool validateAuthority = true)
-        {
-            CommonParameters.AuthorityOverride = AuthorityInfo.FromAadAuthority(authorityUri, validateAuthority);
             return (T)this;
         }
 

--- a/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// users sign-in. This is classically a GUID or a domain name. See https://aka.ms/msal-net-application-configuration.
         /// Although it is also possible to set <paramref name="tenantId"/> to <c>common</c>,
         /// <c>organizations</c>, and <c>consumers</c>, it's recommended to use one of the
-        /// overrides of <see cref="WithAadAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
+        /// overrides of <see cref="WithAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
         /// </summary>
         /// <param name="tenantId">tenant ID of the Azure AD tenant
         /// or a domain associated with this Azure AD tenant, in order to sign-in a user of a specific organization only</param>
@@ -308,7 +308,7 @@ namespace Microsoft.Identity.Client.AppConfig
             else
             {
                 // Add the default.
-                WithAadAuthority(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, true);
+                WithAuthority(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, true);
             }
         }
 
@@ -361,7 +361,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// Adds a known authority to the application from its Uri. See https://aka.ms/msal-net-application-configuration.
         /// This constructor is mainly used for scenarios where the authority is not a standard Azure AD authority,
         /// nor an ADFS authority, nor an Azure AD B2C authority. For Azure AD, even in national and sovereign clouds, prefer
-        /// using other overrides such as <see cref="WithAadAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
+        /// using other overrides such as <see cref="WithAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
         /// </summary>
         /// <param name="authorityUri">Uri of the authority</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
@@ -380,7 +380,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// <param name="tenantId">Guid of the tenant from which to sign-in users</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             string cloudInstanceUri,
             Guid tenantId,
             bool validateAuthority = true)
@@ -400,11 +400,11 @@ namespace Microsoft.Identity.Client.AppConfig
         /// <remarks>
         /// <paramref name="tenant"/> can also contain the string representation of a GUID (tenantId),
         /// or even <c>common</c>, <c>organizations</c> or <c>consumers</c> but in this case
-        /// it's recommended to use another override (<see cref="WithAadAuthority(AzureCloudInstance, Guid, bool)"/>
-        /// and <see cref="WithAadAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
+        /// it's recommended to use another override (<see cref="WithAuthority(AzureCloudInstance, Guid, bool)"/>
+        /// and <see cref="WithAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
         /// </remarks>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             string cloudInstanceUri,
             string tenant,
             bool validateAuthority = true)
@@ -423,7 +423,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// <param name="tenantId">Tenant Id of the tenant from which to sign-in users</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             AzureCloudInstance azureCloudInstance,
             Guid tenantId,
             bool validateAuthority = true)
@@ -443,7 +443,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// to sign-in users. This can also be a guid</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(
+        public T WithAuthority(
             AzureCloudInstance azureCloudInstance,
             string tenant,
             bool validateAuthority = true)
@@ -463,7 +463,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// accounts</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(AzureCloudInstance azureCloudInstance, AadAuthorityAudience authorityAudience, bool validateAuthority = true)
+        public T WithAuthority(AzureCloudInstance azureCloudInstance, AadAuthorityAudience authorityAudience, bool validateAuthority = true)
         {
             Config.AuthorityInfo = AuthorityInfo.FromAadAuthority(azureCloudInstance, authorityAudience, validateAuthority);
             return (T)this;
@@ -478,7 +478,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// accounts</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(AadAuthorityAudience authorityAudience, bool validateAuthority = true)
+        public T WithAuthority(AadAuthorityAudience authorityAudience, bool validateAuthority = true)
         {
             Config.AuthorityInfo = AuthorityInfo.FromAadAuthority(authorityAudience, validateAuthority);
             return (T)this;
@@ -500,7 +500,7 @@ namespace Microsoft.Identity.Client.AppConfig
         ///  Note that this setting needs to be consistent with what is declared in the application registration portal</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public T WithAadAuthority(string authorityUri, bool validateAuthority = true)
+        public T WithAuthority(string authorityUri, bool validateAuthority = true)
         {
             Config.AuthorityInfo = AuthorityInfo.FromAadAuthority(authorityUri, validateAuthority);
             return (T)this;

--- a/tests/Microsoft.Identity.Test.Unit.net45/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             // Azure Cloud Instance + AAD Authority Audience
             app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                .WithAadAuthority(
+                                                .WithAuthority(
                                                     AzureCloudInstance.AzureChina,
                                                     AadAuthorityAudience.AzureAdMultipleOrgs)
                                                 .Build();
@@ -279,7 +279,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             // Azure Cloud Instance + common
             app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                .WithAadAuthority(
+                                                .WithAuthority(
                                                     AzureCloudInstance.AzureChina,
                                                     "common")
                                                 .Build();
@@ -287,7 +287,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             // Azure Cloud Instance + consumers
             app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                .WithAadAuthority(
+                                                .WithAuthority(
                                                     AzureCloudInstance.AzureChina,
                                                     "consumers")
                                                 .Build();
@@ -295,7 +295,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             // Azure Cloud Instance + domain
             app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                .WithAadAuthority(
+                                                .WithAuthority(
                                                     AzureCloudInstance.AzureChina,
                                                     "contoso.com")
                                                 .Build();
@@ -304,7 +304,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
             // Azure Cloud Instance + tenantId(GUID)
             Guid tenantId = Guid.NewGuid();
             app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                .WithAadAuthority(
+                                                .WithAuthority(
                                                     AzureCloudInstance.AzureChina,
                                                     tenantId)
                                                 .Build();
@@ -313,7 +313,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
             // Azure Cloud Instance + tenantId(string)
             tenantId = Guid.NewGuid();
             app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                .WithAadAuthority(
+                                                .WithAuthority(
                                                     AzureCloudInstance.AzureChina,
                                                     tenantId.ToString())
                                                 .Build();
@@ -326,7 +326,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
             try
             {
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                    .WithAadAuthority(AadAuthorityAudience.AzureAdMyOrg)
+                                                    .WithAuthority(AadAuthorityAudience.AzureAdMyOrg)
                                                     .WithTenantId("contoso.com")
                                                     .Build();
                 Assert.Fail("Should not reach here, exception should be thrown");
@@ -344,7 +344,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
             try
             {
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                        .WithAadAuthority("https://login.microsoftonline.fr")
+                                                        .WithAuthority("https://login.microsoftonline.fr")
                                                         .Build();
                 Assert.Fail("Should not reach here, exception should be thrown");
             }

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         public void ConstructorsTest()
         {
             var app = ConfidentialClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                          .WithAadAuthority(AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount)
+                                                          .WithAuthority(AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount)
                                                           .WithRedirectUri(MsalTestConstants.RedirectUri)
                                                           .WithClientSecret(MsalTestConstants.ClientSecret)
                                                           .BuildConcrete();

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -1582,13 +1582,13 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 #endif
         public static void CheckBuilderCommonMethods<T>(AbstractAcquireTokenParameterBuilder<T> builder) where T : AbstractAcquireTokenParameterBuilder<T>
         {
-            builder.WithAadAuthority(AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, true)
-                .WithAadAuthority(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMultipleOrgs, true)
-                .WithAadAuthority(AzureCloudInstance.AzurePublic, Guid.NewGuid(), true)
-                .WithAadAuthority(AzureCloudInstance.AzureChina, Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture), true)
-                .WithAadAuthority(MsalTestConstants.AuthorityCommonTenant, Guid.NewGuid(), true)
-                .WithAadAuthority(MsalTestConstants.AuthorityCommonTenant, Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture), true)
-                .WithAadAuthority(MsalTestConstants.AuthorityGuestTenant, true)
+            builder.WithAuthority(AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, true)
+                .WithAuthority(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMultipleOrgs, true)
+                .WithAuthority(AzureCloudInstance.AzurePublic, Guid.NewGuid(), true)
+                .WithAuthority(AzureCloudInstance.AzureChina, Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture), true)
+                .WithAuthority(MsalTestConstants.AuthorityCommonTenant, Guid.NewGuid(), true)
+                .WithAuthority(MsalTestConstants.AuthorityCommonTenant, Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture), true)
+                .WithAuthority(MsalTestConstants.AuthorityGuestTenant, true)
                 .WithAdfsAuthority(MsalTestConstants.AuthorityGuestTenant, true)
                 .WithB2CAuthority(MsalTestConstants.B2CAuthority)
                 .WithExtraQueryParameters(

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     });
 
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                        .WithAadAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                                                        .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .BuildConcrete();
 
@@ -625,7 +625,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     });
 
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                        .WithAadAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                                                        .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .BuildConcrete();
 
@@ -651,7 +651,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 AddMockResponseforManagedAccounts(httpManager);
 
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                        .WithAadAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                                                        .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .BuildConcrete();
 
@@ -699,7 +699,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     });
 
                 var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                        .WithAadAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                                                        .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .BuildConcrete();
 


### PR DESCRIPTION
Pretty mechanical.
The only thing to watch out is that we had one override with .WithAadAuthority which had the same signature than a WithAuthority method. 
I merged the XML comments, and removed one of them (the AAD specific one)