### PR TITLE
add nsurlsessionhandler as httpclient for ios 7+

### DIFF
--- a/src/Microsoft.Identity.Client/Http/HttpClientFactory.cs
+++ b/src/Microsoft.Identity.Client/Http/HttpClientFactory.cs
@@ -27,6 +27,10 @@
 
 using System.Net.Http;
 using System.Net.Http.Headers;
+#if iOS
+using Foundation;
+using UIKit;
+#endif
 
 namespace Microsoft.Identity.Client.Http
 {
@@ -39,11 +43,21 @@ namespace Microsoft.Identity.Client.Http
 
         public HttpClientFactory()
         {
+#if iOS
+            // See https://aka.ms/msal-net-httpclient for details
+            if (UIDevice.CurrentDevice.CheckSystemVersion(7, 0))
+            {
+                _httpClient = new HttpClient(new NSUrlSessionHandler())
+                {
+                    MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
+                };
+            }
+#else
             _httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
             {
                 MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
             };
-
+#endif
             _httpClient.DefaultRequestHeaders.Accept.Clear();
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }


### PR DESCRIPTION
regarding this [issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1019)