### PR TITLE
Fix [969]: CreateWithApplicationOptions does not respect the audience

### DIFF
--- a/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -301,21 +301,13 @@ namespace Microsoft.Identity.Client.AppConfig
                 return;
             }
 
-            if (!string.IsNullOrWhiteSpace(Config.Instance) || !string.IsNullOrWhiteSpace(Config.TenantId))
-            {
-                string defaultAuthorityInstance = GetDefaultAuthorityInstance();
-                string defaultAuthorityAudience = GetDefaultAuthorityAudience();
+            string defaultAuthorityInstance = GetDefaultAuthorityInstance();
+            string defaultAuthorityAudience = GetDefaultAuthorityAudience();
 
-                Config.AuthorityInfo = new AuthorityInfo(
-                        AuthorityType.Aad,
-                        new Uri($"{defaultAuthorityInstance}/{defaultAuthorityAudience}").ToString(),
-                        true);
-            }
-            else
-            {
-                // Add the default.
-                WithAuthority(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, true);
-            }
+            Config.AuthorityInfo = new AuthorityInfo(
+                    AuthorityType.Aad,
+                    new Uri($"{defaultAuthorityInstance}/{defaultAuthorityAudience}").ToString(),
+                    true);
         }
 
         private string GetDefaultAuthorityAudience()
@@ -338,7 +330,7 @@ namespace Microsoft.Identity.Client.AppConfig
                 return Config.TenantId;
             }
 
-            return AuthorityInfo.GetAadAuthorityAudienceValue(AadAuthorityAudience.AzureAdMultipleOrgs, string.Empty);
+            return AuthorityInfo.GetAadAuthorityAudienceValue(AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, string.Empty);
         }
 
         private string GetDefaultAuthorityInstance()

--- a/tests/Microsoft.Identity.Test.Unit.net45/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -261,6 +261,84 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         }
 
         [TestMethod]
+        public void TestCreateWithOptionsAuthorityAudience()
+        {
+            var options = new PublicClientApplicationOptions
+            {
+                AzureCloudInstance = AzureCloudInstance.AzurePublic,
+                AadAuthorityAudience = AadAuthorityAudience.AzureAdMultipleOrgs,
+                ClientId = MsalTestConstants.ClientId
+            };
+            var pca = PublicClientApplicationBuilder.CreateWithApplicationOptions(options)
+                                                    .Build();
+            Assert.AreEqual(MsalTestConstants.AuthorityOrganizationsTenant, pca.Authority);
+        }
+
+        [TestMethod]
+        public void EnsureCreatePublicClientWithAzureAdMyOrgAndNoTenantThrowsException()
+        {
+            var options = new PublicClientApplicationOptions
+            {
+                AzureCloudInstance = AzureCloudInstance.AzurePublic,
+                AadAuthorityAudience = AadAuthorityAudience.AzureAdMyOrg,
+                ClientId = MsalTestConstants.ClientId
+            };
+
+            try
+            {
+                var pca = PublicClientApplicationBuilder.CreateWithApplicationOptions(options)
+                                                        .Build();
+                Assert.Fail("Should have thrown exception here due to missing TenantId");
+            }
+            catch (Exception ex)
+            {
+                Assert.IsTrue(ex is InvalidOperationException);
+            }
+        }
+
+        [TestMethod]
+        public void EnsureCreatePublicClientWithAzureAdMyOrgAndValidTenantSucceeds()
+        {
+            const string tenantId = "d3adb33f-c1de-ed1c-c1de-deadb33fc1d3";
+
+            var options = new PublicClientApplicationOptions
+            {
+                AzureCloudInstance = AzureCloudInstance.AzurePublic,
+                AadAuthorityAudience = AadAuthorityAudience.AzureAdMyOrg,
+                TenantId = tenantId,
+                ClientId = MsalTestConstants.ClientId
+            };
+
+            var pca = PublicClientApplicationBuilder.CreateWithApplicationOptions(options)
+                                                    .Build();
+
+            Assert.AreEqual($"https://login.microsoftonline.com/{tenantId}/", pca.Authority);
+        }
+
+        [DataTestMethod]
+        [DataRow(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdMultipleOrgs, MsalTestConstants.AuthorityOrganizationsTenant, DisplayName = "AzurePublic + AzureAdMultipleOrgs")]
+        [DataRow(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, MsalTestConstants.AuthorityCommonTenant, DisplayName = "AzurePublic + AzureAdAndPersonalMicrosoftAccount")]
+        [DataRow(AzureCloudInstance.AzurePublic, AadAuthorityAudience.PersonalMicrosoftAccount, "https://login.microsoftonline.com/consumers/", DisplayName = "AzurePublic + PersonalMicrosoftAccount")]
+        [DataRow(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMultipleOrgs, "https://login.chinacloudapi.cn/organizations/", DisplayName = "AzureChina + AzureAdMultipleOrgs")]
+        [DataRow(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, "https://login.chinacloudapi.cn/common/", DisplayName = "AzureChina + AzureAdAndPersonalMicrosoftAccount")]
+        [DataRow(AzureCloudInstance.AzureChina, AadAuthorityAudience.PersonalMicrosoftAccount, "https://login.chinacloudapi.cn/consumers/", DisplayName = "AzureChina + PersonalMicrosoftAccount")]
+        public void TestAuthorityPermutations(
+            AzureCloudInstance cloudInstance,
+            AadAuthorityAudience audience,
+            string expectedAuthority)
+        {
+            var options = new PublicClientApplicationOptions
+            {
+                AzureCloudInstance = cloudInstance,
+                AadAuthorityAudience = audience,
+                ClientId = MsalTestConstants.ClientId
+            };
+            var pca = PublicClientApplicationBuilder.CreateWithApplicationOptions(options)
+                                                    .Build();
+            Assert.AreEqual(expectedAuthority, pca.Authority);
+        }
+
+        [TestMethod]
         public void TestAuthorities()
         {
             IPublicClientApplication app;


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/969