### PR TITLE
Add tracing to tests and product and a trace 2 file

### DIFF
--- a/src/Microsoft.Identity.Client/Instance/AadInstanceDiscovery.cs
+++ b/src/Microsoft.Identity.Client/Instance/AadInstanceDiscovery.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.Instance
 {
@@ -47,7 +49,10 @@ namespace Microsoft.Identity.Client.Instance
             Uri authority,
             RequestContext requestContext)
         {
-            if (!TryGetValue(authority.Host, out var entry))
+            bool foundInCache = TryGetValue(authority.Host, out var entry);
+            TraceWrapper.WriteLine("GetMetadataEntryAsync - response from cache? " + foundInCache);
+
+            if (!foundInCache)
             {
                 await DoInstanceDiscoveryAndCacheAsync(authority, requestContext).ConfigureAwait(false);
                 TryGetValue(authority.Host, out entry);

--- a/src/Microsoft.Identity.Client/Utils/TraceWrapper.cs
+++ b/src/Microsoft.Identity.Client/Utils/TraceWrapper.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace Microsoft.Identity.Client.Utils
+{
+    internal class TraceWrapper
+    {
+        public static void WriteLine(string message) 
+        {
+#if !NETSTANDARD && !WINDOWS_APP
+            Trace.WriteLine(message);
+#endif
+        }
+
+    }
+}

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
@@ -10,6 +10,7 @@ using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Test.Unit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Common.Core.Mocks
 {
@@ -19,9 +20,10 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             TelemetryCallback telemetryCallback = null,
             LogCallback logCallback = null,
             bool isExtendedTokenLifetimeEnabled = false,
-            string authority = ClientApplicationBase.DefaultAuthority)
+            string authority = ClientApplicationBase.DefaultAuthority,
+            TestContext testContext = null)
         {
-            HttpManager = new MockHttpManager();
+            HttpManager = new MockHttpManager(testContext);
             ServiceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(
                 HttpManager,
                 telemetryCallback: telemetryCallback,

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Identity.Test.Common
             string authority = ClientApplicationBase.DefaultAuthority,
             bool isExtendedTokenLifetimeEnabled = false,
             bool enablePiiLogging = false,
-            string clientId = MsalTestConstants.ClientId)
+            string clientId = MsalTestConstants.ClientId,
+            bool clearCaches = true)
         {
             var appConfig = new ApplicationConfiguration()
             {
@@ -41,7 +42,8 @@ namespace Microsoft.Identity.Test.Common
                 IsExtendedTokenLifetimeEnabled = isExtendedTokenLifetimeEnabled,
                 AuthorityInfo = AuthorityInfo.FromAuthorityUri(authority, false)
             };
-            return ServiceBundle.Create(appConfig);
+
+            return new ServiceBundle(appConfig, clearCaches);
         }
 
         public static IServiceBundle CreateDefaultServiceBundle()

--- a/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
@@ -13,21 +13,15 @@ using System;
 namespace Microsoft.Identity.Test.Unit
 {
     [TestClass]
-    public class BrokerParametersTest
+    public class BrokerParametersTest : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         public static readonly string CanonicalizedAuthority = AuthorityInfo.CanonicalizeAuthorityUri(CoreHelpers.UrlDecode(MsalTestConstants.AuthorityTestTenant));
 
         [TestMethod]
         [Description("Test setting of the broker parameters in the BrokerInteractiveRequest constructor.")]
         public void BrokerInteractiveRequest_CreateBrokerParametersTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // Arrange
                 var parameters = harness.CreateAuthenticationRequestParameters(

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheNotificationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheNotificationTests.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Identity.Test.Unit.CacheTests
 {
     [TestClass]
-    public class TokenCacheNotificationTests
+    public class TokenCacheNotificationTests : TestBase
     {
         [TestMethod]
         public async Task TestSubscribeNonAsync()
@@ -101,7 +101,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             var sb = new StringBuilder();
 
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheTests.cs
@@ -24,39 +24,19 @@ using NSubstitute;
 namespace Microsoft.Identity.Test.Unit.CacheTests
 {
     [TestClass]
-    public class TokenCacheTests
+    public class TokenCacheTests : TestBase
     {
         public static long ValidExpiresIn = 3600;
         public static long ValidExtendedExpiresIn = 7200;
 
         private readonly TokenCacheHelper _tokenCacheHelper = new TokenCacheHelper();
 
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
-        private void AddHostToInstanceCache(IServiceBundle serviceBundle, string host)
-        {
-            serviceBundle.AadInstanceDiscovery.TryAddValue(
-                host,
-                new InstanceDiscoveryMetadataEntry
-                {
-                    PreferredNetwork = host,
-                    PreferredCache = host,
-                    Aliases = new string[]
-                    {
-                        host
-                    }
-                });
-        }
 
         [TestMethod]
         [TestCategory("TokenCacheTests")]
         public void GetExactScopesMatchedAccessTokenTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -88,7 +68,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetSubsetScopesMatchedAccessTokenTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -126,7 +106,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetIntersectedScopesMatchedAccessTokenTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -166,7 +146,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetExpiredAccessTokenTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -197,7 +177,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetExpiredAccessToken_WithExtendedExpireStillValid_Test()
         {
-            using (var harness = new MockHttpAndServiceBundle(isExtendedTokenLifetimeEnabled: true))
+            using (var harness = CreateTestHarness(isExtendedTokenLifetimeEnabled: true))
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -232,7 +212,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetAccessTokenExpiryInRangeTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -263,7 +243,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetRefreshTokenTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -296,10 +276,9 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         }
 
         [TestMethod]
-        [TestCategory("TokenCacheTests")]
         public void GetRefreshTokenDifferentEnvironmentTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -318,7 +297,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     account: MsalTestConstants.User);
 
                 var rt = cache.FindRefreshTokenAsync(authParams).Result;
-                Assert.IsNull(rt);
+                Assert.IsNull(rt);                
             }
         }
 
@@ -327,7 +306,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetAppTokenFromCacheTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -399,7 +378,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetAccessTokenNoUserAssertionInCacheTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -440,7 +419,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetAccessTokenUserAssertionMismatchInCacheTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -481,7 +460,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestCategory("TokenCacheTests")]
         public void GetAccessTokenMatchedUserAssertionInCacheTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -549,7 +528,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public async Task NoAppMetadata_WhenFociIsDisabledAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // Arrange
                 var testFlags = Substitute.For<IFeatureFlags>();
@@ -943,7 +922,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void TestIsFociMember()
         {
             // Arrange
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -981,7 +960,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void TestIsFociMember_EnvAlias()
         {
             // Arrange
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
@@ -1021,6 +1000,21 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // Assert
             Assert.AreEqual(expectedResult, result, errMessage);
             Assert.AreEqual(1, cache.Accessor.GetAllAppMetadata().Count());
+        }
+
+        private void AddHostToInstanceCache(IServiceBundle serviceBundle, string host)
+        {
+            serviceBundle.AadInstanceDiscovery.TryAddValue(
+                host,
+                new InstanceDiscoveryMetadataEntry
+                {
+                    PreferredNetwork = host,
+                    PreferredCache = host,
+                    Aliases = new string[]
+                    {
+                        host
+                    }
+                });
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheFormatTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheFormatTests.cs
@@ -29,14 +29,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
     [DeploymentItem(@"Resources\MSATestData.txt")]
     [DeploymentItem(@"Resources\B2CNoTenantIdTestData.txt")]
     [DeploymentItem(@"Resources\B2CWithTenantIdTestData.txt")]
-    public class UnifiedCacheFormatTests
+    public class UnifiedCacheFormatTests : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         private void Init(MockHttpManager httpManager)
         {
             httpManager.AddMockHandler(
@@ -133,7 +127,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [Description("Test unified token cache")]
         public async Task AAD_CacheFormatValidationTestAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("AADTestData.txt"));
                 Init(harness.HttpManager);
@@ -145,7 +139,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [Description("Test unified token cache")]
         public async Task MSA_CacheFormatValidationTestAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("MSATestData.txt"));
                 Init(harness.HttpManager);
@@ -158,7 +152,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [Ignore] // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1037
         public async Task B2C_NoTenantId_CacheFormatValidationTestAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 TestCommon.ResetInternalStaticCaches();
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("B2CNoTenantIdTestData.txt"));
@@ -173,7 +167,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         // test data generated based on GUID, Msal uses tenantId from passed in authotiry
         public async Task B2C_WithTenantId_CacheFormatValidationTestAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("B2CWithTenantIdTestData.txt"));
                 await RunCacheFormatValidationAsync(harness).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheTests.cs
@@ -22,14 +22,8 @@ using System.Threading.Tasks;
 namespace Microsoft.Identity.Test.Unit.CacheTests
 {
     [TestClass]
-    public class UnifiedCacheTests
-    {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
+    public class UnifiedCacheTests : TestBase
+    {    
         [TestMethod]
         [Description("Test unified token cache")]
         public void UnifiedCache_MsalStoresToAndReadRtFromAdalCache()
@@ -189,7 +183,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [Description("Test for duplicate key in ADAL cache")]
         public void UnifiedCache_ProcessAdalDictionaryForDuplicateKeyTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 var app = PublicClientApplicationBuilder
                           .Create(MsalTestConstants.ClientId).WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheV2Tests/TokenCacheV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheV2Tests/TokenCacheV2Tests.cs
@@ -19,7 +19,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Identity.Test.Unit.CacheV2Tests
 {
     [TestClass]
-    public class TokenCacheV2Tests
+    public class TokenCacheV2Tests : TestBase
     {
         private InMemoryCachePathStorage _cachePathStorage;
         private FileSystemCredentialPathManager _credentialPathManager;
@@ -29,9 +29,9 @@ namespace Microsoft.Identity.Test.Unit.CacheV2Tests
         private const string TheSecret = "the_secret";
 
         [TestInitialize]
-        public void TestInitialize()
+        public override void TestInitialize()
         {
-            TestCommon.ResetInternalStaticCaches();
+            base.TestInitialize();
 
             var serviceBundle = TestCommon.CreateDefaultServiceBundle();
             _cachePathStorage = new InMemoryCachePathStorage();
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Test.Unit.CacheV2Tests
                     atItem
                 });
 
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // TODO:  In MSALC++, the request parameters only really needs the
                 // Authority URI itself since the cache isn't meant to

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -22,19 +22,13 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
     [TestClass]
     [DeploymentItem("Resources\\OpenidConfiguration.json")]
     [DeploymentItem("Resources\\OpenidConfiguration-MissingFields.json")]
-    public class AadAuthorityTests
+    public class AadAuthorityTests : TestBase
     {
-        [TestInitialize]
-        public void Init()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         [TestMethod]
         [TestCategory("AadAuthorityTests")]
         public void SuccessfulValidationTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for instance validation
                 harness.HttpManager.AddMockHandler(
@@ -90,7 +84,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AadAuthorityTests")]
         public void ValidationOffSuccessTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for tenant endpoint discovery
                 harness.HttpManager.AddMockHandler(
@@ -127,7 +121,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AadAuthorityTests")]
         public void FailedValidationTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for instance validation
                 harness.HttpManager.AddMockHandler(
@@ -179,7 +173,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AadAuthorityTests")]
         public void FailedValidationMissingFieldsTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for instance validation
                 harness.HttpManager.AddMockHandler(
@@ -220,7 +214,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AadAuthorityTests")]
         public void FailedTenantDiscoveryMissingEndpointsTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for tenant endpoint discovery
                 harness.HttpManager.AddMockHandler(

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AdfsAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AdfsAuthorityTests.cs
@@ -26,25 +26,14 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
     [DeploymentItem("Resources\\OpenidConfiguration-OnPremise.json")]
     [DeploymentItem("Resources\\OpenidConfiguration-MissingFields-OnPremise.json")]
     [Ignore] // disable until we support ADFS
-    public class AdfsAuthorityTests
+    public class AdfsAuthorityTests : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-
-        }
 
         [TestMethod]
         [TestCategory("AdfsAuthorityTests")]
         public void SuccessfulValidationUsingOnPremiseDrsTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for on-premise DRS request
                 harness.HttpManager.AddMockHandler(
@@ -121,7 +110,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AdfsAuthorityTests")]
         public void SuccessfulValidationUsingCloudDrsFallbackTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock failure response for on-premise DRS request
                 harness.HttpManager.AddMockHandler(
@@ -197,7 +186,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AdfsAuthorityTests")]
         public void ValidationOffSuccessTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for tenant endpoint discovery
                 harness.HttpManager.AddMockHandler(
@@ -230,7 +219,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AdfsAuthorityTests")]
         public void FailedValidationTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for on-premise DRS request
                 harness.HttpManager.AddMockHandler(
@@ -286,7 +275,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AdfsAuthorityTests")]
         public void FailedValidationResourceNotInTrustedRealmTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for on-premise DRS request
                 harness.HttpManager.AddMockHandler(
@@ -341,7 +330,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AdfsAuthorityTests")]
         public void FailedValidationMissingFieldsInDrsResponseTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock failure response for on-premise DRS request
                 harness.HttpManager.AddMockHandler(
@@ -382,7 +371,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestCategory("AdfsAuthorityTests")]
         public void FailedTenantDiscoveryMissingEndpointsTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for tenant endpoint discovery
                 harness.HttpManager.AddMockHandler(

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/B2cAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/B2cAuthorityTests.cs
@@ -16,19 +16,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
     [TestClass]
     [DeploymentItem("Resources\\OpenidConfiguration-B2C.json")]
     [DeploymentItem("Resources\\OpenidConfiguration-B2CLogin.json")]
-    public class B2CAuthorityTests
+    public class B2CAuthorityTests : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-        }
-
         [TestMethod]
         [TestCategory("B2CAuthorityTests")]
         public void NotEnoughPathSegmentsTest()
@@ -106,7 +95,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [Ignore] // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1038
         public void B2CMicrosoftOnlineCreateAuthority()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 // add mock response for tenant endpoint discovery
                 harness.HttpManager.AddMockHandler(

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/OAuth2Tests/TokenResponseTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/OAuth2Tests/TokenResponseTests.cs
@@ -16,14 +16,8 @@ using Microsoft.Identity.Test.Common;
 namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
 {
     [TestClass]
-    public class TokenResponseTests
+    public class TokenResponseTests : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         [TestMethod]
         [TestCategory("TokenResponseTests")]
         public void ExpirationTimeTest()
@@ -42,7 +36,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
         [TestCategory("TokenResponseTests")]
         public void JsonDeserializationTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(MsalTestConstants.AuthorityCommonTenant);
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/Telemetry/XmsCliTelemTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/Telemetry/XmsCliTelemTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.Telemetry
     [TestClass]
     public class XmsCliTelemTests
     {
-        private RequestContext _requestContext;
         private ICoreLogger _coreLogger;
 
         [TestInitialize]

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/MexParserTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/MexParserTests.cs
@@ -17,16 +17,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
 {
     [TestClass]
     [DeploymentItem(@"Resources\TestMex2005.xml")]
-    public class MexParserTests
+    public class MexParserTests : TestBase
     {
-        public TestContext TestContext { get; set; }
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         [TestMethod]
         [Description("WS-Trust Address Extraction Test")]
         public void WsTrust2005AddressExtractionTest()
@@ -58,7 +50,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
         public async Task MexEndpointFailsToResolveTestAsync()
         {
             // TODO: should we move this into a separate test class for WsTrustWebRequestManager?
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddMockHandlerContentNotFound(HttpMethod.Get);
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
@@ -17,14 +17,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
 {
     [TestClass]
     [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
-    public class WsTrustTests
+    public class WsTrustTests : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         [TestMethod]
         [Description("WS-Trust Request Test")]
         public async Task WsTrustRequestTestAsync()
@@ -32,7 +26,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
             string wsTrustAddress = "https://some/address/usernamemixed";
             var endpoint = new WsTrustEndpoint(new Uri(wsTrustAddress), WsTrustVersion.WsTrust13);
 
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler()
@@ -62,7 +56,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
             string uri = "https://some/address/usernamemixed";
             var endpoint = new WsTrustEndpoint(new Uri(uri), WsTrustVersion.WsTrust13);
 
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddMockHandlerContentNotFound(HttpMethod.Post, url: uri);
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/MatsTests/MatsPublicClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/MatsTests/MatsPublicClientTests.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Identity.Test.Unit.MatsTests
 {
     [TestClass]
-    public class MatsPublicClientTests
+    public class MatsPublicClientTests : TestBase
     {
         private const string AppName = "The app Name";
         private const string AppVersion = "1.2.3.4";
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Test.Unit.MatsTests
         {
             var batches = new List<IMatsTelemetryBatch>();
 
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 var pca = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                     .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)

--- a/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
@@ -20,20 +20,14 @@ using static Microsoft.Identity.Test.Unit.RequestsTests.InteractiveRequestTests;
 namespace Microsoft.Identity.Test.Unit
 {
     [TestClass]
-    public class OAuthClientTests
+    public class OAuthClientTests : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         [TestMethod]
         public void RedirectUriContainsFragmentErrorTest()
         {
             try
             {
-                using (var harness = new MockHttpAndServiceBundle())
+                using (var harness = CreateTestHarness())
                 {
                     AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                         MsalTestConstants.AuthorityHomeTenant,
@@ -169,9 +163,9 @@ namespace Microsoft.Identity.Test.Unit
                 });
         }
 
-        private static void ValidateOathClient(HttpResponseMessage httpResponseMessage, Action<Exception> validationHandler)
+        private void ValidateOathClient(HttpResponseMessage httpResponseMessage, Action<Exception> validationHandler)
         {
-            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Identity.Test.Unit
     [TestClass]
     [DeploymentItem(@"Resources\valid_cert.pfx")]
     [DeploymentItem(@"Resources\testCert.crtfile")]
-    public class ConfidentialClientWithCertTests
+    public class ConfidentialClientWithCertTests : TestBase
     {
         private static MockHttpMessageHandler CreateTokenResponseHttpHandlerWithX5CValidation(bool clientCredentialFlow)
         {
@@ -56,13 +56,6 @@ namespace Microsoft.Identity.Test.Unit
                           MockHelpers.CreateClientInfo(MsalTestConstants.Uid, MsalTestConstants.Utid + "more"));
         }
 
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-
-        }
-
         internal void SetupMocks(MockHttpManager httpManager)
         {
             httpManager.AddInstanceDiscoveryMockHandler();
@@ -73,7 +66,7 @@ namespace Microsoft.Identity.Test.Unit
         [Description("Test for client assertion with X509 public certificate using sendCertificate")]
         public async Task JsonWebTokenWithX509PublicCertSendCertificateTestAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 SetupMocks(harness.HttpManager);
                 var certificate = new X509Certificate2(
@@ -110,7 +103,7 @@ namespace Microsoft.Identity.Test.Unit
         [Description("Test for client assertion with X509 public certificate using sendCertificate")]
         public async Task JsonWebTokenWithX509PublicCertSendCertificateOnBehalfOfTestAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 SetupMocks(harness.HttpManager);
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -1,20 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.Cache.Items;
-using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Mats.Internal.Constants;
-using Microsoft.Identity.Client.Mats.Internal.Events;
-using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.UI;
-using Microsoft.Identity.Client.Utils;
-using Microsoft.Identity.Test.Common;
-using Microsoft.Identity.Test.Common.Core.Helpers;
-using Microsoft.Identity.Test.Common.Core.Mocks;
-using Microsoft.Identity.Test.Common.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSubstitute;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -23,19 +9,29 @@ using System.Net.Http;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Mats.Internal.Constants;
+using Microsoft.Identity.Client.Mats.Internal.Events;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Common.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.PublicApiTests
 {
     [TestClass]
-    public class PublicClientApplicationTests
+    public class PublicClientApplicationTests : TestBase
     {
         private TokenCacheHelper _tokenCacheHelper;
 
         [TestInitialize]
-        public void TestInitialize()
+        public override void TestInitialize()
         {
-            TestCommon.ResetInternalStaticCaches();
-
+            base.TestInitialize();
             _tokenCacheHelper = new TokenCacheHelper();
         }
 
@@ -145,7 +141,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             var receiver = new MyReceiver();
 
-            using (var harness = new MockHttpAndServiceBundle(telemetryCallback: receiver.HandleTelemetryEvents))
+            using (var harness = CreateTestHarness(telemetryCallback: receiver.HandleTelemetryEvents))
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
@@ -195,7 +191,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             var receiver = new MyReceiver();
 
-            using (var harness = new MockHttpAndServiceBundle(telemetryCallback: receiver.HandleTelemetryEvents))
+            using (var harness = CreateTestHarness(telemetryCallback: receiver.HandleTelemetryEvents))
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
@@ -235,7 +231,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [TestCategory("PublicClientApplicationTests")]
         public async Task AcquireTokenNoClientInfoReturnedTestAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
@@ -280,7 +276,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [TestCategory("PublicClientApplicationTests")]
         public void AcquireTokenSameUserTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
@@ -330,7 +326,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [TestCategory("PublicClientApplicationTests")]
         public void AcquireTokenAddTwoUsersTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
@@ -950,7 +946,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [TestCategory("B2C")]
         public void B2CAcquireTokenWithB2CLoginAuthorityTest()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 ValidateB2CLoginAuthority(harness, MsalTestConstants.B2CAuthority);
                 ValidateB2CLoginAuthority(harness, MsalTestConstants.B2CLoginAuthority);

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
@@ -16,15 +16,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
     [TestClass]
-    public class BrokerRequestTests
+    public class BrokerRequestTests : TestBase
     {
         private BrokerInteractiveRequest _brokerInteractiveRequest;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
 
         [TestMethod]
         [TestCategory("BrokerRequestTests")]
@@ -118,7 +112,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
         private void CreateBrokerHelper()
         {
-            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
                 AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityHomeTenant,

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/DeviceCodeRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/DeviceCodeRequestTests.cs
@@ -26,7 +26,7 @@ using Microsoft.Identity.Test.Common;
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
     [TestClass]
-    public class DeviceCodeRequestTests
+    public class DeviceCodeRequestTests : TestBase
     {
         private const string ExpectedDeviceCode =
             "BAQABAAEAAADXzZ3ifr-GRbDT45zNSEFEfU4P-bZYS1vkvv8xiXdb1_zX2xAcdcfEoei1o-t9-zTB9sWyTcddFEWahP1FJJJ_YVA1zvPM2sV56d_8O5G23ti5uu0nRbIsniczabYYEr-2ZsbgRO62oZjKlB1zF3EkuORg2QhMOjtsk-KP0aw8_iAA";
@@ -60,11 +60,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             $"\"message\":\"{ExpectedMessage}\"," +
             $"}}";
 
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
+
 
         private HttpResponseMessage CreateDeviceCodeResponseSuccessMessage()
         {
@@ -82,7 +78,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             const int NumberOfAuthorizationPendingRequestsToInject = 1;
 
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 var parameters = CreateAuthenticationParametersAndSetupMocks(
                     harness,
@@ -194,7 +190,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("DeviceCodeRequestTests")]
         public async Task TestDeviceCodeCancelAsync()
         {
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 const int NumberOfAuthorizationPendingRequestsToInject = 0;
                 var parameters = CreateAuthenticationParametersAndSetupMocks(
@@ -233,7 +229,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
             var logCallbacks = new List<_LogData>();
 
-            using (var harness = new MockHttpAndServiceBundle(logCallback: (level, message, pii) =>
+            using (var harness = CreateTestHarness(logCallback: (level, message, pii) =>
             {
                 if (level == LogLevel.Error)
                 {

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/FociTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/FociTests.cs
@@ -20,7 +20,7 @@ using NSubstitute;
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
     [TestClass]
-    public class FociTests
+    public class FociTests : TestBase
     {
         private enum ServerTokenResponse
         {
@@ -39,7 +39,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestInitialize]
         public void Init()
         {
-            TestCommon.ResetInternalStaticCaches();
+            base.TestInitialize();
+
             _inMemoryCache = "{}";
             _instanceAndEndpointRequestPerformed = false;
         }
@@ -51,7 +52,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         public async Task FociHappyPathAsync()
         {
             // Arrange
-            using (_harness = new MockHttpAndServiceBundle())
+            using (_harness = CreateTestHarness())
             {
                 InitApps();
 
@@ -75,7 +76,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestMethod]
         public async Task FociAndNonFociAppsCoexistAsync()
         {
-            using (_harness = new MockHttpAndServiceBundle())
+            using (_harness = CreateTestHarness())
             {
                 InitApps();
 
@@ -105,7 +106,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [WorkItem(1067)] // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1067
         public async Task FociDoesNotHideRTRefreshErrorsAsync()
         {
-            using (_harness = new MockHttpAndServiceBundle())
+            using (_harness = CreateTestHarness())
             {
                 InitApps();
 
@@ -134,7 +135,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestMethod]
         public async Task FociAppWithTokensJoinsFamilyAsync()
         {
-            using (_harness = new MockHttpAndServiceBundle())
+            using (_harness = CreateTestHarness())
             {
                 InitApps();
 
@@ -165,7 +166,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestMethod]
         public async Task FociAppLeavesFamilyAsync()
         {
-            using (_harness = new MockHttpAndServiceBundle())
+            using (_harness = CreateTestHarness())
             {
                 InitApps();
 
@@ -191,7 +192,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestMethod]
         public async Task TestGetAndRemoveAccountsFociDisabledAsync()
         {
-            using (_harness = new MockHttpAndServiceBundle())
+            using (_harness = CreateTestHarness())
             {
                 InitApps();
 
@@ -230,7 +231,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestMethod]
         public async Task TestGetAndRemoveAccountsFociEnabledAsync()
         {
-            using (_harness = new MockHttpAndServiceBundle())
+            using (_harness = CreateTestHarness())
             {
                 InitApps();
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
@@ -25,14 +25,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
     [TestClass]
-    public class InteractiveRequestTests
+    public class InteractiveRequestTests : TestBase
     {
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
-
         [TestMethod]
         public void NullArgs()
         {
@@ -70,7 +64,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 MsalTestConstants.ExtraQueryParams.ToDictionary(e => e.Key, e => e.Value);
             extraQueryParamsAndClaims.Add(OAuth2Parameter.Claims, MsalTestConstants.Claims);
 
-            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
                 var cache = new TokenCache(harness.ServiceBundle);
 
@@ -127,7 +121,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             MyReceiver myReceiver = new MyReceiver();
 
-            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle(telemetryCallback: myReceiver.HandleTelemetryEvents))
+            using (MockHttpAndServiceBundle harness = CreateTestHarness(telemetryCallback: myReceiver.HandleTelemetryEvents))
             {
                 TokenCache cache = new TokenCache(harness.ServiceBundle);
 
@@ -208,7 +202,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             try
             {
-                using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
+                using (MockHttpAndServiceBundle harness = CreateTestHarness())
                 {
                     AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                         MsalTestConstants.AuthorityHomeTenant,
@@ -245,7 +239,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void VerifyAuthorizationResultTest()
         {
-            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
                 MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
 
@@ -316,7 +310,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void DuplicateQueryParameterErrorTest()
         {
-            using (MockHttpAndServiceBundle harness = new MockHttpAndServiceBundle())
+            using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 harness.HttpManager.AddMockHandlerForTenantEndpointDiscovery(MsalTestConstants.AuthorityHomeTenant);

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
@@ -21,15 +21,9 @@ using NSubstitute;
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
     [TestClass]
-    public class InteractiveRequestWithCustomWebUiTests
+    public class InteractiveRequestWithCustomWebUiTests : TestBase
     {
         private const string ExpectedRedirectUri = "https://theredirecturi";
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            TestCommon.ResetInternalStaticCaches();
-        }
 
         private static void MockInstanceDiscoveryAndOpenIdRequest(MockHttpManager mockHttpManager)
         {
@@ -37,7 +31,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             mockHttpManager.AddMockHandlerForTenantEndpointDiscovery(MsalTestConstants.AuthorityHomeTenant);
         }
 
-        private static async Task ExecuteTestAsync(
+        private async Task ExecuteTestAsync(
             bool withTokenRequest,
             Action<ICustomWebUi> customizeWebUiBehavior,
             Func<InteractiveRequest, Task> executionBehavior)
@@ -45,7 +39,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             var customWebUi = Substitute.For<ICustomWebUi>();
             customizeWebUiBehavior(customWebUi);
 
-            using (var harness = new MockHttpAndServiceBundle())
+            using (var harness = CreateTestHarness())
             {
                 MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/TestBase.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/TestBase.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit
+{
+    [TestClass]
+    public class TestBase
+    {
+        [AssemblyInitialize]
+        public static void AssemblyInit(TestContext context)
+        {
+            EnableFileTracingOnEnvVar();
+            Trace.WriteLine("Test run started");
+        }
+
+        [AssemblyCleanup()]
+        public static void AssemblyCleanup()
+        {
+            Trace.WriteLine("Test run finished");
+            Trace.Flush();
+        }
+
+        [TestInitialize]
+        public virtual void TestInitialize()
+        {
+            Trace.WriteLine("Test started " + TestContext.TestName);
+            TestCommon.ResetInternalStaticCaches();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Trace.WriteLine("Test finished " + TestContext.TestName);
+        }
+
+        public TestContext TestContext { get; set; }
+
+        internal MockHttpAndServiceBundle CreateTestHarness(
+            TelemetryCallback telemetryCallback = null,
+            LogCallback logCallback = null,
+            bool isExtendedTokenLifetimeEnabled = false)
+        {
+            return new MockHttpAndServiceBundle(
+                telemetryCallback,
+                logCallback,
+                isExtendedTokenLifetimeEnabled,
+                testContext: TestContext);
+        }
+
+
+        private static void EnableFileTracingOnEnvVar()
+        {
+            string traceFile = Environment.GetEnvironmentVariable("MsalTracePath");
+
+            if (!String.IsNullOrEmpty(traceFile))
+            {
+                Trace.Listeners.Add(new TextWriterTraceListener(traceFile, "testListener"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will help debugging threading issues. Tracing is lower level than logging and has a reduced impact (in production, calls to Trace are ignored if no trace listener is registered, in VS traces are routed to the Output window and we can register a trace programatically). 