### PR TITLE
restructure client executors to enable proxy for mats

### DIFF
--- a/src/Microsoft.Identity.Client/ApiConfig/AbstractClientAppBaseAcquireTokenParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AbstractClientAppBaseAcquireTokenParameterBuilder.cs
@@ -39,35 +39,20 @@ namespace Microsoft.Identity.Client.ApiConfig
     public abstract class AbstractClientAppBaseAcquireTokenParameterBuilder<T> : AbstractAcquireTokenParameterBuilder<T>
         where T : AbstractAcquireTokenParameterBuilder<T>
     {
-        /// <summary>
-        /// Constructor of base class for parameter builders common to public client application and confidential
-        /// client application token acquisition operations
-        /// </summary>
-        /// <param name="clientApplicationBase"></param>
-        protected AbstractClientAppBaseAcquireTokenParameterBuilder(IClientApplicationBase clientApplicationBase)
+        internal AbstractClientAppBaseAcquireTokenParameterBuilder(IClientApplicationBaseExecutor clientApplicationBaseExecutor)
         {
-            ClientApplicationBase = clientApplicationBase;
+            ClientApplicationBaseExecutor = clientApplicationBaseExecutor;
         }
 
-        /// <summary>
-        /// Affected application
-        /// </summary>
-        protected IClientApplicationBase ClientApplicationBase { get; }
+        internal IClientApplicationBaseExecutor ClientApplicationBaseExecutor { get; }
 
-        internal abstract Task<AuthenticationResult> ExecuteAsync(
-            IClientApplicationBaseExecutor executor,
-            CancellationToken cancellationToken);
+        internal abstract Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken);
 
         /// <inheritdoc />
         public override Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (ClientApplicationBase is IClientApplicationBaseExecutor executor)
-            {
-                ValidateAndCalculateApiId();
-                return ExecuteAsync(executor, cancellationToken);
-            }
-
-            throw new InvalidOperationException(CoreErrorMessages.ClientApplicationBaseExecutorNotImplemented);
+            ValidateAndCalculateApiId();
+            return ExecuteInternalAsync(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
@@ -41,35 +41,21 @@ namespace Microsoft.Identity.Client.ApiConfig
         : AbstractAcquireTokenParameterBuilder<T>
         where T : AbstractAcquireTokenParameterBuilder<T>
     {
-        /// <summary>
-        /// Constructor from an interface on a confidential client application
-        /// </summary>
-        /// <param name="confidentialClientApplication"></param>
-        protected AbstractConfidentialClientAcquireTokenParameterBuilder(IConfidentialClientApplication confidentialClientApplication)
+        internal AbstractConfidentialClientAcquireTokenParameterBuilder(IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor)
         {
-            ConfidentialClientApplication = confidentialClientApplication;
+            ConfidentialClientApplicationExecutor = confidentialClientApplicationExecutor;
         }
 
-        internal abstract Task<AuthenticationResult> ExecuteAsync(
-            IConfidentialClientApplicationExecutor executor,
-            CancellationToken cancellationToken);
+        internal abstract Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken);
 
         /// <inheritdoc />
         public override Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (ConfidentialClientApplication is IConfidentialClientApplicationExecutor executor)
-            {
-                ValidateAndCalculateApiId();
-                return ExecuteAsync(executor, cancellationToken);
-            }
-
-            throw new InvalidOperationException(
-                CoreErrorMessages.ConfidentialClientDoesntImplementIConfidentialClientApplicationExecutor);
+            ValidateAndCalculateApiId();
+            return ExecuteInternalAsync(cancellationToken);
         }
 
-        /// <summary>
-        /// </summary>
-        protected IConfidentialClientApplication ConfidentialClientApplication { get; }
+        internal IConfidentialClientApplicationExecutor ConfidentialClientApplicationExecutor { get; }
     }
 #endif
 }

--- a/src/Microsoft.Identity.Client/ApiConfig/AbstractPublicClientAcquireTokenParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AbstractPublicClientAcquireTokenParameterBuilder.cs
@@ -39,34 +39,22 @@ namespace Microsoft.Identity.Client.ApiConfig
         : AbstractAcquireTokenParameterBuilder<T>
         where T : AbstractAcquireTokenParameterBuilder<T>
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="publicClientApplication"></param>
-        protected AbstractPublicClientAcquireTokenParameterBuilder(IPublicClientApplication publicClientApplication)
+        internal AbstractPublicClientAcquireTokenParameterBuilder(IPublicClientApplicationExecutor publicClientApplicationExecutor)
         {
-            PublicClientApplication = publicClientApplication;
+            PublicClientApplicationExecutor = publicClientApplicationExecutor;
         }
 
-        internal abstract Task<AuthenticationResult> ExecuteAsync(
-            IPublicClientApplicationExecutor executor,
-            CancellationToken cancellationToken);
+        internal abstract Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken);
 
         /// <inheritdoc />
         public override Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (PublicClientApplication is IPublicClientApplicationExecutor executor)
-            {
-                ValidateAndCalculateApiId();
-                return ExecuteAsync(executor, cancellationToken);
-            }
-
-            throw new InvalidOperationException(
-                "PublicClientApplication implementation does not implement IPublicClientApplicationExecutor.");
+            ValidateAndCalculateApiId();
+            return ExecuteInternalAsync(cancellationToken);
         }
 
         /// <summary>
         /// </summary>
-        protected IPublicClientApplication PublicClientApplication { get; }
+        internal IPublicClientApplicationExecutor PublicClientApplicationExecutor { get; }
     }
 }

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -44,25 +44,18 @@ namespace Microsoft.Identity.Client.ApiConfig
     {
         private AcquireTokenByAuthorizationCodeParameters Parameters { get; } = new AcquireTokenByAuthorizationCodeParameters();
 
-        /// <inheritdoc />
-        internal AcquireTokenByAuthorizationCodeParameterBuilder(IConfidentialClientApplication confidentialClientApplication)
-            : base(confidentialClientApplication)
+        internal AcquireTokenByAuthorizationCodeParameterBuilder(IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor)
+            : base(confidentialClientApplicationExecutor)
         {
             // TODO: where do we pass the authorization code? 
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="confidentialClientApplication"></param>
-        /// <param name="scopes"></param>
-        /// <param name="authorizationCode"></param>
-        /// <returns></returns>
         internal static AcquireTokenByAuthorizationCodeParameterBuilder Create(
-            IConfidentialClientApplication confidentialClientApplication,
+            IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor,
             IEnumerable<string> scopes, 
             string authorizationCode)
         {
-            return new AcquireTokenByAuthorizationCodeParameterBuilder(confidentialClientApplication)
+            return new AcquireTokenByAuthorizationCodeParameterBuilder(confidentialClientApplicationExecutor)
                    .WithScopes(scopes).WithAuthorizationCode(authorizationCode);
         }
 
@@ -90,9 +83,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IConfidentialClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return ConfidentialClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
     }
 #endif

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByIntegratedWindowsAuthParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByIntegratedWindowsAuthParameterBuilder.cs
@@ -42,21 +42,15 @@ namespace Microsoft.Identity.Client.ApiConfig
         private AcquireTokenByIntegratedWindowsAuthParameters Parameters { get; } = new AcquireTokenByIntegratedWindowsAuthParameters();
 
         /// <inheritdoc />
-        internal AcquireTokenByIntegratedWindowsAuthParameterBuilder(IPublicClientApplication publicClientApplication)
-            : base(publicClientApplication)
+        internal AcquireTokenByIntegratedWindowsAuthParameterBuilder(IPublicClientApplicationExecutor publicClientApplicationExecutor)
+            : base(publicClientApplicationExecutor)
         {
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="publicClientApplication"></param>
-        /// <param name="scopes"></param>
-        /// <returns></returns>
         internal static AcquireTokenByIntegratedWindowsAuthParameterBuilder Create(
-            IPublicClientApplication publicClientApplication, IEnumerable<string> scopes)
+            IPublicClientApplicationExecutor publicClientApplicationExecutor, IEnumerable<string> scopes)
         {
-            return new AcquireTokenByIntegratedWindowsAuthParameterBuilder(publicClientApplication).WithScopes(scopes);
+            return new AcquireTokenByIntegratedWindowsAuthParameterBuilder(publicClientApplicationExecutor).WithScopes(scopes);
         }
 
         /// <summary>
@@ -72,10 +66,9 @@ namespace Microsoft.Identity.Client.ApiConfig
             return this;
         }
 
-        /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IPublicClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return PublicClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
@@ -43,23 +43,17 @@ namespace Microsoft.Identity.Client.ApiConfig
         private AcquireTokenByRefreshTokenParameters Parameters { get; } = new AcquireTokenByRefreshTokenParameters();
 
         /// <inheritdoc />
-        internal AcquireTokenByRefreshTokenParameterBuilder(IClientApplicationBase clientApplicationBase)
-            : base(clientApplicationBase)
+        internal AcquireTokenByRefreshTokenParameterBuilder(IClientApplicationBaseExecutor clientApplicationBaseExecutor)
+            : base(clientApplicationBaseExecutor)
         {
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="clientApplicationBase"></param>
-        /// <param name="scopes"></param>
-        /// <param name="refreshToken"></param>
-        /// <returns></returns>
         internal static AcquireTokenByRefreshTokenParameterBuilder Create(
-            IClientApplicationBase clientApplicationBase,
+            IClientApplicationBaseExecutor clientApplicationBaseExecutor,
             IEnumerable<string> scopes,
             string refreshToken)
         {
-            return new AcquireTokenByRefreshTokenParameterBuilder(clientApplicationBase)
+            return new AcquireTokenByRefreshTokenParameterBuilder(clientApplicationBaseExecutor)
                    .WithScopes(scopes).WithRefreshToken(refreshToken);
         }
 
@@ -70,11 +64,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(
-            IClientApplicationBaseExecutor executor,
-            CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return ClientApplicationBaseExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByUsernamePasswordParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenByUsernamePasswordParameterBuilder.cs
@@ -43,26 +43,18 @@ namespace Microsoft.Identity.Client.ApiConfig
     {
         private AcquireTokenByUsernamePasswordParameters Parameters { get; } = new AcquireTokenByUsernamePasswordParameters();
 
-        /// <inheritdoc />
-        internal AcquireTokenByUsernamePasswordParameterBuilder(IPublicClientApplication publicClientApplication)
-            : base(publicClientApplication)
+        internal AcquireTokenByUsernamePasswordParameterBuilder(IPublicClientApplicationExecutor publicClientApplicationExecutor)
+            : base(publicClientApplicationExecutor)
         {
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="publicClientApplication"></param>
-        /// <param name="scopes"></param>
-        /// <param name="username"></param>
-        /// <param name="password"></param>
-        /// <returns></returns>
         internal static AcquireTokenByUsernamePasswordParameterBuilder Create(
-            IPublicClientApplication publicClientApplication,
+            IPublicClientApplicationExecutor publicClientApplicationExecutor,
             IEnumerable<string> scopes,
             string username,
             SecureString password)
         {
-            return new AcquireTokenByUsernamePasswordParameterBuilder(publicClientApplication)
+            return new AcquireTokenByUsernamePasswordParameterBuilder(publicClientApplicationExecutor)
                    .WithScopes(scopes).WithUsername(username).WithPassword(password);
         }
 
@@ -79,9 +71,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IPublicClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return PublicClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -45,21 +45,16 @@ namespace Microsoft.Identity.Client.ApiConfig
         private AcquireTokenForClientParameters Parameters { get; } = new AcquireTokenForClientParameters();
 
         /// <inheritdoc />
-        internal AcquireTokenForClientParameterBuilder(IConfidentialClientApplication confidentialClientApplication)
-            : base(confidentialClientApplication)
+        internal AcquireTokenForClientParameterBuilder(IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor)
+            : base(confidentialClientApplicationExecutor)
         {
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="confidentialClientApplication"></param>
-        /// <param name="scopes"></param>
-        /// <returns></returns>
         internal static AcquireTokenForClientParameterBuilder Create(
-            IConfidentialClientApplication confidentialClientApplication,
+            IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor,
             IEnumerable<string> scopes)
         {
-            return new AcquireTokenForClientParameterBuilder(confidentialClientApplication).WithScopes(scopes);
+            return new AcquireTokenForClientParameterBuilder(confidentialClientApplicationExecutor).WithScopes(scopes);
         }
 
         /// <summary>
@@ -94,9 +89,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IConfidentialClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return ConfidentialClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
@@ -56,9 +56,8 @@ namespace Microsoft.Identity.Client.ApiConfig
         private object _ownerWindow;
         private AcquireTokenInteractiveParameters Parameters { get; } = new AcquireTokenInteractiveParameters();
 
-        /// <inheritdoc />
-        internal AcquireTokenInteractiveParameterBuilder(IPublicClientApplication publicClientApplication)
-            : base(publicClientApplication)
+        internal AcquireTokenInteractiveParameterBuilder(IPublicClientApplicationExecutor publicClientApplicationExecutor)
+            : base(publicClientApplicationExecutor)
         {
         }
 
@@ -68,18 +67,12 @@ namespace Microsoft.Identity.Client.ApiConfig
             Parameters.CustomWebUi = customWebUi;
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="publicClientApplication"></param>
-        /// <param name="scopes"></param>
-        /// <param name="parent"></param>
-        /// <returns></returns>
         internal static AcquireTokenInteractiveParameterBuilder Create(
-            IPublicClientApplication publicClientApplication,
+            IPublicClientApplicationExecutor publicClientApplicationExecutor,
             IEnumerable<string> scopes,
             object parent)
         {
-            return new AcquireTokenInteractiveParameterBuilder(publicClientApplication)
+            return new AcquireTokenInteractiveParameterBuilder(publicClientApplicationExecutor)
                 .WithScopes(scopes)
                 .WithParent(parent);
         }
@@ -195,9 +188,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IPublicClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return PublicClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         internal override ApiEvent.ApiIds CalculateApiEventId()

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -45,23 +45,17 @@ namespace Microsoft.Identity.Client.ApiConfig
         private AcquireTokenOnBehalfOfParameters Parameters { get; } = new AcquireTokenOnBehalfOfParameters();
 
         /// <inheritdoc />
-        internal AcquireTokenOnBehalfOfParameterBuilder(IConfidentialClientApplication confidentialClientApplication)
-            : base(confidentialClientApplication)
+        internal AcquireTokenOnBehalfOfParameterBuilder(IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor)
+            : base(confidentialClientApplicationExecutor)
         {
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="confidentialClientApplication"></param>
-        /// <param name="scopes"></param>
-        /// <param name="userAssertion"></param>
-        /// <returns></returns>
         internal static AcquireTokenOnBehalfOfParameterBuilder Create(
-            IConfidentialClientApplication confidentialClientApplication,
+            IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor,
             IEnumerable<string> scopes, 
             UserAssertion userAssertion)
         {
-            return new AcquireTokenOnBehalfOfParameterBuilder(confidentialClientApplication)
+            return new AcquireTokenOnBehalfOfParameterBuilder(confidentialClientApplicationExecutor)
                    .WithScopes(scopes)
                    .WithUserAssertion(userAssertion);
         }
@@ -90,9 +84,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IConfidentialClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return ConfidentialClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -44,38 +44,25 @@ namespace Microsoft.Identity.Client.ApiConfig
     {
         private AcquireTokenSilentParameters Parameters { get; } = new AcquireTokenSilentParameters();
 
-        /// <inheritdoc />
-        internal AcquireTokenSilentParameterBuilder(IClientApplicationBase clientApplicationBase)
-            : base(clientApplicationBase)
+        internal AcquireTokenSilentParameterBuilder(IClientApplicationBaseExecutor clientApplicationBaseExecutor)
+            : base(clientApplicationBaseExecutor)
         {
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="clientApplicationBase"></param>
-        /// <param name="scopes"></param>
-        /// <param name="account"></param>
-        /// <returns></returns>
         internal static AcquireTokenSilentParameterBuilder Create(
-            IClientApplicationBase clientApplicationBase,
+            IClientApplicationBaseExecutor clientApplicationBaseExecutor,
             IEnumerable<string> scopes,
             IAccount account)
         {
-            return new AcquireTokenSilentParameterBuilder(clientApplicationBase).WithScopes(scopes).WithAccount(account);
+            return new AcquireTokenSilentParameterBuilder(clientApplicationBaseExecutor).WithScopes(scopes).WithAccount(account);
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="clientApplicationBase"></param>
-        /// <param name="scopes"></param>
-        /// <param name="loginHint"></param>
-        /// <returns></returns>
         internal static AcquireTokenSilentParameterBuilder Create(
-            IClientApplicationBase clientApplicationBase,
+            IClientApplicationBaseExecutor clientApplicationBaseExecutor,
             IEnumerable<string> scopes,
             string loginHint)
         {
-            return new AcquireTokenSilentParameterBuilder(clientApplicationBase).WithScopes(scopes).WithLoginHint(loginHint);
+            return new AcquireTokenSilentParameterBuilder(clientApplicationBaseExecutor).WithScopes(scopes).WithLoginHint(loginHint);
         }
 
 
@@ -112,9 +99,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IClientApplicationBaseExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return ClientApplicationBaseExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenWithDeviceCodeParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenWithDeviceCodeParameterBuilder.cs
@@ -44,23 +44,17 @@ namespace Microsoft.Identity.Client.ApiConfig
         private AcquireTokenWithDeviceCodeParameters Parameters { get; } = new AcquireTokenWithDeviceCodeParameters();
 
         /// <inheritdoc />
-        internal AcquireTokenWithDeviceCodeParameterBuilder(IPublicClientApplication publicClientApplication)
-            : base(publicClientApplication)
+        internal AcquireTokenWithDeviceCodeParameterBuilder(IPublicClientApplicationExecutor publicClientApplicationExecutor)
+            : base(publicClientApplicationExecutor)
         {
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="publicClientApplication"></param>
-        /// <param name="scopes"></param>
-        /// <param name="deviceCodeResultCallback"></param>
-        /// <returns></returns>
         internal static AcquireTokenWithDeviceCodeParameterBuilder Create(
-            IPublicClientApplication publicClientApplication,
+            IPublicClientApplicationExecutor publicClientApplicationExecutor,
             IEnumerable<string> scopes,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback)
         {
-            return new AcquireTokenWithDeviceCodeParameterBuilder(publicClientApplication)
+            return new AcquireTokenWithDeviceCodeParameterBuilder(publicClientApplicationExecutor)
                    .WithScopes(scopes).WithDeviceCodeResultCallback(deviceCodeResultCallback);
         }
 
@@ -79,9 +73,9 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IPublicClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
-            return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
+            return PublicClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ApiConfig/Executors/AbstractExecutor.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Executors/AbstractExecutor.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Client.ApiConfig.Executors
+{
+    internal abstract class AbstractExecutor
+    {
+        private readonly ClientApplicationBase _clientApplicationBase;
+
+        protected AbstractExecutor(IServiceBundle serviceBundle, ClientApplicationBase clientApplicationBase)
+        {
+            ServiceBundle = serviceBundle;
+            _clientApplicationBase = clientApplicationBase;
+        }
+
+        protected IServiceBundle ServiceBundle { get; }
+
+        protected void LogVersionInfo()
+        {
+            CreateRequestContext().Logger.Info(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "MSAL {0} with assembly version '{1}', file version '{2}' and informational version '{3}'",
+                    ServiceBundle.PlatformProxy.GetProductName(),
+                    MsalIdHelper.GetMsalVersion(),
+                    AssemblyUtils.GetAssemblyFileVersionAttribute(),
+                    AssemblyUtils.GetAssemblyInformationalVersion()));
+        }
+
+        protected RequestContext CreateRequestContext()
+        {
+            return new RequestContext(_clientApplicationBase.ClientId, MsalLogger.Create(Guid.NewGuid(), ServiceBundle.Config));
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Exceptions;
+using Microsoft.Identity.Client.Internal.Requests;
+
+namespace Microsoft.Identity.Client.ApiConfig.Executors
+{
+    internal class ClientApplicationBaseExecutor : AbstractExecutor, IClientApplicationBaseExecutor
+    {
+        private readonly ClientApplicationBase _clientApplicationBase;
+
+        public ClientApplicationBaseExecutor(IServiceBundle serviceBundle, ClientApplicationBase clientApplicationBase)
+            : base(serviceBundle, clientApplicationBase)
+        {
+            _clientApplicationBase = clientApplicationBase;
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenSilentParameters silentParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            IAccount account = GetAccountFromParamsOrLoginHint(silentParameters);
+
+            var customAuthority = commonParameters.AuthorityOverride == null
+                                      ? _clientApplicationBase.GetAuthority(account)
+                                      : Instance.Authority.CreateAuthorityWithOverride(
+                                          ServiceBundle, 
+                                          commonParameters.AuthorityOverride);
+
+            var requestParameters = _clientApplicationBase.CreateRequestParameters(commonParameters, _clientApplicationBase.UserTokenCacheInternal, customAuthority);
+            requestParameters.Account = account;
+
+            var handler = new SilentRequest(ServiceBundle, requestParameters, silentParameters);
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenByRefreshTokenParameters refreshTokenParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestContext = CreateRequestContext();
+            if (commonParameters.Scopes == null || !commonParameters.Scopes.Any())
+            {
+                commonParameters.Scopes = new SortedSet<string>
+                {
+                    _clientApplicationBase.ClientId + "/.default"
+                };
+                requestContext.Logger.Info(LogMessages.NoScopesProvidedForRefreshTokenRequest);
+            }
+
+            var requestParameters = _clientApplicationBase.CreateRequestParameters(commonParameters, _clientApplicationBase.UserTokenCacheInternal);
+            requestParameters.IsRefreshTokenRequest = true;
+
+            requestContext.Logger.Info(LogMessages.UsingXScopesForRefreshTokenRequest(commonParameters.Scopes.Count()));
+
+            var handler = new ByRefreshTokenRequest(ServiceBundle, requestParameters, refreshTokenParameters);
+            return await handler.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private IAccount GetSingleAccountForLoginHint(string loginHint)
+        {
+            var accounts = _clientApplicationBase.UserTokenCacheInternal.GetAccounts(_clientApplicationBase.Authority)
+                .Where(
+                    a => !string.IsNullOrWhiteSpace(a.Username) &&
+                    a.Username.Equals(loginHint, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (!accounts.Any())
+            {
+                throw new MsalUiRequiredException(
+                    MsalUiRequiredException.NoAccountForLoginHint,
+                    MsalErrorMessage.NoAccountForLoginHint);
+            }
+
+            if (accounts.Count() > 1)
+            {
+                throw new MsalUiRequiredException(
+                    MsalUiRequiredException.MultipleAccountsForLoginHint,
+                    MsalErrorMessage.MultipleAccountsForLoginHint);
+            }
+
+            return accounts.First();
+        }
+
+
+        private IAccount GetAccountFromParamsOrLoginHint(AcquireTokenSilentParameters silentParameters)
+        {
+            if (silentParameters.Account != null)
+            {
+                return silentParameters.Account;
+            }
+
+            return GetSingleAccountForLoginHint(silentParameters.LoginHint);
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client/ApiConfig/Executors/ClientExecutorFactory.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Executors/ClientExecutorFactory.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Client.ApiConfig.Executors
+{
+    internal static class ClientExecutorFactory
+    {
+        public static IPublicClientApplicationExecutor CreatePublicClientExecutor(
+            PublicClientApplication publicClientApplication)
+        {
+            var executor = new PublicClientExecutor(publicClientApplication.ServiceBundle, publicClientApplication);
+
+            // TODO: wrap in proxy object to handle mats actions
+            //if (publicClientApplication.AppConfig.IsMatsEnabled)
+            //{
+            //    executor = new MatsPublicClientExecutor(executor, publicClientApplication.Mats);
+            //}
+
+            return executor;
+        }
+
+#if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide confidential client on mobile platforms
+        public static IConfidentialClientApplicationExecutor CreateConfidentialClientExecutor(
+            ConfidentialClientApplication confidentialClientApplication)
+        {
+            var executor = new ConfidentialClientExecutor(confidentialClientApplication.ServiceBundle, confidentialClientApplication);
+
+            // TODO: wrap in proxy object to handle mats actions
+            //if (publicClientApplication.AppConfig.IsMatsEnabled)
+            //{
+            //    executor = new MatsPublicClientExecutor(executor, publicClientApplication.Mats);
+            //}
+
+            return executor;
+        }
+#endif
+
+        public static IClientApplicationBaseExecutor CreateClientApplicationBaseExecutor(
+            ClientApplicationBase clientApplicationBase)
+        {
+            var executor = new ClientApplicationBaseExecutor(clientApplicationBase.ServiceBundle, clientApplicationBase);
+
+            // TODO: wrap in proxy object to handle mats actions
+            //if (publicClientApplication.AppConfig.IsMatsEnabled)
+            //{
+            //    executor = new MatsPublicClientExecutor(executor, publicClientApplication.Mats);
+            //}
+
+            return executor;
+        }
+
+    }
+}

--- a/src/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal.Requests;
+
+namespace Microsoft.Identity.Client.ApiConfig.Executors
+{
+#if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide confidential client on mobile platforms
+
+    internal class ConfidentialClientExecutor : AbstractExecutor, IConfidentialClientApplicationExecutor
+    {
+        private readonly ConfidentialClientApplication _confidentialClientApplication;
+
+        public ConfidentialClientExecutor(IServiceBundle serviceBundle, ConfidentialClientApplication confidentialClientApplication)
+            : base(serviceBundle, confidentialClientApplication)
+        {
+            _confidentialClientApplication = confidentialClientApplication;
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenByAuthorizationCodeParameters authorizationCodeParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParams = _confidentialClientApplication.CreateRequestParameters(commonParameters, _confidentialClientApplication.UserTokenCacheInternal);
+            var handler = new AuthorizationCodeRequest(
+                ServiceBundle,
+                requestParams,
+                authorizationCodeParameters); 
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenForClientParameters clientParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParams = _confidentialClientApplication.CreateRequestParameters(commonParameters, _confidentialClientApplication.AppTokenCacheInternal);
+            requestParams.SendX5C = clientParameters.SendX5C;
+            requestParams.IsClientCredentialRequest = true;
+
+            var handler = new ClientCredentialRequest(
+                ServiceBundle,
+                requestParams,
+                clientParameters);
+
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenOnBehalfOfParameters onBehalfOfParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParams = _confidentialClientApplication.CreateRequestParameters(commonParameters, _confidentialClientApplication.UserTokenCacheInternal);
+            requestParams.SendX5C = onBehalfOfParameters.SendX5C;
+            requestParams.UserAssertion = onBehalfOfParameters.UserAssertion;
+
+            var handler = new OnBehalfOfRequest(
+                ServiceBundle,
+                requestParams,
+                onBehalfOfParameters);
+
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<Uri> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            GetAuthorizationRequestUrlParameters authorizationRequestUrlParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParameters = _confidentialClientApplication.CreateRequestParameters(commonParameters, _confidentialClientApplication.UserTokenCacheInternal);
+            requestParameters.Account = authorizationRequestUrlParameters.Account;
+            requestParameters.LoginHint = authorizationRequestUrlParameters.LoginHint;
+
+            if (!string.IsNullOrWhiteSpace(authorizationRequestUrlParameters.RedirectUri))
+            {
+                requestParameters.RedirectUri = new Uri(authorizationRequestUrlParameters.RedirectUri);
+            }
+
+            var handler = new InteractiveRequest(
+                ServiceBundle,
+                requestParameters,
+                authorizationRequestUrlParameters.ToInteractiveParameters(),
+                null);
+
+            // todo: need to pass through cancellation token here
+            return await handler.CreateAuthorizationUriAsync().ConfigureAwait(false);
+        }
+    }
+#endif
+}

--- a/src/Microsoft.Identity.Client/ApiConfig/Executors/PublicClientExecutor.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Executors/PublicClientExecutor.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal.Requests;
+using Microsoft.Identity.Client.UI;
+
+namespace Microsoft.Identity.Client.ApiConfig.Executors
+{
+    internal class PublicClientExecutor : AbstractExecutor, IPublicClientApplicationExecutor
+    {
+        private readonly PublicClientApplication _publicClientApplication;
+
+        public PublicClientExecutor(IServiceBundle serviceBundle, PublicClientApplication publicClientApplication)
+            : base(serviceBundle, publicClientApplication)
+        {
+            _publicClientApplication = publicClientApplication;
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenInteractiveParameters interactiveParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParams = _publicClientApplication.CreateRequestParameters(commonParameters, _publicClientApplication.UserTokenCacheInternal);
+            requestParams.LoginHint = interactiveParameters.LoginHint;
+            requestParams.Account = interactiveParameters.Account;
+
+            var handler = new InteractiveRequest(
+                ServiceBundle,
+                requestParams,
+                interactiveParameters,
+                CreateWebAuthenticationDialog(interactiveParameters, requestParams.RequestContext));
+
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenWithDeviceCodeParameters deviceCodeParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParams = _publicClientApplication.CreateRequestParameters(commonParameters, _publicClientApplication.UserTokenCacheInternal);
+
+            var handler = new DeviceCodeRequest(
+                ServiceBundle,
+                requestParams,
+                deviceCodeParameters);
+
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenByIntegratedWindowsAuthParameters integratedWindowsAuthParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParams = _publicClientApplication.CreateRequestParameters(commonParameters, _publicClientApplication.UserTokenCacheInternal);
+
+            var handler = new IntegratedWindowsAuthRequest(
+                ServiceBundle,
+                requestParams,
+                integratedWindowsAuthParameters);
+
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<AuthenticationResult> ExecuteAsync(
+            AcquireTokenCommonParameters commonParameters,
+            AcquireTokenByUsernamePasswordParameters usernamePasswordParameters,
+            CancellationToken cancellationToken)
+        {
+            LogVersionInfo();
+
+            var requestParams = _publicClientApplication.CreateRequestParameters(commonParameters, _publicClientApplication.UserTokenCacheInternal);
+            var handler = new UsernamePasswordRequest(
+                ServiceBundle,
+                requestParams,
+                usernamePasswordParameters);
+
+            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private IWebUI CreateWebAuthenticationDialog(
+            AcquireTokenInteractiveParameters interactiveParameters,
+            RequestContext requestContext)
+        {
+            if (interactiveParameters.CustomWebUi != null)
+            {
+                return new CustomWebUiHandler(interactiveParameters.CustomWebUi);
+            }
+
+            var coreUiParent = interactiveParameters.UiParent.CoreUiParent;
+
+#if ANDROID || iOS
+            coreUiParent.UseEmbeddedWebview = interactiveParameters.UseEmbeddedWebView;
+#endif
+
+#if WINDOWS_APP || DESKTOP
+            // hidden web view can be used in both WinRT and desktop applications.
+            coreUiParent.UseHiddenBrowser = interactiveParameters.Prompt.Equals(Prompt.Never);
+#if WINDOWS_APP
+            coreUiParent.UseCorporateNetwork = _publicClientApplication.AppConfig.UseCorporateNetwork;
+#endif
+#endif
+            return ServiceBundle.PlatformProxy.GetWebUiFactory().CreateAuthenticationDialog(coreUiParent, requestContext);
+        }
+
+    }
+}

--- a/src/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -47,16 +47,16 @@ namespace Microsoft.Identity.Client.ApiConfig
     {
         private GetAuthorizationRequestUrlParameters Parameters { get; } = new GetAuthorizationRequestUrlParameters();
 
-        internal GetAuthorizationRequestUrlParameterBuilder(IConfidentialClientApplication confidentialClientApplication)
-            : base(confidentialClientApplication)
+        internal GetAuthorizationRequestUrlParameterBuilder(IConfidentialClientApplicationExecutor confidentialClientApplicationexecutor)
+            : base(confidentialClientApplicationexecutor)
         {
         }
 
         internal static GetAuthorizationRequestUrlParameterBuilder Create(
-            IConfidentialClientApplication confidentialClientApplication,
+            IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor,
             IEnumerable<string> scopes)
         {
-            return new GetAuthorizationRequestUrlParameterBuilder(confidentialClientApplication).WithScopes(scopes);
+            return new GetAuthorizationRequestUrlParameterBuilder(confidentialClientApplicationExecutor).WithScopes(scopes);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Microsoft.Identity.Client.ApiConfig
         }
 
         /// <inheritdoc />
-        internal override Task<AuthenticationResult> ExecuteAsync(IConfidentialClientApplicationExecutor executor, CancellationToken cancellationToken)
+        internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
             throw new InvalidOperationException("This is a developer BUG.  This should never get executed.");
         }
@@ -116,14 +116,8 @@ namespace Microsoft.Identity.Client.ApiConfig
             // This method is marked "public new" because it only differs in return type from the base class
             // ExecuteAsync() and we need this one to return Uri and not AuthenticationResult.
 
-            if (ConfidentialClientApplication is IConfidentialClientApplicationExecutor executor)
-            {
-                ValidateAndCalculateApiId();
-                return executor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
-            }
-
-            throw new InvalidOperationException(
-                "ConfidentialClientApplication implementation does not implement IConfidentialClientApplicationExecutor.");
+            ValidateAndCalculateApiId();
+            return ConfidentialClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Identity.Client/ClientApplicationBase.WithBuilders.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.WithBuilders.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Identity.Client.ApiConfig;
+using Microsoft.Identity.Client.ApiConfig.Executors;
 using Microsoft.Identity.Client.AppConfig;
 
 namespace Microsoft.Identity.Client
@@ -63,7 +64,10 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         public AcquireTokenSilentParameterBuilder AcquireTokenSilent(IEnumerable<string> scopes, IAccount account)
         {
-            return AcquireTokenSilentParameterBuilder.Create(this, scopes, account);
+            return AcquireTokenSilentParameterBuilder.Create(
+                ClientExecutorFactory.CreateClientApplicationBaseExecutor(this),
+                scopes,
+                account);
         }
 
         /// <summary>
@@ -101,7 +105,10 @@ namespace Microsoft.Identity.Client
                 throw new ArgumentNullException(nameof(loginHint));
             }
 
-            return AcquireTokenSilentParameterBuilder.Create(this, scopes, loginHint);
+            return AcquireTokenSilentParameterBuilder.Create(
+                ClientExecutorFactory.CreateClientApplicationBaseExecutor(this),
+                scopes,
+                loginHint);
         }
 
         internal ClientApplicationBase(ApplicationConfiguration config)

--- a/src/Microsoft.Identity.Client/ConfidentialClientApplication.WithBuilders.cs
+++ b/src/Microsoft.Identity.Client/ConfidentialClientApplication.WithBuilders.cs
@@ -25,24 +25,15 @@
 // 
 // ------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig;
-using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.ApiConfig.Executors;
 using Microsoft.Identity.Client.AppConfig;
-using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.Internal.Requests;
-using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 
 namespace Microsoft.Identity.Client
 {
 #if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide confidential client on mobile platforms
-    public partial class ConfidentialClientApplication : IConfidentialClientApplicationExecutor
+    public partial class ConfidentialClientApplication
     {
         internal ConfidentialClientApplication(ApplicationConfiguration configuration)
             : base(configuration)
@@ -72,7 +63,7 @@ namespace Microsoft.Identity.Client
             string authorizationCode)
         {
             return AcquireTokenByAuthorizationCodeParameterBuilder.Create(
-                this,
+                ClientExecutorFactory.CreateConfidentialClientExecutor(this),
                 scopes,
                 authorizationCode);
         }
@@ -93,7 +84,9 @@ namespace Microsoft.Identity.Client
         public AcquireTokenForClientParameterBuilder AcquireTokenForClient(
             IEnumerable<string> scopes)
         {
-            return AcquireTokenForClientParameterBuilder.Create(this, scopes);
+            return AcquireTokenForClientParameterBuilder.Create(
+                ClientExecutorFactory.CreateConfidentialClientExecutor(this),
+                scopes);
         }
 
         /// <summary>
@@ -114,7 +107,10 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             UserAssertion userAssertion)
         {
-            return AcquireTokenOnBehalfOfParameterBuilder.Create(this, scopes, userAssertion);
+            return AcquireTokenOnBehalfOfParameterBuilder.Create(
+                ClientExecutorFactory.CreateConfidentialClientExecutor(this),
+                scopes,
+                userAssertion);
         }
 
         /// <summary>
@@ -134,88 +130,10 @@ namespace Microsoft.Identity.Client
         public GetAuthorizationRequestUrlParameterBuilder GetAuthorizationRequestUrl(
             IEnumerable<string> scopes)
         {
-            return GetAuthorizationRequestUrlParameterBuilder.Create(this, scopes);
+            return GetAuthorizationRequestUrlParameterBuilder.Create(
+                ClientExecutorFactory.CreateConfidentialClientExecutor(this),
+                scopes);
         }
-
-        async Task<AuthenticationResult> IConfidentialClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            AcquireTokenByAuthorizationCodeParameters authorizationCodeParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParams = CreateRequestParameters(commonParameters, UserTokenCacheInternal);
-            var handler = new AuthorizationCodeRequest(
-                ServiceBundle,
-                requestParams,
-                authorizationCodeParameters); 
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        async Task<AuthenticationResult> IConfidentialClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            AcquireTokenForClientParameters clientParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParams = CreateRequestParameters(commonParameters, AppTokenCacheInternal);
-            requestParams.SendX5C = clientParameters.SendX5C;
-            requestParams.IsClientCredentialRequest = true;
-
-            var handler = new ClientCredentialRequest(
-                ServiceBundle,
-                requestParams,
-                clientParameters);
-
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        async Task<AuthenticationResult> IConfidentialClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            AcquireTokenOnBehalfOfParameters onBehalfOfParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParams = CreateRequestParameters(commonParameters, UserTokenCacheInternal);
-            requestParams.SendX5C = onBehalfOfParameters.SendX5C;
-            requestParams.UserAssertion = onBehalfOfParameters.UserAssertion;
-
-            var handler = new OnBehalfOfRequest(
-                ServiceBundle,
-                requestParams,
-                onBehalfOfParameters);
-
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        async Task<Uri> IConfidentialClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            GetAuthorizationRequestUrlParameters authorizationRequestUrlParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParameters = CreateRequestParameters(commonParameters, UserTokenCacheInternal);
-            requestParameters.Account = authorizationRequestUrlParameters.Account;
-            requestParameters.LoginHint = authorizationRequestUrlParameters.LoginHint;
-
-            if (!string.IsNullOrWhiteSpace(authorizationRequestUrlParameters.RedirectUri))
-            {
-                requestParameters.RedirectUri = new Uri(authorizationRequestUrlParameters.RedirectUri);
-            }
-
-            var handler = new InteractiveRequest(
-                ServiceBundle,
-                requestParameters,
-                authorizationRequestUrlParameters.ToInteractiveParameters(),
-                null);
-
-            // todo: need to pass through cancellation token here
-            return await handler.CreateAuthorizationUriAsync().ConfigureAwait(false);
-        }
-
     }
 #endif
 }

--- a/src/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -39,6 +39,7 @@ using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.ApiConfig.Executors;
 
 namespace Microsoft.Identity.Client
 {
@@ -419,7 +420,10 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             string refreshToken)
         {
-            return AcquireTokenByRefreshTokenParameterBuilder.Create(this, scopes, refreshToken);
+            return AcquireTokenByRefreshTokenParameterBuilder.Create(
+                ClientExecutorFactory.CreateClientApplicationBaseExecutor(this),
+                scopes,
+                refreshToken);
         }
 
         internal ClientCredential ClientCredential => ServiceBundle.Config.ClientCredential;

--- a/src/Microsoft.Identity.Client/PublicClientApplication.WithBuilders.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.WithBuilders.cs
@@ -28,27 +28,20 @@
 using System;
 using System.Collections.Generic;
 using System.Security;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig;
-using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.ApiConfig.Executors;
 using Microsoft.Identity.Client.AppConfig;
-using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Exceptions;
-using Microsoft.Identity.Client.Internal.Requests;
-using Microsoft.Identity.Client.TelemetryCore;
-using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client
 {
-    public partial class PublicClientApplication : IPublicClientApplicationExecutor
+    public partial class PublicClientApplication
     {
         internal PublicClientApplication(ApplicationConfiguration configuration)
             : base(configuration)
         {
         }
 
-        #region ParameterBuilders
         /// <summary>
         /// Interactive request to acquire token for the specified scopes. The interactive window will be parented to the specified
         /// window. The user will be required to select an account
@@ -77,7 +70,10 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             object parent)
         {
-            return AcquireTokenInteractiveParameterBuilder.Create(this, scopes, parent);
+            return AcquireTokenInteractiveParameterBuilder.Create(
+                ClientExecutorFactory.CreatePublicClientExecutor(this),
+                scopes,
+                parent);
         }
 
         /// <summary>
@@ -106,7 +102,10 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback)
         {
-            return AcquireTokenWithDeviceCodeParameterBuilder.Create(this, scopes, deviceCodeResultCallback);
+            return AcquireTokenWithDeviceCodeParameterBuilder.Create(
+                ClientExecutorFactory.CreatePublicClientExecutor(this),
+                scopes,
+                deviceCodeResultCallback);
         }
 
         /// <summary>
@@ -132,7 +131,9 @@ namespace Microsoft.Identity.Client
         public AcquireTokenByIntegratedWindowsAuthParameterBuilder AcquireTokenByIntegratedWindowsAuth(
             IEnumerable<string> scopes)
         {
-            return AcquireTokenByIntegratedWindowsAuthParameterBuilder.Create(this, scopes);
+            return AcquireTokenByIntegratedWindowsAuthParameterBuilder.Create(
+                ClientExecutorFactory.CreatePublicClientExecutor(this),
+                scopes);
         }
 
         /// <summary>
@@ -155,108 +156,11 @@ namespace Microsoft.Identity.Client
             string username,
             SecureString password)
         {
-            return AcquireTokenByUsernamePasswordParameterBuilder.Create(this, scopes, username, password);
-        }
-        #endregion // ParameterBuilders
-
-        #region ParameterExecutors
-
-        async Task<AuthenticationResult> IPublicClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            AcquireTokenInteractiveParameters interactiveParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParams = CreateRequestParameters(commonParameters, UserTokenCacheInternal);
-            requestParams.LoginHint = interactiveParameters.LoginHint;
-            requestParams.Account = interactiveParameters.Account;
-
-            var handler = new InteractiveRequest(
-                ServiceBundle,
-                requestParams,
-                interactiveParameters,
-                CreateWebAuthenticationDialog(interactiveParameters, requestParams.RequestContext));
-
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
-
-        }
-
-        async Task<AuthenticationResult> IPublicClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            AcquireTokenWithDeviceCodeParameters deviceCodeParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParams = CreateRequestParameters(commonParameters, UserTokenCacheInternal);
-
-            var handler = new DeviceCodeRequest(
-                ServiceBundle,
-                requestParams,
-                deviceCodeParameters);
-
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        async Task<AuthenticationResult> IPublicClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            AcquireTokenByIntegratedWindowsAuthParameters integratedWindowsAuthParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParams = CreateRequestParameters(commonParameters, UserTokenCacheInternal);
-
-            var handler = new IntegratedWindowsAuthRequest(
-                ServiceBundle,
-                requestParams,
-                integratedWindowsAuthParameters);
-
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        async Task<AuthenticationResult> IPublicClientApplicationExecutor.ExecuteAsync(
-            AcquireTokenCommonParameters commonParameters,
-            AcquireTokenByUsernamePasswordParameters usernamePasswordParameters,
-            CancellationToken cancellationToken)
-        {
-            LogVersionInfo();
-
-            var requestParams = CreateRequestParameters(commonParameters, UserTokenCacheInternal);
-            var handler = new UsernamePasswordRequest(
-                ServiceBundle,
-                requestParams,
-                usernamePasswordParameters);
-
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        #endregion // ParameterExecutors
-
-        private IWebUI CreateWebAuthenticationDialog(
-            AcquireTokenInteractiveParameters interactiveParameters,
-            RequestContext requestContext)
-        {
-            if (interactiveParameters.CustomWebUi != null)
-            {
-                return new CustomWebUiHandler(interactiveParameters.CustomWebUi);
-            }
-
-            var coreUiParent = interactiveParameters.UiParent.CoreUiParent;
-
-#if ANDROID || iOS
-            coreUiParent.UseEmbeddedWebview = interactiveParameters.UseEmbeddedWebView;
-#endif
-
-#if WINDOWS_APP || DESKTOP
-            // hidden web view can be used in both WinRT and desktop applications.
-            coreUiParent.UseHiddenBrowser = interactiveParameters.Prompt.Equals(Prompt.Never);
-#if WINDOWS_APP
-            coreUiParent.UseCorporateNetwork = AppConfig.UseCorporateNetwork;
-#endif
-#endif
-            return ServiceBundle.PlatformProxy.GetWebUiFactory().CreateAuthenticationDialog(coreUiParent, requestContext);
+            return AcquireTokenByUsernamePasswordParameterBuilder.Create(
+                ClientExecutorFactory.CreatePublicClientExecutor(this),
+                scopes,
+                username,
+                password);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -41,6 +41,7 @@ using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.PlatformsCommon.Factories;
 using Microsoft.Identity.Client.WsTrust;
+using Microsoft.Identity.Client.ApiConfig.Executors;
 
 #if iOS
 using Microsoft.Identity.Client.Platforms.iOS;
@@ -619,7 +620,10 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             string refreshToken)
         {
-            return AcquireTokenByRefreshTokenParameterBuilder.Create(this, scopes, refreshToken);
+            return AcquireTokenByRefreshTokenParameterBuilder.Create(
+                ClientExecutorFactory.CreateClientApplicationBaseExecutor(this),
+                scopes,
+                refreshToken);
         }
 
 #if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !MAC_BUILDTIME

--- a/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/AcquireTokenInteractiveBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/AcquireTokenInteractiveBuilderTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         [TestMethod]
         public async Task TestAcquireTokenInteractiveBuilderAsync()
         {
-            await AcquireTokenInteractiveParameterBuilder.Create(_harness.ClientApplication, MsalTestConstants.Scope, null)
+            await AcquireTokenInteractiveParameterBuilder.Create(_harness.Executor, MsalTestConstants.Scope, null)
                                                          .ExecuteAsync()
                                                          .ConfigureAwait(false);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
             var account = Substitute.For<IAccount>();
             account.Username.Returns(MsalTestConstants.DisplayableId);
 
-            await AcquireTokenInteractiveParameterBuilder.Create(_harness.ClientApplication, MsalTestConstants.Scope, null)
+            await AcquireTokenInteractiveParameterBuilder.Create(_harness.Executor, MsalTestConstants.Scope, null)
                                                          .WithAccount(account)
                                                          .ExecuteAsync()
                                                          .ConfigureAwait(false);
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         [TestMethod]
         public async Task TestAcquireTokenInteractiveBuilderWithLoginHintAsync()
         {
-            await AcquireTokenInteractiveParameterBuilder.Create(_harness.ClientApplication, MsalTestConstants.Scope, null)
+            await AcquireTokenInteractiveParameterBuilder.Create(_harness.Executor, MsalTestConstants.Scope, null)
                                                          .WithLoginHint(MsalTestConstants.DisplayableId)
                                                          .ExecuteAsync()
                                                          .ConfigureAwait(false);
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
             var account = Substitute.For<IAccount>();
             account.Username.Returns(MsalTestConstants.DisplayableId);
 
-            await AcquireTokenInteractiveParameterBuilder.Create(_harness.ClientApplication, MsalTestConstants.Scope, null)
+            await AcquireTokenInteractiveParameterBuilder.Create(_harness.Executor, MsalTestConstants.Scope, null)
                                                          .WithAccount(account)
                                                          .WithLoginHint("SomeOtherLoginHint")
                                                          .ExecuteAsync()
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         [TestMethod]
         public async Task TestAcquireTokenInteractiveBuilderWithPromptAndExtraQueryParametersAsync()
         {
-            await AcquireTokenInteractiveParameterBuilder.Create(_harness.ClientApplication, MsalTestConstants.Scope, null)
+            await AcquireTokenInteractiveParameterBuilder.Create(_harness.Executor, MsalTestConstants.Scope, null)
                                                          .WithLoginHint(MsalTestConstants.DisplayableId)
                                                          .WithExtraQueryParameters("domain_hint=mydomain.com")
                                                          .ExecuteAsync()
@@ -126,7 +126,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         {
             var customWebUi = Substitute.For<ICustomWebUi>();
 
-            await AcquireTokenInteractiveParameterBuilder.Create(_harness.ClientApplication, MsalTestConstants.Scope, null)
+            await AcquireTokenInteractiveParameterBuilder.Create(_harness.Executor, MsalTestConstants.Scope, null)
                                                          .WithCustomWebUi(customWebUi)
                                                          .ExecuteAsync()
                                                          .ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/Harnesses/AcquireTokenInteractiveBuilderHarness.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/Harnesses/AcquireTokenInteractiveBuilderHarness.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests.Harnesses
         public AcquireTokenInteractiveParameters InteractiveParametersReceived { get; private set; }
         public IPublicClientApplication ClientApplication { get; private set; }
 
+        public IPublicClientApplicationExecutor Executor => (IPublicClientApplicationExecutor)ClientApplication;
+
         public async Task SetupAsync()
         {
             ClientApplication = Substitute.For<IPublicClientApplication, IPublicClientApplicationExecutor>();


### PR DESCRIPTION
We need to be able to wrap every one of our APIs in appropriate success/failure telemetry actions via MATS.  So this restructures the executors a bit to make them independent classes that we can wrap in a proxy instead of having PCA/CCA implement the I***Executor interfaces directly.

This does NOT impact the public API surface as all of this is internal implementation.