### PR TITLE
updating comment on acquire token silent api

### DIFF
--- a/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -161,9 +161,7 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-acquiretokensilent for more details
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="account">Account for which the token is requested.
-        /// If nothing is passed and no Account or LoginHint are provided, then, if one, and only
-        /// one, account is in the cache, that account is used.  Otherwise, an exception will be thrown.  <see cref="IAccount"/></param>
+        /// <param name="account">Account for which the token is requested.</param>
         /// <returns>An <see cref="AcquireTokenSilentParameterBuilder"/> used to build the token request, adding optional
         /// parameters</returns>
         /// <exception cref="MsalUiRequiredException">will be thrown in the case where an interaction is required with the end user of the application,

--- a/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-acquiretokensilent for more details
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="account">Account for which the token is requested. This parameter is optional.
+        /// <param name="account">Account for which the token is requested.
         /// If nothing is passed and no Account or LoginHint are provided, then, if one, and only
         /// one, account is in the cache, that account is used.  Otherwise, an exception will be thrown.  <see cref="IAccount"/></param>
         /// <returns>An <see cref="AcquireTokenSilentParameterBuilder"/> used to build the token request, adding optional


### PR DESCRIPTION
for the public method public AcquireTokenSilentParameterBuilder AcquireTokenSilent(IEnumerable<string> scopes, IAccount account),

The comment said that the account parameter was optional. However, if you do not pass in an account, MSAL throws an MsalUiRequiredException stating that no account was passed into the method. thus, the comment is wrong. 

