### PR TITLE
Create mockable AcquireToken calls

### DIFF
--- a/src/Microsoft.Identity.Client/ClientApplicationBase.WithBuilders.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.WithBuilders.cs
@@ -27,6 +27,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig;
 using Microsoft.Identity.Client.ApiConfig.Executors;
 using Microsoft.Identity.Client.AppConfig;
@@ -68,6 +70,17 @@ namespace Microsoft.Identity.Client
                 ClientExecutorFactory.CreateClientApplicationBaseExecutor(this),
                 scopes,
                 account);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenSilentParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Client/ConfidentialClientApplication.WithBuilders.cs
+++ b/src/Microsoft.Identity.Client/ConfidentialClientApplication.WithBuilders.cs
@@ -25,7 +25,10 @@
 // 
 // ------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig;
 using Microsoft.Identity.Client.ApiConfig.Executors;
 using Microsoft.Identity.Client.AppConfig;
@@ -69,6 +72,17 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenByAuthorizationCodeParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Acquires a token from the authority configured in the app, for the confidential client itself (in the name of no user)
         /// using the client credentials flow. (See https://aka.ms/msal-net-client-credentials)
         /// </summary>
@@ -87,6 +101,17 @@ namespace Microsoft.Identity.Client
             return AcquireTokenForClientParameterBuilder.Create(
                 ClientExecutorFactory.CreateConfidentialClientExecutor(this),
                 scopes);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenForClientParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
         }
 
         /// <summary>
@@ -114,6 +139,17 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenOnBehalfOfParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Computes the URL of the authorization request letting the user sign-in and consent to the application accessing specific scopes in
         /// the user's name. The URL targets the /authorize endpoint of the authority configured in the application.
         /// This override enables you to specify a login hint and extra query parameter.
@@ -134,6 +170,18 @@ namespace Microsoft.Identity.Client
                 ClientExecutorFactory.CreateConfidentialClientExecutor(this),
                 scopes);
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<Uri> ExecuteAsync(GetAuthorizationRequestUrlParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
+        }
+
     }
 #endif
 }

--- a/src/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig;
 using Microsoft.Identity.Client.AppConfig;
@@ -177,6 +178,14 @@ namespace Microsoft.Identity.Client
         /// specify extra query parameters
         /// </remarks>
         AcquireTokenSilentParameterBuilder AcquireTokenSilent(IEnumerable<string> scopes, string loginHint);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenSilentParameterBuilder builder, CancellationToken cancellationToken);
 
         /// <summary>
         /// Removes all tokens in the cache for the specified account.

--- a/src/Microsoft.Identity.Client/IConfidentialClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IConfidentialClientApplication.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig;
 
@@ -70,6 +71,14 @@ namespace Microsoft.Identity.Client
             string authorizationCode);
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenByAuthorizationCodeParameterBuilder builder, CancellationToken cancellationToken);
+
+        /// <summary>
         /// [V3 API] Acquires a token from the authority configured in the app, for the confidential client itself (in the name of no user)
         /// using the client credentials flow. (See https://aka.ms/msal-net-client-credentials)
         /// </summary>
@@ -83,6 +92,14 @@ namespace Microsoft.Identity.Client
         /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithExtraQueryParameters(Dictionary{string, string})"/>
         /// </remarks>
         AcquireTokenForClientParameterBuilder AcquireTokenForClient(IEnumerable<string> scopes);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenForClientParameterBuilder builder, CancellationToken cancellationToken);
 
         /// <summary>
         /// [V3 API] Acquires an access token for this application (usually a Web API) from the authority configured in the application,
@@ -99,6 +116,14 @@ namespace Microsoft.Identity.Client
         /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithExtraQueryParameters(Dictionary{string, string})"/>
         /// </remarks>
         AcquireTokenOnBehalfOfParameterBuilder AcquireTokenOnBehalfOf(IEnumerable<string> scopes, UserAssertion userAssertion);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenOnBehalfOfParameterBuilder builder, CancellationToken cancellationToken);
 
         /// <summary>
         /// [V3 API] Acquires token using On-Behalf-Of flow. (See https://aka.ms/msal-net-on-behalf-of)
@@ -167,6 +192,13 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         GetAuthorizationRequestUrlParameterBuilder GetAuthorizationRequestUrl(IEnumerable<string> scopes);
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<Uri> ExecuteAsync(GetAuthorizationRequestUrlParameterBuilder builder, CancellationToken cancellationToken);
 
         /// <summary>
         /// [V2 API] URL of the authorize endpoint including the query parameters.

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -68,6 +68,14 @@ namespace Microsoft.Identity.Client
         AcquireTokenInteractiveParameterBuilder AcquireTokenInteractive(IEnumerable<string> scopes, object parent);
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenInteractiveParameterBuilder builder, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Acquires a security token on a device without a Web browser, by letting the user authenticate on
         /// another device. This is done in two steps:
         /// <list type="bullet">
@@ -94,6 +102,14 @@ namespace Microsoft.Identity.Client
             Func<DeviceCodeResult, Task> deviceCodeResultCallback);
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenWithDeviceCodeParameterBuilder builder, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Non-interactive request to acquire a security token for the signed-in user in Windows,
         /// via Integrated Windows Authentication. See https://aka.ms/msal-net-iwa.
         /// The account used in this overrides is pulled from the operating system as the current user principal name
@@ -117,6 +133,14 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes);
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenByIntegratedWindowsAuthParameterBuilder builder, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Non-interactive request to acquire a security token from the authority, via Username/Password Authentication.
         /// Available only on .net desktop and .net core. See https://aka.ms/msal-net-up for details.
         /// </summary>
@@ -135,6 +159,14 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             string username,
             SecureString password);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<AuthenticationResult> ExecuteAsync(AcquireTokenByUsernamePasswordParameterBuilder builder, CancellationToken cancellationToken);
 
 #if !NET_CORE_BUILDTIME
         // expose the interactive API without UIParent only for platforms that 

--- a/src/Microsoft.Identity.Client/PublicClientApplication.WithBuilders.cs
+++ b/src/Microsoft.Identity.Client/PublicClientApplication.WithBuilders.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig;
 using Microsoft.Identity.Client.ApiConfig.Executors;
@@ -77,6 +78,17 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenInteractiveParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Acquires a security token on a device without a Web browser, by letting the user authenticate on
         /// another device. This is done in two steps:
         /// <list type="bullet">
@@ -109,6 +121,17 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenWithDeviceCodeParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Non-interactive request to acquire a security token for the signed-in user in Windows,
         /// via Integrated Windows Authentication. See https://aka.ms/msal-net-iwa.
         /// The account used in this overrides is pulled from the operating system as the current user principal name
@@ -137,6 +160,17 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenByIntegratedWindowsAuthParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Non-interactive request to acquire a security token from the authority, via Username/Password Authentication.
         /// Available only on .net desktop and .net core. See https://aka.ms/msal-net-up for details.
         /// </summary>
@@ -161,6 +195,17 @@ namespace Microsoft.Identity.Client
                 scopes,
                 username,
                 password);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<AuthenticationResult> ExecuteAsync(AcquireTokenByUsernamePasswordParameterBuilder builder, CancellationToken cancellationToken)
+        {
+            return builder.ExecuteAsync(cancellationToken);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/ApiMockingTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/ApiConfigTests/ApiMockingTests.cs
@@ -1,0 +1,198 @@
+﻿// ------------------------------------------------------------------------------
+// 
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+// 
+// This code is licensed under the MIT License.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ApiConfig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Microsoft.Identity.Test.Unit.ApiConfigTests
+{
+    [TestClass]
+    public class ApiMockingTests
+    {
+        private const string ExpectedAccessToken = "yay access token";
+
+        private IPublicClientApplication _pca;
+        private IConfidentialClientApplication _cca;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _pca = Substitute.For<IPublicClientApplication>();
+            _cca = Substitute.For<IConfidentialClientApplication>();
+        }
+
+        private AuthenticationResult CreateExpectedAuthenticationResult()
+        {
+            return new AuthenticationResult(
+                ExpectedAccessToken,
+                false,
+                string.Empty,
+                new DateTimeOffset(),
+                new DateTimeOffset(),
+                string.Empty,
+                null,
+                string.Empty,
+                new List<string>());
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenSilentOnPublicClientAsync()
+        {
+            // arrange
+            _pca.ExecuteAsync(Arg.Any<AcquireTokenSilentParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _pca.ExecuteAsync(_pca.AcquireTokenSilent(new List<string> { "hello" }, string.Empty), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenByIntegratedWindowsAuthAsync()
+        {
+            // arrange
+            _pca.ExecuteAsync(Arg.Any<AcquireTokenByIntegratedWindowsAuthParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _pca.ExecuteAsync(_pca.AcquireTokenByIntegratedWindowsAuth(new List<string> { "hello" }), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenByUsernamePasswordAsync()
+        {
+            // arrange
+            _pca.ExecuteAsync(Arg.Any<AcquireTokenByUsernamePasswordParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _pca.ExecuteAsync(_pca.AcquireTokenByUsernamePassword(new List<string> { "hello" }, string.Empty, null), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenInteractiveAsync()
+        {
+            // arrange
+            _pca.ExecuteAsync(Arg.Any<AcquireTokenInteractiveParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _pca.ExecuteAsync(_pca.AcquireTokenInteractive(new List<string> { "hello" }, null), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenSilentOnConfidentialClientAsync()
+        {
+            // arrange
+            _cca.ExecuteAsync(Arg.Any<AcquireTokenSilentParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _cca.ExecuteAsync(_cca.AcquireTokenSilent(new List<string> { "hello" }, string.Empty), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenOnBehalfOfAsync()
+        {
+            // arrange
+            _cca.ExecuteAsync(Arg.Any<AcquireTokenOnBehalfOfParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _cca.ExecuteAsync(_cca.AcquireTokenOnBehalfOf(new List<string> { "hello" }, null), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenForClientAsync()
+        {
+            // arrange
+            _cca.ExecuteAsync(Arg.Any<AcquireTokenForClientParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _cca.ExecuteAsync(_cca.AcquireTokenForClient(new List<string> { "hello" }), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockAcquireTokenByAuthorizationCodeAsync()
+        {
+            // arrange
+            _cca.ExecuteAsync(Arg.Any<AcquireTokenByAuthorizationCodeParameterBuilder>(), CancellationToken.None)
+                .Returns<AuthenticationResult>(CreateExpectedAuthenticationResult());
+
+            // act
+            var result = await _cca.ExecuteAsync(_cca.AcquireTokenByAuthorizationCode(new List<string> { "hello" }, string.Empty), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(ExpectedAccessToken, result.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task MockGetAuthorizationRequestUrlAsync()
+        {
+            Uri expectedUri = new Uri("http://foo.bar/baz");
+
+            // arrange
+            _cca.ExecuteAsync(Arg.Any<GetAuthorizationRequestUrlParameterBuilder>(), CancellationToken.None)
+                .Returns<Uri>(expectedUri);
+
+            // act
+            var result = await _cca.ExecuteAsync(_cca.GetAuthorizationRequestUrl(new List<string> { "hello" }), CancellationToken.None).ConfigureAwait(false);
+
+            // assert
+            Assert.AreEqual(expectedUri, result);
+        }
+
+    }
+}
+


### PR DESCRIPTION
Based on customer feedback our I[Public|Confidential]Client interfaces aren't mockable due to the way the fluent API works.  This is a proposal to enable mockability that we can discuss.

Currently missing API documentation until we lock on the decision of how to proceed here.