### PR TITLE
chained token providers, env config and managed identity support

### DIFF
--- a/src/Microsoft.Identity.Client/Azure/ChainedTokenProvider.cs
+++ b/src/Microsoft.Identity.Client/Azure/ChainedTokenProvider.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Azure
+{
+    /// <summary>
+    /// ChainedTokenProvider creates an ordered list of probes that will determine if the environment will allow it to build
+    /// a ICredentialProvider. The ICredentialProvider is then used to generate authentication credentials for the
+    /// consumer.
+    /// </summary>
+    public class ChainedTokenProvider : ITokenProvider
+    {
+        private readonly IList<IProbe> _probes;
+
+        /// <summary>
+        /// Create an instance of a ChainedTokenProvider providing a list of IProbes which will be executed in order to create a ICredentialProvider
+        /// </summary>
+        /// <param name="probes">probes to be executed in order to create a ICredentialProvider</param>
+        /// <exception cref="ArgumentException">throws if no probes were provided or if no probe is able to build a ICredentialProvider</exception>
+        public ChainedTokenProvider(IList<IProbe> probes)
+        {
+            if (probes == null || probes.Count() < 1)
+            {
+                throw new ArgumentException("must provide 1 or more IProbes");
+            }
+            _probes = probes;
+        }
+
+        /// <summary>
+        ///     GetTokenAsync returns a token for a given set of scopes
+        /// </summary>
+        /// <param name="scopes">Scopes requested to access a protected API</param>
+        /// <returns>A token with expiration</returns>
+        public async Task<IToken> GetTokenAsync(IEnumerable<string> scopes = null)
+        {
+            ITokenProvider provider = null;
+            foreach (var probe in _probes)
+            {
+                if (await probe.AvailableAsync().ConfigureAwait(false))
+                {
+                    provider = await probe.ProviderAsync().ConfigureAwait(false);
+                    break;
+                }
+            }
+
+            if (provider == null)
+            {
+                throw new NoProbesAvailableException();
+            }
+
+            return await provider.GetTokenAsync(scopes).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// NoProbesAvailableException is thrown when the chain of providers doesn't contain any token providers able to fetch a token
+    /// </summary>
+    public class NoProbesAvailableException : MsalClientException
+    {
+        private const string Code = "no_probes_are_available";
+        private const string ErrorMessage = "All of the IProbes provided were unable to find the variables needed to successfully create a credential provider.";
+
+        /// <summary>
+        /// Create a NoProbesAvailableException
+        /// </summary>
+        public NoProbesAvailableException() : base(Code, ErrorMessage) { }
+
+        /// <summary>
+        /// Create a NoProbesAvailableException with an error message
+        /// </summary>
+        public NoProbesAvailableException(string errorMessage) : base(Code, errorMessage) { }
+    }
+}

--- a/src/Microsoft.Identity.Client/Azure/Constants.cs
+++ b/src/Microsoft.Identity.Client/Azure/Constants.cs
@@ -1,0 +1,168 @@
+﻿using System;
+
+namespace Microsoft.Identity.Client.Azure
+{
+    /// <summary>
+    ///     Constants for environment variables, application settings and credential lookups
+    /// </summary>
+    public static class Constants
+    {
+        /// <summary>
+        ///     AzureTenantIdEnvName is the name of the environment variable which holds a string representation for a GUID,
+        ///     which is the ID of the tenant where the account resides
+        /// </summary>
+        public static readonly string AzureTenantIdEnvName = "AZURE_TENANT_ID";
+
+        /// <summary>
+        ///     AzureClientIdEnvName is the name of the environment variable which holds a string representation for a GUID
+        ///     ClientId (application ID) of the application
+        /// </summary>
+        public static readonly string AzureClientIdEnvName = "AZURE_CLIENT_ID";
+
+        /// <summary>
+        ///     AzureClientSecretEnvName is the name of the environment variable which holds a string representation of the
+        ///     secret for an application
+        /// </summary>
+        public static readonly string AzureClientSecretEnvName = "AZURE_CLIENT_SECRET";
+
+
+        /// <summary>
+        ///     AzureCertificateEnvName is the name of the environment variable which holds a base64 encoded string
+        ///     representation of an X509 certificate which is the secret for an application
+        /// </summary>
+        public static readonly string AzureCertificateEnvName = "AZURE_CERTIFICATE";
+
+        /// <summary>
+        ///     AzureCertificateThumbprintEnvName is the name of the environment variable which holds a string
+        ///     representation of the thumbprint of a certificate stored in the Windows Certificate Store
+        /// </summary>
+        public static readonly string AzureCertificateThumbprintEnvName = "AZURE_CERTIFICATE_THUMBPRINT";
+
+        /// <summary>
+        /// AzureCertificateSubjectDistinguishedNameEnvName is the name of the environment variable which holds the
+        /// subject distinguished name of a certificate stored in the Windows Certificate Store
+        /// </summary>
+        public static readonly string AzureCertificateSubjectDistinguishedNameEnvName = "AZURE_CERTIFICATE_SUBJECT_NAME";
+
+        /// <summary>
+        ///     AzureCertificateStoreEnvName is the name of the environment variable which holds the name of the certificate
+        ///     store
+        /// </summary>
+        public static readonly string AzureCertificateStoreEnvName = "AZURE_CERTIFICATE_STORE";
+
+        /// <summary>
+        ///     AzureCertificateStoreLocationEnvName is the name of the environment variable which holds the location of the
+        ///     certificate store (CurrentUser or LocalMachine)
+        /// </summary>
+        public static readonly string AzureCertificateStoreLocation = "AZURE_CERTIFICATE_STORE_LOCATION";
+
+        /// <summary>
+        /// API Version used for the Managed Identity metadata endpoint on AppService
+        /// </summary>
+        public static readonly string ManagedIdentityAppServiceApiVersion = "2017-08-01";
+
+        /// <summary>
+        /// API Version used for the Managed Identity metadata endpoint on Virtual Machines
+        /// </summary>
+        public static readonly string ManagedIdentityVMApiVersion = "2018-02-01";
+
+        /// <summary>
+        /// Managed Identity loopback IP address
+        /// </summary>
+        public static readonly string ManagedIdentityLoopbackAddress = "169.254.169.254";
+
+        /// <summary>
+        /// Managed Identity metadata endpoint
+        /// </summary>
+        public static readonly string ManagedIdentityMetadataEndpoint = "http://" + ManagedIdentityLoopbackAddress + "/metadata";
+
+        /// <summary>
+        /// Managed Identity
+        /// </summary>
+        public static readonly string ManagedIdentityTokenEndpoint = ManagedIdentityMetadataEndpoint + "/identity/oauth2/token";
+
+        /// <summary>
+        /// ManagedIdentityEndpointEnvName is the name of the environment variable which holds the endpoint for the
+        /// managed identity service running in Azure AppService
+        /// </summary>
+        public static readonly string ManagedIdentityEndpointEnvName = "MSI_ENDPOINT";
+
+        /// <summary>
+        /// ManagedIdentitySecretEnvName is the name of the environment variable which holds the secret for use in
+        /// calling the managed identity service running in Azure AppService
+        /// </summary>
+        public static readonly string ManagedIdentitySecretEnvName = "MSI_SECRET";
+
+        /// <summary>
+        /// AadAuthorityEnvName is the name of the environment variable which holds the hostname of the service token service (STS) from which MSAL.NET will acquire the tokens. Ex. login.microsoftonline.com
+        /// </summary>
+        public static readonly string AadAuthorityEnvName = "AAD_AUTHORITY";
+    }
+
+    /// <summary>
+    ///     Env provides access to well known environment variables
+    /// </summary>
+    public static class Env
+    {
+        /// <summary>
+        ///     A string representation for a GUID, which is the ID of the tenant where the account resides environment variable
+        /// </summary>
+        public static string TenantId => Environment.GetEnvironmentVariable(Constants.AzureTenantIdEnvName);
+
+        /// <summary>
+        ///     A string representation for a GUID ClientId (application ID) of the application environment variable
+        /// </summary>
+        public static string ClientId => Environment.GetEnvironmentVariable(Constants.AzureClientIdEnvName);
+
+        /// <summary>
+        ///     A string representation of the secret for an application environment variable
+        /// </summary>
+        public static string ClientSecret => Environment.GetEnvironmentVariable(Constants.AzureClientSecretEnvName);
+
+        /// <summary>
+        ///     A base64 encoded string representation of an X509 certificate which is the secret for an application environment variable
+        /// </summary>
+        public static string CertificateBase64 => Environment.GetEnvironmentVariable(Constants.AzureCertificateEnvName);
+
+        /// <summary>
+        ///     A string representation of the thumbprint of a certificate stored in the Windows Certificate Store
+        /// </summary>
+        public static string CertificateThumbprint =>
+            Environment.GetEnvironmentVariable(Constants.AzureCertificateThumbprintEnvName);
+
+        /// <summary>
+        /// The subject distinguished name of a certificate stored in the Windows Certificate Store
+        /// </summary>
+        public static string CertificateSubjectDistinguishedName =>
+            Environment.GetEnvironmentVariable(Constants.AzureCertificateSubjectDistinguishedNameEnvName);
+
+        /// <summary>
+        ///     The name of the certificate store
+        /// </summary>
+        public static string CertificateStoreName =>
+            Environment.GetEnvironmentVariable(Constants.AzureCertificateStoreEnvName);
+
+        /// <summary>
+        ///     The location of the certificate store (CurrentUser or LocalMachine) environment variable
+        /// </summary>
+        public static string CertificateStoreLocation =>
+            Environment.GetEnvironmentVariable(Constants.AzureCertificateStoreLocation);
+
+        /// <summary>
+        /// ManagedIdentityEndpoint is the value of the managed identity endpoint environment variable
+        /// </summary>
+        public static string ManagedIdentityEndpoint =>
+            Environment.GetEnvironmentVariable(Constants.ManagedIdentityEndpointEnvName);
+
+        /// <summary>
+        /// ManagedIdentitySecret is the value of the managed identity secret environment variable
+        /// </summary>
+        public static string ManagedIdentitySecret =>
+            Environment.GetEnvironmentVariable(Constants.ManagedIdentitySecretEnvName);
+
+        /// <summary>
+        /// AadAuthority is the hostname of the security token service (STS) from which MSAL.NET will acquire the tokens. Ex. login.microsoftonline.com
+        /// </summary>
+        public static string AadAuthority => Environment.GetEnvironmentVariable(Constants.AadAuthorityEnvName);
+    }
+}

--- a/src/Microsoft.Identity.Client/Azure/Exponential.cs
+++ b/src/Microsoft.Identity.Client/Azure/Exponential.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Azure
+{
+    /// <summary>
+    /// RetryWithExponentialBackoff runs a task with an exponential backoff
+    /// </summary>
+    internal sealed class RetryWithExponentialBackoff
+    {
+        private readonly int _maxRetries, _delayMilliseconds, _maxDelayMilliseconds;
+
+        /// <summary>
+        /// Create an instance of a RetryWithExponentialBackoff
+        /// </summary>
+        /// <param name="maxRetries">maximum number of retries (default 50)</param>
+        /// <param name="delayMilliseconds">initial delay in milliseconds (default 100)</param>
+        /// <param name="maxDelayMilliseconds">maximum delay in milliseconds (default 2000)</param>
+        public RetryWithExponentialBackoff(int maxRetries = 50, int delayMilliseconds = 100, int maxDelayMilliseconds = 2000)
+        {
+            _maxRetries = maxRetries;
+            _delayMilliseconds = delayMilliseconds;
+            _maxDelayMilliseconds = maxDelayMilliseconds;
+        }
+
+        /// <summary>
+        /// RunAsync will attempt to execute the a task with a exponential retry
+        /// </summary>
+        /// <param name="func">task to execute</param>
+        /// <returns>exponentially backed off task</returns>
+        public async Task RunAsync(Func<Task> func)
+        {
+            var backoff = new ExponentialBackoff(_maxRetries, _delayMilliseconds, _maxDelayMilliseconds);
+        retry:
+            try
+            {
+                await func().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is TimeoutException || ex is HttpRequestException || ex is TaskCanceledException || ex is TransientManagedIdentityException)
+            {
+                Debug.WriteLine(ex.ToString());
+                await backoff.DelayAsync().ConfigureAwait(false);
+                goto retry;
+            }
+        }
+    }
+
+    /// <summary>
+    /// ExponentialBackoff implements an exponential backoff for a task
+    /// </summary>
+    internal class ExponentialBackoff
+    {
+        private readonly int _maxRetries, _maxPower;
+        private readonly long _delayTicks, _maxDelayTicks;
+        private int _retries;
+
+        /// <summary>
+        /// Create an instance of an ExponentialBackoff
+        /// </summary>
+        /// <param name="maxRetries">maximum number of retries</param>
+        /// <param name="delayMilliseconds">initial delay in milliseconds</param>
+        /// <param name="maxDelayMilliseconds">maximum delay in milliseconds</param>
+        public ExponentialBackoff(int maxRetries, int delayMilliseconds, int maxDelayMilliseconds)
+        {
+            if(delayMilliseconds <= 0)
+            {
+                throw new ArgumentException("delayMilliseconds must be greater than 0");
+            }
+
+            _maxRetries = maxRetries;
+            _delayTicks = delayMilliseconds * TimeSpan.TicksPerMillisecond;
+            _maxDelayTicks = maxDelayMilliseconds * TimeSpan.TicksPerMillisecond;
+            _retries = 0;
+            _maxPower = 30 - (int)Math.Ceiling(Math.Log(delayMilliseconds, 2));
+        }
+
+        /// <summary>
+        /// DelayAsync will create an exponentially growing delay task
+        /// </summary>
+        /// <returns>a task to be delayed</returns>
+        /// <exception cref="TimeoutException">thrown upon exceeding the max number of retries</exception>
+        public async Task DelayAsync()
+        {
+            if (_retries == _maxRetries)
+            {
+                throw new TooManyRetryAttemptsException();
+            }
+
+            var delay = GetDelay(++_retries);
+            await Task.Delay(delay).ConfigureAwait(false);
+        }
+
+        internal TimeSpan GetDelay(int retryCount)
+        {
+            var ticks = long.MaxValue;
+            if(retryCount < _maxPower)
+            {
+                ticks = (long)Math.Pow(2, retryCount) *_delayTicks;
+            }
+            long waitTicks = Math.Min(ticks, _maxDelayTicks);
+            return TimeSpan.FromTicks(waitTicks);
+        }
+    }
+
+    /// <summary>
+    /// TooManyRetryAttemptsException occurs when a retry strategy exceeds the max number of retries
+    /// </summary>
+    public class TooManyRetryAttemptsException : MsalClientException
+    {
+        private const string Code = "max_retries_exhausted";
+        private const string ErrorMessage = "max retry attempts exceeded.";
+
+        /// <summary>
+        /// Create a TooManyRetryAttemptsException
+        /// </summary>
+        public TooManyRetryAttemptsException() : base(Code, ErrorMessage) { }
+
+        /// <summary>
+        /// Create a TooManyRetryAttemptsException with an error message
+        /// </summary>
+        public TooManyRetryAttemptsException(string errorMessage) : base(Code, errorMessage) { }
+    }
+
+    /// <summary>
+    /// TransientManagedIdentityException occurs when a 404, 429 or a 500 series error is encountered.
+    ///
+    /// see: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#error-handling
+    /// </summary>
+    public class TransientManagedIdentityException : MsalClientException
+    {
+        private const string Code = "transient_managed_identity_error";
+        private const string ErrorMessage = "encountered a transient error response from the managed identity service";
+
+        /// <summary>
+        /// Create a TransientManagedIdentityException
+        /// </summary>
+        public TransientManagedIdentityException() : base(Code, ErrorMessage) { }
+
+        /// <summary>
+        /// Create a TransientManagedIdentityException with an error message
+        /// </summary>
+        public TransientManagedIdentityException(string errorMessage) : base(Code, errorMessage) { }
+    }
+
+    /// <summary>
+    /// BadManagedIdentityException occurs when a 400 is returned from the managed identity service
+    ///
+    /// see: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#error-handling
+    /// </summary>
+    public class BadRequestManagedIdentityException : MsalServiceException
+    {
+        private const string Code = "bad_managed_identity_error";
+        private const string ErrorMessage = "invalid resource; the application was not found in the tenant.";
+
+        /// <summary>
+        /// Create a BadManagedIdentityException
+        /// </summary>
+        public BadRequestManagedIdentityException() : base(Code, ErrorMessage) { }
+
+        /// <summary>
+        /// Create a BadManagedIdentityException with an error message
+        /// </summary>
+        /// <param name="errorMessage">exception error message</param>
+        public BadRequestManagedIdentityException(string errorMessage) : base(Code, errorMessage) { }
+    }
+}

--- a/src/Microsoft.Identity.Client/Azure/IProbe.cs
+++ b/src/Microsoft.Identity.Client/Azure/IProbe.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Azure
+{
+    /// <summary>
+    /// IProbe provides an interface for describing an entity that discovers environmental capabilities which enable
+    /// a consumer to build a credential provider to assist authenticating to Azure
+    /// </summary>
+    public interface IProbe
+    {
+        /// <summary>
+        /// Check if the probe is available for use in the current environment
+        /// </summary>
+        /// <returns>True if a credential provider can be built</returns>
+        Task<bool> AvailableAsync();
+
+        /// <summary>
+        /// Create a credential provider from the information discovered by the probe
+        /// </summary>
+        /// <returns>A credential provider instance</returns>
+        Task<ITokenProvider> ProviderAsync();
+    }
+}

--- a/src/Microsoft.Identity.Client/Azure/ManagedIdentity.cs
+++ b/src/Microsoft.Identity.Client/Azure/ManagedIdentity.cs
@@ -1,0 +1,388 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.NetworkInformation;
+using System.Threading.Tasks;
+using System.Runtime.Serialization;
+using Microsoft.Identity.Client.Utils;
+using System.Text;
+
+namespace Microsoft.Identity.Client.Azure
+{
+#if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide confidential client on mobile platforms
+
+    /// <summary>
+    ///     ManagedIdentityProbe will look in environment variable to determine if the managed identity provider is
+    ///     available. If the managed identity provider is available, the probe will allow for building a managed identity
+    ///     credential provider to fetch AAD tokens using the IMDS endpoint.
+    /// </summary>
+    public class ManagedIdentityProbe : IProbe
+    {
+
+        private readonly HttpClient _httpClient;
+        private readonly IManagedIdentityConfiguration _config;
+        private readonly string _overrideClientId;
+
+        internal ManagedIdentityProbe(HttpClient httpClient, IManagedIdentityConfiguration config = null, string overrideClientId = null)
+        {
+            _httpClient = httpClient;
+            _config = config ?? new DefaultManagedIdentityConfiguration();
+            _overrideClientId = overrideClientId;
+        }
+
+        /// <summary>
+        ///     Create a Managed Identity probe with a specified client identity
+        /// </summary>
+        /// <param name="config">option configuration structure -- if not supplied, a default environmental configuration is used.</param>
+        /// <param name="overrideClientId">override the client identity found in the config for use when querying the Azure IMDS endpoint</param>
+        public ManagedIdentityProbe(IManagedIdentityConfiguration config = null, string overrideClientId = null)
+            : this(null, config, overrideClientId) { }
+
+        /// <summary>
+        ///     Check if the probe is available for use in the current environment
+        /// </summary>
+        /// <returns>True if a credential provider can be built</returns>
+        public async Task<bool> AvailableAsync()
+        {
+            // check App Service MSI
+            if (IsAppService())
+            {
+                return true;
+            }
+
+#if net45  || NETSTANDARD2_0
+
+            // Check if there is no service listening on VM IP
+            //
+            // This is a performance optimization to avoid retrying requests to the Managed Identity service
+
+            if(!IsVMManagedIdentityListening())
+            {
+                return false;
+            }
+#endif
+
+            try
+            {
+                // if service is listening on VM IP check if a token can be acquired
+                var provider = BuildProvider(maxRetries: 2, httpClient: _httpClient);
+                var token = await provider.GetTokenAsync(new List<string> { @"https://management.azure.com//.default" }).ConfigureAwait(false);
+                return token != null;
+            }
+            catch (TooManyRetryAttemptsException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// IsAppService tells us if we are executing within AppService with Managed Identities enabled
+        /// </summary>
+        /// <returns></returns>
+        private bool IsAppService()
+        {
+            var vars = new List<string> { _config.ManagedIdentitySecret, _config.ManagedIdentityEndpoint };
+            return vars.All(item => !string.IsNullOrWhiteSpace(item));
+        }
+
+#if net45 || NETSTANDARD2_0
+        private static bool IsVMManagedIdentityListening()
+        {
+            var loopback = IPAddress.Parse(Constants.ManagedIdentityLoopbackAddress);
+            foreach (var tcpEndpoint in IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners())
+            {
+                if (tcpEndpoint.Address == loopback && tcpEndpoint.Port == 80)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+#endif
+
+        /// <summary>
+        ///     Create a managed identity credential provider from the information discovered by the probe
+        /// </summary>
+        /// <returns>A managed identity credential provider instance</returns>
+        public async Task<ITokenProvider> ProviderAsync()
+        {
+            if (!await AvailableAsync().ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("The required environment variables are not available.");
+            }
+
+            return BuildProvider(httpClient: _httpClient);
+        }
+
+        private ITokenProvider BuildProvider(int maxRetries = 5, HttpClient httpClient = null)
+        {
+            var endpoint = IsAppService() ? _config.ManagedIdentityEndpoint : Constants.ManagedIdentityTokenEndpoint;
+            return new ManagedIdentityCredentialProvider(endpoint, httpClient: httpClient, secret: _config.ManagedIdentitySecret, clientId: ClientId, maxRetries: maxRetries);
+        }
+
+        private string ClientId
+        {
+            get { return string.IsNullOrWhiteSpace(_overrideClientId) ? _config.ClientId : _overrideClientId; }
+        }
+    }
+
+    /// <summary>
+    ///     ManagedIdentityCredentialProvider will fetch AAD JWT tokens from the IMDS endpoint for the default client id or
+    ///     a specified client id.
+    /// </summary>
+    public class ManagedIdentityCredentialProvider : ITokenProvider
+    {
+        private static readonly HttpClient DefaultClient;
+
+        private readonly ManagedIdentityClient _client;
+
+        static ManagedIdentityCredentialProvider()
+        {
+            DefaultClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromMilliseconds(100) // 100 milliseconds -- make sure there is an extremely short timeout to ensure we fail fast
+            };
+        }
+
+        internal ManagedIdentityCredentialProvider(string endpoint, HttpClient httpClient = null, string secret = null, string clientId = null, int maxRetries = 5)
+        {
+            if (string.IsNullOrWhiteSpace(secret))
+            {
+                _client = new ManagedIdentityVMClient(endpoint, httpClient ?? DefaultClient, clientId: clientId, maxRetries: maxRetries);
+            }
+            else
+            {
+                _client = new ManagedIdentityAppServiceClient(endpoint, secret, httpClient ?? DefaultClient, maxRetries: maxRetries);
+            }
+        }
+
+        /// <summary>
+        /// Create an instance of a ManagedIdentityCredentialProvider which will talk to either AppService or VM managed identity token endpoint
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <param name="secret"></param>
+        /// <param name="clientId"></param>
+        /// <param name="maxRetries"></param>
+        public ManagedIdentityCredentialProvider(string endpoint, string secret = null, string clientId = null, int maxRetries = 5)
+            : this(endpoint, httpClient: DefaultClient, secret: secret, clientId: clientId, maxRetries: maxRetries) { }
+
+        /// <summary>
+        ///     GetTokenAsync returns a token for a given set of scopes
+        /// </summary>
+        /// <param name="scopes">Scopes requested to access a protected API</param>
+        /// <returns>A token with expiration</returns>
+        public async Task<IToken> GetTokenAsync(IEnumerable<string> scopes = null)
+        {
+            var resourceUriInScopes = scopes?.FirstOrDefault(i => i.EndsWith(@"/.default", StringComparison.OrdinalIgnoreCase));
+            if (resourceUriInScopes == null)
+            {
+                throw new NoResourceUriInScopesException();
+            }
+
+            return await _client.FetchTokenWithRetryAsync(resourceUriInScopes).ConfigureAwait(false);
+        }
+    }
+
+
+    /// <summary>
+    /// NoResourceUriInScopesException is thrown when the managed identity token provider does not find a .default
+    /// scope for a resource in the enumeration of scopes.
+    /// </summary>
+    public class NoResourceUriInScopesException : MsalClientException
+    {
+        private const string Code = "no_resource_uri_with_slash_.default_in_scopes";
+        private const string ErrorMessage = "The scopes provided is either empty or none that end in `/.default`.";
+
+        /// <summary>
+        /// Create a TooManyRetryAttemptsException
+        /// </summary>
+        public NoResourceUriInScopesException() : base(Code, ErrorMessage) { }
+
+        /// <summary>
+        /// Create a TooManyRetryAttemptsException with an error message
+        /// </summary>
+        public NoResourceUriInScopesException(string errorMessage) : base(Code, errorMessage) { }
+    }
+
+    internal abstract class ManagedIdentityClient
+    {
+        protected const string FailedParseOfManagedIdentityExpiration = "failed_parse_of_managed_identity_token_expiry";
+
+        protected readonly string _endpoint;
+        protected readonly int _maxRetries;
+        protected readonly HttpClient _client;
+
+        internal ManagedIdentityClient(string endpoint, HttpClient client, int maxRetries = 5)
+        {
+            _endpoint = endpoint;
+            _client = client;
+            _maxRetries = maxRetries;
+        }
+
+        protected abstract HttpRequestMessage BuildTokenRequest(string resourceUri);
+
+        public async Task<IToken> FetchTokenWithRetryAsync(string resourceUri)
+        {
+            var strategy = new RetryWithExponentialBackoff(_maxRetries, 50, 60000);
+            HttpResponseMessage res = null;
+            await strategy.RunAsync(async () =>
+            {
+                var req = BuildTokenRequest(resourceUri);
+                res = await _client.SendAsync(req).ConfigureAwait(false);
+
+                var intCode = (int)res.StatusCode;
+                switch (intCode) {
+                    case 404:
+                    case 429:
+                    case var _ when intCode >= 500:
+                        throw new TransientManagedIdentityException($"encountered transient managed identity service error with status code {intCode}");
+                    case 400:
+                        throw new BadRequestManagedIdentityException();
+                }
+            }).ConfigureAwait(false);
+
+            var json = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if(string.IsNullOrEmpty(json))
+            {
+                return null;
+            }
+
+            var tokenRes = TokenResponse.Parse(json);
+            var startOfUnixTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            if (!double.TryParse(tokenRes.ExpiresOn, out var seconds))
+            {
+                throw new MsalException(FailedParseOfManagedIdentityExpiration, $"unable to parse the expires on token into an int: {tokenRes.ExpiresOn}");
+            }
+            return new AccessTokenWithExpiration { ExpiresOn = startOfUnixTime.AddSeconds(seconds), AccessToken = tokenRes.AccessToken };
+        }
+    }
+
+    internal class ManagedIdentityVMClient : ManagedIdentityClient
+    {
+        private readonly string _clientId;
+
+        public ManagedIdentityVMClient(string endpoint, HttpClient client, string clientId = null, int maxRetries = 10) : base(endpoint, client, maxRetries)
+        {
+            _clientId = clientId;
+        }
+
+        protected override HttpRequestMessage BuildTokenRequest(string resourceUri)
+        {
+            string clientIdParameter = string.IsNullOrWhiteSpace(_clientId)
+                    ? string.Empty :
+                    $"&client_id={_clientId}";
+
+            var requestUri = $"{_endpoint}?resource={resourceUri}{clientIdParameter}&api-version={Constants.ManagedIdentityVMApiVersion}";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Add("Metadata", "true");
+            return request;
+        }
+    }
+
+    internal class ManagedIdentityAppServiceClient : ManagedIdentityClient
+    {
+        private readonly string _secret;
+
+        public ManagedIdentityAppServiceClient(string endpoint, string secret, HttpClient client, int maxRetries = 5) : base(endpoint, client, maxRetries)
+        {
+            _secret = secret;
+        }
+
+        protected override HttpRequestMessage BuildTokenRequest(string resourceUri)
+        {
+            var requestUri = $"{_endpoint}?resource={resourceUri}&api-version={Constants.ManagedIdentityAppServiceApiVersion}";
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            request.Headers.Add("Secret", _secret);
+            return request;
+        }
+    }
+
+    /// <summary>
+    /// Used to hold the deserialized token response.
+    /// </summary>
+    [DataContract]
+    internal class TokenResponse
+    {
+        private const string TokenResponseFormatExceptionMessage = "Token response is not in the expected format.";
+
+        internal enum DateFormat
+        {
+            Unix,
+            DateTimeString
+        };
+
+        // MSI endpoint return access_token
+        [DataMember(Name = "access_token", IsRequired = false)]
+        public string AccessToken { get; private set; }
+
+        // MSI endpoint return expires_on
+        [DataMember(Name = "expires_on", IsRequired = false)]
+        public string ExpiresOn { get; private set; }
+
+        [DataMember(Name = "error_description", IsRequired = false)]
+        public string ErrorDescription { get; private set; }
+
+        // MSI endpoint return token_type
+        [DataMember(Name = "token_type", IsRequired = false)]
+        public string TokenType { get; private set; }
+
+        /// <summary>
+        /// Parse token response returned from OAuth provider.
+        /// While more fields are returned, we only need the access token.
+        /// </summary>
+        /// <param name="tokenResponse">This is the response received from OAuth endpoint that has the access token in it.</param>
+        /// <returns></returns>
+        public static TokenResponse Parse(string tokenResponse)
+        {
+            try
+            {
+                return JsonHelper.DeserializeFromJson<TokenResponse>(Encoding.UTF8.GetBytes(tokenResponse));
+            }
+            catch (Exception exp)
+            {
+                throw new FormatException($"{TokenResponseFormatExceptionMessage} Exception Message: {exp.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// IManagedIdentityConfiguration provides the configurable properties for the ManagedIdentityProbe
+    /// </summary>
+    public interface IManagedIdentityConfiguration
+    {
+        /// <summary>
+        /// ManagedIdentitySecret is the secret for use in Azure AppService
+        /// </summary>
+        string ManagedIdentitySecret { get; }
+
+        /// <summary>
+        /// ManagedIdentityEndpoint is the AppService endpoint
+        /// </summary>
+        string ManagedIdentityEndpoint { get; }
+
+        /// <summary>
+        /// VMManagedIdentityEndpoint is the VM's default managed identity endpoint
+        /// </summary>
+        string VMManagedIdentityEndpoint { get; }
+
+        /// <summary>
+        /// ClientId is the user assigned managed identity for use in VM managed identity
+        /// </summary>
+        string ClientId { get; }
+    }
+
+    internal class DefaultManagedIdentityConfiguration : IManagedIdentityConfiguration
+    {
+        public string ManagedIdentitySecret => Env.ManagedIdentitySecret;
+
+        public string ManagedIdentityEndpoint => Env.ManagedIdentityEndpoint;
+
+        public string ClientId => Env.ClientId;
+
+        public string VMManagedIdentityEndpoint => Constants.ManagedIdentityTokenEndpoint;
+    }
+
+#endif
+}

--- a/src/Microsoft.Identity.Client/Azure/ServicePrincipal.cs
+++ b/src/Microsoft.Identity.Client/Azure/ServicePrincipal.cs
@@ -1,0 +1,271 @@
+﻿using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Instance;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Azure
+{
+#if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide confidential client on mobile platforms
+
+    /// <summary>
+    ///     ServicePrincipalProbe looks to the application setting and environment variables to build a ICredentialProvider.
+    /// </summary>
+    public class ServicePrincipalProbe : IProbe
+    {
+        private readonly IServicePrincipalConfiguration _config;
+
+        /// <summary>
+        /// Create a new instance of a ServicePrincipalProbe
+        /// </summary>
+        /// <param name="config">optional configuration; if not specified the default configuration will use environment variables</param>
+        public ServicePrincipalProbe(IServicePrincipalConfiguration config = null)
+        {
+            _config = config ?? new DefaultServicePrincipalConfiguration();
+        }
+
+        // Async method lacks 'await' operators and will run synchronously
+        /// <summary>
+        /// Check if the probe is available for use in the current environment
+        /// </summary>
+        /// <returns>True if a credential provider can be built</returns>
+        public Task<bool> AvailableAsync() => Task.FromResult(IsClientSecret() || IsClientCertificate());
+
+        /// <summary>
+        /// Create a credential provider from the information discovered by the probe
+        /// </summary>
+        /// <returns>A service principal credential provider</returns>
+        public async Task<ITokenProvider> ProviderAsync()
+        {
+            var available = await AvailableAsync().ConfigureAwait(false);
+            if (!available)
+            {
+                throw new InvalidOperationException("The required environment variables are not available.");
+            }
+
+            var authorityWithTenant = string.Format(CultureInfo.InvariantCulture, AadAuthority.AADCanonicalAuthorityTemplate, _config.Authority, _config.TenantId);
+
+            if (!IsClientCertificate())
+            {
+                return new ServicePrincipalTokenProvider(authorityWithTenant, _config.TenantId, _config.ClientId, _config.ClientSecret);
+            }
+
+            X509Certificate2 cert;
+            if (!string.IsNullOrWhiteSpace(_config.CertificateBase64))
+            {
+                // If the certificate is provided as base64 encoded string in env, decode and hydrate a x509 cert
+                var decoded = Convert.FromBase64String(_config.CertificateBase64);
+                cert = new X509Certificate2(decoded);
+            }
+            else
+            {
+                // Try to use the certificate store
+                var store = new X509Store(StoreNameWithDefault, StoreLocationFromEnv);
+                store.Open(OpenFlags.ReadOnly);
+                X509Certificate2Collection certs;
+                if(!string.IsNullOrEmpty(_config.CertificateSubjectDistinguishedName))
+                {
+                    certs = store.Certificates.Find(X509FindType.FindBySubjectDistinguishedName, _config.CertificateSubjectDistinguishedName, true);
+                }
+                else
+                {
+                    certs = store.Certificates.Find(X509FindType.FindByThumbprint, _config.CertificateThumbprint, true);
+                }
+
+                if (certs.Count < 1)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to find certificate with thumbprint '{_config.CertificateThumbprint}' in certificate store named '{StoreNameWithDefault}' and store location {StoreLocationFromEnv}");
+                }
+
+                cert = certs[0];
+            }
+
+            return new ServicePrincipalTokenProvider(authorityWithTenant, _config.TenantId, _config.ClientId, cert);
+        }
+
+        internal StoreLocation StoreLocationFromEnv
+        {
+            get
+            {
+                var loc = _config.CertificateStoreLocation;
+                if (!string.IsNullOrWhiteSpace(loc) && Enum.TryParse(loc, true, out StoreLocation sLocation))
+                {
+                    return sLocation;
+                }
+
+                return StoreLocation.CurrentUser;
+            }
+        }
+
+        internal string StoreNameWithDefault
+        {
+            get
+            {
+                var name = _config.CertificateStoreName;
+                return string.IsNullOrWhiteSpace(name) ? "My" : name;
+            }
+        }
+
+        internal bool IsClientSecret()
+        {
+            var vars = new List<string> { _config.TenantId, _config.ClientId, _config.ClientSecret };
+            return vars.All(item => !string.IsNullOrWhiteSpace(item));
+        }
+
+        internal bool IsClientCertificate()
+        {
+            var tenantAndClient = new List<string> { _config.TenantId, _config.ClientId };
+            var env = Environment.GetEnvironmentVariables();
+            if (tenantAndClient.All(item => !string.IsNullOrWhiteSpace(item)))
+            {
+                return !string.IsNullOrWhiteSpace(_config.CertificateBase64) ||
+                       !string.IsNullOrWhiteSpace(_config.CertificateThumbprint);
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// IManagedIdentityConfiguration provides the configurable properties for the ManagedIdentityProbe
+    /// </summary>
+    public interface IServicePrincipalConfiguration
+    {
+        /// <summary>
+        /// CertificateBase64 is the base64 encoded representation of an x509 certificate
+        /// </summary>
+        string CertificateBase64 { get; }
+
+        /// <summary>
+        /// CertificateThumbprint is the thumbprint of the certificate in the Windows Certificate Store
+        /// </summary>
+        string CertificateThumbprint { get; }
+
+        /// <summary>
+        /// CertificateSubjectDistinguishedName is the subject distinguished name of the certificate in the Windows Certificate Store
+        /// </summary>
+        string CertificateSubjectDistinguishedName { get; }
+
+        /// <summary>
+        /// CertificateStoreName is the name of the certificate store on Windows where the certificate is stored
+        /// </summary>
+        string CertificateStoreName { get; }
+
+        /// <summary>
+        /// CertificateStoreLocation is the location of the certificate store on Windows where the certificate is stored
+        /// </summary>
+        string CertificateStoreLocation { get; }
+
+        /// <summary>
+        /// TenantId is the AAD TenantID
+        /// </summary>
+        string TenantId { get; }
+
+        /// <summary>
+        /// ClientId is the service principal (application) ID
+        /// </summary>
+        string ClientId { get; }
+
+        /// <summary>
+        /// ClientSecret is the service principal (application) string secret
+        /// </summary>
+        string ClientSecret { get; }
+
+        /// <summary>
+        /// Authority is the URI pointing to the AAD endpoint
+        /// </summary>
+        string Authority { get; }
+    }
+
+    internal class DefaultServicePrincipalConfiguration : IServicePrincipalConfiguration
+    {
+        public string ClientId => Env.ClientId;
+
+        public string CertificateBase64 => Env.CertificateBase64;
+
+        public string CertificateThumbprint => Env.CertificateThumbprint;
+
+        public string CertificateStoreName => Env.CertificateStoreName;
+
+        public string TenantId => Env.TenantId;
+
+        public string ClientSecret => Env.ClientSecret;
+
+        public string CertificateStoreLocation => Env.CertificateStoreLocation;
+
+        public string CertificateSubjectDistinguishedName => Env.CertificateSubjectDistinguishedName;
+
+        public string Authority => string.IsNullOrWhiteSpace(Env.AadAuthority) ? AadAuthority.DefaultTrustedHost : Env.AadAuthority;
+    }
+
+    /// <summary>
+    /// ServicePrincipalTokenProvider fetches an AAD token provided Service Principal credentials.
+    /// </summary>
+    public class ServicePrincipalTokenProvider : ITokenProvider
+    {
+        private readonly ConfidentialClientApplication _client;
+
+        internal ServicePrincipalTokenProvider(string authority, string tenantId, string clientId, ClientCredential cred, IHttpManager httpManager)
+        {
+            _client = ConfidentialClientApplicationBuilder.Create(clientId)
+                .WithTenantId(tenantId)
+                .WithAuthority(new Uri(authority), true)
+                .WithClientCredential(cred)
+                .WithHttpManager(httpManager)
+                .BuildConcrete();
+        }
+
+        /// <summary>
+        ///     ServicePrincipalCredentialProvider constructor to build the provider with a certificate
+        /// </summary>
+        /// <param name="authority">Hostname of the security token service (STS) from which MSAL.NET will acquire the tokens. Ex: login.microsoftonline.com
+        /// </param>
+        /// <param name="tenantId">A string representation for a GUID, which is the ID of the tenant where the account resides</param>
+        /// <param name="clientId">A string representation for a GUID ClientId (application ID) of the application</param>
+        /// <param name="cert">A ClientAssertionCertificate which is the certificate secret for the application</param>
+        public ServicePrincipalTokenProvider(string authority, string tenantId, string clientId, X509Certificate2 cert)
+        {
+            _client = ConfidentialClientApplicationBuilder.Create(clientId)
+                .WithTenantId(tenantId)
+                .WithAuthority(new Uri(authority), true)
+                .WithCertificate(cert)
+                .BuildConcrete();
+        }
+
+        /// <summary>
+        ///     ServicePrincipalCredentialProvider constructor to build the provider with a string secret
+        /// </summary>
+        /// <param name="authority">Hostname of the security token service (STS) from which MSAL.NET will acquire the tokens. Ex: login.microsoftonline.com
+        /// </param>
+        /// <param name="tenantId">A string representation for a GUID, which is the ID of the tenant where the account resides</param>
+        /// <param name="clientId">A string representation for a GUID ClientId (application ID) of the application</param>
+        /// <param name="secret">A string secret for the application</param>
+        public ServicePrincipalTokenProvider(string authority, string tenantId, string clientId, string secret)
+        {
+            _client = ConfidentialClientApplicationBuilder.Create(clientId)
+                .WithTenantId(tenantId)
+                .WithAuthority(new Uri(authority), true)
+                .WithClientSecret(secret)
+                .BuildConcrete();
+        }
+
+        /// <summary>
+        ///     GetTokenAsync returns a token for a given set of scopes
+        /// </summary>
+        /// <param name="scopes">Scopes requested to access a protected API</param>
+        /// <returns>A token with expiration</returns>
+        public async Task<IToken> GetTokenAsync(IEnumerable<string> scopes = null)
+        {
+            var res = await _client.AcquireTokenForClientAsync(scopes).ConfigureAwait(false);
+            return new AccessTokenWithExpiration { ExpiresOn = res.ExpiresOn, AccessToken = res.AccessToken };
+        }
+    }
+
+#endif
+}

--- a/src/Microsoft.Identity.Client/Azure/SharedTokenCache.cs
+++ b/src/Microsoft.Identity.Client/Azure/SharedTokenCache.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Cache;
+
+namespace Microsoft.Identity.Client.Azure
+{
+#if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME
+
+    /// <summary>
+    /// SharedTokenCacheProbe (wip) provides shared access to tokens from the Microsoft family of products.
+    /// This probe will provided access to tokens from accounts that have been authenticated in other Microsoft products to provide a single sign-on experience.
+    /// </summary>
+    public class SharedTokenCacheProbe : IProbe
+    {
+        /// <summary>
+        ///     Check if the probe is available for use in the current environment
+        /// </summary>
+        /// <returns>True if a credential provider can be built</returns>
+        public Task<bool> AvailableAsync()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Create a managed identity credential provider from the information discovered by the probe
+        /// </summary>
+        /// <returns>A managed identity credential provider instance</returns>
+        public Task<ITokenProvider> ProviderAsync()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
+#endif
+}

--- a/src/Microsoft.Identity.Client/Azure/TokenProvider.cs
+++ b/src/Microsoft.Identity.Client/Azure/TokenProvider.cs
@@ -1,0 +1,43 @@
+using Microsoft.Identity.Client.Http;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Azure
+{
+    /// <summary>
+    /// ITokenProvider describes the interface for fetching an access token
+    /// </summary>
+    public interface ITokenProvider
+    {
+        /// <summary>
+        /// GetTokenAsync will attempt to fetch a token for a given set of scopes
+        /// </summary>
+        /// <param name="scopes">Scopes requested to access a protected API</param>
+        /// <returns>An access token as a string</returns>
+       Task<IToken> GetTokenAsync(IEnumerable<string> scopes = null);
+    }
+
+    /// <summary>
+    /// IToken is an AAD access token with an expiration
+    /// </summary>
+    public interface IToken
+    {
+        /// <summary>
+        /// ExpiresOn provides an expiry for the access token. If null, there is no expiration.
+        /// </summary>
+        DateTimeOffset? ExpiresOn { get; }
+
+        /// <summary>
+        /// AccessToken is a string representation of an AAD access token
+        /// </summary>
+        string AccessToken { get; }
+    }
+
+    internal class AccessTokenWithExpiration : IToken
+    {
+        public DateTimeOffset? ExpiresOn { get; set; }
+
+        public string AccessToken { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -22,6 +22,15 @@
     <DefineConstants>$(DefineConstants);NETSTANDARD_RUNTIME</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Internal\Broker\BrokerInteractiveRequest.cs" />
+    <Compile Include="Internal\Broker\BrokerResponseConst.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Azure\ChainedTokenProvider.cs" />
+    <Compile Include="Azure\SharedTokenCache.cs" />
+    <Compile Include="Azure\TokenProvider.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <ReferenceAssemblyProjectReference Include="..\Microsoft.Identity.Client.Ref\Microsoft.Identity.Client.Ref.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ChainedTokenProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ChainedTokenProviderTests.cs
@@ -1,0 +1,120 @@
+﻿// ------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Azure;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Instance;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.netcore.AzureTests
+{
+    [TestClass]
+    public class ChainedTokenProviderTests
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+        }
+
+        private void AddHostToInstanceCache(IServiceBundle serviceBundle, string host)
+        {
+            serviceBundle.AadInstanceDiscovery.TryAddValue(
+                host,
+                new InstanceDiscoveryMetadataEntry
+                {
+                    PreferredNetwork = host,
+                    PreferredCache = host,
+                    Aliases = new string[]
+                    {
+                        host
+                    }
+                });
+        }
+
+        [TestMethod]
+        [TestCategory("ChainedTokenProviderTests")]
+        public async Task SelectTheFirstAvailableProbeTestAsync()
+        {
+            var probes = new List<IProbe>
+            {
+                new MockProbe{ Available = false, Provider = new MockProvider() },
+                new MockProbe{ Available = false, Provider = new MockProvider() },
+                new MockProbe{ Available = true, Provider = new MockProvider{ Token = new MockToken{ AccessToken = "foo", ExpiresOn = DateTime.UtcNow.AddSeconds(60)} } },
+                new MockProbe{ Available = true, Provider = new MockProvider{ Token = new MockToken{ AccessToken = "bar", ExpiresOn = DateTime.UtcNow.AddSeconds(60)} } },
+            };
+            var chain = new ChainedTokenProvider(probes);
+
+            var token = await chain.GetTokenAsync(new List<string> { "something" }).ConfigureAwait(false);
+            Assert.AreEqual("foo", token.AccessToken);
+        }
+
+        [TestMethod]
+        [TestCategory("ChainedTokenProviderTests")]
+        public async Task NoAvailableProbesTestAsync()
+        {
+            var probes = new List<IProbe>
+            {
+                new MockProbe{ Available = false, Provider = new MockProvider() },
+            };
+            var chain = new ChainedTokenProvider(probes);
+
+            await Assert.ThrowsExceptionAsync<NoProbesAvailableException>(async () => await chain.GetTokenAsync(new List<string> { "something" }).ConfigureAwait(false)).ConfigureAwait(false);
+        }
+    }
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    public class MockProbe : IProbe
+    {
+        public ITokenProvider Provider { get; set; }
+
+        public bool Available { get; set; }
+
+
+        public async Task<bool> AvailableAsync() => Available;
+
+
+        public async Task<ITokenProvider> ProviderAsync() => Provider;
+    }
+
+    public class MockProvider : ITokenProvider
+    {
+        public IToken Token { get; set; }
+
+        public async Task<IToken> GetTokenAsync(IEnumerable<string> scopes = null) => Token;
+    }
+
+    public class MockToken : IToken
+    {
+        public DateTimeOffset? ExpiresOn { get; set; }
+
+        public string AccessToken { get; set; }
+    }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+}

--- a/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ExponentialBackoffTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ExponentialBackoffTest.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.netcore.AzureTests
+{
+    [TestClass]
+    public class ExponentialBackoffTest
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+        }
+
+        [TestMethod]
+        [TestCategory("ExponentialBackoffTests")]
+        public async Task ExponentialBackoffTestShouldThrowTooManyRetriesAsync()
+        {
+            var subject = new ExponentialBackoff(1, 1, 2);
+            await subject.DelayAsync().ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<TooManyRetryAttemptsException>(async () => await subject.DelayAsync().ConfigureAwait(false)).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ExponentialBackoffTests")]
+        public void ExponentialBackoffTestShouldProgressExponentially()
+        {
+            var maxDelay = 500000;
+            var maxLog = (int)Math.Ceiling(Math.Log(maxDelay, 2));
+            var subject = new ExponentialBackoff(20, 1, maxDelay);
+            for(var i = 0; i < maxLog; i++)
+            {
+                Assert.AreEqual(TimeSpan.FromMilliseconds(Math.Pow(2, i)), subject.GetDelay(i));
+            }
+
+            for(var i = maxLog; i < 5000; i++)
+            {
+                Assert.AreEqual(TimeSpan.FromMilliseconds(maxDelay), subject.GetDelay(i));
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ExponentialBackoffTests")]
+        public void ExponentialBackoffTestShouldThrowIfInitialDelayIsLessThanOrEqualToZero()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new ExponentialBackoff(20, 0, 0));
+            Assert.ThrowsException<ArgumentException>(() => new ExponentialBackoff(20, -1, 0));
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ManagedIdentityTests.cs
@@ -1,0 +1,360 @@
+﻿using Microsoft.Identity.Client.Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Test.Unit.netcore.AzureTests
+{
+    [TestClass]
+    public class ManagedIdentityTests
+    {
+        private const string AccessToken = "abcdefg";
+        private const string RefreshToken = "hijklmn";
+        private const string ExpiresOn = "1506484173";
+
+        private const string AzureManagementManagedIdentityJson = @"{
+          ""access_token"": """ + AccessToken + @""",
+          ""refresh_token"": """ + RefreshToken + @""",
+          ""expires_in"": ""3599"",
+          ""expires_on"": """ + ExpiresOn + @""",
+          ""not_before"": ""1506480273"",
+          ""resource"": ""https://management.azure.com/"",
+          ""token_type"": ""Bearer""
+        }";
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeShouldNotBeAvailableWithoutManagedIdentityServiceAsync()
+        {
+            var probe = new ManagedIdentityProbe(config: new ManagedIdentityConfiguration { });
+            var st = DateTime.Now;
+            Assert.IsFalse(await probe.AvailableAsync().ConfigureAwait(false));
+            Assert.IsTrue((DateTime.Now - st) < TimeSpan.FromMilliseconds(800), "should take less than 800 milliseconds");
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeShouldBeAvailableWithAppServiceConfigManagedIdentityServiceAsync()
+        {
+            var probe = new ManagedIdentityProbe(config: new ManagedIdentityConfiguration
+            {
+                ManagedIdentityEndpoint = "http://127.0.0.1/foo",
+                ManagedIdentitySecret = "secret",
+            });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeShouldFetchTokenFromAppServiceManagedIdentityServiceAsync()
+        {
+            var handler = new MockManagedIdentityHttpMessageHandler();
+            handler.Responders.Add(new Responder
+            {
+                Matcher = (req, state) =>
+                {
+                    var apiVersion = Client.Azure.Constants.ManagedIdentityAppServiceApiVersion;
+                    return req.RequestUri.ToString() == "http://127.0.0.1/foo?resource=https://management.azure.com//.default&api-version=" + apiVersion &&
+                        req.Headers.GetValues("Secret").FirstOrDefault() == "secret";
+                },
+                MockResponse = (req, state) =>
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new MockJsonContent(AzureManagementManagedIdentityJson)
+                    };
+                    return resp;
+                }
+            });
+            var client = new HttpClient(handler);
+            var probe = new ManagedIdentityProbe(httpClient: client, config: new ManagedIdentityConfiguration
+            {
+                ManagedIdentityEndpoint = "http://127.0.0.1/foo",
+                ManagedIdentitySecret = "secret",
+            });
+            var provider = await probe.ProviderAsync().ConfigureAwait(false);
+            var token = await provider.GetTokenAsync(new List<string> { "https://management.azure.com//.default" }).ConfigureAwait(false);
+            Assert.IsNotNull(token);
+            var seconds = double.Parse(ExpiresOn, CultureInfo.InvariantCulture);
+            var startOfUnixTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            Assert.AreEqual(token.ExpiresOn, startOfUnixTime.AddSeconds(seconds));
+            Assert.AreEqual(AccessToken, token.AccessToken);
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeShouldFetchTokenWithClientIdFromManagedIdentityServiceAsync()
+        {
+            var handler = new MockManagedIdentityHttpMessageHandler();
+            handler.Responders.Add(new Responder
+            {
+                Matcher = (req, state) =>
+                {
+                    var tokenEndpoint = Client.Azure.Constants.ManagedIdentityTokenEndpoint;
+                    var apiVersion = Client.Azure.Constants.ManagedIdentityVMApiVersion;
+                    return req.RequestUri.ToString() == tokenEndpoint + "?resource=https://management.azure.com//.default&client_id=foo&api-version=" + apiVersion;
+                },
+                MockResponse = (req, state) =>
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new MockJsonContent(AzureManagementManagedIdentityJson)
+                    };
+                    return resp;
+                }
+            });
+            var client = new HttpClient(handler);
+            var probe = new ManagedIdentityProbe(httpClient: client, config: new ManagedIdentityConfiguration { ClientId = "foo" });
+            var provider = await probe.ProviderAsync().ConfigureAwait(false);
+            var token = await provider.GetTokenAsync(new List<string> { "https://management.azure.com//.default" }).ConfigureAwait(false);
+            Assert.IsNotNull(token);
+            var seconds = double.Parse(ExpiresOn, CultureInfo.InvariantCulture);
+            var startOfUnixTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            Assert.AreEqual(token.ExpiresOn, startOfUnixTime.AddSeconds(seconds));
+            Assert.AreEqual(AccessToken, token.AccessToken);
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeBeAvailableWhenTokenReturnedManagedIdentityServiceAsync()
+        {
+            var handler = new MockManagedIdentityHttpMessageHandler();
+            handler.Responders.Add(new Responder
+            {
+                Matcher = (req, state) =>
+                {
+                    var tokenEndpoint = Client.Azure.Constants.ManagedIdentityTokenEndpoint;
+                    var apiVersion = Client.Azure.Constants.ManagedIdentityVMApiVersion;
+                    return req.RequestUri.ToString() == tokenEndpoint + "?resource=https://management.azure.com//.default&api-version=" + apiVersion;
+                },
+                MockResponse = (req, state) =>
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new MockJsonContent(AzureManagementManagedIdentityJson)
+                    };
+                    return resp;
+                }
+            });
+            var client = new HttpClient(handler);
+            var probe = new ManagedIdentityProbe(httpClient: client, config: new ManagedIdentityConfiguration { });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeNotBeAvailableWhen400ReturnedFromManagedIdentityServiceAsync()
+        {
+            var handler = new MockManagedIdentityHttpMessageHandler();
+            handler.Responders.Add(new Responder
+            {
+                Matcher = (req, state) =>
+                {
+                    var tokenEndpoint = Client.Azure.Constants.ManagedIdentityTokenEndpoint;
+                    var apiVersion = Client.Azure.Constants.ManagedIdentityVMApiVersion;
+                    return req.RequestUri.ToString() == tokenEndpoint + "?resource=https://management.azure.com//.default&api-version=" + apiVersion;
+                },
+                MockResponse = (req, state) =>
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest);
+                }
+            });
+            var client = new HttpClient(handler);
+            var probe = new ManagedIdentityProbe(httpClient: client, config: new ManagedIdentityConfiguration { });
+            await Assert.ThrowsExceptionAsync<BadRequestManagedIdentityException>(async () => await probe.AvailableAsync().ConfigureAwait(false)).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeBeAvailableWhenInitial404ReturnedFromManagedIdentityServiceAsync()
+        {
+            var handler = new MockManagedIdentityHttpMessageHandler();
+            handler.Responders.Add(new Responder
+            {
+                Matcher = (req, state) =>
+                {
+                    var tokenEndpoint = Client.Azure.Constants.ManagedIdentityTokenEndpoint;
+                    var apiVersion = Client.Azure.Constants.ManagedIdentityVMApiVersion;
+                    return req.RequestUri.ToString() == tokenEndpoint + "?resource=https://management.azure.com//.default&api-version=" + apiVersion;
+                },
+                MockResponse = (req, state) =>
+                {
+                    if (state.Keys.Contains("error"))
+                    {
+                        var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new MockJsonContent(AzureManagementManagedIdentityJson)
+                        };
+                        return resp;
+                    }
+                    else
+                    {
+                        state["error"] = true;
+                        return new HttpResponseMessage(HttpStatusCode.NotFound);
+                    }
+                }
+            });
+            var client = new HttpClient(handler);
+            var probe = new ManagedIdentityProbe(httpClient: client, config: new ManagedIdentityConfiguration { });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeBeAvailableWhenInitial429ReturnedFromManagedIdentityServiceAsync()
+        {
+            var handler = new MockManagedIdentityHttpMessageHandler();
+            handler.Responders.Add(new Responder
+            {
+                Matcher = (req, state) =>
+                {
+                    var tokenEndpoint = Client.Azure.Constants.ManagedIdentityTokenEndpoint;
+                    var apiVersion = Client.Azure.Constants.ManagedIdentityVMApiVersion;
+                    return req.RequestUri.ToString() == tokenEndpoint + "?resource=https://management.azure.com//.default&api-version=" + apiVersion;
+                },
+                MockResponse = (req, state) =>
+                {
+                    if (state.Keys.Contains("error"))
+                    {
+                        var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new MockJsonContent(AzureManagementManagedIdentityJson)
+                        };
+                        return resp;
+                    }
+                    else
+                    {
+                        state["error"] = true;
+                        return new HttpResponseMessage((HttpStatusCode)429);
+                    }
+                }
+            });
+            var client = new HttpClient(handler);
+            var probe = new ManagedIdentityProbe(httpClient: client, config: new ManagedIdentityConfiguration { });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+        }
+
+        [TestMethod]
+        [TestCategory("ManagedIdentityTests")]
+        public async Task ProbeBeAvailableWhenInitial500sReturnedFromManagedIdentityServiceAsync()
+        {
+            var handler = new MockManagedIdentityHttpMessageHandler();
+            handler.Responders.Add(new Responder
+            {
+                Matcher = (req, state) =>
+                {
+                    var tokenEndpoint = Client.Azure.Constants.ManagedIdentityTokenEndpoint;
+                    var apiVersion = Client.Azure.Constants.ManagedIdentityVMApiVersion;
+                    return req.RequestUri.ToString() == tokenEndpoint + "?resource=https://management.azure.com//.default&api-version=" + apiVersion;
+                },
+                MockResponse = (req, state) =>
+                {
+                    if (state.Keys.Contains("error1") && state.Keys.Contains("error2"))
+                    {
+                        var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new MockJsonContent(AzureManagementManagedIdentityJson)
+                        };
+                        return resp;
+                    }
+                    else if (!state.Keys.Contains("error1"))
+                    {
+                        state["error1"] = true;
+                        return new HttpResponseMessage((HttpStatusCode)500);
+                    }
+                    else
+                    {
+                        state["error2"] = true;
+                        return new HttpResponseMessage((HttpStatusCode)501);
+                    }
+                }
+            });
+            var client = new HttpClient(handler);
+            var probe = new ManagedIdentityProbe(httpClient: client, config: new ManagedIdentityConfiguration { });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+        }
+    }
+
+    public class ManagedIdentityConfiguration : IManagedIdentityConfiguration
+    {
+        /// <summary>
+        /// ManagedIdentitySecret is the secret for use in Azure AppService
+        /// </summary>
+        public string ManagedIdentitySecret { get; set; }
+
+        /// <summary>
+        /// ManagedIdentityEndpoint is the AppService endpoint
+        /// </summary>
+        public string ManagedIdentityEndpoint { get; set; }
+
+        /// <summary>
+        /// VMManagedIdentityEndpoint is the VM's default managed identity endpoint
+        /// </summary>
+        public string VMManagedIdentityEndpoint { get; set; }
+
+        /// <summary>
+        /// ClientId is the user assigned managed identity for use in VM managed identity
+        /// </summary>
+        public string ClientId { get; set; }
+    }
+
+    public class MockManagedIdentityHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var responder = Responders.FirstOrDefault(i => i.Matcher(request, i.State));
+            if (responder == null)
+                Assert.Fail($"responder was not found that matched the request: {request}");
+            return Task.FromResult(responder.MockResponse(request, responder.State));
+        }
+
+        public IList<Responder> Responders { get; } = new List<Responder>();
+    }
+
+    public class MockJsonContent : HttpContent
+    {
+        private readonly MemoryStream _stream = new MemoryStream();
+
+        public MockJsonContent(string json)
+        {
+
+            Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            var sw = new StreamWriter(_stream, new UnicodeEncoding());
+            sw.Write(json);
+            sw.Flush();//otherwise you are risking empty stream
+            _stream.Seek(0, SeekOrigin.Begin);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            return _stream.CopyToAsync(stream);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _stream.Length;
+            return true;
+        }
+    }
+
+    public class Responder
+    {
+        public Dictionary<string, object> State { get; } = new Dictionary<string, object>();
+        public Func<HttpRequestMessage, Dictionary<string, object>, bool> Matcher { get; set; }
+        public Func<HttpRequestMessage, Dictionary<string, object>, HttpResponseMessage> MockResponse { get; set; }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ServicePrincipalTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.netcore/AzureTests/ServicePrincipalTests.cs
@@ -1,0 +1,171 @@
+﻿using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Azure;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Test.Unit.netcore.AzureTests
+{
+    [TestClass]
+    public class ServicePrincipalTests
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+        }
+
+        private void AddHostToInstanceCache(IServiceBundle serviceBundle, string host)
+        {
+            serviceBundle.AadInstanceDiscovery.TryAddValue(
+                host,
+                new InstanceDiscoveryMetadataEntry
+                {
+                    PreferredNetwork = host,
+                    PreferredCache = host,
+                    Aliases = new string[]
+                    {
+                        host
+                    }
+                });
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProbeShouldNotBeAvailableWithoutEnvironmentVarsAsync()
+        {
+            var probe = new ServicePrincipalProbe(config: new ServicePrincipalConfiguration { });
+            Assert.IsFalse(await probe.AvailableAsync().ConfigureAwait(false));
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProbeShouldThrowIfNotAvailablesAsync()
+        {
+            var probe = new ServicePrincipalProbe(config: new ServicePrincipalConfiguration { });
+            Assert.IsFalse(await probe.AvailableAsync().ConfigureAwait(false));
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await probe.ProviderAsync().ConfigureAwait(false)).ConfigureAwait(false);
+            Assert.AreEqual("The required environment variables are not available.", ex.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProbeShouldBeAvailableWithServicePrincipalAndSecretAsync()
+        {
+            var probe = new ServicePrincipalProbe(config: new ServicePrincipalConfiguration
+            {
+                ClientId = "foo",
+                ClientSecret = "bar",
+                TenantId = "Bazz"
+            });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+            Assert.IsFalse(probe.IsClientCertificate());
+            Assert.IsTrue(probe.IsClientSecret());
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProviderShouldFetchTokenWithServicePrincipalAndSecretAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var authority = "https://login.microsoftonline.com/tenantid/";
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerForTenantEndpointDiscovery(authority);
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                var provider = new ServicePrincipalTokenProvider(authority, "tenantid", MsalTestConstants.ClientId, new ClientCredential(MsalTestConstants.ClientSecret), httpManager);
+                var token = await provider.GetTokenAsync(new List<string> { @"https://management.azure.com//.default" }).ConfigureAwait(false);
+                Assert.IsNotNull(token);
+            }
+
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProbeShouldBeAvailableWithServicePrincipalAndCertificateBase64Async()
+        {
+            var probe = new ServicePrincipalProbe(config: new ServicePrincipalConfiguration
+            {
+                ClientId = "foo",
+                CertificateBase64 = "bar",
+                TenantId = "Bazz"
+            });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+            Assert.IsTrue(probe.IsClientCertificate());
+            Assert.IsFalse(probe.IsClientSecret());
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProbeShouldThrowIfCertificateIsNotInStoreAsync()
+        {
+            var cfg = new ServicePrincipalConfiguration
+            {
+                ClientId = "foo",
+                CertificateThumbprint = "bar",
+                CertificateStoreName = "My",
+                TenantId = "Bazz"
+            };
+            var probe = new ServicePrincipalProbe(config: cfg);
+            var msg = $"Unable to find certificate with thumbprint '{cfg.CertificateThumbprint}' in certificate store named 'My' and store location CurrentUser";
+            var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await probe.ProviderAsync().ConfigureAwait(false)).ConfigureAwait(false);
+            Assert.AreEqual(msg, ex.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProbeShouldBeAvailableWithServicePrincipalAndCertificateThumbAndStoreAsync()
+        {
+            var probe = new ServicePrincipalProbe(config: new ServicePrincipalConfiguration
+            {
+                ClientId = "foo",
+                CertificateThumbprint = "bar",
+                CertificateStoreName = "My",
+                TenantId = "Bazz"
+            });
+            Assert.IsTrue(await probe.AvailableAsync().ConfigureAwait(false));
+            Assert.IsTrue(probe.IsClientCertificate());
+            Assert.IsFalse(probe.IsClientSecret());
+        }
+
+        [TestMethod]
+        [TestCategory("ServicePrincipalTests")]
+        public async Task ProbeShouldNotBeAvailableWithoutTenantIDAsync()
+        {
+            var probe = new ServicePrincipalProbe(config: new ServicePrincipalConfiguration
+            {
+                ClientId = "foo",
+                CertificateThumbprint = "bar",
+                CertificateStoreName = "My",
+            });
+            Assert.IsFalse(await probe.AvailableAsync().ConfigureAwait(false));
+        }
+    }
+
+    internal class ServicePrincipalConfiguration : IServicePrincipalConfiguration
+    {
+        public string ClientId { get; set; }
+
+        public string CertificateBase64 { get; set; }
+
+        public string CertificateThumbprint { get; set; }
+
+        public string CertificateSubjectDistinguishedName { get; set; }
+
+        public string CertificateStoreName { get; set; }
+
+        public string TenantId { get; set; }
+
+        public string ClientSecret { get; set; }
+
+        public string CertificateStoreLocation { get; set; }
+
+        public string Authority => "login.microsoftonline.com";
+
+        public IHttpManager HttpManager { get; set; }
+    }
+}


### PR DESCRIPTION
This is a draft pull request for chained token provider support which provides a simplified path for server to server authentication in Azure, running on servers outside of Azure and on developers' local machine.

### Problem
Developers want to be able to author code once and not change code between local development, testing in the CI environment, and running in production. We need to have an abstraction to make life easier for the developer. 

### Goals
- Simplify developer experience by combining several token acquisition strategies into a single, simple interface.
- Enable developers to write code once and not change it between environments.
- Create a single sign-on like experience for developers such that if they have an ambient identity from Microsoft developer tools they already have authenticated that identity will be used for local development rather than requiring the creation of a service principal.
- Standardize environment variable names so that we can simplify the guidance for injecting configuration as is best practice.

### High level design
A `Chain` consists of a list of `Probes`. A `Probe` can determine if it is available for use (has all data needed to successfully produce a token), and if available, the probe can produce a `TokenProvider` that is able to fetch a `Token` for a list of scopes. A `Token` consists of an `AccessToken` and an `Expiry`. A `Chain` is also a `TokenProvider` and when asked for a token will query each of it's `Probes` to determine if any are available. The first probe that is available will be used to produce a `TokenProvider`, and the provider will be used to return a token to the consumer.

- In Azure:
  - Managed Identity: probe for managed identity service enabling user assigned and default identities on VMs. Also enable probing for environmental, managed identity configuration in App Service.
- Developer's Machine:
  - `SharedTokenCacheProbe` will provide a local developer single sign-on like experience for a collection of developer tools. This is a work in progress and waiting on some features in MSAL to properly implement.
- Anywhere:
  - Service Principal: probe for Service Principal environment variables and configure a token provider to simplify token acquisition.

For a little more background on the goals and problem statement, please see: https://github.com/Azure/azure-auth-wg/blob/master/docs/sdk_auth_helpers.md

### Impersonation local application development (Future?)
When a developer is building applications locally, it would be super useful to be able to express the rights required for an application declarative and enable some form of impersonation to limit the rights the current developer has to only the rights required for the application. If an application developer is unable to replicate the right required locally, they will likely run into issues when deploying the application to be run under a managed identity or service principal with a reduced set of rights, which is often the case since developers generally have more rights than applications.

This feature would require work to define an application manifest or some other way to declare rights, coordination with deployment pipelines and coordination with identity team & libraries.

---

I'm sure there will be a lot of comments. I'm committed to implementing all guidance. Thank you ahead of time for reviewing this PR.

/cc @jmprieur 