### PR TITLE
move error codes into their exception types [1004]

### DIFF
--- a/src/Microsoft.Identity.Client/Cache/TokenCacheDictionarySerializer.cs
+++ b/src/Microsoft.Identity.Client/Cache/TokenCacheDictionarySerializer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Client.Cache
             }
             catch (Exception ex)
             {
-                throw MsalExceptionFactory.GetClientException(MsalError.JsonParseError, MsalErrorMessage.TokenCacheDictionarySerializerFailedParse, ex);
+                throw MsalExceptionFactory.GetClientException(MsalClientException.JsonParseError, MsalErrorMessage.TokenCacheDictionarySerializerFailedParse, ex);
             }
 
             if (cacheDict == null || cacheDict.Count == 0)

--- a/src/Microsoft.Identity.Client/Cache/TokenCacheJsonSerializer.cs
+++ b/src/Microsoft.Identity.Client/Cache/TokenCacheJsonSerializer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Client.Cache
             }
             catch (Exception ex)
             {
-                throw MsalExceptionFactory.GetClientException(MsalError.JsonParseError, MsalErrorMessage.TokenCacheJsonSerializerFailedParse, ex);
+                throw MsalExceptionFactory.GetClientException(MsalClientException.JsonParseError, MsalErrorMessage.TokenCacheJsonSerializerFailedParse, ex);
             }
 
             if (cache.AccessTokens != null)

--- a/src/Microsoft.Identity.Client/Core/ClientInfo.cs
+++ b/src/Microsoft.Identity.Client/Core/ClientInfo.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client.Core
             if (string.IsNullOrEmpty(clientInfo))
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.JsonParseError,
+                    MsalClientException.JsonParseError,
                     "client info is null");
             }
 
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Client.Core
             catch (Exception exc)
             {
                 throw MsalExceptionFactory.GetClientException(
-                     MsalError.JsonParseError,
+                     MsalClientException.JsonParseError,
                      "Failed to parse the returned client info.",
                      exc);
             }

--- a/src/Microsoft.Identity.Client/Core/IdToken.cs
+++ b/src/Microsoft.Identity.Client/Core/IdToken.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Client.Core
             if (idTokenSegments.Length < 2)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.InvalidJwtError,
+                    MsalClientException.InvalidJwtError,
                     MsalErrorMessage.IDTokenMustHaveTwoParts);
             }
 
@@ -111,7 +111,7 @@ namespace Microsoft.Identity.Client.Core
             catch (Exception exc)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.JsonParseError,
+                    MsalClientException.JsonParseError,
                     MsalErrorMessage.FailedToParseIDToken, 
                     exc);
             }

--- a/src/Microsoft.Identity.Client/Core/MsalIdHelper.cs
+++ b/src/Microsoft.Identity.Client/Core/MsalIdHelper.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 // 
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Client.Core
             if (platformProxy == null)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.PlatformNotSupported,
+                    MsalClientException.PlatformNotSupported,
                     MsalErrorMessage.PlatformNotSupported);
             }
 

--- a/src/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Identity.Client.Http
                 if (timeoutException != null)
                 {
                     throw MsalExceptionFactory.GetServiceException(
-                        MsalError.RequestTimeout,
+                        MsalServiceException.RequestTimeout,
                         "Request to the endpoint timed out.",
                         null,
                         innerException: timeoutException); // no http response to add more details to this exception
@@ -193,7 +193,7 @@ namespace Microsoft.Identity.Client.Http
                 }
 
                 throw MsalExceptionFactory.GetServiceException(
-                        MsalError.ServiceNotAvailable,
+                        MsalServiceException.ServiceNotAvailable,
                     "Service is unavailable to process the request",
                     response);
             }

--- a/src/Microsoft.Identity.Client/Http/RedirectUriHelper.cs
+++ b/src/Microsoft.Identity.Client/Http/RedirectUriHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Client.Http
             if (redirectUri == null)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.NoRedirectUri,
+                    MsalClientException.NoRedirectUri,
                     MsalErrorMessage.NoRedirectUri);
 
             }
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Http
                 Constants.DefaultRedirectUri.Equals(redirectUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.DefaultRedirectUriIsInvalid,
+                    MsalClientException.DefaultRedirectUriIsInvalid,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         MsalErrorMessage.DefaultRedirectUriIsInvalid,

--- a/src/Microsoft.Identity.Client/Instance/AdfsOpenIdConfigurationEndpointManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/AdfsOpenIdConfigurationEndpointManager.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.Instance
                 if (drsResponse.IdentityProviderService?.PassiveAuthEndpoint == null)
                 {
                     throw MsalExceptionFactory.GetServiceException(
-                        MsalError.MissingPassiveAuthEndpoint,
+                        MsalServiceException.MissingPassiveAuthEndpoint,
                         MsalErrorMessage.CannotFindTheAuthEndpont,
                         drsResponse);
                 }
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Instance
                 if (httpResponse.StatusCode != HttpStatusCode.OK)
                 {
                     throw MsalExceptionFactory.GetServiceException(
-                        MsalError.InvalidAuthority,
+                        MsalServiceException.InvalidAuthority,
                         MsalErrorMessage.AuthorityValidationFailed,
                         httpResponse);
                 }
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Client.Instance
                              a.Href.Equals(resource, StringComparison.OrdinalIgnoreCase)) == null)
                 {
                     throw MsalExceptionFactory.GetClientException(
-                        MsalError.InvalidAuthority,
+                        MsalServiceException.InvalidAuthority,
                         MsalErrorMessage.InvalidAuthorityOpenId);
                 }
             }

--- a/src/Microsoft.Identity.Client/Instance/Authority.cs
+++ b/src/Microsoft.Identity.Client/Instance/Authority.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Client.Instance
             {
             case AuthorityType.Adfs:
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.InvalidAuthorityType,
+                    MsalClientException.InvalidAuthorityType,
                     "ADFS is not a supported authority");
 
             case AuthorityType.B2C:
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Client.Instance
 
             default:
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.InvalidAuthorityType,
+                    MsalClientException.InvalidAuthorityType,
                     "Unsupported authority type");
             }
         }

--- a/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Instance
             if (authorityInfo.AuthorityType == AuthorityType.Adfs && string.IsNullOrEmpty(userPrincipalName))
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.UpnRequired,
+                    MsalServiceException.UpnRequired,
                     MsalErrorMessage.UpnRequiredForAuthroityValidation);
             }
 
@@ -93,21 +93,21 @@ namespace Microsoft.Identity.Client.Instance
             if (string.IsNullOrEmpty(edr.AuthorizationEndpoint))
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.TenantDiscoveryFailedError,
+                    MsalClientException.TenantDiscoveryFailedError,
                     "Authorize endpoint was not found in the openid configuration");
             }
 
             if (string.IsNullOrEmpty(edr.TokenEndpoint))
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.TenantDiscoveryFailedError,
+                    MsalClientException.TenantDiscoveryFailedError,
                     "Token endpoint was not found in the openid configuration");
             }
 
             if (string.IsNullOrEmpty(edr.Issuer))
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.TenantDiscoveryFailedError,
+                    MsalClientException.TenantDiscoveryFailedError,
                     "Issuer was not found in the openid configuration");
             }
 

--- a/src/Microsoft.Identity.Client/Instance/B2COpenIdConfigurationEndpointManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/B2COpenIdConfigurationEndpointManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client.Instance
             }
 
             throw MsalExceptionFactory.GetClientException(
-                        MsalError.B2CHostNotTrusted,
+                        MsalClientException.B2CHostNotTrusted,
                         MsalErrorMessage.B2CHostNotTrusted);
         }
     }

--- a/src/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequest.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             else
             {
                 _authenticationRequestParameters.RequestContext.Logger.Info(LogMessages.UnknownErrorReturnedInBrokerResponse);
-                throw new MsalServiceException(MsalError.BrokerResponseReturnedError, MsalErrorMessage.BrokerResponseReturnedError, null);
+                throw new MsalServiceException(MsalServiceException.BrokerResponseReturnedError, MsalErrorMessage.BrokerResponseReturnedError, null);
             }
         }
     }

--- a/src/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Client.Internal
             // Length check before sign
             if (MaxTokenLength < token.Length)
             {
-                throw new MsalException(MsalError.EncodedTokenTooLong);
+                throw new MsalException(MsalException.EncodedTokenTooLong);
             }
 
             return string.Concat(token, ".", UrlEncodeSegment(credential.Sign(_cryptographyManager, token)));

--- a/src/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 }
             }
 
-            throw new MsalClientException(MsalError.CodeExpired, "Verification code expired before contacting the server");
+            throw new MsalClientException(MsalClientException.CodeExpired, "Verification code expired before contacting the server");
         }
 
         private Dictionary<string, string> GetBodyParameters(DeviceCodeResult deviceCodeResult)

--- a/src/Microsoft.Identity.Client/Internal/Requests/IntegratedWindowsAuthRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/IntegratedWindowsAuthRequest.cs
@@ -101,12 +101,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (userRealmResponse.IsManaged)
             {
                 throw new MsalClientException(
-                    MsalError.IntegratedWindowsAuthNotSupportedForManagedUser, 
+                    MsalClientException.IntegratedWindowsAuthNotSupportedForManagedUser, 
                     MsalErrorMessage.IwaNotSupportedForManagedUser);
             }
 
             throw new MsalClientException(
-                MsalError.UnknownUserType,
+                MsalClientException.UnknownUserType,
                 string.Format(
                     CultureInfo.CurrentCulture,
                     MsalErrorMessage.UnsupportedUserType,

--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     AuthenticationRequestParameters.Account.HomeAccountId.TenantId),
                 string.Empty);
 
-            throw new MsalClientException(MsalError.UserMismatch, MsalErrorMessage.UserMismatchSaveToken);
+            throw new MsalClientException(MsalClientException.UserMismatch, MsalErrorMessage.UserMismatchSaveToken);
         }
 
         internal async Task ResolveAuthorityEndpointsAsync()

--- a/src/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
@@ -103,14 +103,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // handle grant flow
                 if (_usernamePasswordParameters.Password == null)
                 {
-                    throw new MsalClientException(MsalError.PasswordRequiredForManagedUserError);
+                    throw new MsalClientException(MsalClientException.PasswordRequiredForManagedUserError);
                 }
 
                 return null;
             }
 
             throw new MsalClientException(
-                MsalError.UnknownUserType,
+                MsalClientException.UnknownUserType,
                 string.Format(
                     CultureInfo.CurrentCulture,
                     MsalErrorMessage.UnsupportedUserType,

--- a/src/Microsoft.Identity.Client/MsalClientException.cs
+++ b/src/Microsoft.Identity.Client/MsalClientException.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Client
         /// implementing chrome tabs is missing on the Android phone (that's only an example: this exception can apply to other
         /// platforms as well)
         /// </summary>
-        public const string AuthenticationUiFailedError = "authentication_ui_failed";
+        public const string AuthenticationUiFailed = "authentication_ui_failed";
 
         /// <summary>
         /// Authentication canceled.
@@ -133,6 +133,117 @@ namespace Microsoft.Identity.Client
         /// 
         /// </summary>
         public const string BrokerResponseHashMismatch = "Unencrypted broker response hash did not match the expected hash";
+
+        /// <summary>
+        /// RedirectUri validation failed.
+        /// </summary>
+        public const string DefaultRedirectUriIsInvalid = "redirect_uri_validation_failed";
+
+        /// <summary>
+        /// No Redirect URI.
+        /// </summary>
+        public const string NoRedirectUri = "no_redirect_uri";
+
+        /// <summary>
+        /// No Redirect URI.
+        /// </summary>
+        public const string B2CHostNotTrusted = "B2C_host_not_trusted";
+
+        /// <summary>
+        /// Error code used when the CustomWebUI has returned an uri, but it does not match the Authroity and AbsolutePath of 
+        /// the configured redirect uri.
+        /// </summary>
+        public const string CustomWebUiRedirectUriMismatch = "custom_webui_invalid_mismatch";
+
+        /// <summary>
+        /// Error code used when the CustomWebUI has returned an uri, but it is invalid - it is either null or has no code.
+        /// Consider throwing an exception if you are unable to intercept the uri containing the code. 
+        /// </summary>
+        public const string CustomWebUiReturnedInvalidUri = "custom_webui_returned_invalid_uri";
+
+        /// <summary>
+        /// TODO: UPDATE DOCUMENTATION!
+        /// On Android, the UIParent constructor with an Activiy parameter must be used. See https://aka.ms/msal-interactive-android
+        /// </summary>
+        public const string ActivityRequired = "activity_required";
+
+        /// <summary>
+        /// Integrated Windows Auth is only supported for "federated" users
+        /// </summary>
+        public const string IntegratedWindowsAuthNotSupportedForManagedUser = "integrated_windows_auth_not_supported_managed_user";
+
+        /// <summary>
+        /// In the context of Device code flow (See https://aka.ms/msal-net-device-code-flow),
+        /// this error happens when the device code expired before the user signed-in on another device (this is usually after 15 mins).
+        /// 
+        /// Mitigation: None. Inform the user that they took too long to sign-in at the provided URL and enter the provided code.
+        /// </summary>
+        public const string CodeExpired = "code_expired";
+
+        /// <summary>
+        /// Cannot get the user from the OS (UWP)
+        /// </summary>
+        public const string UapCannotFindUpn = "uap_cannot_find_upn";
+
+        /// <summary>
+        /// Cannot access the user from the OS (UWP)
+        /// </summary>
+        public const string UapCannotFindDomainUser = "user_information_access_failed";
+
+        /// <summary>
+        /// Password is required for managed user.
+        /// </summary>
+        public const string PasswordRequiredForManagedUserError = "password_required_for_managed_user";
+
+        /// <summary>
+        /// Failed to get user name.
+        /// </summary>
+        public const string GetUserNameFailed = "get_user_name_failed";
+
+        /// <summary>
+        /// Unknown User.
+        /// </summary>
+        public const string UnknownUser = "unknown_user";
+
+        /// <summary>
+        /// Unknown User Type.
+        /// </summary>
+        public const string UnknownUserType = "unknown_user_type";
+
+        /// <summary>
+        /// Parsing WS-Trust Response Failed.
+        /// </summary>
+        public const string ParsingWsTrustResponseFailed = "parsing_wstrust_response_failed";
+
+        /// <summary>
+        /// WS-Trust Endpoint Not Found in Metadata Document.
+        /// </summary>
+        public const string WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found";
+
+        /// <summary>
+        /// Parsing WS Metadata Exchange Failed.
+        /// </summary>
+        public const string ParsingWsMetadataExchangeFailed = "parsing_ws_metadata_exchange_failed";
+
+        /// <summary>
+        /// User Realm Discovery Failed.
+        /// </summary>
+        public const string UserRealmDiscoveryFailed = "user_realm_discovery_failed";
+
+        /// <summary>
+        /// User Mismatch.
+        /// </summary>
+        public const string UserMismatch = "user_mismatch";
+
+        /// <summary>
+        /// Invalid authority type.
+        /// </summary>
+        public const string InvalidAuthorityType = "invalid_authority_type";
+
+        /// <summary>
+        /// Cannot Access User Information or User is Not Domain Joined.
+        /// </summary>
+        public const string CannotAccessUserInformationOrUserNotDomainJoined = "user_information_access_failed";
 
 #if iOS
         /// <summary>

--- a/src/Microsoft.Identity.Client/MsalError.cs
+++ b/src/Microsoft.Identity.Client/MsalError.cs
@@ -32,328 +32,338 @@ namespace Microsoft.Identity.Client
     /// </summary>
     public static class MsalError
     {
-        /// <summary>
-        /// Authentication failed.
-        /// </summary>
-        public const string AuthenticationFailed = "authentication_failed";
+        ///// <summary>
+        ///// Authentication failed.
+        ///// </summary>
+        //public const string AuthenticationFailed = "authentication_failed";
 
-        /// <summary>
-        /// Authority validation failed.
-        /// </summary>
-        public const string AuthorityValidationFailed = "authority_validation_failed";
+        ///// <summary>
+        ///// Authority validation failed.
+        ///// </summary>
+        //public const string AuthorityValidationFailed = "authority_validation_failed";
 
-        /// <summary>
-        /// Invalid owner window type.
-        /// </summary>
-        public const string InvalidOwnerWindowType = "invalid_owner_window_type";
+        ///// <summary>
+        ///// Invalid owner window type.
+        ///// </summary>
+        //public const string InvalidOwnerWindowType = "invalid_owner_window_type";
 
-        /// <summary>
-        /// Invalid authority type.
-        /// </summary>
-        public const string InvalidAuthorityType = "invalid_authority_type";
+        ///// <summary>
+        ///// Invalid authority type.
+        ///// </summary>
+        //public const string InvalidAuthorityType = "invalid_authority_type";
 
+        // todo: not used anywhere
         /// <summary>
         /// Invalid service URL.
         /// </summary>
         public const string InvalidServiceUrl = "invalid_service_url";
 
-        /// <summary>
-        /// Encoded token too long.
-        /// </summary>
-        public const string EncodedTokenTooLong = "encoded_token_too_long";
+        ///// <summary>
+        ///// Encoded token too long.
+        ///// </summary>
+        //public const string EncodedTokenTooLong = "encoded_token_too_long";
 
+        // todo: not used anywhere
         /// <summary>
         /// No data from STS.
         /// </summary>
         public const string NoDataFromSts = "no_data_from_sts";
 
-        /// <summary>
-        /// User Mismatch.
-        /// </summary>
-        public const string UserMismatch = "user_mismatch";
+        ///// <summary>
+        ///// User Mismatch.
+        ///// </summary>
+        //public const string UserMismatch = "user_mismatch";
 
+        // todo: not used anywhere
         /// <summary>
         /// Failed to refresh token.
         /// </summary>
         public const string FailedToRefreshToken = "failed_to_refresh_token";
-               
+
+        // todo: not used anywhere
         /// <summary>
         /// Failed to acquire token silently. Used in broker scenarios.
         /// </summary>
         public const string FailedToAcquireTokenSilentlyFromBroker = "failed_to_acquire_token_silently_from_broker";
 
+        // todo: not used anywhere
         /// <summary>
         /// RedirectUri validation failed.
         /// </summary>
         public const string RedirectUriValidationFailed = "redirect_uri_validation_failed";
 
-        /// <summary>
-        /// The request could not be preformed because of an unknown failure in the UI flow.
-        /// </summary>
-        public const string AuthenticationUiFailed = "authentication_ui_failed";
+        ///// <summary>
+        ///// The request could not be preformed because of an unknown failure in the UI flow.
+        ///// </summary>
+        //public const string AuthenticationUiFailed = "authentication_ui_failed";
 
-        /// <summary>
-        /// Non https redirect failed
-        /// </summary>
-        public const string NonHttpsRedirectNotSupported = "non_https_redirect_failed";
+        ///// <summary>
+        ///// Non https redirect failed
+        ///// </summary>
+        //public const string NonHttpsRedirectNotSupported = "non_https_redirect_failed";
 
+        // todo: not used
         /// <summary>
         /// Internal error
         /// </summary>
         public const string InternalError = "internal_error";
 
-        /// <summary>
-        /// Accessing WS Metadata Exchange Failed.
-        /// </summary>
-        public const string AccessingWsMetadataExchangeFailed = "accessing_ws_metadata_exchange_failed";
+        ///// <summary>
+        ///// Accessing WS Metadata Exchange Failed.
+        ///// </summary>
+        //public const string AccessingWsMetadataExchangeFailed = "accessing_ws_metadata_exchange_failed";
 
-        /// <summary>
-        /// Federated service returned error.
-        /// </summary>
-        public const string FederatedServiceReturnedError = "federated_service_returned_error";
+        ///// <summary>
+        ///// Federated service returned error.
+        ///// </summary>
+        //public const string FederatedServiceReturnedError = "federated_service_returned_error";
 
-        /// <summary>
-        /// User Realm Discovery Failed.
-        /// </summary>
-        public const string UserRealmDiscoveryFailed = "user_realm_discovery_failed";
+        ///// <summary>
+        ///// User Realm Discovery Failed.
+        ///// </summary>
+        //public const string UserRealmDiscoveryFailed = "user_realm_discovery_failed";
 
+        // todo: not used anywhere
         /// <summary>
         /// Federation Metadata Url is missing for federated user.
         /// </summary>
         public const string MissingFederationMetadataUrl = "missing_federation_metadata_url";
 
-        /// <summary>
-        /// Parsing WS Metadata Exchange Failed.
-        /// </summary>
-        public const string ParsingWsMetadataExchangeFailed = "parsing_ws_metadata_exchange_failed";
+        ///// <summary>
+        ///// Parsing WS Metadata Exchange Failed.
+        ///// </summary>
+        //public const string ParsingWsMetadataExchangeFailed = "parsing_ws_metadata_exchange_failed";
 
-        /// <summary>
-        /// WS-Trust Endpoint Not Found in Metadata Document.
-        /// </summary>
-        public const string WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found";
+        ///// <summary>
+        ///// WS-Trust Endpoint Not Found in Metadata Document.
+        ///// </summary>
+        //public const string WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found";
 
-        /// <summary>
-        /// Parsing WS-Trust Response Failed.
-        /// </summary>
-        public const string ParsingWsTrustResponseFailed = "parsing_wstrust_response_failed";
+        ///// <summary>
+        ///// Parsing WS-Trust Response Failed.
+        ///// </summary>
+        //public const string ParsingWsTrustResponseFailed = "parsing_wstrust_response_failed";
 
-        /// <summary>
-        /// Unknown User Type.
-        /// </summary>
-        public const string UnknownUserType = "unknown_user_type";
+        ///// <summary>
+        ///// Unknown User Type.
+        ///// </summary>
+        //public const string UnknownUserType = "unknown_user_type";
 
-        /// <summary>
-        /// Unknown User.
-        /// </summary>
-        public const string UnknownUser = "unknown_user";
+        ///// <summary>
+        ///// Unknown User.
+        ///// </summary>
+        //public const string UnknownUser = "unknown_user";
 
-        /// <summary>
-        /// Failed to get user name.
-        /// </summary>
-        public const string GetUserNameFailed = "get_user_name_failed";
+        ///// <summary>
+        ///// Failed to get user name.
+        ///// </summary>
+        //public const string GetUserNameFailed = "get_user_name_failed";
 
-        /// <summary>
-        /// Password is required for managed user.
-        /// </summary>
-        public const string PasswordRequiredForManagedUserError = "password_required_for_managed_user";
+        ///// <summary>
+        ///// Password is required for managed user.
+        ///// </summary>
+        //public const string PasswordRequiredForManagedUserError = "password_required_for_managed_user";
 
+        // todo: not used on an exception
         /// <summary>
         /// Request is invalid.
         /// </summary>
         public const string InvalidRequest = "invalid_request";
 
-        /// <summary>
-        /// Cannot access the user from the OS (UWP)
-        /// </summary>
-        public const string UapCannotFindDomainUser = "user_information_access_failed";
+        ///// <summary>
+        ///// Cannot access the user from the OS (UWP)
+        ///// </summary>
+        //public const string UapCannotFindDomainUser = "user_information_access_failed";
 
-        /// <summary>
-        /// Cannot get the user from the OS (UWP)
-        /// </summary>
-        public const string UapCannotFindUpn = "uap_cannot_find_upn";
+        ///// <summary>
+        ///// Cannot get the user from the OS (UWP)
+        ///// </summary>
+        //public const string UapCannotFindUpn = "uap_cannot_find_upn";
 
-        /// <summary>
-        /// An error response was returned by the OAuth2 server and it could not be parsed
-        /// </summary>
-        public const string NonParsableOAuthError = "non_parsable_oauth_error";
+        ///// <summary>
+        ///// An error response was returned by the OAuth2 server and it could not be parsed
+        ///// </summary>
+        //public const string NonParsableOAuthError = "non_parsable_oauth_error";
 
-        /// <summary>
-        /// In the context of Device code flow (See https://aka.ms/msal-net-device-code-flow),
-        /// this error happens when the device code expired before the user signed-in on another device (this is usually after 15 mins).
-        /// 
-        /// Mitigation: None. Inform the user that they took too long to sign-in at the provided URL and enter the provided code.
-        /// </summary>
-        public const string CodeExpired = "code_expired";
+        ///// <summary>
+        ///// In the context of Device code flow (See https://aka.ms/msal-net-device-code-flow),
+        ///// this error happens when the device code expired before the user signed-in on another device (this is usually after 15 mins).
+        ///// 
+        ///// Mitigation: None. Inform the user that they took too long to sign-in at the provided URL and enter the provided code.
+        ///// </summary>
+        //public const string CodeExpired = "code_expired";
 
-        /// <summary>
-        /// Integrated Windows Auth is only supported for "federated" users
-        /// </summary>
-        public const string IntegratedWindowsAuthNotSupportedForManagedUser = "integrated_windows_auth_not_supported_managed_user";
+        ///// <summary>
+        ///// Integrated Windows Auth is only supported for "federated" users
+        ///// </summary>
+        //public const string IntegratedWindowsAuthNotSupportedForManagedUser = "integrated_windows_auth_not_supported_managed_user";
 
-        /// <summary>
-        /// TODO: UPDATE DOCUMENTATION!
-        /// On Android, the UIParent constructor with an Activiy parameter must be used. See https://aka.ms/msal-interactive-android
-        /// </summary>
-        public const string ActivityRequired = "activity_required";
+        ///// <summary>
+        ///// TODO: UPDATE DOCUMENTATION!
+        ///// On Android, the UIParent constructor with an Activiy parameter must be used. See https://aka.ms/msal-interactive-android
+        ///// </summary>
+        //public const string ActivityRequired = "activity_required";
 
+        // todo: this isn't used on any exceptions
         /// <summary>
         /// Broker response hash did not match
         /// </summary>
         public const string BrokerResponseHashMismatch = "broker_response_hash_mismatch";
 
-        /// <summary>
-        /// Broker response returned an error
-        /// </summary>
-        public const string BrokerResponseReturnedError = "broker_response_returned_error";
+        ///// <summary>
+        ///// Broker response returned an error
+        ///// </summary>
+        //public const string BrokerResponseReturnedError = "broker_response_returned_error";
 
+        // todo: this one isn't used anywhere
         /// <summary>
         /// MSAL is not able to invoke the broker. Possible reasons are the broker is not installed on the user's device, 
         /// or there were issues with the UiParent or CallerViewController being null. See https://aka.ms/msal-brokers
         /// </summary>
         public const string CannotInvokeBroker = "cannot_invoke_broker";
 
-        /// <summary>
-        /// Error code used when the http response returns HttpStatusCode.NotFound
-        /// </summary>
-        public const string HttpStatusNotFound = "not_found";
+        ///// <summary>
+        ///// Error code used when the http response returns HttpStatusCode.NotFound
+        ///// </summary>
+        //public const string HttpStatusNotFound = "not_found";
 
-        /// <summary>
-        /// ErrorCode used when the http response returns something different from 200 (OK)
-        /// </summary>
-        /// <remarks>
-        /// HttpStatusCode.NotFound have a specific error code. <see cref="MsalError.HttpStatusNotFound"/>
-        /// </remarks>
-        public const string HttpStatusCodeNotOk = "http_status_not_200";
+        ///// <summary>
+        ///// ErrorCode used when the http response returns something different from 200 (OK)
+        ///// </summary>
+        ///// <remarks>
+        ///// HttpStatusCode.NotFound have a specific error code. <see cref="MsalError.HttpStatusNotFound"/>
+        ///// </remarks>
+        //public const string HttpStatusCodeNotOk = "http_status_not_200";
 
-        /// <summary>
-        /// Error code used when the CustomWebUI has returned an uri, but it is invalid - it is either null or has no code.
-        /// Consider throwing an exception if you are unable to intercept the uri containing the code. 
-        /// </summary>
-        public const string CustomWebUiReturnedInvalidUri = "custom_webui_returned_invalid_uri";
+        ///// <summary>
+        ///// Error code used when the CustomWebUI has returned an uri, but it is invalid - it is either null or has no code.
+        ///// Consider throwing an exception if you are unable to intercept the uri containing the code. 
+        ///// </summary>
+        //public const string CustomWebUiReturnedInvalidUri = "custom_webui_returned_invalid_uri";
 
-        /// <summary>
-        /// Error code used when the CustomWebUI has returned an uri, but it does not match the Authroity and AbsolutePath of 
-        /// the configured redirect uri.
-        /// </summary>
-        public const string CustomWebUiRedirectUriMismatch = "custom_webui_invalid_mismatch";
+        ///// <summary>
+        ///// Error code used when the CustomWebUI has returned an uri, but it does not match the Authroity and AbsolutePath of 
+        ///// the configured redirect uri.
+        ///// </summary>
+        //public const string CustomWebUiRedirectUriMismatch = "custom_webui_invalid_mismatch";
 
-        /// <summary>
-        /// Access denied.
-        /// </summary>
-        public const string AccessDenied = "access_denied";
+        ///// <summary>
+        ///// Access denied.
+        ///// </summary>
+        //public const string AccessDenied = "access_denied";
 
-        /// <summary>
-        /// JSON Parse error.
-        /// </summary>
-        public const string JsonParseError = "json_parse_failed";
+        ///// <summary>
+        ///// JSON Parse error.
+        ///// </summary>
+        //public const string JsonParseError = "json_parse_failed";
 
-        /// <summary>
-        /// Request Timeout.
-        /// </summary>
-        public const string RequestTimeout = "request_timeout";
+        ///// <summary>
+        ///// Request Timeout.
+        ///// </summary>
+        //public const string RequestTimeout = "request_timeout";
 
-        /// <summary>
-        /// Service not available.
-        /// </summary>
-        public const string ServiceNotAvailable = "service_not_available";
+        ///// <summary>
+        ///// Service not available.
+        ///// </summary>
+        //public const string ServiceNotAvailable = "service_not_available";
 
-        /// <summary>
-        /// Invalid JWT.
-        /// </summary>
-        public const string InvalidJwtError = "invalid_jwt";
+        ///// <summary>
+        ///// Invalid JWT.
+        ///// </summary>
+        //public const string InvalidJwtError = "invalid_jwt";
 
-        /// <summary>
-        /// Tenant Discovery Failed.
-        /// </summary>
-        public const string TenantDiscoveryFailedError = "tenant_discovery_failed";
+        ///// <summary>
+        ///// Tenant Discovery Failed.
+        ///// </summary>
+        //public const string TenantDiscoveryFailedError = "tenant_discovery_failed";
 
-        /// <summary>
-        /// Authentication UI Failed.
-        /// </summary>
-        public const string AuthenticationUiFailedError = "authentication_ui_failed";
+        ///// <summary>
+        ///// Authentication UI Failed.
+        ///// </summary>
+        //public const string AuthenticationUiFailedError = "authentication_ui_failed";
 
-        /// <summary>
-        /// Invalid Grant.
-        /// </summary>
-        public const string InvalidGrantError = "invalid_grant";
+        ///// <summary>
+        ///// Invalid Grant.
+        ///// </summary>
+        //public const string InvalidGrantError = "invalid_grant";
 
-        /// <summary>
-        /// Unknown Error.
-        /// </summary>
-        public const string UnknownError = "unknown_error";
+        ///// <summary>
+        ///// Unknown Error.
+        ///// </summary>
+        //public const string UnknownError = "unknown_error";
 
-        /// <summary>
-        /// Authentication Canceled.
-        /// </summary>
-        public const string AuthenticationCanceledError = "authentication_canceled";
+        ///// <summary>
+        ///// Authentication Canceled.
+        ///// </summary>
+        //public const string AuthenticationCanceledError = "authentication_canceled";
 
-        /// <summary>
-        /// UPN Required.
-        /// </summary>
-        public const string UpnRequired = "upn_required";
+        ///// <summary>
+        ///// UPN Required.
+        ///// </summary>
+        //public const string UpnRequired = "upn_required";
 
-        /// <summary>
-        /// Missing Passive Auth Endpoint.
-        /// </summary>
-        public const string MissingPassiveAuthEndpoint = "missing_passive_auth_endpoint";
+        ///// <summary>
+        ///// Missing Passive Auth Endpoint.
+        ///// </summary>
+        //public const string MissingPassiveAuthEndpoint = "missing_passive_auth_endpoint";
 
-        /// <summary>
-        /// Invalid Authority.
-        /// </summary>
-        public const string InvalidAuthority = "invalid_authority";
+        ///// <summary>
+        ///// Invalid Authority.
+        ///// </summary>
+        //public const string InvalidAuthority = "invalid_authority";
 
-        /// <summary>
-        /// Platform is Not Supported.
-        /// </summary>
-        public const string PlatformNotSupported = "platform_not_supported";
+        ///// <summary>
+        ///// Platform is Not Supported.
+        ///// </summary>
+        //public const string PlatformNotSupported = "platform_not_supported";
 
-        /// <summary>
-        /// Cannot Access User Information or User is Not Domain Joined.
-        /// </summary>
-        public const string CannotAccessUserInformationOrUserNotDomainJoined = "user_information_access_failed";
+        ///// <summary>
+        ///// Cannot Access User Information or User is Not Domain Joined.
+        ///// </summary>
+        //public const string CannotAccessUserInformationOrUserNotDomainJoined = "user_information_access_failed";
 
-        /// <summary>
-        /// RedirectUri validation failed.
-        /// </summary>
-        public const string DefaultRedirectUriIsInvalid = "redirect_uri_validation_failed";
+        ///// <summary>
+        ///// RedirectUri validation failed.
+        ///// </summary>
+        //public const string DefaultRedirectUriIsInvalid = "redirect_uri_validation_failed";
 
-        /// <summary>
-        /// No Redirect URI.
-        /// </summary>
-        public const string NoRedirectUri = "no_redirect_uri";
+        ///// <summary>
+        ///// No Redirect URI.
+        ///// </summary>
+        //public const string NoRedirectUri = "no_redirect_uri";
 
-        /// <summary>
-        /// No Redirect URI.
-        /// </summary>
-        public const string B2CHostNotTrusted = "B2C_host_not_trusted";
+        ///// <summary>
+        ///// No Redirect URI.
+        ///// </summary>
+        //public const string B2CHostNotTrusted = "B2C_host_not_trusted";
 
-#if iOS
-        /// <summary>
-        /// Cannot Access Publisher KeyChain.
-        /// </summary>
-        public const string CannotAccessPublisherKeyChain = "cannot_access_publisher_keychain";
+//#if iOS
+//        /// <summary>
+//        /// Cannot Access Publisher KeyChain.
+//        /// </summary>
+//        public const string CannotAccessPublisherKeyChain = "cannot_access_publisher_keychain";
 
-        /// <summary>
-        /// Missing Entitlements.
-        /// </summary>
-        public const string MissingEntitlements = "missing_entitlements";
-#endif
+//        /// <summary>
+//        /// Missing Entitlements.
+//        /// </summary>
+//        public const string MissingEntitlements = "missing_entitlements";
+//#endif
 
-#if ANDROID
-        /// <summary>
-        /// Failed To Create Shared Preference.
-        /// </summary>
-        public const string FailedToCreateSharedPreference = "shared_preference_creation_failed";
+//#if ANDROID
+//        /// <summary>
+//        /// Failed To Create Shared Preference.
+//        /// </summary>
+//        public const string FailedToCreateSharedPreference = "shared_preference_creation_failed";
 
-        /// <summary>
-        /// Android Activity Not Found.
-        /// </summary>
-        public const string AndroidActivityNotFound = "android_activity_not_found";
+//        /// <summary>
+//        /// Android Activity Not Found.
+//        /// </summary>
+//        public const string AndroidActivityNotFound = "android_activity_not_found";
 
-        /// <summary>
-        /// Unresolvable Intent.
-        /// </summary>
-        public const string UnresolvableIntentError = "unresolvable_intent";
-#endif
+//        /// <summary>
+//        /// Unresolvable Intent.
+//        /// </summary>
+//        public const string UnresolvableIntentError = "unresolvable_intent";
+//#endif
     }
 }

--- a/src/Microsoft.Identity.Client/MsalException.cs
+++ b/src/Microsoft.Identity.Client/MsalException.cs
@@ -50,6 +50,26 @@ namespace Microsoft.Identity.Client
         public const string UnknownError = "unknown_error";
 
         /// <summary>
+        /// Encoded token too long.
+        /// </summary>
+        public const string EncodedTokenTooLong = "encoded_token_too_long";
+
+        /// <summary>
+        /// Invalid owner window type.
+        /// </summary>
+        public const string InvalidOwnerWindowType = "invalid_owner_window_type";
+
+        /// <summary>
+        /// Authentication failed.
+        /// </summary>
+        public const string AuthenticationFailed = "authentication_failed";
+
+        /// <summary>
+        /// Access denied.
+        /// </summary>
+        public const string AccessDenied = "access_denied";
+
+        /// <summary>
         /// Initializes a new instance of the exception class.
         /// </summary>
         public MsalException()
@@ -181,7 +201,7 @@ namespace Microsoft.Identity.Client
                 return ex;
             }
 
-            throw new MsalClientException(MsalError.JsonParseError,  MsalErrorMessage.MsalExceptionFailedToParse);
+            throw new MsalClientException(MsalClientException.JsonParseError,  MsalErrorMessage.MsalExceptionFailedToParse);
         }
 
         #endregion // SERIALIZATION

--- a/src/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/Microsoft.Identity.Client/MsalServiceException.cs
@@ -80,6 +80,44 @@ namespace Microsoft.Identity.Client
         public const string InvalidAuthority = "invalid_authority";
 
         /// <summary>
+        /// Error code used when the http response returns HttpStatusCode.NotFound
+        /// </summary>
+        public const string HttpStatusNotFound = "not_found";
+
+        /// <summary>
+        /// ErrorCode used when the http response returns something different from 200 (OK)
+        /// </summary>
+        /// <remarks>
+        /// HttpStatusCode.NotFound have a specific error code. <see cref="MsalServiceException.HttpStatusNotFound"/>
+        /// </remarks>
+        public const string HttpStatusCodeNotOk = "http_status_not_200";
+
+        /// <summary>
+        /// Broker response returned an error
+        /// </summary>
+        public const string BrokerResponseReturnedError = "broker_response_returned_error";
+
+        /// <summary>
+        /// An error response was returned by the OAuth2 server and it could not be parsed
+        /// </summary>
+        public const string NonParsableOAuthError = "non_parsable_oauth_error";
+
+        /// <summary>
+        /// Federated service returned error.
+        /// </summary>
+        public const string FederatedServiceReturnedError = "federated_service_returned_error";
+
+        /// <summary>
+        /// Accessing WS Metadata Exchange Failed.
+        /// </summary>
+        public const string AccessingWsMetadataExchangeFailed = "accessing_ws_metadata_exchange_failed";
+
+        /// <summary>
+        /// Authority validation failed.
+        /// </summary>
+        public const string AuthorityValidationFailed = "authority_validation_failed";
+
+        /// <summary>
         /// Initializes a new instance of the exception class with a specified
         /// error code, error message and a reference to the inner exception that is the cause of
         /// this exception.

--- a/src/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Identity.Client.OAuth2
                 {
                     try
                     {
-                        httpEvent.OauthErrorCode = MsalError.UnknownError;
+                        httpEvent.OauthErrorCode = MsalException.UnknownError;
                         // In cases where the end-point is not found (404) response.body will be empty.
                         // CreateResponse handles throwing errors - in the case of HttpStatusCode <> and ErrorResponse will be created.
                         if (!string.IsNullOrWhiteSpace(response.Body))
@@ -192,20 +192,20 @@ namespace Microsoft.Identity.Client.OAuth2
             catch (SerializationException) // in the rare case we get an error response we cannot deserialize
             {
                 exceptionToThrow = MsalExceptionFactory.GetServiceException(
-                    MsalError.NonParsableOAuthError,
+                    MsalServiceException.NonParsableOAuthError,
                     MsalErrorMessage.NonParsableOAuthError,
                     response);
             }
             catch (Exception ex)
             {
-                exceptionToThrow = MsalExceptionFactory.GetServiceException(MsalError.UnknownError, response.Body, response, ex);
+                exceptionToThrow = MsalExceptionFactory.GetServiceException(MsalException.UnknownError, response.Body, response, ex);
             }
 
             if (exceptionToThrow == null)
             {
                 exceptionToThrow = response.StatusCode != HttpStatusCode.NotFound ?
-                    MsalExceptionFactory.GetServiceException(MsalError.HttpStatusCodeNotOk, httpErrorCodeMessage, response) :
-                    MsalExceptionFactory.GetServiceException(MsalError.HttpStatusNotFound, httpErrorCodeMessage, response);
+                    MsalExceptionFactory.GetServiceException(MsalServiceException.HttpStatusCodeNotOk, httpErrorCodeMessage, response) :
+                    MsalExceptionFactory.GetServiceException(MsalServiceException.HttpStatusNotFound, httpErrorCodeMessage, response);
             }
 
             if (shouldLogAsError)
@@ -237,10 +237,10 @@ namespace Microsoft.Identity.Client.OAuth2
                 return null;
             }
             
-            if (MsalError.InvalidGrantError.Equals(msalTokenResponse.Error, StringComparison.OrdinalIgnoreCase))
+            if (MsalUiRequiredException.InvalidGrantError.Equals(msalTokenResponse.Error, StringComparison.OrdinalIgnoreCase))
             {
                 exceptionToThrow = MsalExceptionFactory.GetUiRequiredException(
-                    MsalError.InvalidGrantError,
+                    MsalUiRequiredException.InvalidGrantError,
                     msalTokenResponse.ErrorDescription,
                     response);
             }

--- a/src/Microsoft.Identity.Client/Platforms/Android/AndroidTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/AndroidTokenCacheAccessor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
                 || _idTokenSharedPreference == null || _accountSharedPreference == null)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.FailedToCreateSharedPreference,
+                    MsalClientException.FailedToCreateSharedPreference,
                     "Fail to create SharedPreference");
             }
         }

--- a/src/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/AuthenticationAgentActivity.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/AuthenticationAgentActivity.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
                         Query = string.Format(
                             CultureInfo.InvariantCulture,
                             "error={0}&error_description={1}",
-                            MsalError.NonHttpsRedirectNotSupported,
+                            MsalClientException.NonHttpsRedirectNotSupported,
                             MsalErrorMessage.NonHttpsRedirectNotSupported)
                     };
                     Finish(Activity, errorUri.ToString());

--- a/src/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/EmbeddedWebUI.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
             catch (Exception ex)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.AuthenticationUiFailedError, 
+                    MsalClientException.AuthenticationUiFailed, 
                     "AuthenticationActivity failed to start", 
                     ex);
             }

--- a/src/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
             if (Intent == null)
             {
                 SendError(
-                    MsalError.UnresolvableIntentError,
+                    MsalClientException.UnresolvableIntentError,
                     "Received null data intent from caller");
                 return;
             }
@@ -140,7 +140,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
                 catch (ActivityNotFoundException ex)
                 {
                     throw MsalExceptionFactory.GetClientException(
-                           MsalError.AndroidActivityNotFound,
+                           MsalClientException.AndroidActivityNotFound,
                            MsalErrorMessage.AndroidActivityNotFound, ex);
                 }
             }

--- a/src/Microsoft.Identity.Client/Platforms/Android/SystemWebview/SystemWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/SystemWebview/SystemWebUI.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
             {
                 requestContext.Logger.ErrorPii(ex);
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.AuthenticationUiFailedError, 
+                    MsalClientException.AuthenticationUiFailed, 
                     "AuthenticationActivity failed to start", 
                     ex);
             }

--- a/src/Microsoft.Identity.Client/Platforms/Android/UIParent.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/UIParent.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Client
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UIParent() // do not delete this ctor because it exists on NetStandard
         {
-            throw new MsalClientException(MsalError.ActivityRequired, MsalErrorMessage.ActivityRequired);
+            throw new MsalClientException(MsalClientException.ActivityRequired, MsalErrorMessage.ActivityRequired);
         }
 
         /// <summary>

--- a/src/Microsoft.Identity.Client/Platforms/Mac/AuthenticationAgentNSWindowController.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Mac/AuthenticationAgentNSWindowController.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -251,7 +251,7 @@ namespace Microsoft.Identity.Client.Platforms.Mac
                 !request.Url.Scheme.Equals("https", StringComparison.CurrentCultureIgnoreCase))
             {
                 var result = new AuthorizationResult(AuthorizationStatus.ErrorHttp);
-                result.Error = MsalError.NonHttpsRedirectNotSupported;
+                result.Error = MsalClientException.NonHttpsRedirectNotSupported;
                 result.ErrorDescription = MsalErrorMessage.NonHttpsRedirectNotSupported;
                 _callbackMethod(result);
                 WebView.DecideIgnore(decisionToken);

--- a/src/Microsoft.Identity.Client/Platforms/Mac/MacEmbeddedWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Mac/MacEmbeddedWebUI.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -85,7 +85,7 @@ namespace Microsoft.Identity.Client.Platforms.Mac
             catch (Exception ex)
             {
                 throw new MsalClientException(
-                    MsalError.AuthenticationUiFailed,
+                    MsalClientException.AuthenticationUiFailed,
                     "See inner exception for details",
                     ex);
             }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -87,7 +87,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
             catch (Exception ex)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.AuthenticationUiFailed, 
+                    MsalClientException.AuthenticationUiFailed, 
                     "See inner exception for details", 
                     ex);
             }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
             {
                 AuthorizationResult result = new AuthorizationResult(AuthorizationStatus.ErrorHttp)
                 {
-                    Error = MsalError.NonHttpsRedirectNotSupported,
+                    Error = MsalClientException.NonHttpsRedirectNotSupported,
                     ErrorDescription = MsalErrorMessage.NonHttpsRedirectNotSupported
                 };
                 AuthenticationAgentUIViewController.DismissViewController(true, () => AuthenticationAgentUIViewController.callbackMethod(result));

--- a/src/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.SystemWebview
             {
                 requestContext.Logger.ErrorPii(ex);
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.AuthenticationUiFailedError,
+                    MsalClientException.AuthenticationUiFailed,
                     "Failed to invoke SFSafariViewController",
                     ex);
             }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             }
 
             throw MsalExceptionFactory.GetClientException(
-                MsalError.CannotAccessPublisherKeyChain,
+                MsalClientException.CannotAccessPublisherKeyChain,
                 MsalErrorMessage.CannotAccessPublisherKeyChain);
         }
 
@@ -242,7 +242,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             if (secStatusCode == SecStatusCode.MissingEntitlement)
             {
                 throw MsalExceptionFactory.GetClientException(
-                MsalError.MissingEntitlements,
+                MsalClientException.MissingEntitlements,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     MsalErrorMessage.MissingEntitlements,

--- a/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
             if (userNameSize == 0)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.GetUserNameFailed,
+                    MsalClientException.GetUserNameFailed,
                     MsalErrorMessage.GetUserNameFailed,
                     new Win32Exception(Marshal.GetLastWin32Error()));
             }
@@ -102,7 +102,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
             if (!WindowsNativeMethods.GetUserNameEx(nameFormat, sb, ref userNameSize))
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.GetUserNameFailed,
+                    MsalClientException.GetUserNameFailed,
                     MsalErrorMessage.GetUserNameFailed,
                     new Win32Exception(Marshal.GetLastWin32Error()));
             }

--- a/src/Microsoft.Identity.Client/Platforms/net45/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/WindowsFormsWebAuthenticationDialogBase.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
             }
             else
             {
-                throw new MsalException(MsalError.InvalidOwnerWindowType,
+                throw new MsalException(MsalException.InvalidOwnerWindowType,
                     "Invalid owner window type. Expected types are IWin32Window or IntPtr (for window handle).");
             }
 
@@ -399,12 +399,12 @@ namespace Microsoft.Identity.Client.Platforms.net45
             {
                 string format = "The browser based authentication dialog failed to complete. Reason: {0}";
                 string message = string.Format(CultureInfo.InvariantCulture, format, NavigateErrorStatus.Messages[statusCode]);
-                return new MsalClientException(MsalClientException.AuthenticationUiFailedError, message);
+                return new MsalClientException(MsalClientException.AuthenticationUiFailed, message);
             }
 
             string formatUnknown = "The browser based authentication dialog failed to complete for an unknown reason. StatusCode: {0}";
             string messageUnknown = string.Format(CultureInfo.InvariantCulture, formatUnknown, statusCode);
-            return new MsalClientException(MsalClientException.AuthenticationUiFailedError, messageUnknown);
+            return new MsalClientException(MsalClientException.AuthenticationUiFailed, messageUnknown);
         }
 
         private sealed class WindowsFormsWin32Window : IWin32Window

--- a/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client.Platforms.uap
             if (users == null || !users.Any())
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.CannotAccessUserInformationOrUserNotDomainJoined,
+                    MsalClientException.CannotAccessUserInformationOrUserNotDomainJoined,
                     MsalErrorMessage.UapCannotFindDomainUser);
             }
 
@@ -112,13 +112,13 @@ namespace Microsoft.Identity.Client.Platforms.uap
             if (userDetails.Any(d => !string.IsNullOrWhiteSpace(d.Domain)))
             {
                 throw MsalExceptionFactory.GetClientException(
-                   MsalError.CannotAccessUserInformationOrUserNotDomainJoined,
+                   MsalClientException.CannotAccessUserInformationOrUserNotDomainJoined,
                    MsalErrorMessage.UapCannotFindUpn);
             }
 
             // no domain, no upn -> missing User Info capability
             throw MsalExceptionFactory.GetClientException(
-                MsalError.CannotAccessUserInformationOrUserNotDomainJoined,
+                MsalClientException.CannotAccessUserInformationOrUserNotDomainJoined,
                 MsalErrorMessage.UapCannotFindDomainUser);
 
         }

--- a/src/Microsoft.Identity.Client/Platforms/uap/WebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/uap/WebUI.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Client.Platforms.uap
             catch (Exception ex)
             {
                 requestContext.Logger.ErrorPii(ex);
-                throw new MsalException(MsalClientException.AuthenticationUiFailedError, "WAB authentication failed",
+                throw new MsalException(MsalClientException.AuthenticationUiFailed, "WAB authentication failed",
                     ex);
             }
 

--- a/src/Microsoft.Identity.Client/UI/AuthorizationResult.cs
+++ b/src/Microsoft.Identity.Client/UI/AuthorizationResult.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client.UI
         {
             if (Status == AuthorizationStatus.UserCancel)
             {
-                Error = MsalError.AuthenticationCanceledError;
+                Error = MsalClientException.AuthenticationCanceledError;
                 #if ANDROID
                 ErrorDescription = MsalErrorMessage.AuthenticationCanceledAndroid;
                 #else
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.UI
             }
             else if (Status == AuthorizationStatus.UnknownError)
             {
-                Error = MsalError.UnknownError;
+                Error = MsalException.UnknownError;
                 ErrorDescription = MsalErrorMessage.Unknown;
             }
             else
@@ -133,7 +133,7 @@ namespace Microsoft.Identity.Client.UI
                 }
                 else
                 {
-                    Error = MsalError.AuthenticationFailed;
+                    Error = MsalClientException.AuthenticationFailed;
                     ErrorDescription = MsalErrorMessage.AuthorizationServerInvalidResponse;
                     Status = AuthorizationStatus.UnknownError;
                 }
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Client.UI
             }
             else
             {
-                Error = MsalError.AuthenticationFailed;
+                Error = MsalClientException.AuthenticationFailed;
                 ErrorDescription = MsalErrorMessage.AuthorizationServerInvalidResponse;
                 Status = AuthorizationStatus.UnknownError;
             }

--- a/src/Microsoft.Identity.Client/UI/CustomWebUiHandler.cs
+++ b/src/Microsoft.Identity.Client/UI/CustomWebUiHandler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client.UI
                 if (uri == null || String.IsNullOrWhiteSpace(uri.Query))
                 {
                     throw new MsalClientException(
-                        MsalError.CustomWebUiReturnedInvalidUri,
+                        MsalClientException.CustomWebUiReturnedInvalidUri,
                         MsalErrorMessage.CustomWebUiReturnedInvalidUri);
                 }
 
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Client.UI
                 }
 
                 throw new MsalClientException(
-                    MsalError.CustomWebUiRedirectUriMismatch,
+                    MsalClientException.CustomWebUiRedirectUriMismatch,
                     MsalErrorMessage.CustomWebUiRedirectUriMismatch(
                         uri.AbsolutePath,
                         redirectUri.AbsolutePath));

--- a/src/Microsoft.Identity.Client/WsTrust/CommonNonInteractiveHandler.cs
+++ b/src/Microsoft.Identity.Client/WsTrust/CommonNonInteractiveHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.WsTrust
                 _requestContext.Logger.Error("Could not find UPN for logged in user.");
 
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.UnknownUser,
+                    MsalClientException.UnknownUser,
                     MsalErrorMessage.UnknownUser);
             }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client.WsTrust
             if (userRealmResponse == null)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.UserRealmDiscoveryFailed,
+                    MsalClientException.UserRealmDiscoveryFailed,
                     MsalErrorMessage.UserRealmDiscoveryFailed);
             }
 
@@ -101,7 +101,7 @@ namespace Microsoft.Identity.Client.WsTrust
             catch (XmlException ex)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.ParsingWsMetadataExchangeFailed,
+                    MsalClientException.ParsingWsMetadataExchangeFailed,
                     MsalErrorMessage.ParsingMetadataDocumentFailed,
                     ex);
             }
@@ -113,7 +113,7 @@ namespace Microsoft.Identity.Client.WsTrust
             if (wsTrustEndpoint == null)
             {
                 throw MsalExceptionFactory.GetClientException(
-                  MsalError.WsTrustEndpointNotFoundInMetadataDocument,
+                  MsalClientException.WsTrustEndpointNotFoundInMetadataDocument,
                   MsalErrorMessage.WsTrustEndpointNotFoundInMetadataDocument);
             }
 
@@ -158,7 +158,7 @@ namespace Microsoft.Identity.Client.WsTrust
             catch (Exception ex)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.ParsingWsTrustResponseFailed,
+                    MsalClientException.ParsingWsTrustResponseFailed,
                     ex.Message,
                     ex);
             }

--- a/src/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.WsTrust
                         (int)httpResponse.StatusCode, httpResponse.StatusCode);
 
                 throw MsalExceptionFactory.GetServiceException(
-                    MsalError.AccessingWsMetadataExchangeFailed,
+                    MsalServiceException.AccessingWsMetadataExchangeFailed,
                     message,
                     httpResponse,
                     innerException: null);
@@ -112,7 +112,7 @@ namespace Microsoft.Identity.Client.WsTrust
                         errorMessage);
 
                 throw MsalExceptionFactory.GetServiceException(
-                    MsalError.FederatedServiceReturnedError,
+                    MsalServiceException.FederatedServiceReturnedError,
                     message,
                     resp,
                     innerException: null);
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Client.WsTrust
             catch (System.Xml.XmlException ex)
             {
                 throw MsalExceptionFactory.GetClientException(
-                    MsalError.ParsingWsTrustResponseFailed, MsalError.ParsingWsTrustResponseFailed, ex);
+                    MsalClientException.ParsingWsTrustResponseFailed, MsalClientException.ParsingWsTrustResponseFailed, ex);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/HttpTests/HttpManagerTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
                 catch (MsalServiceException exc)
                 {
                     Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalError.ServiceNotAvailable, exc.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.ServiceNotAvailable, exc.ErrorCode);
                 }
             }
         }
@@ -187,7 +187,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
                 catch (MsalServiceException exc)
                 {
                     Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalError.ServiceNotAvailable, exc.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.ServiceNotAvailable, exc.ErrorCode);
                 }
             }
         }
@@ -213,7 +213,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
                 catch (MsalServiceException exc)
                 {
                     Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalError.RequestTimeout, exc.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.RequestTimeout, exc.ErrorCode);
                     Assert.IsTrue(exc.InnerException is TaskCanceledException);
                 }
             }
@@ -241,7 +241,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
                 catch (MsalServiceException exc)
                 {
                     Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalError.RequestTimeout, exc.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.RequestTimeout, exc.ErrorCode);
                     Assert.IsTrue(exc.InnerException is TaskCanceledException);
                 }
             }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 }
                 catch (MsalClientException exc)
                 {
-                    Assert.AreEqual(MsalError.TenantDiscoveryFailedError, exc.ErrorCode);
+                    Assert.AreEqual(MsalClientException.TenantDiscoveryFailedError, exc.ErrorCode);
                 }
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AdfsAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AdfsAuthorityTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 }
                 catch (MsalServiceException exc)
                 {
-                    Assert.AreEqual(MsalError.TenantDiscoveryFailedError, exc.ErrorCode);
+                    Assert.AreEqual(MsalClientException.TenantDiscoveryFailedError, exc.ErrorCode);
                 }
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/MexParserTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/MexParserTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
                 }
                 catch (MsalException ex)
                 {
-                    Assert.AreEqual(MsalError.AccessingWsMetadataExchangeFailed, ex.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.AccessingWsMetadataExchangeFailed, ex.ErrorCode);
                 }
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
                 }
                 catch (MsalException ex)
                 {
-                    Assert.AreEqual(MsalError.FederatedServiceReturnedError, ex.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.FederatedServiceReturnedError, ex.ErrorCode);
                 }
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.AreEqual(429, serverEx.StatusCode);
                     Assert.AreEqual(MockHelpers.TooManyRequestsContent, serverEx.ResponseBody);
                     Assert.AreEqual(MockHelpers.TestRetryAfterDuration, serverEx.Headers.RetryAfter.Delta);
-                    Assert.AreEqual(MsalError.NonParsableOAuthError, serverEx.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.NonParsableOAuthError, serverEx.ErrorCode);
                 });
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.IsNotNull(serverEx);
                     Assert.AreEqual((int)HttpStatusCode.BadRequest, serverEx.StatusCode);
                     Assert.IsNotNull(serverEx.ResponseBody);
-                    Assert.AreEqual(MsalError.HttpStatusCodeNotOk, serverEx.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.HttpStatusCodeNotOk, serverEx.ErrorCode);
                 });
         }
 
@@ -160,7 +160,7 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.IsNotNull(serverEx);
                     Assert.AreEqual((int)HttpStatusCode.BadRequest, serverEx.StatusCode);
                     Assert.IsNull(serverEx.ResponseBody);
-                    Assert.AreEqual(MsalError.HttpStatusCodeNotOk, serverEx.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.HttpStatusCodeNotOk, serverEx.ErrorCode);
                 });
         }
 
@@ -175,7 +175,7 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.IsNotNull(serverEx);
                     Assert.AreEqual((int)HttpStatusCode.BadRequest, serverEx.StatusCode);
                     Assert.IsNotNull(serverEx.ResponseBody);
-                    Assert.AreEqual(MsalError.HttpStatusCodeNotOk, serverEx.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.HttpStatusCodeNotOk, serverEx.ErrorCode);
                 });
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.IsNotNull(serverEx);
                     Assert.AreEqual((int)HttpStatusCode.NotFound, serverEx.StatusCode);
                     Assert.IsNotNull(serverEx.ResponseBody);
-                    Assert.AreEqual(MsalError.HttpStatusNotFound, serverEx.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.HttpStatusNotFound, serverEx.ErrorCode);
                 });
         }
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -485,7 +485,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 {
                     MsalClientException exc = (MsalClientException)ex.InnerException;
                     Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalError.UserMismatch, exc.ErrorCode);
+                    Assert.AreEqual(MsalClientException.UserMismatch, exc.ErrorCode);
                 }
 
                 Assert.IsNotNull(
@@ -760,7 +760,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     new MockWebUI()
                     {
                         ExceptionToThrow = new MsalClientException(
-                            MsalClientException.AuthenticationUiFailedError,
+                            MsalClientException.AuthenticationUiFailed,
                             "Failed to invoke webview",
                             new InvalidOperationException("some-inner-Exception"))
                     });
@@ -777,7 +777,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 catch (MsalClientException exc)
                 {
                     Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalClientException.AuthenticationUiFailedError, exc.ErrorCode);
+                    Assert.AreEqual(MsalClientException.AuthenticationUiFailed, exc.ErrorCode);
                     Assert.AreEqual("some-inner-Exception", exc.InnerException.Message);
                 }
             }

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 {
                     var exc = exception as MsalServiceException;
                     Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalError.BrokerResponseReturnedError, exc.ErrorCode);
+                    Assert.AreEqual(MsalServiceException.BrokerResponseReturnedError, exc.ErrorCode);
                     Assert.AreEqual(MsalErrorMessage.BrokerResponseReturnedError, exc.Message);
                 });
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         .ConfigureAwait(false));
 
                 // Assert
-                Assert.AreEqual(MsalError.IntegratedWindowsAuthNotSupportedForManagedUser, exception.ErrorCode);
+                Assert.AreEqual(MsalClientException.IntegratedWindowsAuthNotSupportedForManagedUser, exception.ErrorCode);
             }
         }
 
@@ -268,7 +268,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         .ConfigureAwait(false));
 
                 // Assert
-                Assert.AreEqual(MsalError.UnknownUserType, exception.ErrorCode);
+                Assert.AreEqual(MsalClientException.UnknownUserType, exception.ErrorCode);
             }
         }
 
@@ -430,7 +430,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         _secureString).ExecuteAsync(CancellationToken.None).ConfigureAwait(false));
 
                 // Check exception message
-                Assert.AreEqual(MsalError.ParsingWsTrustResponseFailed, result.ErrorCode);
+                Assert.AreEqual(MsalClientException.ParsingWsTrustResponseFailed, result.ErrorCode);
 
                 // There should be no cached entries.
                 Assert.AreEqual(0, app.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count());
@@ -503,7 +503,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         str).ExecuteAsync(CancellationToken.None).ConfigureAwait(false));
 
                 // Check inner exception
-                Assert.AreEqual(MsalError.ParsingWsTrustResponseFailed, result.ErrorCode);
+                Assert.AreEqual(MsalClientException.ParsingWsTrustResponseFailed, result.ErrorCode);
 
                 // There should be no cached entries.
                 Assert.AreEqual(0, app.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count());
@@ -668,7 +668,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         str).ExecuteAsync(CancellationToken.None).ConfigureAwait(false));
 
                 // Check error code
-                Assert.AreEqual(MsalError.PasswordRequiredForManagedUserError, result.ErrorCode);
+                Assert.AreEqual(MsalClientException.PasswordRequiredForManagedUserError, result.ErrorCode);
 
                 // There should be no cached entries.
                 Assert.AreEqual(0, app.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count());
@@ -714,7 +714,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         str).ExecuteAsync(CancellationToken.None).ConfigureAwait(false));
 
                 // Check error code
-                Assert.AreEqual(MsalError.InvalidGrantError, result.ErrorCode);
+                Assert.AreEqual(MsalUiRequiredException.InvalidGrantError, result.ErrorCode);
 
                 // There should be no cached entries.
                 Assert.AreEqual(0, app.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count());

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 {
 
                     var ex = AssertException.TaskThrows<MsalClientException>(() => request.ExecuteAsync(CancellationToken.None));
-                    Assert.AreEqual(MsalError.CustomWebUiReturnedInvalidUri, ex.ErrorCode);
+                    Assert.AreEqual(MsalClientException.CustomWebUiReturnedInvalidUri, ex.ErrorCode);
 
                 });
         }
@@ -176,7 +176,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 {
                     var ex = AssertException.TaskThrows<MsalClientException>(
                         () => request.ExecuteAsync(CancellationToken.None));
-                    Assert.AreEqual(MsalError.CustomWebUiReturnedInvalidUri, ex.ErrorCode);
+                    Assert.AreEqual(MsalClientException.CustomWebUiReturnedInvalidUri, ex.ErrorCode);
                 });
         }
 


### PR DESCRIPTION
I've started working on [1004] for moving MsalError error constants into their respective exception classes.

Looking through the first run of this change, I'm actually not a fan of this approach.  I believe we should go the other way and remove the constants from the exception class and have everything in MsalError (with corresponding messages in MsalErrorMessage)

- Not all MsalError values are used in an MsalException, sometimes it's a response value or other usage.
- A few of the errors cross boundaries and are used in ClientException and ServiceException
- We throw MsalException itself in a few cases.  I'm not sure why/how that makes sense and what this hierarchy is providing for customers
- Now the error codes are in one of 3 classes (MsalException, MsalClientException, MsalErrorException) but the messages are all in one file (MsalErrorMessage).  It's not always clear which place to pull the constant from.  They were ALL in MsalError before.

Please comment on this feedback as well as what we should do with the errors that aren't used on any of the exceptions if you still believe we should go this way.  Should they just go into MsalException (even though they'll never be attached to an exception)?

https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1004