### PR TITLE
Addressing issues observed in the latest work on enabling B2C in sove…

### DIFF
--- a/src/Microsoft.Identity.Client/Instance/B2CAuthority.cs
+++ b/src/Microsoft.Identity.Client/Instance/B2CAuthority.cs
@@ -37,8 +37,7 @@ namespace Microsoft.Identity.Client.Instance
     {
         public const string Prefix = "tfp"; // The http path of B2C authority looks like "/tfp/<your_tenant_name>/..."
         public const string B2CCanonicalAuthorityTemplate = "https://{0}/{1}/{2}/{3}/";
-        // public const string B2CTrustedHost = "b2clogin.com";
-        private string[] B2CTrustedHosts = { "b2clogin.com", "b2cLogin.cn" };
+        private string[] B2CTrustedHosts = { "b2clogin.com", "b2cLogin.cn", "b2clogin.de", "b2clogin.us" };
 
         internal B2CAuthority(IServiceBundle serviceBundle, AuthorityInfo authorityInfo)
             : base(serviceBundle, authorityInfo)

--- a/src/Microsoft.Identity.Client/Instance/B2CAuthority.cs
+++ b/src/Microsoft.Identity.Client/Instance/B2CAuthority.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Identity.Client.Instance
     {
         public const string Prefix = "tfp"; // The http path of B2C authority looks like "/tfp/<your_tenant_name>/..."
         public const string B2CCanonicalAuthorityTemplate = "https://{0}/{1}/{2}/{3}/";
-        public const string B2CTrustedHost = "b2clogin.com";
+        // public const string B2CTrustedHost = "b2clogin.com";
+        private string[] B2CTrustedHosts = { "b2clogin.com", "b2cLogin.cn" };
 
         internal B2CAuthority(IServiceBundle serviceBundle, AuthorityInfo authorityInfo)
             : base(serviceBundle, authorityInfo)
@@ -57,7 +58,12 @@ namespace Microsoft.Identity.Client.Instance
 
         private bool IsB2CLoginHost(string host)
         {
-            return host.EndsWith(B2CTrustedHost, StringComparison.OrdinalIgnoreCase);
+            var isB2CLogin = false;
+            foreach (var b2CTrustedHost in B2CTrustedHosts)
+            {
+                isB2CLogin |= host.EndsWith(b2CTrustedHost, StringComparison.OrdinalIgnoreCase);
+            }
+            return isB2CLogin;
         }
 
         internal override string GetTenantId()

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string AuthorityWindowsNet = "https://" + ProductionPrefCacheEnvironment + "/" + Utid + "/";
         public const string B2CAuthority = "https://login.microsoftonline.in/tfp/tenant/policy/";
         public const string B2CLoginAuthority = "https://sometenantid.b2clogin.com/tfp/sometenantid/policy/";
+        public const string B2CMooncakeAuthority = "https://sometenantid.b2clogin.cn/tfp/sometenantid/policy/";
         public const string B2CRandomHost = "https://sometenantid.randomhost.com/tfp/sometenantid/policy/";
         public const string ClientId = "d3adb33f-c0de-ed0c-c0de-deadb33fc0d3";
         public static readonly string ClientId_1 = "d3adb33f-c1de-ed1c-c1de-deadb33fc1d3";

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -1463,6 +1463,31 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
         [TestMethod]
         [TestCategory("PublicClientApplicationTests")]
+        public void B2CLoginMooncakeAcquireTokenTest()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                                                                            .WithAuthority(new Uri(MsalTestConstants.B2CMooncakeAuthority), true)
+                                                                            .WithHttpManager(httpManager)
+                                                                            .BuildConcrete();
+
+                MsalMockHelpers.ConfigureMockWebUI(
+                    app.ServiceBundle.PlatformProxy,
+                    new AuthorizationResult(AuthorizationStatus.Success, app.AppConfig.RedirectUri + "?code=some-code"));
+
+                httpManager.AddMockHandlerForTenantEndpointDiscovery(MsalTestConstants.B2CMooncakeAuthority);
+                httpManager.AddSuccessTokenResponseMockHandlerForPost(MsalTestConstants.B2CMooncakeAuthority);
+
+                AuthenticationResult result = app.AcquireTokenAsync(MsalTestConstants.Scope).Result;
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.Account);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("PublicClientApplicationTests")]
         public void EnsurePublicApiSurfaceExistsOnInterface()
         {
             IPublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)


### PR DESCRIPTION
Addressing issues observed in the latest work on enabling B2C in sovereign clouds.
* Add b2clogin.cn as trusted host
* Null Reference Exception: additional error handling and logging around OAuth2Client in case of http errors related to authorities/end-points which doesn't exist.
