### PR TITLE
Add docs directory with markdown for developers of MSAL library

### DIFF
--- a/docs/CodeReviews.md
+++ b/docs/CodeReviews.md
@@ -1,0 +1,6 @@
+# Code Reviews and Coding Standards
+
+## Helpful Tools
+
+* Use the GitHub plugin for Visual Studio 2019 which can be installed from the Visual Studio Installer in order to view pull requests and do inline code reviews
+* Use the GitHub plugin for Visual Studio Code, [available from the marketplace](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)

--- a/docs/DevBoxSetup.md
+++ b/docs/DevBoxSetup.md
@@ -27,6 +27,12 @@ to build from the command line.
 
 * Android SDK level 27 (oreo) and 28 (pie), and Android SDK build tools 27.0.3 are also required. These are not installed through the VS Installer, so instead use the Android SDK Manager (Visual Studio > Tools > Android > Android SDK Manager…)
 
+### Optional but recommended tools
+
+* [Fiddler](https://www.telerik.com/fiddler)
+* [Visual Studio Code](https://code.visualstudio.com)
+
+
 ## Debugging or running samples on Windows 10
 
 * The dev-built binaries are not signed so you will regularly need to run `sn -Vr *` (from an admin console) to bypass strong name validation.  If you're at MSFT on CorpNet then group policy will likely revert this setting and you may need to run this often or setup a Scheduled Task.

--- a/docs/DevBoxSetup.md
+++ b/docs/DevBoxSetup.md
@@ -1,0 +1,77 @@
+# Dev Box Setup
+
+These instructions are for setting up your machine if you're working on the MSAL.NET library itself.
+
+## Windows Setup
+
+Windows is the primary development environment for the library at this time.
+VS for Mac is not able to understand and layout the project correctly.  You should be able
+to build from the command line.
+
+### Visual Studio 2019
+
+* Install or update VS 2019 (Community is sufficient but any SKU should work) with the following workloads:
+  * .Net Desktop Development
+  * Universal Windows Platform Development
+  * Mobile Development with .Net
+  * .Net Core cross-platform development
+
+* Then from the "Individual Components" tab, make sure these additional items are selected:
+  * .NET Framework 4.5 targeting pack
+  * .NET Framework 4.5.2 targeting pack
+  * .NET Framework 4.6.1 SDK
+  * .NET Framework 4.6.1 targeting pack
+  * .NET Framework 4.6.2 targeting pack
+  * Android SDK setup (API level 27)
+  * Windows 10 SDK (10.0.17134.0)
+
+* Android SDK level 27 (oreo) and 28 (pie), and Android SDK build tools 27.0.3 are also required. These are not installed through the VS Installer, so instead use the Android SDK Manager (Visual Studio > Tools > Android > Android SDK Manager…)
+
+## Debugging or running samples on Windows 10
+
+* The dev-built binaries are not signed so you will regularly need to run `sn -Vr *` (from an admin console) to bypass strong name validation.  If you're at MSFT on CorpNet then group policy will likely revert this setting and you may need to run this often or setup a Scheduled Task.
+* [Microsoft Only] You will need the Lab Certificate from [here](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/57f88e5d-dc7d-422b-b87a-e215ad6a352c/resourceGroups/DevEx_Automation/providers/Microsoft.KeyVault/vaults/BuildAutomation/certificates) installed on your machines in order to access the KeyVault containing passwords for the lab accounts.
+
+## Debugging or running samples on iOS
+
+* You will need a Macintosh running the latest macOS and XCode installed
+* From Visual Studio 2019 on the PC, go to Tools / iOS and select "Pair to Mac"
+* TODO: how to setup entitlements to get the simulator/samples to work
+
+## Debugging or running samples on macOS
+
+## Debugging or running samples on Android
+
+* As part of the Visual Studio 2019 installation on your PC, add the optional component "Intel Hardware Accelerated Execution Manager (HAXM) (local install)" from the Visual Studio Installer
+
+## Debugging or running samples on UWP
+
+## Build
+
+* Run <repo_root>/build/install_dependencies.ps1 from an admin powershell console to setup additional dependencies and environment variables
+* You can run <repo_root>/restore.ps1 to do a full NuGet package restore from the command line.
+* LibsNoSamples.sln is the base solution to build the library and run unit tests.  It does not contain sample or test applications so it builds faster and with less dependencies.
+* Load LibsAndSamples.sln for a bigger solution with lots of apps that exercise MSAL.
+
+## Run tests
+
+You won't be able to run the Integration test or Automation tests because they require access to a Microsoft KeyVault which is locked down. These tests will run as part of our DevOps pipelines though.
+
+Run the unit tests from the assemblies:
+
+- Microsoft.Identity.Test.Unit.net45
+- Microsoft.Identity.Test.Unit.netcore
+
+## Package
+
+From VS or from the command line if you wish to control the versioning:
+
+`msbuild <msal>.csproj /t:pack /p:MsalClientSemVer=3.1.0-preview`
+
+### Command Line
+
+Use `msbuild` commands - `msbuild /t:restore` and `msbuild`. Do not rely on `dotnet` command line because it is only for .Net Core, but this library has many other targets.
+
+Note: To enable us to target Xamarin as well as .Net core, we took a dependency on the MsBuild SDK extras - https://github.com/onovotny/MSBuildSdkExtras See this [issue](https://github.com/onovotny/MSBuildSdkExtras/issues/102) about using `dotnet`
+
+

--- a/docs/TestPassInstructions.md
+++ b/docs/TestPassInstructions.md
@@ -1,0 +1,150 @@
+# Manual Test Pass Instructions
+
+## Spreadsheet: [MSAL.NET Release Signoff Spreadsheet](https://microsoft.sharepoint.com/:x:/r/teams/aad/devex/_layouts/15/doc2.aspx?sourcedoc=%7B88CE7D1B-889A-4A32-93B9-942DD0FB7D8C%7D&file=dotNet%20MSAL%20Releases.xlsx)
+
+---
+## Web App calls graph on behalf of user
+* Insert first step here
+* Insert second step here
+
+---
+## Web API call graph on behalf of user
+---
+## Web App calls V1 Web API on behalf of user
+---
+## Web App calls V2 Web API on behalf of AAD user
+---
+## Web App calls V2 Web API on behalf of MSA user
+---
+## An ASP.NET Core web app with Azure AD B2C
+---
+## Enumerating through tenants - sample coming - 
+---
+## Domain/AAD Joined - Interactive Auth to handle Device Auth
+---
+## Hidden webview Auth with Prompt=never
+---
+## Application signing in users with B2C
+---
+## Foci happy path (2 Foci apps sharing the cache, A interactive, B silent). See OneNote for clientIds.
+---
+## Foci global sign out  
+
+Application: FociTestApp
+
+**TODO: add link to internal site with client ids**
+
+Foci happy path test
+* Start with empty cache
+* Login to Office interactively
+* Close app.
+* Login to Teams silently.
+
+Foci global sign-out test
+* Sign in into Office
+* Get Accounts using Teams – you should see the Office account
+* Sign out of one Teams
+* Get Accounts with Office – no accounts present
+
+**iOS / Android have FOCI disabled.**
+
+---
+## Multi-cloud for 1st parties 
+
+Application: MultiCloudTestApp
+
+**TODO: add link to internal site with client ids**
+
+The list of users you can login with is
+
+|Cloud|UPN|KeyVault|
+|-----|---|-------|
+|DE|DEIDLAB@blfmsidlab1.onmicrosoft.de|https://aka.ms/GetLabUserSecret?Secret=blfmsidlab1|
+|CN|idlab@mncmsidlab1.partner.onmschina.cn|https://aka.ms/GetLabUserSecret?Secret=mncmsidlab1|
+|Public|IDLAB@msidlab4.onmicrosoft.com|https://aka.ms/GetLabUserSecret?Secret=msidlab4|
+
+Happy path test case:
+* Sign in with DE user
+* Sign in with CN user
+* Sign in wih public cloud user
+* Silent sign in with CN, DE and public cloud user (in a different order)
+* Remove Accounts and verify each removal
+---
+## Silent Auth by using Refresh Token (AT is expired)
+---
+## Silent Auth for guest tenant authority
+---
+## Silent Auth with Refresh Token Rejected
+---
+## Silent Auth with Valid AT in Cache
+---
+## Silent Auth with ForceRefresh=true
+---
+## Silent Auth with ForceRefresh=true with B2C account
+---
+## Interactive Auth w/Prompt (force, consent, login, no_prompt) w/login hint
+---
+## Interactive Auth w/Prompt (select_account, consent, login, no_prompt) no login hint
+---
+## .NET Xamarin AcquireToken interactive auth with system browser
+---
+## Refresh token flow, no Broker
+---
+## Acquire Token w/Chrome disabled, launch alternate browser w/out custom tabs
+---
+## Acquire Token w/Chrome disabled and no browser installed on device
+---
+## Acquire Token w/Chrome disabled and launch alternate browser w/custom tabs
+---
+## Acquire Token w/Chrome disabled on Android device use IsSystemWebviewAvailable() helper method
+---
+## .NET AcquireToken with embedded webview with Xamarin
+---
+## Azure AD B2C with b2clogin.com 
+---
+## Azure AD B2C with b2clogin.com with prompt_none 
+---
+## Azure AD B2C with login.microsoftonline.com
+---
+## Azure AD B2C with custom domain
+---
+## Azure AD B2C ROPC
+---
+## .NET Embedded auth with Claims challenge - MFA
+---
+## Token Cache works cross platform - xamarin iOS to native iOS
+---
+## Token Cache works cross platform - C++ to .net
+---
+## Interactive auth. Restart App. Silent Auth. Do NOT use EQUIVALENT.
+---
+## Set custom serialization. Interactive Auth. Restart App. Silent Auth
+---
+## Set custom serialization. U/P Auth. Restart App. Silent Auth.
+---
+## ADAL V3 Token Cache is compatibile with MSAL token cache
+---
+## ADAL V4 Token Cache is compatibile with MSAL token cache (See comment).
+---
+## Token Cache supports authority migration
+---
+## Interactive Auth from an Xforms app - UWP, Android, iOS; Some code must be in common
+---
+## Token cache is backwards compatible (MSAL v_current to MSAL v_next). This includes ### platforms with custom token cache serialization.
+---
+## Integrated Auth, federated / managed user,  empty username.
+---
+## Username/Passsword, with username. All users (AAD, ADFS v4 Fed & NonFed, ADFSv3 Fed & NonFed, ADFV2 Fed)
+---
+## "Interactive auth, clear cache, interactive, silent. 
+---
+## AAD, ADFSv2, ADFSv3 (Fed, NonFed), ADSFv4 (Fed, NonFed)"
+---
+## DeviceCode registration followed by AcquireToken
+---
+## Verify that the 2 packages and their contents are signed
+---
+## Check the associated release build for warnings and inconclusive steps
+---
+## Smoke test a sample
+---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# MSAL Developer Documentation
+
+This documentation is for folks working on the MSAL library itself.  It includes how to setup your machine, build, test, and debug the library, test automation, samples, and so on.
+
+
+## Machine Setup
+* [DevBoxSetup](DevBoxSetup.md)
+
+## Build
+* [Code Reviews and Coding Standards](CodeReviews.md)
+
+## Test
+* [How to run a manual test pass](TestPassInstructions.md)
+
+## Telemetry
+* [MATS Schema](https://aka.ms/mats/schema)
+* [MATS Dashboard](https://aka.ms/mats/dashboard)
+
+## Important Links
+* [Docs](https://aka.ms/aaddevv2)
+* [Samples](https://aka.ms/aadsamplesv2)
+* [MSAL.NET Wiki](https://github.com/AzureAd/microsoft-authentication-library-for-dotnet/wiki)
+* [MSAL.NET GitHub](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+* [MSAL Extensions GitHub](https://github.com/azuread/microsoft-authentication-extensions-for-dotnet)
+* [ADAL.NET GitHub](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet)
+
+## Important Links (MS Employees Only)
+* [.NET Builds Dashboard](https://identitydivision.visualstudio.com/IDDP/_dashboards/dashboard/36f4b28e-e748-4ac1-9c4c-4a29c899b7d2)
+* [MSAL.NET V3 Release Build](https://identitydivision.visualstudio.com/IDDP/_build?definitionId=773)
+* [MSAL.NET Release Signoff Spreadsheet](https://microsoft.sharepoint.com/:x:/r/teams/aad/devex/_layouts/15/doc2.aspx?sourcedoc=%7B88CE7D1B-889A-4A32-93B9-942DD0FB7D8C%7D&file=dotNet%20MSAL%20Releases.xlsx)
+* [MSAL.NET OneNote](https://microsoft.sharepoint.com/teams/ADAL/_layouts/15/WopiFrame.aspx?sourcedoc={0339bdd6-b5e5-4d94-b4c9-ea47127f5023}&action=edit&wd=target%28_NET.one%7C9d48e37a-cb07-487f-866c-f6c524337949%2F%29&wdorigin=717)
+* [MS ID Labs](https://aka.ms/msidlab)
+* [Auth Libraries API Reviews](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequests?_a=mine)


### PR DESCRIPTION
Starting point of documentation for our libraries directly in the repo.  This will allow us to ensure that as we add test passes that we properly document them as part of a PR and if machine updates are needed (e.g. we need a new .net framework installed) then we ensure we update the docs with that change.  It's also easily viewable from browsing the repo on github (or within vscode with side-by-side preview).