### PR TITLE
Jennyf/b2c ropc

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private async Task<UserAssertion> FetchAssertionFromWsTrustAsync()
         {
-            if (AuthenticationRequestParameters.AuthorityInfo.AuthorityType == AuthorityType.Adfs)
+            if (AuthenticationRequestParameters.AuthorityInfo.AuthorityType == AuthorityType.Adfs ||
+                AuthenticationRequestParameters.AuthorityInfo.AuthorityType == AuthorityType.B2C)
             {
                 return null;
             }

--- a/tests/Microsoft.Identity.Test.Core.UIAutomation/CoreUiTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Core.UIAutomation/CoreUiTestConstants.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         public const string AcquireTokenButtonId = "acquireToken_button";
         public const string AcquireTokenWithPromptBehaviorAlwaysId = "acquireTokenPromptBehaviorAlways";
         public const string AcquireTokenSilentButtonId = "acquireTokenSilent_button";
+        public const string AcquireTokenROPCButtonId = "acquireTokenByUsernamePassword";
         public const string ClientIdEntryId = "clientIdEntry";
         public const string ResourceEntryId = "resourceEntry";
         public const string PromptBehaviorEntryId = "promptBehaviorEntry";
@@ -86,6 +87,7 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         public const string MicrosoftOnlineAuthority = "login.microsoftonline.com";
         public const string NonB2CAuthority = "non-b2c authority";
         public const string B2CEditProfileAuthority = "Edit profile policy authority";
+        public const string B2CROPCAuthority = "ROPC";
         public const string FacebookAccountId = "FacebookExchange";
         public const string WebUpnB2CFacebookInputId = "m_login_email";
         public const string B2CWebPasswordFacebookId = "m_login_password";
@@ -107,5 +109,7 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         public const int ResultCheckPolliInterval = 1000;
         public const int MaximumResultCheckRetryAttempts = 20;
 
+        public const string UsernameId = "usernameId";
+        public const string PasswordId = "passwordId";
     }
 }

--- a/tests/Microsoft.Identity.Test.Core.UIAutomation/CoreUiTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Core.UIAutomation/CoreUiTestConstants.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         public const string AcquireTokenButtonId = "acquireToken_button";
         public const string AcquireTokenWithPromptBehaviorAlwaysId = "acquireTokenPromptBehaviorAlways";
         public const string AcquireTokenSilentButtonId = "acquireTokenSilent_button";
-        public const string AcquireTokenROPCButtonId = "acquireTokenByUsernamePassword";
         public const string ClientIdEntryId = "clientIdEntry";
         public const string ResourceEntryId = "resourceEntry";
         public const string PromptBehaviorEntryId = "promptBehaviorEntry";
@@ -87,7 +86,6 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         public const string MicrosoftOnlineAuthority = "login.microsoftonline.com";
         public const string NonB2CAuthority = "non-b2c authority";
         public const string B2CEditProfileAuthority = "Edit profile policy authority";
-        public const string B2CROPCAuthority = "ROPC";
         public const string FacebookAccountId = "FacebookExchange";
         public const string WebUpnB2CFacebookInputId = "m_login_email";
         public const string B2CWebPasswordFacebookId = "m_login_password";
@@ -108,8 +106,5 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         // Test Constants
         public const int ResultCheckPolliInterval = 1000;
         public const int MaximumResultCheckRetryAttempts = 20;
-
-        public const string UsernameId = "usernameId";
-        public const string PasswordId = "passwordId";
     }
 }

--- a/tests/Microsoft.Identity.Test.Core.UIAutomation/MobileTestHelper.cs
+++ b/tests/Microsoft.Identity.Test.Core.UIAutomation/MobileTestHelper.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -159,21 +159,6 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
             controller.Tap(_acquirePageId);
         }
 
-        private void ValidateUiBehaviorString(string uiBehavior)
-        {
-            var okList = new[] {
-                CoreUiTestConstants.UiBehaviorConsent,
-                CoreUiTestConstants.UiBehaviorLogin,
-                CoreUiTestConstants.UiBehaviorSelectAccount };
-
-            bool isInList = okList.Any(item => string.Equals(item, uiBehavior, StringComparison.InvariantCulture));
-
-            if (!isInList)
-            {
-                throw new InvalidOperationException("Test Setup Error: invalid uiBehavior " + uiBehavior);
-            }
-        }
-
         /// <summary>
         /// Runs through the B2C acquire token flow with local account
         /// </summary>
@@ -181,7 +166,7 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         {
             PerformB2CSignInFlow(controller, labResponse.User, B2CIdentityProvider.Local, isB2CLoginAuthority);
         }
-
+               
         /// <summary>
         /// Runs through the B2C acquire token flow with Facebook Provider
         /// </summary>
@@ -196,7 +181,7 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         /// </summary>
         public void B2CFacebookEditPolicyAcquireTokenInteractiveTestHelper(ITestController controller)
         {
-            PerformB2CSignInEditProfileFlow(controller, B2CIdentityProvider.Facebook);
+            PerformB2CSignInEditProfileFlow(controller);
         }
 
         /// <summary>
@@ -350,18 +335,18 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
 
             switch (b2CIdentityProvider)
             {
-                case B2CIdentityProvider.Local:
-                    PerformB2CLocalAccountSignInFlow(controller, user, userInformationFieldIds);
-                    break;
-                case B2CIdentityProvider.Google:
-                    PerformB2CGoogleProviderSignInFlow(controller, user, userInformationFieldIds);
-                    break;
+            case B2CIdentityProvider.Local:
+                PerformB2CLocalAccountSignInFlow(controller, user, userInformationFieldIds);
+                break;
+            case B2CIdentityProvider.Google:
+                PerformB2CGoogleProviderSignInFlow(controller, user, userInformationFieldIds);
+                break;
 
-                case B2CIdentityProvider.Facebook:
-                    PerformB2CFacebookProviderSignInFlow(controller, user, userInformationFieldIds);
-                    break;
-                default:
-                    throw new InvalidOperationException("B2CIdentityProvider unknown");
+            case B2CIdentityProvider.Facebook:
+                PerformB2CFacebookProviderSignInFlow(controller, user, userInformationFieldIds);
+                break;
+            default:
+                throw new InvalidOperationException("B2CIdentityProvider unknown");
             }
             VerifyResult(controller);
         }
@@ -377,16 +362,16 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
 
             switch (b2CIdentityProvider)
             {
-                case B2CIdentityProvider.Facebook:
-                    controller.Tap(CoreUiTestConstants.FacebookAccountId, XamarinSelector.ByHtmlIdAttribute);
-                    break;
-                default:
-                    throw new InvalidOperationException("B2CIdentityProvider unknown");
+            case B2CIdentityProvider.Facebook:
+                controller.Tap(CoreUiTestConstants.FacebookAccountId, XamarinSelector.ByHtmlIdAttribute);
+                break;
+            default:
+                throw new InvalidOperationException("B2CIdentityProvider unknown");
             }
             VerifyResult(controller);
         }
 
-        public void PerformB2CSignInEditProfileFlow(ITestController controller, B2CIdentityProvider b2CIdentityProvider)
+        public void PerformB2CSignInEditProfileFlow(ITestController controller)
         {
             SetB2CInputDataForEditProfileAuthority(controller);
 
@@ -400,6 +385,19 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
             controller.Tap(CoreUiTestConstants.B2CEditProfileContinueId, XamarinSelector.ByHtmlIdAttribute);
 
             controller.WaitForWebElementByCssId(CoreUiTestConstants.B2CEditProfileContinueId);
+
+            VerifyResult(controller);
+        }
+
+        public void PerformROPCFlow(ITestController controller, LabResponse labResponse)
+        {
+            controller.Tap(_acquirePageId);
+
+            controller.EnterText(CoreUiTestConstants.UsernameId, labResponse.User.HomeUPN, XamarinSelector.ByAutomationId);
+            controller.EnterText(CoreUiTestConstants.PasswordId, labResponse.User.Password, XamarinSelector.ByAutomationId);
+
+            //Acquire token flow
+            controller.Tap(CoreUiTestConstants.AcquireTokenROPCButtonId);
 
             VerifyResult(controller);
         }
@@ -503,14 +501,14 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
 
                     switch (ex.Error)
                     {
-                        case VerificationError.ResultIndicatesFailure:
-                            Assert.Fail("Test result indicates failure");
-                            break;
-                        case VerificationError.ResultNotFound:
-                            Task.Delay(CoreUiTestConstants.ResultCheckPolliInterval).Wait();
-                            break;
-                        default:
-                            throw;
+                    case VerificationError.ResultIndicatesFailure:
+                        Assert.Fail("Test result indicates failure");
+                        break;
+                    case VerificationError.ResultNotFound:
+                        Task.Delay(CoreUiTestConstants.ResultCheckPolliInterval).Wait();
+                        break;
+                    default:
+                        throw;
                     }
                 }
             } while (true);
@@ -520,16 +518,16 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
         {
             switch (platform)
             {
-                case Xamarin.UITest.Platform.Android:
-                    _cachePageId = CoreUiTestConstants.CachePageAndroidID;
-                    _acquirePageId = CoreUiTestConstants.AcquirePageAndroidId;
-                    _settingsPageId = CoreUiTestConstants.SettingsPageAndroidId;
-                    break;
-                case Xamarin.UITest.Platform.iOS:
-                    _cachePageId = CoreUiTestConstants.CachePageID;
-                    _acquirePageId = CoreUiTestConstants.AcquirePageId;
-                    _settingsPageId = CoreUiTestConstants.SettingsPageId;
-                    break;
+            case Xamarin.UITest.Platform.Android:
+                _cachePageId = CoreUiTestConstants.CachePageAndroidID;
+                _acquirePageId = CoreUiTestConstants.AcquirePageAndroidId;
+                _settingsPageId = CoreUiTestConstants.SettingsPageAndroidId;
+                break;
+            case Xamarin.UITest.Platform.iOS:
+                _cachePageId = CoreUiTestConstants.CachePageID;
+                _acquirePageId = CoreUiTestConstants.AcquirePageId;
+                _settingsPageId = CoreUiTestConstants.SettingsPageId;
+                break;
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Core.UIAutomation/MobileTestHelper.cs
+++ b/tests/Microsoft.Identity.Test.Core.UIAutomation/MobileTestHelper.cs
@@ -389,19 +389,6 @@ namespace Microsoft.Identity.Test.UIAutomation.Infrastructure
             VerifyResult(controller);
         }
 
-        public void PerformROPCFlow(ITestController controller, LabResponse labResponse)
-        {
-            controller.Tap(_acquirePageId);
-
-            controller.EnterText(CoreUiTestConstants.UsernameId, labResponse.User.HomeUPN, XamarinSelector.ByAutomationId);
-            controller.EnterText(CoreUiTestConstants.PasswordId, labResponse.User.Password, XamarinSelector.ByAutomationId);
-
-            //Acquire token flow
-            controller.Tap(CoreUiTestConstants.AcquireTokenROPCButtonId);
-
-            VerifyResult(controller);
-        }
-
         public void PromptBehaviorTestHelperWithConsent(ITestController controller, LabResponse labResponse)
         {
             // 1. Acquire token with uiBehavior set to consent

--- a/tests/Microsoft.Identity.Test.Integration/HeadlessTests/B2CUsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration/HeadlessTests/B2CUsernamePasswordIntegrationTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.LabInfrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Integration.HeadlessTests
+{
+    // Note: these tests require permission to a KeyVault Microsoft account; 
+    // Please ignore them if you are not a Microsoft FTE, they will run as part of the CI build
+    [TestClass]
+    public class B2CUsernamePasswordIntegrationTests
+    {
+        private const string _b2CROPCAuthority = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth";
+
+        private static readonly string[] s_b2cScopes = { "https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read" };
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+        }
+
+        [TestMethod]
+        public async Task ROPC_B2C_Async()
+        {
+            var labResponse = LabUserHelper.GetB2CLocalAccount();
+            await RunB2CHappyPathTestAsync(labResponse).ConfigureAwait(false);
+        }
+
+        private async Task RunB2CHappyPathTestAsync(LabResponse labResponse)
+        {
+            var user = labResponse.User;
+
+            SecureString securePassword = new NetworkCredential("", user.Password).SecurePassword;
+
+            var msalPublicClient = PublicClientApplicationBuilder.Create("e3b9ad76-9763-4827-b088-80c7a7888f79").WithB2CAuthority(_b2CROPCAuthority).Build();
+
+            AuthenticationResult authResult = await msalPublicClient
+                .AcquireTokenByUsernamePassword(s_b2cScopes, user.Upn, securePassword)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(authResult);
+            Assert.IsNotNull(authResult.AccessToken);
+            // Assert.IsNotNull(authResult.IdToken);
+            // Assert.AreEqual(user.Upn, authResult.Account.Username);
+            // If test fails with "user needs to consent to the application, do an interactive request" error,
+            // Do the following: 
+            // 1) Add in code to pull the user's password before creating the SecureString, and put a breakpoint there.
+            // string password = ((LabUser)user).GetPassword();
+            // 2) Using the MSAL Desktop app, make sure the ClientId matches the one used in integration testing.
+            // 3) Do the interactive sign-in with the MSAL Desktop app with the username and password from step 1.
+            // 4) After successful log-in, remove the password line you added in with step 1, and run the integration test again.
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.iOS.UIAutomation/iOSTests.cs
+++ b/tests/Microsoft.Identity.Test.iOS.UIAutomation/iOSTests.cs
@@ -94,7 +94,7 @@ namespace Test.Microsoft.Identity.UIAutomation
                 //B2CGoogleB2CLoginAuthorityAcquireTokenTest,
                 //B2CGoogleMicrosoftAuthorityAcquireTokenTest,
                 //B2CLocalAccountAcquireTokenTest,
-                //B2CFacebookEditPolicyAcquireTokenTest
+                //B2CFacebookEditPolicyAcquireTokenTest,
             };
 
             var hasFailed = false;

--- a/tests/devapps/XForms/XForms/AcquirePage.xaml
+++ b/tests/devapps/XForms/XForms/AcquirePage.xaml
@@ -9,24 +9,35 @@
         </OnPlatform>
     </ContentPage.Padding>
 
-    <StackLayout Padding="10,0">
-
-        <Label Text="Acquire" HorizontalTextAlignment="Center" HorizontalOptions="FillAndExpand" Margin="5" />
-
+    <StackLayout Padding="5,0">
         <StackLayout Orientation="Horizontal"  HorizontalOptions="FillAndExpand">
-            <Label Text="Scopes" HorizontalTextAlignment="Center"  Margin="5" Font="Bold,13"/>
+            <Label Text="Scopes" HorizontalTextAlignment="Center"  Margin="2" Font="Bold,10"/>
             <Entry x:Name="ScopesEntry" Text=""  HorizontalOptions="FillAndExpand" AutomationId="scopesList"/>
         </StackLayout>
 
         <StackLayout Orientation="Horizontal"  HorizontalOptions="FillAndExpand">
-            <Label Text="Users" HorizontalTextAlignment="Center" Margin="5" Font="Bold,13"/>
+            <Label Text="Users" HorizontalTextAlignment="Center" Margin="2" Font="Bold,10"/>
             <Picker x:Name="usersPicker" HorizontalOptions="FillAndExpand" AutomationId="userList"/>
         </StackLayout>
 
-        <Frame OutlineColor="Black" Padding="10">
+        <Frame OutlineColor="Blue" Padding="5">
             <StackLayout Orientation="Vertical">
                 <StackLayout Orientation="Horizontal"  HorizontalOptions="FillAndExpand">
-                    <Label Text="UIBehavior" HorizontalTextAlignment="Center"  Margin="5" Font="Bold,13"/>
+                    <Label Text="UserName" HorizontalTextAlignment="Center" Margin="2" Font="Bold,10"/>
+                    <Entry x:Name="UserName" Text=""  HorizontalOptions="FillAndExpand" AutomationId="usernameId"/>
+                </StackLayout>
+
+                <StackLayout Orientation="Horizontal"  HorizontalOptions="FillAndExpand">
+                    <Label Text="Password" HorizontalTextAlignment="Center" Margin="2" Font="Bold,10"/>
+                    <Entry x:Name="Password" Text=""  HorizontalOptions="FillAndExpand" AutomationId="passwordId"/>
+                </StackLayout>
+            </StackLayout>
+        </Frame>
+
+        <Frame OutlineColor="Black" Padding="5">
+            <StackLayout Orientation="Vertical">
+                <StackLayout Orientation="Horizontal"  HorizontalOptions="FillAndExpand">
+                    <Label Text="UIBehavior" HorizontalTextAlignment="Center"  Margin="2" Font="Bold,13"/>
                     <Picker x:Name="UIBehaviorPicker" AutomationId="uiBehavior"/>
                 </StackLayout>
 
@@ -42,29 +53,26 @@
                 </StackLayout>
 
                 <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
-                    <Button  Text="Acquire" Clicked="OnAcquireClickedAsync" TextColor="Blue" Font="Bold,15" HorizontalOptions="Center" AutomationId="acquireToken_button"/>
-                    <Button  Text="DeviceCode" Clicked="OnAcquireByDeviceCodeClickedAsync" TextColor="Blue" Font="Bold,15" HorizontalOptions="Center" AutomationId="acquireTokenByDeviceCode"/>
+                    <Button  Text="Acquire" Clicked="OnAcquireClickedAsync" TextColor="Blue" Font="Bold,13" HorizontalOptions="Center" AutomationId="acquireToken_button"/>
+                    <Button  Text="DeviceCode" Clicked="OnAcquireByDeviceCodeClickedAsync" TextColor="Blue" Font="Bold,13" HorizontalOptions="Center" AutomationId="acquireTokenByDeviceCode"/>
+                    <Button  Text="ROPC" Clicked="OnAcquireByUsernamePasswordClickedAsync" TextColor="Blue" Font="Bold,13" HorizontalOptions="Center" AutomationId="acquireTokenByUsernamePassword"/>
                 </StackLayout>
             </StackLayout>
         </Frame>
 
-        <Frame OutlineColor="Black" Padding="10">
+        <Frame OutlineColor="Black" Padding="5">
             <StackLayout Orientation="Vertical"  >
                 <StackLayout Orientation="Vertical"  HorizontalOptions="FillAndExpand">
-
-                    <StackLayout Orientation="Horizontal"  HorizontalOptions="Start">
-                        <Label Text="Force Refresh" Margin="5" Font="Bold,13"/>
+                    <StackLayout Orientation="Horizontal"  HorizontalOptions="FillAndExpand">
+                        <Label Text="Force Refresh" Font="Bold,13" HorizontalOptions="Center"/>
                         <Switch x:Name="ForceRefreshSwitch" AutomationId="forceRefreshSwitch"/>
-                    </StackLayout>
 
-                    <StackLayout Orientation="Horizontal"  HorizontalOptions="Start">
-                        <Label Text="Pass Authority" Margin="5" Font="Bold,13"/>
+                        <Label Text="Pass Authority" Font="Bold,13" HorizontalOptions="Center"/>
                         <Switch x:Name="PassAuthoritySwitch" AutomationId="passAuthoritySwitch"/>
-                    </StackLayout>
-
+                    </StackLayout>                    
                 </StackLayout>
-                <Button  Text="AcquireSilently" Clicked="OnAcquireSilentlyClickedAsync" TextColor="Blue" Font="Bold,15" HorizontalOptions="Center" AutomationId="acquireTokenSilent_button"/>
-
+                
+                <Button  Text="AcquireSilently" Clicked="OnAcquireSilentlyClickedAsync" TextColor="Blue" Font="Bold,13" HorizontalOptions="Center" AutomationId="acquireTokenSilent_button"/>
             </StackLayout>
         </Frame>
 
@@ -72,12 +80,10 @@
 
         <ScrollView Orientation="Vertical" VerticalOptions="FillAndExpand">
             <StackLayout Orientation="Vertical" VerticalOptions="FillAndExpand">
-                <Frame OutlineColor="Black" Padding="10">
+                <Frame OutlineColor="Black" Padding="5">
                     <Label x:Name="acquireResponseLabel" Text=""/>
                 </Frame>
             </StackLayout>
         </ScrollView>
-
     </StackLayout>
-
 </ContentPage>

--- a/tests/devapps/XForms/XForms/App.xaml.cs
+++ b/tests/devapps/XForms/XForms/App.xaml.cs
@@ -60,6 +60,7 @@ namespace XForms
         public const string B2cAuthority = "https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SISOPolicy/";
         public const string B2CLoginAuthority = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SISOPolicy/";
         public const string B2CEditProfilePolicyAuthority = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ProfileEditPolicy/";
+        public const string B2CROPCAuthority = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth";
 
         public static string[] DefaultScopes = { "User.Read" };
         public static string[] B2cScopes = { "https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read" };

--- a/tests/devapps/XForms/XForms/SettingsPage.xaml
+++ b/tests/devapps/XForms/XForms/SettingsPage.xaml
@@ -37,6 +37,7 @@
                             <x:String>login.microsoftonline.com</x:String>
                             <x:String>b2clogin.com</x:String>
                             <x:String>Edit profile policy authority</x:String>
+                            <x:String>ROPC</x:String>
                             <x:String>non-b2c authority</x:String>
                         </x:Array>
                     </Picker.ItemsSource>

--- a/tests/devapps/XForms/XForms/SettingsPage.xaml.cs
+++ b/tests/devapps/XForms/XForms/SettingsPage.xaml.cs
@@ -104,24 +104,28 @@ namespace XForms
 
             switch (selectedIndex)
             {
-                case 0:
-                    App.Authority = App.B2cAuthority;
-                    CreateB2CAppSettings();
-                    break;
+            case 0:
+                App.Authority = App.B2cAuthority;
+                CreateB2CAppSettings();
+                break;
 
-                case 1:
-                    App.Authority = App.B2CLoginAuthority;
-                    CreateB2CAppSettings();
-                    break;
-                case 2:
-                    App.Authority = App.B2CEditProfilePolicyAuthority;
-                    CreateB2CAppSettings();
-                    break;
-                default:
-                    App.Authority = App.DefaultAuthority;
-                    App.Scopes = App.DefaultScopes;
-                    App.ClientId = App.DefaultClientId;
-                    break;
+            case 1:
+                App.Authority = App.B2CLoginAuthority;
+                CreateB2CAppSettings();
+                break;
+            case 2:
+                App.Authority = App.B2CEditProfilePolicyAuthority;
+                CreateB2CAppSettings();
+                break;
+            case 3:
+                App.Authority = App.B2CROPCAuthority;
+                CreateB2CAppSettings();
+                break;
+            default:
+                App.Authority = App.DefaultAuthority;
+                App.Scopes = App.DefaultScopes;
+                App.ClientId = App.DefaultClientId;
+                break;
             }
 
             InitPublicClientAndRefreshView();


### PR DESCRIPTION
B2C w/ROPC does not work because in `UsernamePasswordRequest` we are only checking for `AuthorityType.ADFS`, and if it's B2C, we are moving forward with doing the UserRealm, which B2C does not have. This why the customers in the [issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/926) have reported the user realm error. I was able to repro it.

Now works as expected, we just [skip that part and return](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/jennyf/b2cROPC/src/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs#L76), as we do w/ADFS. I checked with Parakh on this as well. We now have ROPC policy with the lab b2c account for testing.

**Known issue** at the moment is we're not able to get back an id_token from B2C, so there is no way to populate the cache account, as the cache account is made from the id_token, so an AT silent call will not work, but doing ROPC does not show UI anyway.
Looked at this with Parakh today and if we send `Response_type=id_token` using Postman, we get the id_token back, so he's checking if this will be a fix on B2C or on us. I'm pushing for them. :) 

Add in headless test will add more once we have some things resolved w/b2c😹 