### PR TITLE
Jmprieur/script to update azure samples

### DIFF
--- a/samples/azure-samples/scriptReadme.md
+++ b/samples/azure-samples/scriptReadme.md
@@ -1,0 +1,16 @@
+## What this script does
+
+- clones the Azure-sample MSAL.NET samples repos in a sub folder of the folder containing the script
+- updates the sample to use the  `UsedLibraryVersion` version
+- builds the sample
+- if the sample builds, commits the changes and pushes the `cd/updateLatestMSAL` branch
+
+Then, you just need to go to each of the samples repos and accepts or not the PRs:
+
+- the list of PRs to review is in `todo.txt`,
+- whereas the list of projects that failed to build are in `failed.txt`
+
+## Prerequisites**
+
+- have NuGet.exe in the path
+- change the `UsedLibraryVersion` variable to the version to which to upgrade the samples

--- a/samples/azure-samples/updateMSALSamplesToLatest.bat
+++ b/samples/azure-samples/updateMSALSamplesToLatest.bat
@@ -1,0 +1,233 @@
+echo OFF
+set Usedlibrary="Microsoft.Identity.Client"
+set UsedLibraryVersion="2.7.0"
+cd %~dp0
+echo Updating v2-wabapp-msgraph
+set repo="https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2"
+set folder="v2-wabapp-msgraph"
+set solution="WebApp-OpenIDConnect-DotNet.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout aspnetcore2-2-signInAndCallGraph
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-webapp-admin-restricted-scopes
+set repo="https://github.com/azure-samples/active-directory-dotnet-admin-restricted-scopes-v2"
+set folder="v2-webapp-admin-restricted-scopes"
+set solution="GroupManager.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-wpf-msgraph
+set repo="https://github.com/azure-samples/active-directory-dotnet-desktop-msgraph-v2"
+set folder="v2-wpf-msgraph"
+set solution="active-directory-wpf-msgraph-v2.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-wpf-webapi
+set repo="https://github.com/azure-samples/active-directory-dotnet-native-aspnetcore-v2"
+set folder="v2-wpf-webapi"
+set solution="2. Web API now calls Microsoft Graph\Web-API-Calls-Graph.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-desktop-iwa
+set repo="https://github.com/azure-samples/active-directory-dotnet-iwa-v2"
+set folder="v2-desktop-iwa"
+set solution="iwa-console\iwa-console.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-desktop-up
+set repo="https://github.com/azure-samples/active-directory-dotnetcore-console-up-v2"
+set folder="v2-desktop-up"
+set solution="up-console.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-uwp
+set repo="https://github.com/azure-samples/active-directory-dotnet-native-uwp-v2"
+set folder="v2-uwp"
+set solution="active-directory-dotnet-native-uwp-v2.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-xamarin
+set repo="https://github.com/azure-samples/active-directory-xamarin-native-v2"
+set folder="v2-xamarin"
+set solution="active-directory-Xamarin-native-v2.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-xamarin
+set repo="https://github.com/azure-samples/active-directory-xamarin-native-v2"
+set folder="v2-xamarin"
+set solution="active-directory-Xamarin-native-v2.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-daemon-console
+set repo="https://github.com/azure-samples/active-directory-dotnetcore-daemon-v2"
+set folder="v2-daemon-console"
+set solution="daemon-console.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-daemon-web
+set repo="https://github.com/azure-samples/active-directory-dotnet-daemon-v2"
+set folder="v2-daemon-web"
+set solution="UserSync.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0
+echo Updating v2-browserless
+set repo="https://github.com/azure-samples/active-directory-dotnetcore-devicecodeflow-v2"
+set folder="v2-browserless"
+set solution="device-code-flow-console.sln"
+git clone %repo% %folder%
+cd %folder%
+git checkout -b cd/updateLatestMSAL
+nuget restore %solution%
+msbuild /t:restore %solution%
+nuget.exe update %solution% -Id %Usedlibrary% -Version %UsedLibraryVersion%
+msbuild %solution%
+if ERRORLEVEL 1 (echo "%folder% build failed" >> ..\failed.txt ) else (
+git add *
+git commit -m "Updating the solution to MSAL %UsedLibraryVersion%"
+git push --set-upstream origin cd/updateLatestMSAL 2>> ..\todo.txt
+)
+ver > nul
+
+cd %~dp0


### PR DESCRIPTION
This PR contains a scrit that updates the Azure-Samples MSAL samples with a specific version of MSAL.NET

## What this script does

- clones the Azure-sample MSAL.NET samples repos in a sub folder of the folder containing the script
- updates the sample to use the  `UsedLibraryVersion` version
- builds the sample
- if the sample builds, commits the changes and pushes the `cd/updateLatestMSAL` branch

Then, you just need to go to each of the samples repos and accepts or not the PRs:

- the list of PRs to review is in `todo.txt`,
- whereas the list of projects that failed to build are in `failed.txt`

## Prerequisites**

- have NuGet.exe in the path
- change the `UsedLibraryVersion` variable to the version to which to upgrade the samples

## Possible improvements

- with a .nuget.config file, the script could update (therefore test breaking changes) with any version of MSAL.NET, including the one built locally
- the script does not yet run the AppCreationScripts, for samples which have some. This would configure the apps before building them, and therefore have the samples ready for manual testing.