### PR TITLE
Propagate CancellationToken to CustomWebUI

### DIFF
--- a/src/Microsoft.Identity.Client/Extensibility/ICustomWebUI.cs
+++ b/src/Microsoft.Identity.Client/Extensibility/ICustomWebUI.cs
@@ -26,6 +26,7 @@
 // ------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client.Extensibility
@@ -45,7 +46,14 @@ namespace Microsoft.Identity.Client.Extensibility
         ///     URI computed by MSAL.NET that will let the UI extension
         ///     navigate to the STS authorization endpoint in order to sign-in the user and have them consent
         /// </param>
-        /// <param name="redirectUri"></param>
+        /// <param name="redirectUri">
+        ///     The redirect Uri that was configured. The auth code will be appended to this redirect uri and the browser
+        ///     will redirect to it. 
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     The cancellation token to which you should respond to. See https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/task-cancellation
+        ///     for details.
+        /// </param>
         /// <returns>
         ///     The URI returned back from the STS authorization endpoint. This URI contains a code=CODE
         ///     parameters that MSAL.NET will extract
@@ -57,6 +65,6 @@ namespace Microsoft.Identity.Client.Extensibility
         ///     In the event of cancellation, the implementer should return OperationCanceledException.
         ///     In the event of failure, the implementer should throw MsalCustomWebUiFailedException.
         /// </remarks>
-        Task<Uri> AcquireAuthorizationCodeAsync(Uri authorizationUri, Uri redirectUri);
+        Task<Uri> AcquireAuthorizationCodeAsync(Uri authorizationUri, Uri redirectUri, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Identity.Client/Extensibility/MsalCustomWebUiFailedException.cs
+++ b/src/Microsoft.Identity.Client/Extensibility/MsalCustomWebUiFailedException.cs
@@ -35,11 +35,21 @@ namespace Microsoft.Identity.Client.Extensibility
     public class MsalCustomWebUiFailedException : MsalExtensionException
     {
         /// <summary>
-        /// Constructs a MsalCustomWebUiFailedException.
+        /// Constructs a <see cref="MsalCustomWebUiFailedException"/>
         /// </summary>
         /// <param name="message">Message containing description of failure.</param>
         public MsalCustomWebUiFailedException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="MsalCustomWebUiFailedException"/>
+        /// </summary>
+        /// <param name="message">Message containing description of failure.</param>
+        /// <param name="innerException">Root cause exception</param>
+        public MsalCustomWebUiFailedException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/src/Microsoft.Identity.Client/Extensibility/MsalExtensionException.cs
+++ b/src/Microsoft.Identity.Client/Extensibility/MsalExtensionException.cs
@@ -42,5 +42,15 @@ namespace Microsoft.Identity.Client.Extensibility
             : base(message)
         {
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        public MsalExtensionException(string message, Exception innerException)
+            : base(message, string.Empty, innerException)
+        {
+        }
     }
 }

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -87,13 +87,13 @@ namespace Microsoft.Identity.Client.Internal.Requests
         internal override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
             await ResolveAuthorityEndpointsAsync().ConfigureAwait(false);
-            await AcquireAuthorizationAsync().ConfigureAwait(false);
+            await AcquireAuthorizationAsync(cancellationToken).ConfigureAwait(false);
             VerifyAuthorizationResult();
             var msalTokenResponse = await SendTokenRequestAsync(GetBodyParameters(), cancellationToken).ConfigureAwait(false);
             return CacheTokenResponseAndCreateAuthenticationResult(msalTokenResponse);
         }
 
-        private async Task AcquireAuthorizationAsync()
+        private async Task AcquireAuthorizationAsync(CancellationToken cancellationToken)
         {
             var authorizationUri = CreateAuthorizationUri(true, true);
 
@@ -106,7 +106,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 _authorizationResult = await _webUi.AcquireAuthorizationAsync(
                                            authorizationUri,
                                            AuthenticationRequestParameters.RedirectUri,
-                                           AuthenticationRequestParameters.RequestContext).ConfigureAwait(false);
+                                           AuthenticationRequestParameters.RequestContext,
+                                           cancellationToken).ConfigureAwait(false);
                 uiEvent.UserCancelled = _authorizationResult.Status == AuthorizationStatus.UserCancel;
                 uiEvent.AccessDenied = _authorizationResult.Status == AuthorizationStatus.ProtocolError;
             }

--- a/src/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/EmbeddedWebUI.cs
@@ -46,7 +46,11 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
             _coreUIParent = coreUIParent;
         }
 
-        public async override Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, RequestContext requestContext)
+        public async override Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri, 
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
         {
             returnedUriReady = new SemaphoreSlim(0);
 
@@ -65,7 +69,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
                     ex);
             }
 
-            await returnedUriReady.WaitAsync().ConfigureAwait(false);
+            await returnedUriReady.WaitAsync(cancellationToken).ConfigureAwait(false);
             return authorizationResult;
         }
 

--- a/src/Microsoft.Identity.Client/Platforms/Android/SystemWebview/SystemWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/SystemWebview/SystemWebUI.cs
@@ -49,7 +49,11 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
 
         public RequestContext RequestContext { get; set; }
 
-        public async override Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, RequestContext requestContext)
+        public async override Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri, 
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
         {
             returnedUriReady = new SemaphoreSlim(0);
 
@@ -70,7 +74,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
                     ex);
             }
 
-            await returnedUriReady.WaitAsync().ConfigureAwait(false);
+            await returnedUriReady.WaitAsync(cancellationToken).ConfigureAwait(false);
             return authorizationResult;
         }
 

--- a/src/Microsoft.Identity.Client/Platforms/Android/WebviewBase.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/WebviewBase.cs
@@ -55,7 +55,11 @@ namespace Microsoft.Identity.Client.Platforms.Android
             returnedUriReady.Release();
         }
 
-        public abstract Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, RequestContext requestContext);
+        public abstract Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri, 
+            RequestContext requestContext, 
+            CancellationToken cancellationToken);
 
         public abstract void ValidateRedirectUri(Uri redirectUri);
     }

--- a/src/Microsoft.Identity.Client/Platforms/Mac/MacEmbeddedWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Mac/MacEmbeddedWebUI.cs
@@ -48,11 +48,12 @@ namespace Microsoft.Identity.Client.Platforms.Mac
         public async Task<AuthorizationResult> AcquireAuthorizationAsync(
             Uri authorizationUri, 
             Uri redirectUri, 
-            RequestContext requestContext)
+            RequestContext requestContext, 
+            CancellationToken cancellationToken)
         {
             _returnedUriReady = new SemaphoreSlim(0);
             Authenticate(authorizationUri, redirectUri, requestContext);
-            await _returnedUriReady.WaitAsync().ConfigureAwait(false);
+            await _returnedUriReady.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             return _authorizationResult;
         }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
@@ -41,11 +41,15 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
         public RequestContext RequestContext { get; internal set; }
         public CoreUIParent CoreUIParent { get; set; }
 
-        public async override Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, RequestContext requestContext)
+        public async override Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri, 
+            RequestContext requestContext, 
+            CancellationToken cancellationToken)
         {
             returnedUriReady = new SemaphoreSlim(0);
             Authenticate(authorizationUri, redirectUri, requestContext);
-            await returnedUriReady.WaitAsync().ConfigureAwait(false);
+            await returnedUriReady.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             return authorizationResult;
         }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
@@ -42,8 +42,11 @@ namespace Microsoft.Identity.Client.Platforms.iOS.SystemWebview
     {
         public RequestContext RequestContext { get; set; }
 
-        public override async Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri,
-            RequestContext requestContext)
+        public override async Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri,
+            RequestContext requestContext, 
+            CancellationToken cancellationToken)
         {
             viewController = null;
             InvokeOnMainThread(() =>
@@ -54,7 +57,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.SystemWebview
 
             returnedUriReady = new SemaphoreSlim(0);
             Authenticate(authorizationUri, redirectUri, requestContext);
-            await returnedUriReady.WaitAsync().ConfigureAwait(false);
+            await returnedUriReady.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             //dismiss safariviewcontroller
             viewController.InvokeOnMainThread(() =>

--- a/src/Microsoft.Identity.Client/Platforms/iOS/WebviewBase.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/WebviewBase.cs
@@ -59,8 +59,11 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             willEnterForegroundNotification = NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.WillEnterForegroundNotification, OnMoveToForeground);
         }
 
-        public abstract Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri,
-            RequestContext requestContext);
+        public abstract Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri,
+            Uri redirectUri,
+            RequestContext requestContext,
+            CancellationToken cancellationToken);
 
         public static bool ContinueAuthentication(string url)
         {

--- a/src/Microsoft.Identity.Client/Platforms/net45/WebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/WebUI.cs
@@ -44,8 +44,11 @@ namespace Microsoft.Identity.Client.Platforms.net45
 
         public RequestContext RequestContext { get; set; }
 
-        public async Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri,
-            RequestContext requestContext)
+        public async Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri,
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
         {
             AuthorizationResult authorizationResult = null;
 
@@ -60,7 +63,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
                 {
                     try
                     {
-                        Task.Factory.StartNew(sendAuthorizeRequest, CancellationToken.None, TaskCreationOptions.None,
+                        Task.Factory.StartNew(sendAuthorizeRequest, cancellationToken, TaskCreationOptions.None,
                             staTaskScheduler).Wait();
                     }
                     catch (AggregateException ae)

--- a/src/Microsoft.Identity.Client/Platforms/uap/WebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/uap/WebUI.cs
@@ -35,6 +35,7 @@ using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Exceptions;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.UI;
+using System.Threading;
 
 namespace Microsoft.Identity.Client.Platforms.uap
 {
@@ -51,8 +52,11 @@ namespace Microsoft.Identity.Client.Platforms.uap
             silentMode = parent.UseHiddenBrowser;
         }
 
-        public async Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri,
-            RequestContext requestContext)
+        public async Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri,
+            RequestContext requestContext, 
+            CancellationToken cancellationToken)
         {
             bool ssoMode = string.Equals(redirectUri.OriginalString, Constants.UapWEBRedirectUri, StringComparison.OrdinalIgnoreCase);
 

--- a/src/Microsoft.Identity.Client/UI/IWebUI.cs
+++ b/src/Microsoft.Identity.Client/UI/IWebUI.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 
@@ -33,7 +34,11 @@ namespace Microsoft.Identity.Client.UI
 {
     internal interface IWebUI
     {
-        Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, RequestContext requestContext);
+        Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri, 
+            RequestContext requestContext, 
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Extra validations on the redirect uri, for example system web views cannot work with the urn:oob... uri because 

--- a/tests/Microsoft.Identity.Test.Common/Mocks/MockWebUI.cs
+++ b/tests/Microsoft.Identity.Test.Common/Mocks/MockWebUI.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http;
@@ -59,7 +60,8 @@ namespace Microsoft.Identity.Test.Common.Mocks
         public async Task<AuthorizationResult> AcquireAuthorizationAsync(
             Uri authorizationUri, 
             Uri redirectUri, 
-            RequestContext requestContext)
+            RequestContext requestContext, 
+            CancellationToken cancellationToken)
         {
             ActualAuthorizationUri = authorizationUri;
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
@@ -124,6 +124,32 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 });
         }
 
+
+        [TestMethod]
+        public void TestInteractiveWithCustomWebUi_UnhandledException()
+        {
+            // The CustomWebUi is only going to return the Uri value here with no additional data to parse to get the code, so we'll expect to fail.
+            ExecuteTest(
+                false,
+                 ui => ui.AcquireAuthorizationCodeAsync(null, null, CancellationToken.None)
+                        .ReturnsForAnyArgs<Uri>(x => { throw new InvalidOperationException(); } ),
+                request =>
+                {
+                    try
+                    {
+                        request.ExecuteAsync(CancellationToken.None)
+                               .GetAwaiter().GetResult();
+                        Assert.Fail("MsalException should have been thrown here");
+                    }
+                    catch (Exception exc)
+                    {
+                        Assert.IsTrue(exc is MsalCustomWebUiFailedException);
+                        Assert.IsTrue(exc.InnerException is InvalidOperationException);
+
+                    }
+                });
+        }
+
         [TestMethod]
         public void TestInteractiveWithCustomWebUi_CorrectRedirectUri_NoQueryDataForCode()
         {

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
@@ -107,20 +107,19 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             ExecuteTest(
                 false,
-                ui => ui.AcquireAuthorizationCodeAsync(null, null)
+                ui => ui.AcquireAuthorizationCodeAsync(null, null, CancellationToken.None)
                         .ReturnsForAnyArgs(Task.FromResult(new Uri("http://blech"))),
                 request =>
                 {
                     try
                     {
                         request.ExecuteAsync(CancellationToken.None)
-                               .Wait();
+                               .GetAwaiter().GetResult();
                         Assert.Fail("MsalException should have been thrown here");
                     }
                     catch (Exception exc)
                     {
-                        Assert.IsTrue(exc.InnerException is MsalServiceException);
-                        Assert.AreEqual(CoreErrorCodes.UnknownError, ((MsalServiceException)exc.InnerException).ErrorCode);
+                        Assert.IsTrue(exc is MsalCustomWebUiFailedException);
                     }
                 });
         }
@@ -131,7 +130,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             // The CustomWebUi is only going to return the Uri value here with no additional data to parse to get the code, so we'll expect to fail.
             ExecuteTest(
                 false,
-                ui => ui.AcquireAuthorizationCodeAsync(null, null)
+                ui => ui.AcquireAuthorizationCodeAsync(null, null, CancellationToken.None)
                         .ReturnsForAnyArgs(Task.FromResult(new Uri(ExpectedRedirectUri))),
                 request =>
                 {
@@ -155,7 +154,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             // The CustomWebUi is only going to return the Uri value here with no additional data to parse to get the code, so we'll expect to fail.
             ExecuteTest(
                 true,
-                ui => ui.AcquireAuthorizationCodeAsync(null, null)
+                ui => ui.AcquireAuthorizationCodeAsync(null, null, CancellationToken.None)
                         .ReturnsForAnyArgs(Task.FromResult(new Uri(ExpectedRedirectUri + "?code=some-code"))),
                 request =>
                 {


### PR DESCRIPTION
We already pass a cancellation token around, but we ignore it completely for interactive auth. This PR will make sure the cancellation token is propagated but doesn't perform extensive checks if the cancellation was requested. 

More importantly, the CustomWebUI now gets passed this token, which is important for extenders, as I have found out by refactoring Selenium as a CustomWebUI (separate PR)