### PR TITLE
update dotnet sdk to 2.1.602 in global json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-  "sdk": { "version": "2.1.502" },
+  "sdk": { "version": "2.1.602" },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "1.6.61"
   }


### PR DESCRIPTION
This enables a machine with only VS2019 on it to actually work.

I've created a clone PR project just changing to 602 there as well and it passes:

https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=325168&_a=summary