### PR TITLE
Fix 1196 handling of Instance value in builder with trailing slash

### DIFF
--- a/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -345,6 +345,7 @@ namespace Microsoft.Identity.Client
 
             if (!string.IsNullOrWhiteSpace(Config.Instance))
             {
+                Config.Instance = Config.Instance.TrimEnd(' ', '/');
                 return Config.Instance;
             }
 

--- a/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         bool IsSystemWebViewAvailable { get; }
 
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
         /// <summary>
         /// Interactive request to acquire a token for the specified scopes. The interactive window will be parented to the specified
         /// window. The user will be required to select an account
@@ -47,6 +48,7 @@ namespace Microsoft.Identity.Client
         /// of the known authorities added to the application construction.
         /// </remarks>
         AcquireTokenInteractiveParameterBuilder AcquireTokenInteractive(IEnumerable<string> scopes);
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
         /// <summary>
         /// Acquires a security token on a device without a Web browser, by letting the user authenticate on

--- a/src/Microsoft.Identity.Client/MsalError.cs
+++ b/src/Microsoft.Identity.Client/MsalError.cs
@@ -575,6 +575,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string WebviewUnavailable = "no_system_webview";
 
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
         /// <summary>
         /// <para>What happens?</para>You configured MSAL interactive authentication to use an embedded webview and you also configured <see cref="SystemWebViewOptions"/>.
         /// These are mutually exclusive.
@@ -582,6 +583,7 @@ namespace Microsoft.Identity.Client
         /// <see cref="AcquireTokenInteractiveParameterBuilder.WithSystemWebViewOptions(SystemWebViewOptions)"/>
         /// </summary>
         public const string SystemWebviewOptionsNotApplicable = "embedded_webview_not_compatible_default_browser";
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
 #if iOS
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1196