### PR TITLE
updating msal to use $(AppIdentifierPrefix)$(CFBundleIdentifier) as t…

### DIFF
--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
         // Identifier for the keychain item used to retrieve current team ID
         private const string TeamIdKey = "DotNetTeamIDHint";
+        private const string DefaultKeychainAccessGroup = "com.microsoft.adalcache";
 
         private string _keychainGroup;
         private readonly RequestContext _requestContext;
@@ -35,9 +36,9 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
         public void SetiOSKeychainSecurityGroup(string keychainSecurityGroup)
         {
-            if (keychainSecurityGroup == null)
+            if (String.IsNullOrEmpty(keychainSecurityGroup))
             {
-                _keychainGroup = GetTeamId() + '.' + GetBundleId();
+                _keychainGroup = GetTeamId() + '.' + DefaultKeychainAccessGroup;
             }
             else
             {

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         private const bool _defaultSyncSetting = false;
         private const SecAccessible _defaultAccessiblityPolicy = SecAccessible.AfterFirstUnlockThisDeviceOnly;
 
-        private const string DefaultKeychainGroup = "com.microsoft.adalcache";
         // Identifier for the keychain item used to retrieve current team ID
         private const string TeamIdKey = "DotNetTeamIDHint";
 
@@ -38,7 +37,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         {
             if (keychainSecurityGroup == null)
             {
-                _keychainGroup = GetBundleId();
+                _keychainGroup = GetTeamId() + '.' + GetBundleId();
             }
             else
             {
@@ -75,7 +74,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
         public iOSTokenCacheAccessor()
         {
-            _keychainGroup = GetTeamId() + '.' + DefaultKeychainGroup;
+            SetiOSKeychainSecurityGroup(null);
         }
 
         public iOSTokenCacheAccessor(RequestContext requestContext) : this()

--- a/tests/devapps/XForms/XForms.iOS/Entitlements.plist
+++ b/tests/devapps/XForms/XForms.iOS/Entitlements.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
 	</array>
 </dict>
 </plist>

--- a/tests/devapps/XForms/XForms.iOS/Entitlements.plist
+++ b/tests/devapps/XForms/XForms.iOS/Entitlements.plist
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>keychain-access-groups</key>
-  <array>
-    <string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
-  </array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
 </dict>
 </plist>

--- a/tests/devapps/XForms/XForms/App.xaml.cs
+++ b/tests/devapps/XForms/XForms/App.xaml.cs
@@ -73,7 +73,6 @@ namespace XForms
             if (UseBroker)
             {
                 //builder.WithBroker(true);
-                builder = builder.WithIosKeychainSecurityGroup("com.microsoft.adalcache");
                 builder = builder.WithRedirectUri(BrokerRedirectUriOnIos);
             }
 
@@ -84,7 +83,6 @@ namespace XForms
                 {
                 case "iOS":
                     builder = builder.WithRedirectUri(RedirectUriOnIos);
-                    builder = builder.WithIosKeychainSecurityGroup("com.microsoft.adalcache");
                     break;
                 case "Android":
                     builder = builder.WithRedirectUri(RedirectUriOnAndroid);


### PR DESCRIPTION
updating MSAL to use $(AppIdentifierPrefix)$(CFBundleIdentifier) as the default access group. This was acquired from the [xamarin.iOS entitlements documentation](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/provisioning/entitlements?tabs=windows#keychain-sharing).
now users can set the entitlements.plist to the above default keychain access group to enable keychain access. If they would like to use a specific group, they can use the .WithIosKeychainSecurityGroup() method.
