### PR TITLE
null ref fix in adfs w/no login hint

### DIFF
--- a/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
@@ -103,10 +103,13 @@ namespace Microsoft.Identity.Client.Instance
                 return true;
             }
 
-            if (!cacheEntry.ValidForDomainsList.Contains(AdfsUpnHelper.GetDomainFromUpn(userPrincipalName)))
+            if( !string.IsNullOrEmpty(userPrincipalName))
             {
-                return false;
-            }
+                if (!cacheEntry.ValidForDomainsList.Contains(AdfsUpnHelper.GetDomainFromUpn(userPrincipalName)))
+                {
+                    return false;
+                }
+            }           
 
             endpoints = cacheEntry.Endpoints;
             return true;

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -143,5 +143,34 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                     ExceptionToThrow = new InvalidOperationException("Error")
                 });
         }
+
+        public static void AddAdfs2019MockHandler(this MockHttpManager httpManager)
+        {
+            httpManager.AddMockHandler(
+                new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedUrl = "https://fs.contoso.com/.well-known/webfinger",
+                    ExpectedQueryParams = new Dictionary<string, string>
+                    {
+                            {"resource", "https://fs.contoso.com"},
+                            {"rel", "http://schemas.microsoft.com/rel/trusted-realm"}
+                    },
+                    ResponseMessage = MockHelpers.CreateSuccessWebFingerResponseMessage("https://fs.contoso.com")
+                });
+
+            //add mock response for tenant endpoint discovery
+            httpManager.AddMockHandler(new MockHttpMessageHandler
+            {
+                ExpectedMethod = HttpMethod.Get,
+                ResponseMessage = MockHelpers.CreateOpenIdConfigurationResponse(MsalTestConstants.OnPremiseAuthority)
+            });
+
+            httpManager.AddMockHandler(new MockHttpMessageHandler
+            {
+                ExpectedMethod = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateAdfsSuccessTokenResponseMessage()
+            });
+        }
     }
 }


### PR DESCRIPTION
utests

[issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1214)