### PR TITLE
Adding a constant for the default interactive redirect URI in desktop…

### DIFF
--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client
         ///         .Build();
         /// </code>
         /// </example>
-        public static Uri DefaultInteractiveDesktopRedirectUri = new Uri("https://login.microsoftonline.com/common/oauth2/nativeclient");
+        public static string DefaultInteractiveDesktopRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
 
         internal PublicClientApplicationBuilder WithUserTokenLegacyCachePersistenceForTest(ILegacyCachePersistence legacyCachePersistence)
         {

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -68,6 +68,23 @@ namespace Microsoft.Identity.Client
             return new PublicClientApplicationBuilder(config).WithClientId(clientId);
         }
 
+        /// <summary>
+        /// Default redirect URI for desktop interactive public client applications. 
+        /// </summary>
+        /// <example>
+        /// If your application uses AcquireTokenInteractive, you want to register the
+        /// <c>https://login.microsoftonline.com/common/oauth2/nativeclient</c> redirect URI
+        /// and build your application using
+        /// <c>.WithRedirectUri(PublicClientApplicationBuilder.DefaultInteractiveDesktopRedirectUri)</c>
+        /// <code>
+        /// IPublicClientApplication app;
+        /// app = PublicClientApplicationBuilder.Create(clientId)
+        ///         .WithRedirectUri(PublicClientApplicationBuilder.DefaultInteractiveDesktopRedirectUri)
+        ///         .Build();
+        /// </code>
+        /// </example>
+        public static Uri DefaultInteractiveDesktopRedirectUri = new Uri("https://login.microsoftonline.com/common/oauth2/nativeclient");
+
         internal PublicClientApplicationBuilder WithUserTokenLegacyCachePersistenceForTest(ILegacyCachePersistence legacyCachePersistence)
         {
             Config.UserTokenLegacyCachePersistenceForTest = legacyCachePersistence;

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client
         ///         .Build();
         /// </code>
         /// </example>
-        public static string DefaultInteractiveDesktopRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        public const string DefaultInteractiveDesktopRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
 
         internal PublicClientApplicationBuilder WithUserTokenLegacyCachePersistenceForTest(ILegacyCachePersistence legacyCachePersistence)
         {


### PR DESCRIPTION
The `urn:ietf:wg:oauth:2.0:oob` redirect URI used by default by MSAL.NET for desktop applications is going to be deprecated in favor of `https://login.microsoftonline.com/common/oauth2/nativeclient`

This PR is to trigger a discussion on how best to manage the change. Here proposing to adding a constant for the default interactive redirect URI in desktop public client applications, which would be used in building the application (a bit of a step back :( )

```CSharp
IPublicClientApplication app;
app = PublicClientApplicationBuilder.Create(clientId)
               .WithRedirectUri(PublicClientApplicationBuilder.DefaultInteractiveDesktopRedirectUri)
              .Build();
```
Alternatively would we want to have .WtihInteractiveDesktopRedirectUri(true) which would override the default URI?  