### PR TITLE
Disabling unstable test

### DIFF
--- a/tests/Microsoft.Identity.Test.iOS.UIAutomation/iOSTests.cs
+++ b/tests/Microsoft.Identity.Test.iOS.UIAutomation/iOSTests.cs
@@ -59,7 +59,7 @@ namespace Test.Microsoft.Identity.UIAutomation
             var tests = new List<Action>()
             {
                 AcquireTokenTest,
-                AcquireTokenSilentTest,
+                //AcquireTokenSilentTest,
                 AcquireTokenADFSV3InteractiveFederatedTest,
                 AcquireTokenADFSV3InteractiveNonFederatedTest,
                 AcquireTokenADFSV4InteractiveFederatedTest,


### PR DESCRIPTION
disabling temporarily.
Scenario will be covered by manual testing until resolved

BUG:
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1154