### PR TITLE
Implementing sendX5C on silent client credential call

### DIFF
--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Specifies if the x5c claim (public key of the certificate) should be sent to the STS.
-        /// Sending the x5x enables application developers to achieve easy certificate roll-over in Azure AD:
+        /// Sending the x5c enables application developers to achieve easy certificate roll-over in Azure AD:
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -94,6 +94,24 @@ namespace Microsoft.Identity.Client
         internal override ApiTelemetryId ApiTelemetryId => ApiTelemetryId.AcquireTokenSilent;
 
         /// <summary>
+        /// Specifies if the x5c claim (public key of the certificate) should be sent to the STS.
+        /// Sending the x5x enables application developers to achieve easy certificate roll-over in Azure AD:
+        /// this method will send the public certificate to Azure AD along with the token request,
+        /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
+        /// This saves the application admin from the need to explicitly manage the certificate rollover
+        /// (either via portal or powershell/CLI operation)
+        /// </summary>
+        /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
+        /// The default is <c>false</c></param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
+        {
+            CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);
+            Parameters.SendX5C = withSendX5C;
+            return this;
+        }
+
+        /// <summary>
         /// 
         /// </summary>
         protected override void Validate()

--- a/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Specifies if the x5c claim (public key of the certificate) should be sent to the STS.
-        /// Sending the x5x enables application developers to achieve easy certificate roll-over in Azure AD:
+        /// Sending the x5c enables application developers to achieve easy certificate roll-over in Azure AD:
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover

--- a/src/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 requestContext,
                 _clientApplicationBase.UserTokenCacheInternal);
 
+            requestParameters.SendX5C = silentParameters.SendX5C;
+
             var handler = new SilentRequest(ServiceBundle, requestParameters, silentParameters);
             return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/src/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
+++ b/src/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public bool ForceRefresh { get; set; }
         public string LoginHint { get; set; }
         public IAccount Account { get; set; }
+        public bool SendX5C { get; set; }
 
         /// <inheritdoc />
         public void LogParameters(ICoreLogger logger)

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string FamilyName = "Doe";
         public const string Username = "joe@localhost.com";
 
+        public const string Defaultx5cValue = "MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMjIxMTIyWhcNMzAwNTIyMDcwMDAwWjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCh7HjKYyVMDZDT64OgtcGKWxHmK2wqzi2LJb65KxGdNfObWGxh5HQtjzrgHDkACPsgyYseqxhGxHh8I/TR6wBKx/AAKuPHE8jB4hJ1W6FczPfb7FaMV9xP0qNQrbNGZUYbCdy7U5zIw4XrGq22l6yTqpCAh59DLufd4d7x8fCgUDV3l1ZwrncF0QrBRzns/O9Ex9pXsi2DzMa1S1PKR81D9q5QSW7LZkCgSSqI6W0b5iodx/a3RBvW3l7dnoW2fPqkZ4iMcntGNqgsSGtbXPvUR3fFdjmg+xq9FfqWyNxShlZg4U+wE1v4+kzTJxd9sgD1V0PKgW57zyzdOmTyFPJFAgMBAAGjVTBTMFEGA1UdAQRKMEiAEM9qihCt+12P5FrjVMAEYjShIjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGWCEDOjRWDQSfa3ToivgvdWcxQwDQYJKoZIhvcNAQELBQADggEBAIm6gBOkSdYjXgOvcJGgE4FJkKAMQzAhkdYq5+stfUotG6vZNL3nVOOA6aELMq/ENhrJLC3rTwLOIgj4Cy+B7BxUS9GxTPphneuZCBzjvqhzP5DmLBs8l8qu10XAshy1NFZmB24rMoq8C+HPOpuVLzkwBr+qcCq7ry2326auogvVMGaxhHlwSLR4Q1OhRjKs8JctCk2+5Qs1NHfawa7jWHxdAK6cLm7Rv/c0ig2Jow7wRaI5ciAcEjX7m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgFnDzVtItOnhuFTa0=";
+
         public static readonly IDictionary<string, string> ExtraQueryParams
             = new Dictionary<string, string>()
             {

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Internal;
@@ -73,7 +75,24 @@ namespace Microsoft.Identity.Test.Unit
         public const string FamilyName = "Doe";
         public const string Username = "joe@localhost.com";
 
-        public const string Defaultx5cValue = "MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMjIxMTIyWhcNMzAwNTIyMDcwMDAwWjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCh7HjKYyVMDZDT64OgtcGKWxHmK2wqzi2LJb65KxGdNfObWGxh5HQtjzrgHDkACPsgyYseqxhGxHh8I/TR6wBKx/AAKuPHE8jB4hJ1W6FczPfb7FaMV9xP0qNQrbNGZUYbCdy7U5zIw4XrGq22l6yTqpCAh59DLufd4d7x8fCgUDV3l1ZwrncF0QrBRzns/O9Ex9pXsi2DzMa1S1PKR81D9q5QSW7LZkCgSSqI6W0b5iodx/a3RBvW3l7dnoW2fPqkZ4iMcntGNqgsSGtbXPvUR3fFdjmg+xq9FfqWyNxShlZg4U+wE1v4+kzTJxd9sgD1V0PKgW57zyzdOmTyFPJFAgMBAAGjVTBTMFEGA1UdAQRKMEiAEM9qihCt+12P5FrjVMAEYjShIjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGWCEDOjRWDQSfa3ToivgvdWcxQwDQYJKoZIhvcNAQELBQADggEBAIm6gBOkSdYjXgOvcJGgE4FJkKAMQzAhkdYq5+stfUotG6vZNL3nVOOA6aELMq/ENhrJLC3rTwLOIgj4Cy+B7BxUS9GxTPphneuZCBzjvqhzP5DmLBs8l8qu10XAshy1NFZmB24rMoq8C+HPOpuVLzkwBr+qcCq7ry2326auogvVMGaxhHlwSLR4Q1OhRjKs8JctCk2+5Qs1NHfawa7jWHxdAK6cLm7Rv/c0ig2Jow7wRaI5ciAcEjX7m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgFnDzVtItOnhuFTa0=";
+        //This value is only for testing purposes. It is for a certificate that is not used for anything other than running tests
+        public const string _defaultx5cValue = @"MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMj
+IxMTIyWhcNMzAwNTIyMDcwMDAwWjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCh7HjK
+YyVMDZDT64OgtcGKWxHmK2wqzi2LJb65KxGdNfObWGxh5HQtjzrgHDkACPsgyYseqxhGxHh8I/TR6wBKx/AAKuPHE8jB4hJ1W6FczPfb7FaMV9xP0qNQrbNGZU
+YbCdy7U5zIw4XrGq22l6yTqpCAh59DLufd4d7x8fCgUDV3l1ZwrncF0QrBRzns/O9Ex9pXsi2DzMa1S1PKR81D9q5QSW7LZkCgSSqI6W0b5iodx/a3RBvW3l7d
+noW2fPqkZ4iMcntGNqgsSGtbXPvUR3fFdjmg+xq9FfqWyNxShlZg4U+wE1v4+kzTJxd9sgD1V0PKgW57zyzdOmTyFPJFAgMBAAGjVTBTMFEGA1UdAQRKMEiAEM
+9qihCt+12P5FrjVMAEYjShIjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGWCEDOjRWDQSfa3ToivgvdWcxQwDQYJKoZIhvcNAQELBQADggEBAIm6
+gBOkSdYjXgOvcJGgE4FJkKAMQzAhkdYq5+stfUotG6vZNL3nVOOA6aELMq/ENhrJLC3rTwLOIgj4Cy+B7BxUS9GxTPphneuZCBzjvqhzP5DmLBs8l8qu10XAsh
+y1NFZmB24rMoq8C+HPOpuVLzkwBr+qcCq7ry2326auogvVMGaxhHlwSLR4Q1OhRjKs8JctCk2+5Qs1NHfawa7jWHxdAK6cLm7Rv/c0ig2Jow7wRaI5ciAcEjX7
+m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgFnDzVtItOnhuFTa0=";
+
+        public static string Defaultx5cValue
+        {
+            get
+            {
+                return Regex.Replace(_defaultx5cValue, @"\r\n?|\n", String.Empty);
+            }
+        }
 
         public static readonly IDictionary<string, string> ExtraQueryParams
             = new Dictionary<string, string>()

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Test.Unit
                     var handler = new JwtSecurityTokenHandler();
                     var jsonToken = handler.ReadJwtToken(encodedJwt);
                     var x5c = jsonToken.Header.Where(header => header.Key == "x5c").FirstOrDefault();
-                    Assert.IsTrue((x5c.Key == "x5c"), "x5c should be present");
+                    Assert.AreEqual("x5c", x5c.Key, "x5c should be present");
                     Assert.AreEqual(x5c.Value.ToString(), MsalTestConstants.Defaultx5cValue);
                 }
             };
@@ -94,12 +94,12 @@ namespace Microsoft.Identity.Test.Unit
                     ResourceHelper.GetTestResourceRelativePath("valid_cert.pfx"),
                     MsalTestConstants.DefaultPassword);
 
-                var app = ConfidentialClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                              .WithAuthority(
-                                                                  new System.Uri(ClientApplicationBase.DefaultAuthority),
-                                                                  true).WithRedirectUri(MsalTestConstants.RedirectUri)
-                                                              .WithHttpManager(harness.HttpManager)
-                                                              .WithCertificate(certificate).BuildConcrete();
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(MsalTestConstants.ClientId)
+                    .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority),true)
+                    .WithRedirectUri(MsalTestConstants.RedirectUri)
+                    .WithHttpManager(harness.HttpManager)
+                    .WithCertificate(certificate).BuildConcrete();
 
                 //Check for x5c claim
                 harness.HttpManager.AddMockHandler(CreateTokenResponseHttpHandlerWithX5CValidation(true));
@@ -173,7 +173,7 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
-        [Description("Test for client assertion with X509 public certificate using sendCertificate")]
+        [Description("Test for acqureTokenSilent with X509 public certificate using sendCertificate")]
         public async Task JsonWebTokenWithX509PublicCertSendCertificateSilentTestAsync()
         {
             using (var harness = CreateTestHarness())
@@ -183,12 +183,12 @@ namespace Microsoft.Identity.Test.Unit
                     ResourceHelper.GetTestResourceRelativePath("valid_cert.pfx"),
                     MsalTestConstants.DefaultPassword);
 
-                var app = ConfidentialClientApplicationBuilder.Create(MsalTestConstants.ClientId)
-                                                              .WithAuthority(
-                                                                  new System.Uri("https://login.microsoftonline.com/my-utid"),
-                                                                  true).WithRedirectUri(MsalTestConstants.RedirectUri)
-                                                              .WithHttpManager(harness.HttpManager)
-                                                              .WithCertificate(certificate).BuildConcrete();
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(MsalTestConstants.ClientId)
+                    .WithAuthority(new System.Uri("https://login.microsoftonline.com/my-utid"),true)
+                    .WithRedirectUri(MsalTestConstants.RedirectUri)
+                    .WithHttpManager(harness.HttpManager)
+                    .WithCertificate(certificate).BuildConcrete();
 
                 _tokenCacheHelper.PopulateCacheWithOneAccessToken(app.UserTokenCacheInternal.Accessor);
                 app.UserTokenCacheInternal.Accessor.DeleteAccessToken(


### PR DESCRIPTION
adding withsendX5C() on acquire token silent for the confidential client application
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1149