### PR TITLE
Alterntive approach to locking issue

### DIFF
--- a/src/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Identity.Client
                     }
                     var args = new TokenCacheNotificationArgs
                     {
-                        TokenCache = new NoLockTokenCacheProxy(this),
+                        // TokenCache = new NoLockTokenCacheProxy(this),
+                        TokenCache = this,
                         ClientId = ClientId,
                         Account = account,
                         HasStateChanged = true
@@ -252,7 +253,9 @@ namespace Microsoft.Identity.Client
                 MsalAccessTokenCacheItem msalAccessTokenCacheItem;
                 TokenCacheNotificationArgs args = new TokenCacheNotificationArgs
                 {
-                    TokenCache = new NoLockTokenCacheProxy(this),
+                    //TokenCache = new NoLockTokenCacheProxy(this),
+                    TokenCache = this,
+
                     ClientId = ClientId,
                     Account = requestParams.Account
                 };
@@ -395,7 +398,8 @@ namespace Microsoft.Identity.Client
 
                     TokenCacheNotificationArgs args = new TokenCacheNotificationArgs
                     {
-                        TokenCache = new NoLockTokenCacheProxy(this),
+                        //TokenCache = new NoLockTokenCacheProxy(this),
+                        TokenCache = this,
                         ClientId = ClientId,
                         Account = requestParams.Account
                     };
@@ -478,7 +482,8 @@ namespace Microsoft.Identity.Client
 
             TokenCacheNotificationArgs args = new TokenCacheNotificationArgs
             {
-                TokenCache = new NoLockTokenCacheProxy(this),
+                //TokenCache = new NoLockTokenCacheProxy(this),
+                TokenCache = this,
                 ClientId = ClientId,
                 Account = requestParams?.Account,
                 HasStateChanged = false
@@ -519,7 +524,8 @@ namespace Microsoft.Identity.Client
             {
                 TokenCacheNotificationArgs args = new TokenCacheNotificationArgs
                 {
-                    TokenCache = new NoLockTokenCacheProxy(this),
+                    //TokenCache = new NoLockTokenCacheProxy(this),
+                    TokenCache = this,
                     ClientId = ClientId,
                     Account = null
                 };
@@ -560,7 +566,8 @@ namespace Microsoft.Identity.Client
             {
                 var args = new TokenCacheNotificationArgs
                 {
-                    TokenCache = new NoLockTokenCacheProxy(this),
+                    //TokenCache = new NoLockTokenCacheProxy(this),
+                    TokenCache = this,
                     ClientId = ClientId,
                     Account = null
                 };
@@ -691,7 +698,8 @@ namespace Microsoft.Identity.Client
                 {
                     var args = new TokenCacheNotificationArgs
                     {
-                        TokenCache = new NoLockTokenCacheProxy(this),
+                        //TokenCache = new NoLockTokenCacheProxy(this),
+                        TokenCache = this,
                         ClientId = ClientId,
                         Account = account,
                         HasStateChanged = true
@@ -784,7 +792,8 @@ namespace Microsoft.Identity.Client
             {
                 TokenCacheNotificationArgs args = new TokenCacheNotificationArgs
                 {
-                    TokenCache = new NoLockTokenCacheProxy(this),
+                    //TokenCache = new NoLockTokenCacheProxy(this),
+                    TokenCache = this,
                     ClientId = ClientId,
                     Account = null,
                     HasStateChanged = true

--- a/src/Microsoft.Identity.Client/TokenCache.Serialization.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.Serialization.cs
@@ -157,14 +157,14 @@ namespace Microsoft.Identity.Client
         {
             GuardOnMobilePlatforms();
 
-            _semaphoreSlim.Wait();
+            _semaphoreSlimTC.Wait();
             try
             {
                 return SerializeMsalV3NoLocks();
             }
             finally
             {
-                _semaphoreSlim.Release();
+                _semaphoreSlimTC.Release();
             }
         }
 
@@ -191,14 +191,14 @@ namespace Microsoft.Identity.Client
         {
             GuardOnMobilePlatforms();
 
-            _semaphoreSlim.Wait();
+            _semaphoreSlimTC.Wait();
             try
             {
                 DeserializeMsalV3NoLocks(msalV3State, shouldClearExistingCache);
             }
             finally
             {
-                _semaphoreSlim.Release();
+                _semaphoreSlimTC.Release();
             }
         }
 

--- a/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Identity.Client
 
         internal IServiceBundle ServiceBundle { get; }
         internal ILegacyCachePersistence LegacyCachePersistence { get; }
-        internal readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
+        internal  SemaphoreSlim _semaphoreSlim { get; } = new SemaphoreSlim(1, 1);
+        internal  SemaphoreSlim _semaphoreSlimTC { get; } = new SemaphoreSlim(1, 1);
+
+
         internal string ClientId => ServiceBundle.Config.ClientId;
 
         ITokenCacheAccessor ITokenCacheInternal.Accessor => _accessor;


### PR DESCRIPTION
I probably didn't think this through entirely, but I did test it with @jmprieur sample. The idea is to not use a no-locking token cache proxy. Instead, we use 2 semaphores, 1 for locking all the high level token cache operations (e.g. SaveTokens) and a separate one for low level notifications. The second one is only used by the syncronous notifications. 

Would be great to review (code is prototype quality, no tests etc.) and see if you can think of a deadlock scenario. 

