### PR TITLE
Fix ADAL issue where we're looking up by incorrect value (homeaccount…

### DIFF
--- a/src/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
+++ b/src/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
@@ -239,9 +239,7 @@ namespace Microsoft.Identity.Client.Cache
             ILegacyCachePersistence legacyCachePersistence,
             ISet<string> environmentAliases,
             string clientId,
-            string upn,
-            string uniqueId,
-            string rawClientInfo)
+            string upn)
         {
             try
             {
@@ -254,44 +252,26 @@ namespace Microsoft.Identity.Client.Cache
                         p.Key.ClientId.Equals(clientId, StringComparison.OrdinalIgnoreCase) &&
                         environmentAliases.Contains(new Uri(p.Key.Authority).Host)).ToList();
 
-                //if client info is provided then use it to filter
-                if (!string.IsNullOrEmpty(rawClientInfo))
-                {
-                    List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> clientInfoEntries =
-                        listToProcess.Where(p => rawClientInfo.Equals(p.Value.RawClientInfo, StringComparison.OrdinalIgnoreCase)).ToList();
-                    if (clientInfoEntries.Any())
-                    {
-                        listToProcess = clientInfoEntries;
-                    }
-                }
-
                 //if upn is provided then use it to filter
                 if (!string.IsNullOrEmpty(upn))
                 {
                     List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> upnEntries =
                         listToProcess.Where(p => upn.Equals(p.Key.DisplayableId, StringComparison.OrdinalIgnoreCase)).ToList();
+
                     if (upnEntries.Any())
                     {
                         listToProcess = upnEntries;
                     }
                 }
 
-                //if userId is provided then use it to filter
-                if (!string.IsNullOrEmpty(uniqueId))
-                {
-                    List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> uniqueIdEntries =
-                        listToProcess.Where(p => uniqueId.Equals(p.Key.UniqueId, StringComparison.OrdinalIgnoreCase)).ToList();
-                    if (uniqueIdEntries.Any())
-                    {
-                        listToProcess = uniqueIdEntries;
-                    }
-                }
-
                 List<MsalRefreshTokenCacheItem> list = new List<MsalRefreshTokenCacheItem>();
                 foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> pair in listToProcess)
                 {
-                    list.Add(new MsalRefreshTokenCacheItem
-                        (new Uri(pair.Key.Authority).Host, pair.Key.ClientId, pair.Value.RefreshToken, pair.Value.RawClientInfo));
+                    list.Add(new MsalRefreshTokenCacheItem(
+                        new Uri(pair.Key.Authority).Host,
+                        pair.Key.ClientId,
+                        pair.Value.RefreshToken,
+                        pair.Value.RawClientInfo));
                 }
 
                 return list;
@@ -311,11 +291,9 @@ namespace Microsoft.Identity.Client.Cache
             string preferredEnvironment,
             ISet<string> environmentAliases,
             string clientId,
-            string upn,
-            string uniqueId,
-            string rawClientInfo)
+            string upn)
         {
-            var adalRts = GetAllAdalEntriesForMsal(logger, legacyCachePersistence, environmentAliases, clientId, upn, uniqueId, rawClientInfo);
+            var adalRts = GetAllAdalEntriesForMsal(logger, legacyCachePersistence, environmentAliases, clientId, upn);
 
             List<MsalRefreshTokenCacheItem> filteredByPrefEnv = adalRts.Where
                 (rt => rt.Environment.Equals(preferredEnvironment, StringComparison.OrdinalIgnoreCase)).ToList();

--- a/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.cs
@@ -616,7 +616,8 @@ namespace Microsoft.Identity.Client
                                 preferredEnvironmentHost,
                                 environmentAliases,
                                 requestParams.ClientId,
-                                upn);
+                                upn,
+                                requestParams.Account.HomeAccountId?.Identifier);
                         }
 
                         return null;
@@ -817,7 +818,6 @@ namespace Microsoft.Identity.Client
             {
                 foreach (MsalAccountCacheItem account in accountCacheItems)
                 {
-                    // todo: look at usage of homeaccountid if it's null....
                     if (RtMatchesAccount(rtItem, account))
                     {
                         clientInfoToAccountMap[rtItem.HomeAccountId] = new Account(
@@ -841,7 +841,6 @@ namespace Microsoft.Identity.Client
 
         private bool RtMatchesAccount(MsalRefreshTokenCacheItem rtItem, MsalAccountCacheItem account)
         {
-            // todo: validate homeaccountid
             bool homeAccIdMatch = rtItem.HomeAccountId.Equals(account.HomeAccountId, StringComparison.OrdinalIgnoreCase);
             bool clientIdMatch =
                 rtItem.IsFRT || // Cannot filter by client ID if the RT can be used by multiple clients


### PR DESCRIPTION
…id) that will never be non-null

When we need to do ADAL fallback from MSAL, we were doing the lookup based on account.HomeAccountId or requestParameters.LoginHint.  But an ADAL account will never have a HomeAccountId (by design) and we need to be able to look up by Account.UserName instead.