### PR TITLE
Ensure JsonWebToken sets X509CertificatePublicCertValue on .NET Core

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Identity.Client.Internal
                     return;
                 }
 
-#if NETSTANDARD
+#if NETSTANDARD || NET_CORE
                 X509CertificatePublicCertValue = Convert.ToBase64String(credential.Certificate.RawData);
 #elif DESKTOP
                 X509CertificatePublicCertValue = Convert.ToBase64String(credential.Certificate.GetRawCertData());


### PR DESCRIPTION
When using WithSendX5c, the "x5c" token is not set when running on .NET Core. This change ensures this token gets set on all runtimes.