### PR TITLE
Instance Discovery Caching

### DIFF
--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalAccessTokenCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalAccessTokenCacheKey.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 
 namespace Microsoft.Identity.Client.Cache.Keys
 {
@@ -55,7 +53,6 @@ namespace Microsoft.Identity.Client.Cache.Keys
                 _normalizedScopes);
         }
 
-     
         #region iOS
 
         public string iOSAccount => MsalCacheKeys.GetiOSAccountKey(_homeAccountId, _environment);
@@ -79,7 +76,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             var other = obj as MsalAccessTokenCacheKey;
 
             return string.Equals(
-                this.ToString(),
+                ToString(),
                 other.ToString(),
                 StringComparison.OrdinalIgnoreCase);
         }
@@ -87,7 +84,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
         // override object.GetHashCode
         public override int GetHashCode()
         {
-            return this.ToString().GetHashCode();
+            return ToString().GetHashCode();
         }
         #endregion
     }

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalAccessTokenCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalAccessTokenCacheKey.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 
 namespace Microsoft.Identity.Client.Cache.Keys
@@ -54,6 +55,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
                 _normalizedScopes);
         }
 
+     
         #region iOS
 
         public string iOSAccount => MsalCacheKeys.GetiOSAccountKey(_homeAccountId, _environment);
@@ -64,6 +66,29 @@ namespace Microsoft.Identity.Client.Cache.Keys
 
         public int iOSType => (int)MsalCacheKeys.iOSCredentialAttrType.AccessToken;
 
+        #endregion
+
+        #region Equals and GetHashCode
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var other = obj as MsalAccessTokenCacheKey;
+
+            return string.Equals(
+                this.ToString(),
+                other.ToString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
         #endregion
     }
 }

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalAccountCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalAccountCacheKey.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             var other = obj as MsalAccountCacheKey;
 
             return string.Equals(
-                this.ToString(),
+                ToString(),
                 other.ToString(),
                 StringComparison.OrdinalIgnoreCase);
         }
@@ -88,10 +88,8 @@ namespace Microsoft.Identity.Client.Cache.Keys
         // override object.GetHashCode
         public override int GetHashCode()
         {
-
-            return this.ToString().GetHashCode();
+            return ToString().GetHashCode();
         }
         #endregion
-
     }
 }

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalAccountCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalAccountCacheKey.cs
@@ -68,5 +68,30 @@ namespace Microsoft.Identity.Client.Cache.Keys
 
 
         #endregion
+
+        #region Equals and GetHashCode
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var other = obj as MsalAccountCacheKey;
+
+            return string.Equals(
+                this.ToString(),
+                other.ToString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+
+            return this.ToString().GetHashCode();
+        }
+        #endregion
+
     }
 }

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalAppMetadataCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalAppMetadataCacheKey.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             var other = obj as MsalAppMetadataCacheKey;
 
             return string.Equals(
-                this.ToString(),
+                ToString(),
                 other.ToString(),
                 StringComparison.OrdinalIgnoreCase);
         }
@@ -60,10 +60,8 @@ namespace Microsoft.Identity.Client.Cache.Keys
         // override object.GetHashCode
         public override int GetHashCode()
         {
-
-            return this.ToString().GetHashCode();
+            return ToString().GetHashCode();
         }
         #endregion
-
     }
 }

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalAppMetadataCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalAppMetadataCacheKey.cs
@@ -40,5 +40,30 @@ namespace Microsoft.Identity.Client.Cache.Keys
         public int iOSType => (int)MsalCacheKeys.iOSCredentialAttrType.AppMetadata;
 
         #endregion
+
+        #region Equals and GetHashCode
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var other = obj as MsalAppMetadataCacheKey;
+
+            return string.Equals(
+                this.ToString(),
+                other.ToString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+
+            return this.ToString().GetHashCode();
+        }
+        #endregion
+
     }
 }

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalCacheKeys.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalCacheKeys.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             return stringBuilder.ToString().ToLowerInvariant();
         }
 
-#region iOS
+        #region iOS
 
         internal static readonly Dictionary<string, int> iOSAuthorityTypeToAttrType = new Dictionary<string, int>()
         {

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalIdTokenCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalIdTokenCacheKey.cs
@@ -63,6 +63,31 @@ namespace Microsoft.Identity.Client.Cache.Keys
         public int iOSType => (int)MsalCacheKeys.iOSCredentialAttrType.IdToken;
 
         #endregion
+
+        #region Equals and GetHashCode
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var other = obj as MsalIdTokenCacheKey;
+
+            return string.Equals(
+                this.ToString(),
+                other.ToString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+
+            return this.ToString().GetHashCode();
+        }
+        #endregion
+
     }
 }
 

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalIdTokenCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalIdTokenCacheKey.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             var other = obj as MsalIdTokenCacheKey;
 
             return string.Equals(
-                this.ToString(),
+                ToString(),
                 other.ToString(),
                 StringComparison.OrdinalIgnoreCase);
         }
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
         public override int GetHashCode()
         {
 
-            return this.ToString().GetHashCode();
+            return ToString().GetHashCode();
         }
         #endregion
 

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalRefreshTokenCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalRefreshTokenCacheKey.cs
@@ -108,6 +108,30 @@ namespace Microsoft.Identity.Client.Cache.Keys
 
 
         #endregion
+
+        #region Equals and GetHashCode
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var other = obj as MsalRefreshTokenCacheKey;
+
+            return string.Equals(
+                this.ToString(),
+                other.ToString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
+        #endregion
+
     }
 }
 

--- a/src/Microsoft.Identity.Client/Cache/Keys/MsalRefreshTokenCacheKey.cs
+++ b/src/Microsoft.Identity.Client/Cache/Keys/MsalRefreshTokenCacheKey.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
         public override string ToString()
         {
             // FRT
-            if (!String.IsNullOrWhiteSpace(_familyId))
+            if (!string.IsNullOrWhiteSpace(_familyId))
             {
                 string d = MsalCacheKeys.CacheKeyDelimiter;
                 return $"{_homeAccountId}{d}{_environment}{d}{StorageJsonValues.CredentialTypeRefreshToken}{d}{_familyId}{d}{d}".ToLowerInvariant();
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             get
             {
                 // FRT
-                if (!String.IsNullOrWhiteSpace(_familyId))
+                if (!string.IsNullOrWhiteSpace(_familyId))
                 {
                     return $"{StorageJsonValues.CredentialTypeRefreshToken}{MsalCacheKeys.CacheKeyDelimiter}{_familyId}{MsalCacheKeys.CacheKeyDelimiter}".ToLowerInvariant();
                 }
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             get
             {
                 // FRT
-                if (!String.IsNullOrWhiteSpace(_familyId))
+                if (!string.IsNullOrWhiteSpace(_familyId))
                 {
                     return $"{StorageJsonValues.CredentialTypeRefreshToken}{MsalCacheKeys.CacheKeyDelimiter}{_familyId}{MsalCacheKeys.CacheKeyDelimiter}{MsalCacheKeys.CacheKeyDelimiter}".ToLowerInvariant();
                 }
@@ -120,7 +120,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
             var other = obj as MsalRefreshTokenCacheKey;
 
             return string.Equals(
-                this.ToString(),
+                ToString(),
                 other.ToString(),
                 StringComparison.OrdinalIgnoreCase);
         }
@@ -128,7 +128,7 @@ namespace Microsoft.Identity.Client.Cache.Keys
         // override object.GetHashCode
         public override int GetHashCode()
         {
-            return this.ToString().GetHashCode();
+            return ToString().GetHashCode();
         }
         #endregion
 

--- a/src/Microsoft.Identity.Client/Instance/AadAuthority.cs
+++ b/src/Microsoft.Identity.Client/Instance/AadAuthority.cs
@@ -14,23 +14,6 @@ namespace Microsoft.Identity.Client.Instance
         public const string DefaultTrustedHost = "login.microsoftonline.com";
         public const string AADCanonicalAuthorityTemplate = "https://{0}/{1}/";
 
-        // TODO: bogavril consolidate well known / trusted hosts
-        private static readonly HashSet<string> s_trustedHostList = new HashSet<string>()
-        {
-            "login.partner.microsoftonline.cn", // Microsoft Azure China
-            "login.chinacloudapi.cn",
-            "login.microsoftonline.de", // Microsoft Azure Blackforest
-            "login-us.microsoftonline.com", // Microsoft Azure US Government - Legacy
-            "login.microsoftonline.us", // Microsoft Azure US Government
-             DefaultTrustedHost, // Microsoft Azure Worldwide
-            "login.windows.net"
-        };
-
-        internal static bool IsInTrustedHostList(string host)
-        {
-            return s_trustedHostList.ContainsOrdinalIgnoreCase(host);
-        }
-
         internal AadAuthority(
             IServiceBundle serviceBundle,
             AuthorityInfo authorityInfo) : base(serviceBundle, authorityInfo)

--- a/src/Microsoft.Identity.Client/Instance/AadOpenIdConfigurationEndpointManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/AadOpenIdConfigurationEndpointManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Client.Instance
             {
                 // MSAL will throw if the instance discovery URI does not respond with a valid json
                 await _serviceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
-                                             authorityUri,
+                                             authorityInfo.CanonicalAuthority,
                                              requestContext).ConfigureAwait(false);
             }
 

--- a/src/Microsoft.Identity.Client/Instance/AadOpenIdConfigurationEndpointManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/AadOpenIdConfigurationEndpointManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Instance.Discovery;
 
 namespace Microsoft.Identity.Client.Instance
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Identity.Client.Instance
             RequestContext requestContext)
         {
             var authorityUri = new Uri(authorityInfo.CanonicalAuthority);
-            if (authorityInfo.ValidateAuthority && !AadAuthority.IsInTrustedHostList(authorityUri.Host))
+            if (authorityInfo.ValidateAuthority && !KnownMetadataProvider.IsKnownEnvironment(authorityUri.Host))
             {
                 // MSAL will throw if the instance discovery URI does not respond with a valid json
                 await _serviceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(

--- a/src/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
     {
         Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryTryAvoidNetworkAsync(
             string authority,
-            IEnumerable<string> existingEnviromentsInCache,
+            IEnumerable<string> existingEnvironmentsInCache,
             RequestContext requestContext);
 
         Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryAsync(

--- a/src/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 
@@ -11,8 +11,14 @@ namespace Microsoft.Identity.Client.Instance.Discovery
     /// </summary>
     internal interface IInstanceDiscoveryManager
     {
-        Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryAsync(
-            Uri authority,
+        Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryTryAvoidNetworkAsync(
+            string authority,
+            IEnumerable<string> existingEnviromentsInCache,
             RequestContext requestContext);
+
+        Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryAsync(
+           string authority,
+           RequestContext requestContext);
+
     }
 }

--- a/src/Microsoft.Identity.Client/Instance/Discovery/IKnownMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/IKnownMetadataProvider.cs
@@ -6,6 +6,6 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 {
     internal interface IKnownMetadataProvider
     {
-        InstanceDiscoveryMetadataEntry GetMetadata(string environment, IEnumerable<string> existingEnviromentsInCache);
+        InstanceDiscoveryMetadataEntry GetMetadata(string environment, IEnumerable<string> existingEnvironmentsInCache);
     }
 }

--- a/src/Microsoft.Identity.Client/Instance/Discovery/IKnownMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/IKnownMetadataProvider.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+
+namespace Microsoft.Identity.Client.Instance.Discovery
+{
+    internal interface IKnownMetadataProvider
+    {
+        InstanceDiscoveryMetadataEntry GetMetadata(string environment, IEnumerable<string> existingEnviromentsInCache);
+    }
+}

--- a/src/Microsoft.Identity.Client/Instance/Discovery/INetworkMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/INetworkMetadataProvider.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+
+namespace Microsoft.Identity.Client.Instance.Discovery
+{
+    internal interface INetworkMetadataProvider
+    {
+        Task<InstanceDiscoveryResponse> FetchAllDiscoveryMetadataAsync(Uri authority, RequestContext requestContext);
+    }
+}

--- a/src/Microsoft.Identity.Client/Instance/Discovery/IStaticMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/IStaticMetadataProvider.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Client.Instance.Discovery
+{
+    internal interface IStaticMetadataProvider
+    {
+        void AddMetadata(string environment, InstanceDiscoveryMetadataEntry entry);
+        InstanceDiscoveryMetadataEntry GetMetadata(string environment);
+        void /* for test purposes */ Clear();
+    }
+}

--- a/src/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         public InstanceDiscoveryManager(
             IHttpManager httpManager,
             ITelemetryManager telemetryManager,
-            bool shouldClearCaches,
+            bool /* for test */ shouldClearCaches,
             IKnownMetadataProvider knownMetadataProvider = null,
             IStaticMetadataProvider staticMetadataProvider = null,
             INetworkMetadataProvider networkMetadataProvider = null)
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 
         public async Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryTryAvoidNetworkAsync(
             string authority,
-            IEnumerable<string> existingEnviromentsInCache,
+            IEnumerable<string> existingEnvironmentsInCache,
             RequestContext requestContext)
         {
             AuthorityType type = Authority.GetAuthorityType(authority);
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                         return entry;
                     }
 
-                    entry = _knownMetadataProvider.GetMetadata(environment, existingEnviromentsInCache);
+                    entry = _knownMetadataProvider.GetMetadata(environment, existingEnvironmentsInCache);
 
                     if (entry != null)
                     {

--- a/src/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Identity.Client.Utils;
@@ -13,7 +14,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         private static readonly IDictionary<string, InstanceDiscoveryMetadataEntry> s_knownEntries =
             new Dictionary<string, InstanceDiscoveryMetadataEntry>();
 
-        private static readonly ISet<string> s_knownEnvironments = new HashSet<string>();
+        private static readonly ISet<string> s_knownEnvironments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         static KnownMetadataProvider()
         {
@@ -84,6 +85,11 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             }
 
             return null;
+        }
+
+        public static bool IsKnownEnvironment(string environment)
+        {
+            return s_knownEnvironments.Contains(environment);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Client.Instance.Discovery
+{
+    internal class KnownMetadataProvider : IKnownMetadataProvider
+    {
+        // No need to use a ConcurrentDictionary, because the normal Dictionary is thread safe for read operations
+        private static readonly IDictionary<string, InstanceDiscoveryMetadataEntry> s_knownEntries =
+            new Dictionary<string, InstanceDiscoveryMetadataEntry>();
+
+        private static readonly ISet<string> s_knownEnvironments = new HashSet<string>();
+
+        static KnownMetadataProvider()
+        {
+            InstanceDiscoveryMetadataEntry publicCloudEntry = new InstanceDiscoveryMetadataEntry()
+            {
+                Aliases = new[] { "login.microsoftonline.com", "login.windows.net", "login.microsoft.com", "sts.windows.net" },
+                PreferredNetwork = "login.microsoftonline.com",
+                PreferredCache = "sts.windows.net"
+            };
+
+            InstanceDiscoveryMetadataEntry cnCloudEntry = new InstanceDiscoveryMetadataEntry()
+            {
+                Aliases = new[] { "login.partner.microsoftonline.cn", "login.chinacloudapi.cn" },
+                PreferredNetwork = "login.partner.microsoftonline.cn",
+                PreferredCache = "login.partner.microsoftonline.cn"
+            };
+
+            InstanceDiscoveryMetadataEntry deCloudEntry = new InstanceDiscoveryMetadataEntry()
+            {
+                Aliases = new[] { "login.microsoftonline.de" },
+                PreferredNetwork = "login.microsoftonline.de",
+                PreferredCache = "login.microsoftonline.de"
+            };
+
+            InstanceDiscoveryMetadataEntry usGovCloudEntry = new InstanceDiscoveryMetadataEntry()
+            {
+                Aliases = new[] { "login.microsoftonline.us", "login.usgovcloudapi.net" },
+                PreferredNetwork = "login.microsoftonline.us",
+                PreferredCache = "login.microsoftonline.us"
+            };
+
+            InstanceDiscoveryMetadataEntry usCloudEntry = new InstanceDiscoveryMetadataEntry()
+            {
+                Aliases = new[] { "login-us.microsoftonline.com" },
+                PreferredNetwork = "login-us.microsoftonline.com",
+                PreferredCache = "login-us.microsoftonline.com"
+            };
+
+            AddToKnownCache(publicCloudEntry);
+            AddToKnownCache(cnCloudEntry);
+            AddToKnownCache(deCloudEntry);
+            AddToKnownCache(usGovCloudEntry);
+            AddToKnownCache(usCloudEntry);
+        }
+
+        private static void AddToKnownCache(InstanceDiscoveryMetadataEntry entry)
+        {
+            foreach (string alias in entry.Aliases)
+            {
+                s_knownEntries[alias] = entry;
+                s_knownEnvironments.Add(alias);
+            }
+        }
+
+        public InstanceDiscoveryMetadataEntry GetMetadata(string environment, IEnumerable<string> existingEnviromentsInCache)
+        {
+            if (existingEnviromentsInCache == null)
+            {
+                existingEnviromentsInCache = Enumerable.Empty<string>();
+            }
+
+            bool canUseProvider = existingEnviromentsInCache.All(e => s_knownEnvironments.ContainsOrdinalIgnoreCase(e));
+
+            if (canUseProvider)
+            {
+                s_knownEntries.TryGetValue(environment, out InstanceDiscoveryMetadataEntry entry);
+                return entry;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -18,21 +18,30 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 
         static KnownMetadataProvider()
         {
+            void AddToKnownCache(InstanceDiscoveryMetadataEntry entry)
+            {
+                foreach (string alias in entry.Aliases)
+                {
+                    s_knownEntries[alias] = entry;
+                    s_knownEnvironments.Add(alias);
+                }
+            }
+
             InstanceDiscoveryMetadataEntry publicCloudEntry = new InstanceDiscoveryMetadataEntry()
             {
                 Aliases = new[] { "login.microsoftonline.com", "login.windows.net", "login.microsoft.com", "sts.windows.net" },
                 PreferredNetwork = "login.microsoftonline.com",
-                PreferredCache = "sts.windows.net"
+                PreferredCache = "login.windows.net"
             };
 
-            InstanceDiscoveryMetadataEntry cnCloudEntry = new InstanceDiscoveryMetadataEntry()
+            InstanceDiscoveryMetadataEntry cloudEntryChina = new InstanceDiscoveryMetadataEntry()
             {
                 Aliases = new[] { "login.partner.microsoftonline.cn", "login.chinacloudapi.cn" },
                 PreferredNetwork = "login.partner.microsoftonline.cn",
                 PreferredCache = "login.partner.microsoftonline.cn"
             };
 
-            InstanceDiscoveryMetadataEntry deCloudEntry = new InstanceDiscoveryMetadataEntry()
+            InstanceDiscoveryMetadataEntry cloudEntryGermanay = new InstanceDiscoveryMetadataEntry()
             {
                 Aliases = new[] { "login.microsoftonline.de" },
                 PreferredNetwork = "login.microsoftonline.de",
@@ -54,29 +63,20 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             };
 
             AddToKnownCache(publicCloudEntry);
-            AddToKnownCache(cnCloudEntry);
-            AddToKnownCache(deCloudEntry);
+            AddToKnownCache(cloudEntryChina);
+            AddToKnownCache(cloudEntryGermanay);
             AddToKnownCache(usGovCloudEntry);
             AddToKnownCache(usCloudEntry);
         }
 
-        private static void AddToKnownCache(InstanceDiscoveryMetadataEntry entry)
+        public InstanceDiscoveryMetadataEntry GetMetadata(string environment, IEnumerable<string> existingEnvironmentsInCache)
         {
-            foreach (string alias in entry.Aliases)
+            if (existingEnvironmentsInCache == null)
             {
-                s_knownEntries[alias] = entry;
-                s_knownEnvironments.Add(alias);
-            }
-        }
-
-        public InstanceDiscoveryMetadataEntry GetMetadata(string environment, IEnumerable<string> existingEnviromentsInCache)
-        {
-            if (existingEnviromentsInCache == null)
-            {
-                existingEnviromentsInCache = Enumerable.Empty<string>();
+                existingEnvironmentsInCache = Enumerable.Empty<string>();
             }
 
-            bool canUseProvider = existingEnviromentsInCache.All(e => s_knownEnvironments.ContainsOrdinalIgnoreCase(e));
+            bool canUseProvider = existingEnvironmentsInCache.All(e => s_knownEnvironments.ContainsOrdinalIgnoreCase(e));
 
             if (canUseProvider)
             {
@@ -90,6 +90,11 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         public static bool IsKnownEnvironment(string environment)
         {
             return s_knownEnvironments.Contains(environment);
+        }
+
+        public static IDictionary<string, InstanceDiscoveryMetadataEntry> GetAllEntriesForTest()
+        {
+            return s_knownEntries;
         }
     }
 }

--- a/src/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -39,14 +39,15 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             client.AddQueryParameter("api-version", "1.1");
             client.AddQueryParameter("authorization_endpoint", BuildAuthorizeEndpoint(authority.Host, GetTenant(authority)));
 
-            string discoveryHost = KnownMetadataProvider.IsKnownEnvironment(authority.Host)
-                                       ? authority.Host
-                                       : AadAuthority.DefaultTrustedHost;
+            string discoveryHost = KnownMetadataProvider.IsKnownEnvironment(authority.Host) ? 
+                authority.Host : 
+                AadAuthority.DefaultTrustedHost;
 
             string instanceDiscoveryEndpoint = BuildInstanceDiscoveryEndpoint(discoveryHost);
 
-            InstanceDiscoveryResponse discoveryResponse = await client.DiscoverAadInstanceAsync(new Uri(instanceDiscoveryEndpoint), requestContext)
-                                                .ConfigureAwait(false);
+            InstanceDiscoveryResponse discoveryResponse = await client
+                .DiscoverAadInstanceAsync(new Uri(instanceDiscoveryEndpoint), requestContext)
+                .ConfigureAwait(false);
 
             return discoveryResponse;
         }

--- a/src/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.TelemetryCore;
+
+namespace Microsoft.Identity.Client.Instance.Discovery
+{
+    internal class NetworkMetadataProvider : INetworkMetadataProvider
+    {
+        private readonly IHttpManager _httpManager;
+        private readonly ITelemetryManager _telemetryManager;
+
+        public NetworkMetadataProvider(IHttpManager httpManager, ITelemetryManager telemetryManager)
+        {
+            _httpManager = httpManager;
+            _telemetryManager = telemetryManager;
+        }
+
+        public async Task<InstanceDiscoveryResponse> FetchAllDiscoveryMetadataAsync(
+            Uri authority,
+            RequestContext requestContext)
+        {
+            InstanceDiscoveryResponse discoveryResponse = await SendInstanceDiscoveryRequestAsync(authority, requestContext).ConfigureAwait(false);
+            return discoveryResponse;
+        }
+
+        private async Task<InstanceDiscoveryResponse> SendInstanceDiscoveryRequestAsync(
+          Uri authority,
+          RequestContext requestContext)
+        {
+            var client = new OAuth2Client(requestContext.Logger, _httpManager, _telemetryManager);
+
+            client.AddQueryParameter("api-version", "1.1");
+            client.AddQueryParameter("authorization_endpoint", BuildAuthorizeEndpoint(authority.Host, GetTenant(authority)));
+
+            string discoveryHost = AadAuthority.IsInTrustedHostList(authority.Host)
+                                       ? authority.Host
+                                       : AadAuthority.DefaultTrustedHost;
+
+            string instanceDiscoveryEndpoint = BuildInstanceDiscoveryEndpoint(discoveryHost);
+
+            InstanceDiscoveryResponse discoveryResponse = await client.DiscoverAadInstanceAsync(new Uri(instanceDiscoveryEndpoint), requestContext)
+                                                .ConfigureAwait(false);
+
+            return discoveryResponse;
+        }
+
+        private static string BuildAuthorizeEndpoint(string host, string tenant)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/oauth2/v2.0/authorize", host, tenant);
+        }
+
+        private static string GetTenant(Uri uri)
+        {
+            // AAD specific
+            return uri.AbsolutePath.Split('/')[1];
+        }
+
+        private static string BuildInstanceDiscoveryEndpoint(string host)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "https://{0}/common/discovery/instance", host);
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             client.AddQueryParameter("api-version", "1.1");
             client.AddQueryParameter("authorization_endpoint", BuildAuthorizeEndpoint(authority.Host, GetTenant(authority)));
 
-            string discoveryHost = AadAuthority.IsInTrustedHostList(authority.Host)
+            string discoveryHost = KnownMetadataProvider.IsKnownEnvironment(authority.Host)
                                        ? authority.Host
                                        : AadAuthority.DefaultTrustedHost;
 

--- a/src/Microsoft.Identity.Client/Instance/Discovery/StaticMetadataProvider.cs
+++ b/src/Microsoft.Identity.Client/Instance/Discovery/StaticMetadataProvider.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+
+namespace Microsoft.Identity.Client.Instance.Discovery
+{
+    internal class StaticMetadataProvider : IStaticMetadataProvider
+    {
+        private static readonly ConcurrentDictionary<string, InstanceDiscoveryMetadataEntry> s_cache =
+             new ConcurrentDictionary<string, InstanceDiscoveryMetadataEntry>();
+
+        public InstanceDiscoveryMetadataEntry GetMetadata(string environment)
+        {
+            s_cache.TryGetValue(environment, out InstanceDiscoveryMetadataEntry entry);
+            return entry;
+        }
+
+        public void AddMetadata(string environment, InstanceDiscoveryMetadataEntry entry)
+        {
+            // Always take the most recent value
+            s_cache.AddOrUpdate(environment, entry, (key, oldValue) => entry);
+        }
+
+        public void Clear()
+        {
+            s_cache.Clear();
+        }
+    }
+}

--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 GetType().Name);
 
             if (authenticationRequestParameters.AuthorityInfo != null &&
-                AadAuthority.IsInTrustedHostList(authenticationRequestParameters.AuthorityInfo?.Host))
+                KnownMetadataProvider.IsKnownEnvironment(authenticationRequestParameters.AuthorityInfo?.Host))
             {
                 messageWithoutPii += string.Format(
                     CultureInfo.CurrentCulture,

--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -274,6 +274,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         internal async Task ResolveAuthorityEndpointsAsync()
         {
+            // This will make a network call unless instance discovery is cached, but this ok
+            // GetAccounts and AcquireTokenSilent do not need this
             await UpdateAuthorityWithPreferredNetworkHostAsync().ConfigureAwait(false);
 
             AuthenticationRequestParameters.Endpoints = await ServiceBundle.AuthorityEndpointResolutionManager.ResolveEndpointsAsync(
@@ -370,7 +372,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             InstanceDiscoveryMetadataEntry metadata = await
                 ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
-                    new Uri(AuthenticationRequestParameters.AuthorityInfo.CanonicalAuthority),
+                    AuthenticationRequestParameters.AuthorityInfo.CanonicalAuthority,
                     AuthenticationRequestParameters.RequestContext)
                 .ConfigureAwait(false);
 

--- a/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return null;
             }
 
-            logger.Verbose("[FOCI] App is part of the family or unkown, looking for FRT");
+            logger.Verbose("[FOCI] App is part of the family or unknown, looking for FRT");
             var familyRefreshToken = await CacheManager.FindFamilyRefreshTokenAsync(TheOnlyFamilyId).ConfigureAwait(false);
             logger.Verbose("[FOCI] FRT found? " + (familyRefreshToken != null));
 

--- a/src/Microsoft.Identity.Client/TelemetryCore/Internal/Events/CacheEvent.cs
+++ b/src/Microsoft.Identity.Client/TelemetryCore/Internal/Events/CacheEvent.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
             AT,
             RT,
             ID,
-            ACCOUNT, 
-            APPMETADATA
+            Account, 
+            AppMetadata
         };
 
         public TokenTypes TokenType
@@ -38,8 +38,8 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
                     {TokenTypes.AT, "at"},
                     {TokenTypes.RT, "rt"},
                     {TokenTypes.ID, "id"},
-                    {TokenTypes.ACCOUNT, "account"},
-                    {TokenTypes.APPMETADATA, "appmetadata"}
+                    {TokenTypes.Account, "account"},
+                    {TokenTypes.AppMetadata, "appmetadata"}
                 };
                 this[TokenTypeKey] = types[value];
             }

--- a/src/Microsoft.Identity.Client/TelemetryCore/Internal/Events/CacheEvent.cs
+++ b/src/Microsoft.Identity.Client/TelemetryCore/Internal/Events/CacheEvent.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
             AT,
             RT,
             ID,
-            ACCOUNT
+            ACCOUNT, 
+            APPMETADATA
         };
 
         public TokenTypes TokenType
@@ -37,7 +38,8 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
                     {TokenTypes.AT, "at"},
                     {TokenTypes.RT, "rt"},
                     {TokenTypes.ID, "id"},
-                    {TokenTypes.ACCOUNT, "account"}
+                    {TokenTypes.ACCOUNT, "account"},
+                    {TokenTypes.APPMETADATA, "appmetadata"}
                 };
                 this[TokenTypeKey] = types[value];
             }

--- a/src/Microsoft.Identity.Client/TelemetryCore/Internal/Events/EventBase.cs
+++ b/src/Microsoft.Identity.Client/TelemetryCore/Internal/Events/EventBase.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Constants;
+using Microsoft.Identity.Client.Instance.Discovery;
 
 namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
 {
@@ -54,7 +55,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
             {
                 throw new ArgumentException("Requires an absolute uri");
             }
-            if (!AadAuthority.IsInTrustedHostList(uri.Host)) // only collect telemetry for well-known hosts
+            if (!KnownMetadataProvider.IsKnownEnvironment(uri.Host)) // only collect telemetry for well-known hosts
             {
                 return null;
             }

--- a/src/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -14,8 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client.Instance.Discovery;
-using System.Collections;
+
 
 namespace Microsoft.Identity.Client
 {
@@ -67,9 +66,11 @@ namespace Microsoft.Identity.Client
                 preferredUsername = idToken.PreferredUsername;
             }
 
+            // Do a full instance discovery when saving tokens (if not cached), 
+            // so that the PreferredNetwork environment is up to date.
             var instanceDiscoveryMetadata = await ServiceBundle.InstanceDiscoveryManager
                                 .GetMetadataEntryAsync(
-                                     new Uri(requestParams.TenantUpdatedCanonicalAuthority),
+                                    requestParams.TenantUpdatedCanonicalAuthority,
                                     requestParams.RequestContext)
                                 .ConfigureAwait(false);
 
@@ -210,216 +211,236 @@ namespace Microsoft.Identity.Client
 
         async Task<MsalAccessTokenCacheItem> ITokenCacheInternal.FindAccessTokenAsync(AuthenticationRequestParameters requestParams)
         {
-            IEnumerable<string> environmentAliases = Enumerable.Empty<string>();
-            string preferredEnvironmentAlias = null;
-
-            if (requestParams.AuthorityInfo != null)
-            {
-                InstanceDiscoveryMetadataEntry instanceDiscoveryMetadataEntry =
-                    await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
-                        new Uri(requestParams.AuthorityInfo.CanonicalAuthority),
-                        requestParams.RequestContext)
-                    .ConfigureAwait(false);
-
-                environmentAliases = instanceDiscoveryMetadataEntry.Aliases;
-                preferredEnvironmentAlias = instanceDiscoveryMetadataEntry.PreferredCache;
-            }
-
             // no authority passed
-            if (!environmentAliases.Any())
+            if (requestParams?.AuthorityInfo?.CanonicalAuthority == null)
             {
                 requestParams.RequestContext.Logger.Warning("No authority provided. Skipping cache lookup ");
                 return null;
             }
 
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
-            try
+            requestParams.RequestContext.Logger.Info("Looking up access token in the cache.");
+            IEnumerable<MsalAccessTokenCacheItem> tokenCacheItems = Enumerable.Empty<MsalAccessTokenCacheItem>();
+            await LoadFromCacheAsync(
+                requestParams.RequestContext.TelemetryCorrelationId,
+                CacheEvent.TokenTypes.AT,
+                requestParams.Account,
+                () => tokenCacheItems = GetAllAccessTokensWithNoLocks(true))
+                    .ConfigureAwait(false);
+
+
+            tokenCacheItems = FilterByHomeAccountTenantOrAssertion(requestParams, tokenCacheItems);
+
+            // no match found after initial filtering
+            if (!tokenCacheItems.Any())
             {
-                requestParams.RequestContext.Logger.Info("Looking up access token in the cache.");
-                MsalAccessTokenCacheItem msalAccessTokenCacheItem;
-                TokenCacheNotificationArgs args = new TokenCacheNotificationArgs(this, ClientId, requestParams.Account, false);
-
-                List<MsalAccessTokenCacheItem> tokenCacheItems;
-
-                await OnBeforeAccessAsync(args).ConfigureAwait(false);
-                try
-                {
-                    // filtered by client id.
-                    tokenCacheItems = GetAllAccessTokensWithNoLocks(true).ToList();
-                }
-                finally
-                {
-                    await OnAfterAccessAsync(args).ConfigureAwait(false);
-                }
-
-                tokenCacheItems = FilterByHomeAccountTenantOrAssertion(requestParams, tokenCacheItems);
-
-                // no match found after initial filtering
-                if (!tokenCacheItems.Any())
-                {
-                    requestParams.RequestContext.Logger.Info("No matching entry found for user or assertion");
-                    return null;
-                }
-
-                requestParams.RequestContext.Logger.Info("Matching entry count -" + tokenCacheItems.Count);
-
-                IEnumerable<MsalAccessTokenCacheItem> filteredItems =
-                    tokenCacheItems.Where(item => ScopeHelper.ScopeContains(item.ScopeSet, requestParams.Scope)).ToList();
-
-                requestParams.RequestContext.Logger.Info("Matching entry count after filtering by scopes - " + filteredItems.Count());
-
-                // filter by authority
-                var filteredByPreferredAlias =
-                    filteredItems.Where
-                    (item => item.Environment.Equals(preferredEnvironmentAlias, StringComparison.OrdinalIgnoreCase)).ToList();
-
-                if (filteredByPreferredAlias.Any())
-                {
-                    filteredItems = filteredByPreferredAlias;
-                }
-                else
-                {
-                    filteredItems = filteredItems.Where(
-                        item => environmentAliases.Contains(item.Environment) &&
-                        (item.IsAdfs || item.TenantId.Equals(requestParams.Authority.GetTenantId(), StringComparison.OrdinalIgnoreCase)));
-                }
-
-                // no match
-                if (!filteredItems.Any())
-                {
-                    requestParams.RequestContext.Logger.Info("No tokens found for matching authority, client_id, user and scopes.");
-                    return null;
-                }
-
-                // if only one cached token found
-                if (filteredItems.Count() == 1)
-                {
-                    msalAccessTokenCacheItem = filteredItems.First();
-                }
-                else
-                {
-                    requestParams.RequestContext.Logger.Error("Multiple tokens found for matching authority, client_id, user and scopes.");
-
-                    throw new MsalClientException(
-                        MsalError.MultipleTokensMatchedError,
-                        MsalErrorMessage.MultipleTokensMatched);
-                }
-
-                if (msalAccessTokenCacheItem != null)
-                {
-                    if (msalAccessTokenCacheItem.ExpiresOn >
-                        DateTime.UtcNow + TimeSpan.FromMinutes(DefaultExpirationBufferInMinutes))
-                    {
-                        requestParams.RequestContext.Logger.Info(
-                            "Access token is not expired. Returning the found cache entry. " +
-                            GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
-                        return msalAccessTokenCacheItem;
-                    }
-
-                    if (ServiceBundle.Config.IsExtendedTokenLifetimeEnabled && msalAccessTokenCacheItem.ExtendedExpiresOn >
-                        DateTime.UtcNow + TimeSpan.FromMinutes(DefaultExpirationBufferInMinutes))
-                    {
-                        requestParams.RequestContext.Logger.Info(
-                            "Access token is expired.  IsExtendedLifeTimeEnabled=TRUE and ExtendedExpiresOn is not exceeded.  Returning the found cache entry. " +
-                            GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
-
-                        msalAccessTokenCacheItem.IsExtendedLifeTimeToken = true;
-                        return msalAccessTokenCacheItem;
-                    }
-
-                    requestParams.RequestContext.Logger.Info(
-                        "Access token has expired or about to expire. " +
-                        GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
-                }
-
+                requestParams.RequestContext.Logger.Info("No matching entry found for user or assertion");
                 return null;
             }
-            finally
+
+            requestParams.RequestContext.Logger.Info("Matching entry count -" + tokenCacheItems.Count());
+
+            IEnumerable<MsalAccessTokenCacheItem> filteredItems =
+                tokenCacheItems.Where(item => ScopeHelper.ScopeContains(item.ScopeSet, requestParams.Scope));
+
+            requestParams.RequestContext.Logger.Info("Matching entry count after filtering by scopes - " + filteredItems.Count());
+
+            // at this point we need env aliases, try to get them without a discovery call
+            var instanceMetadata = await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
+                                     requestParams.AuthorityInfo.CanonicalAuthority,
+                                     filteredItems.Select(at => at.Environment),  // if all environments are known, a network call can be avoided
+                                     requestParams.RequestContext)
+                            .ConfigureAwait(false);
+
+            // filter by authority
+            var filteredByPreferredAlias = filteredItems.Where(
+                at => at.Environment.Equals(instanceMetadata.PreferredCache, StringComparison.OrdinalIgnoreCase));
+
+            if (filteredByPreferredAlias.Any())
             {
-                _semaphoreSlim.Release();
+                filteredItems = filteredByPreferredAlias;
             }
+            else
+            {
+                filteredItems = filteredItems.Where(
+                    item => instanceMetadata.Aliases.Contains(item.Environment) &&
+                    (item.IsAdfs || item.TenantId.Equals(requestParams.Authority.GetTenantId(), StringComparison.OrdinalIgnoreCase)));
+            }
+
+            // no match
+            if (!filteredItems.Any())
+            {
+                requestParams.RequestContext.Logger.Info("No tokens found for matching authority, client_id, user and scopes.");
+                return null;
+            }
+
+            MsalAccessTokenCacheItem msalAccessTokenCacheItem;
+
+            // if only one cached token found
+            if (filteredItems.Count() == 1)
+            {
+                msalAccessTokenCacheItem = filteredItems.First();
+            }
+            else
+            {
+                requestParams.RequestContext.Logger.Error("Multiple tokens found for matching authority, client_id, user and scopes.");
+
+                throw new MsalClientException(
+                    MsalError.MultipleTokensMatchedError,
+                    MsalErrorMessage.MultipleTokensMatched);
+            }
+
+            if (msalAccessTokenCacheItem != null)
+            {
+                if (msalAccessTokenCacheItem.ExpiresOn >
+                    DateTime.UtcNow + TimeSpan.FromMinutes(DefaultExpirationBufferInMinutes))
+                {
+                    requestParams.RequestContext.Logger.Info(
+                        "Access token is not expired. Returning the found cache entry. " +
+                        GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
+                    return msalAccessTokenCacheItem;
+                }
+
+                if (ServiceBundle.Config.IsExtendedTokenLifetimeEnabled && msalAccessTokenCacheItem.ExtendedExpiresOn >
+                    DateTime.UtcNow + TimeSpan.FromMinutes(DefaultExpirationBufferInMinutes))
+                {
+                    requestParams.RequestContext.Logger.Info(
+                        "Access token is expired.  IsExtendedLifeTimeEnabled=TRUE and ExtendedExpiresOn is not exceeded.  Returning the found cache entry. " +
+                        GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
+
+                    msalAccessTokenCacheItem.IsExtendedLifeTimeToken = true;
+                    return msalAccessTokenCacheItem;
+                }
+
+                requestParams.RequestContext.Logger.Info(
+                    "Access token has expired or about to expire. " +
+                    GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
+            }
+
+            return null;
         }
+
+
 
         async Task<MsalRefreshTokenCacheItem> ITokenCacheInternal.FindRefreshTokenAsync(
             AuthenticationRequestParameters requestParams,
             string familyId)
         {
+            if (requestParams.Authority == null)
+                return null;
+
+            IEnumerable<MsalRefreshTokenCacheItem> allRts = Enumerable.Empty<MsalRefreshTokenCacheItem>();
+            await LoadFromCacheAsync(
+               requestParams.RequestContext.TelemetryCorrelationId,
+               CacheEvent.TokenTypes.AT,
+               requestParams.Account,
+               () => allRts = _accessor.GetAllRefreshTokens())
+                   .ConfigureAwait(false);
+
+            // TODO: bogavril - do we want to be silent here?
+            var metadata =
+                await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
+                    requestParams.AuthorityInfo.CanonicalAuthority,
+                    allRts.Select(rt => rt.Environment),  // if all environments are known, a network call can be avoided
+                    requestParams.RequestContext)
+                .ConfigureAwait(false);
+            var aliases = metadata.Aliases;
+
+            IEnumerable<MsalRefreshTokenCacheKey> candidateRtKeys = aliases.Select(
+                    al => new MsalRefreshTokenCacheKey(
+                        al,
+                        requestParams.ClientId,
+                        requestParams.Account?.HomeAccountId?.Identifier,
+                        familyId));
+
+            MsalRefreshTokenCacheItem candidateRt = allRts.FirstOrDefault(
+                rt => candidateRtKeys.Any(
+                    candidateKey => object.Equals(rt.GetKey(), candidateKey)));
+
+            requestParams.RequestContext.Logger.Info("Refresh token found in the cache? - " + (candidateRt != null));
+
+            if (candidateRt != null)
+                return candidateRt;
+
+            requestParams.RequestContext.Logger.Info("Checking ADAL cache for matching RT");
+
+            string upn = string.IsNullOrWhiteSpace(requestParams.LoginHint)
+                ? requestParams.Account?.Username
+                : requestParams.LoginHint;
+
+            // ADAL legacy cache does not store FRTs
+            if (requestParams.Account != null && string.IsNullOrEmpty(familyId))
+            {
+                return CacheFallbackOperations.GetAdalEntryForMsal(
+                    Logger,
+                    LegacyCachePersistence,
+                    metadata.PreferredCache,
+                    aliases,
+                    requestParams.ClientId,
+                    upn,
+                    requestParams.Account.HomeAccountId?.Identifier);
+            }
+
+            return null;
+        }
+
+        async Task<bool?> ITokenCacheInternal.IsFociMemberAsync(AuthenticationRequestParameters requestParams, string familyId)
+        {
+            var logger = requestParams.RequestContext.Logger;
+            if (requestParams?.AuthorityInfo?.CanonicalAuthority == null)
+            {
+                logger.Warning("No authority details, can't check app metadata. Returning unknown");
+                return null;
+            }
+
+            IEnumerable<MsalAppMetadataCacheItem> allAppMetadata = Enumerable.Empty<MsalAppMetadataCacheItem>();
+            await LoadFromCacheAsync(
+                    requestParams.RequestContext.TelemetryCorrelationId,
+                    CacheEvent.TokenTypes.APPMETADATA,
+                    requestParams.Account,
+                    () => allAppMetadata = _accessor.GetAllAppMetadata())
+                .ConfigureAwait(false);
+
+            var instanceMetadata = await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
+                    requestParams.AuthorityInfo.CanonicalAuthority,
+                    allAppMetadata.Select(m => m.Environment),
+                    requestParams.RequestContext)
+                .ConfigureAwait(false);
+
+            var appMetadata =
+                instanceMetadata.Aliases
+                .Select(env => _accessor.GetAppMetadata(new MsalAppMetadataCacheKey(ClientId, env)))
+                .FirstOrDefault(item => item != null);
+
+            if (appMetadata == null)
+            {
+                logger.Warning("No app metadata found. Returning unknown");
+                return null;
+            }
+
+            return appMetadata.FamilyId == familyId;
+        }
+
+        private async Task LoadFromCacheAsync(
+            string telemetryId, CacheEvent.TokenTypes type, IAccount account, Action loadingAction)
+        {
             var cacheEvent = new CacheEvent(
                 CacheEvent.TokenCacheLookup,
-                requestParams.RequestContext.TelemetryCorrelationId)
+                telemetryId)
             {
-                TokenType = CacheEvent.TokenTypes.RT
+                TokenType = type
             };
 
             using (ServiceBundle.TelemetryManager.CreateTelemetryHelper(cacheEvent))
             {
-                if (requestParams.Authority == null)
-                {
-                    return null;
-                }
-
-                InstanceDiscoveryMetadataEntry instanceDiscoveryMetadata =
-                    await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
-                        new Uri(requestParams.AuthorityInfo.CanonicalAuthority),
-                        requestParams.RequestContext)
-                    .ConfigureAwait(false);
-
+                TokenCacheNotificationArgs args = new TokenCacheNotificationArgs(this, ClientId, account, false);
                 await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
                 try
                 {
-                    requestParams.RequestContext.Logger.Info("Looking up refresh token in the cache..");
-
-                    TokenCacheNotificationArgs args = new TokenCacheNotificationArgs(this, ClientId, requestParams.Account, false);
-
-                    IEnumerable<MsalRefreshTokenCacheKey> keysAcrossEnvs =
-                        instanceDiscoveryMetadata.GetAliasesWithPreferredCacheFirst().Select(
-                            ea => new MsalRefreshTokenCacheKey(
-                                ea,
-                                requestParams.ClientId,
-                                requestParams.Account?.HomeAccountId?.Identifier,
-                                familyId));
-
                     await OnBeforeAccessAsync(args).ConfigureAwait(false);
-                    try
-                    {
-                        // Try to load from all env aliases, but stop at the first valid one
-                        MsalRefreshTokenCacheItem msalRefreshTokenCacheItem = keysAcrossEnvs
-                            .Select(key => _accessor.GetRefreshToken(key))
-                            .FirstOrDefault(item => item != null);
 
-                        requestParams.RequestContext.Logger.Info("Refresh token found in the cache? - " + (msalRefreshTokenCacheItem != null));
+                    loadingAction();
 
-                        if (msalRefreshTokenCacheItem != null)
-                        {
-                            return msalRefreshTokenCacheItem;
-                        }
-
-                        requestParams.RequestContext.Logger.Info("Checking ADAL cache for matching RT");
-
-                        string upn = string.IsNullOrWhiteSpace(requestParams.LoginHint)
-                            ? requestParams.Account?.Username
-                            : requestParams.LoginHint;
-
-                        // ADAL legacy cache does not store FRTs
-                        if (requestParams.Account != null && string.IsNullOrEmpty(familyId))
-                        {
-                            return CacheFallbackOperations.GetAdalEntryForMsal(
-                                Logger,
-                                LegacyCachePersistence,
-                                instanceDiscoveryMetadata.PreferredCache,
-                                instanceDiscoveryMetadata.Aliases,
-                                requestParams.ClientId,
-                                upn,
-                                requestParams.Account.HomeAccountId?.Identifier);
-                        }
-
-                        return null;
-
-                    }
-                    finally
-                    {
-                        await OnAfterAccessAsync(args).ConfigureAwait(false);
-                    }
+                    await OnAfterAccessAsync(args).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -428,51 +449,7 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        async Task<bool?> ITokenCacheInternal.IsFociMemberAsync(AuthenticationRequestParameters requestParams, string familyId)
-        {
-            var logger = requestParams.RequestContext.Logger;
-            if (requestParams?.AuthorityInfo?.CanonicalAuthority == null)
-            {
-                logger.Warning("No authority details, can't check app metadta. Returning unkown");
-                return null;
-            }
-
-            InstanceDiscoveryMetadataEntry instanceDiscoveryMetadata =
-                   await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
-                       new Uri(requestParams.AuthorityInfo.CanonicalAuthority),
-                       requestParams.RequestContext)
-                   .ConfigureAwait(false);
-
-            TokenCacheNotificationArgs args = new TokenCacheNotificationArgs(this, ClientId, requestParams?.Account, false);
-
-            //TODO: bogavril - is the env ok here? Can I cache it or pass it in?
-            MsalAppMetadataCacheItem appMetadata;
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                await OnBeforeAccessAsync(args).ConfigureAwait(false);
-
-                appMetadata =
-                    instanceDiscoveryMetadata.Aliases
-                    .Select(env => _accessor.GetAppMetadata(new MsalAppMetadataCacheKey(ClientId, env)))
-                    .FirstOrDefault(item => item != null);
-
-                await OnAfterAccessAsync(args).ConfigureAwait(false);
-            }
-            finally
-            {
-                _semaphoreSlim.Release();
-            }
-
-            if (appMetadata == null)
-            {
-                logger.Warning("No app metadata found. Returning unkown");
-                return null;
-            }
-
-            return appMetadata.FamilyId == familyId;
-        }
-
+        // TODO: no telemetry 
         async Task<MsalIdTokenCacheItem> ITokenCacheInternal.GetIdTokenCacheItemAsync(MsalIdTokenCacheKey msalIdTokenCacheKey, RequestContext requestContext)
         {
             await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
@@ -498,8 +475,10 @@ namespace Microsoft.Identity.Client
         }
 
         /// <remarks>
-        /// Get accounts should not make a network call, if possible.
+        /// Get accounts should not make a network call, if possible. This can be achieved if 
+        /// all the environments in the token cache are known to MSAL.
         /// </remarks>
+        // TODO: No telemetry is emitted
         async Task<IEnumerable<IAccount>> ITokenCacheInternal.GetAccountsAsync(string authority, RequestContext requestContext)
         {
             var environment = Authority.GetEnviroment(authority);
@@ -538,20 +517,20 @@ namespace Microsoft.Identity.Client
             }
 
             // Multi-cloud support - must filter by env.
-            // Use all env aliases to filter, in case PreferredCacheEnv changes in the future
-            ISet<string> existingEnvs = new HashSet<string>(
+            // Avoid making a discovery 
+            ISet<string> allEnvironmentsInCache = new HashSet<string>(
                 accountCacheItems.Select(aci => aci.Environment),
                 StringComparer.OrdinalIgnoreCase);
+            allEnvironmentsInCache.UnionWith(rtCacheItems.Select(rt => rt.Environment));
+            allEnvironmentsInCache.UnionWith(adalUsersResult.GetAdalUserEnviroments());
 
-            var aliases = await GetEnvironmentAliasesTryAvoidNetworkCallAsync(
+            var instanceMetadata = await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
                 authority,
-                existingEnvs,
-                adalUsersResult.GetAdalUserEnviroments(),
-                requestContext)
-                .ConfigureAwait(false);
+                allEnvironmentsInCache,
+                requestContext).ConfigureAwait(false);
 
-            rtCacheItems = rtCacheItems.Where(rt => aliases.ContainsOrdinalIgnoreCase(rt.Environment));
-            accountCacheItems = accountCacheItems.Where(acc => aliases.ContainsOrdinalIgnoreCase(acc.Environment));
+            rtCacheItems = rtCacheItems.Where(rt => instanceMetadata.Aliases.ContainsOrdinalIgnoreCase(rt.Environment));
+            accountCacheItems = accountCacheItems.Where(acc => instanceMetadata.Aliases.ContainsOrdinalIgnoreCase(acc.Environment));
 
             IDictionary<string, Account> clientInfoToAccountMap = new Dictionary<string, Account>();
             foreach (MsalRefreshTokenCacheItem rtItem in rtCacheItems)
@@ -570,9 +549,9 @@ namespace Microsoft.Identity.Client
                 }
             }
 
-            List<IAccount> accounts = UpdateWithAdalAccounts(
+            IEnumerable<IAccount> accounts = UpdateWithAdalAccounts(
                 environment,
-                aliases,
+                instanceMetadata.Aliases,
                 adalUsersResult,
                 clientInfoToAccountMap);
 

--- a/src/Microsoft.Identity.Client/UI/AuthorizationResult.cs
+++ b/src/Microsoft.Identity.Client/UI/AuthorizationResult.cs
@@ -147,8 +147,5 @@ namespace Microsoft.Identity.Client.UI
         /// is the same as the system who asked for it. It protects against XSRF https://openid.net/specs/openid-connect-core-1_0.html
         /// </remarks>
         public string State { get; set; }
-
-
-     
     }
 }

--- a/src/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
+++ b/src/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Identity.Client.Core;
@@ -30,15 +31,15 @@ namespace Microsoft.Identity.Client.Utils
             return set.Any(el => el.Equals(toLookFor, System.StringComparison.OrdinalIgnoreCase));
         }
 
-        internal static List<T> FilterWithLogging<T>(
-            this List<T> list,
+        internal static IEnumerable<T> FilterWithLogging<T>(
+            this IEnumerable<T> list,
             Func<T, bool> predicate,
             ICoreLogger logger,
             string logPrefix)
         {
-            int numberBefore = list.Count;
+            int numberBefore = list.Count();
             list = list.Where(predicate).ToList();
-            int numberAfter = list.Count;
+            int numberAfter = list.Count();
 
             logger.Info($"{logPrefix} item count before {numberBefore} after {numberAfter}");
 

--- a/tests/Microsoft.Identity.Test.Common/Core/Helpers/CoreAssert.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Helpers/CoreAssert.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -25,6 +28,37 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
         {
             Assert.AreEqual(val1, val2, "First and second values differ");
             Assert.AreEqual(val1, val3, "First and third values differ");
+        }
+
+        public static void AssertDictionariesAreEqual<TKey, TValue>(
+          IDictionary<TKey, TValue> dict1,
+          IDictionary<TKey, TValue> dict2,
+          IEqualityComparer<TValue> valueComparer)
+        {
+            Assert.IsTrue(DictionariesAreEqual(dict1, dict2, valueComparer));
+        }
+
+        private static bool DictionariesAreEqual<TKey, TValue>(
+            IDictionary<TKey, TValue> dict1, 
+            IDictionary<TKey, TValue> dict2, 
+            IEqualityComparer<TValue> valueComparer)
+        {
+            if (dict1 == dict2)
+                return true;
+            if ((dict1 == null) || (dict2 == null))
+                return false;
+            if (dict1.Count != dict2.Count)
+                return false;
+
+            foreach (var kvp in dict1)
+            {
+                TValue value2;
+                if (!dict2.TryGetValue(kvp.Key, out value2))
+                    return false;
+                if (!valueComparer.Equals(kvp.Value, value2))
+                    return false;
+            }
+            return true;
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Unit;
 
@@ -336,52 +337,13 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 authority, qp));
         }
 
-        public static HttpMessageHandler CreateInstanceDiscoveryMockHandler(string url)
-        {
-            return CreateInstanceDiscoveryMockHandler(url,
-                @"{
-                        ""tenant_discovery_endpoint"":""https://login.microsoftonline.com/tenant/.well-known/openid-configuration"",
-                        ""api-version"":""1.1"",
-                        ""metadata"":[
-                            {
-                            ""preferred_network"":""login.microsoftonline.com"",
-                            ""preferred_cache"":""login.windows.net"",
-                            ""aliases"":[
-                                ""login.microsoftonline.com"",
-                                ""login.windows.net"",
-                                ""login.microsoft.com"",
-                                ""sts.windows.net""]},
-                            {
-                            ""preferred_network"":""login.partner.microsoftonline.cn"",
-                            ""preferred_cache"":""login.partner.microsoftonline.cn"",
-                            ""aliases"":[
-                                ""login.partner.microsoftonline.cn"",
-                                ""login.chinacloudapi.cn""]},
-                            {
-                            ""preferred_network"":""login.microsoftonline.de"",
-                            ""preferred_cache"":""login.microsoftonline.de"",
-                            ""aliases"":[
-                                    ""login.microsoftonline.de""]},
-                            {
-                            ""preferred_network"":""login.microsoftonline.us"",
-                            ""preferred_cache"":""login.microsoftonline.us"",
-                            ""aliases"":[
-                                ""login.microsoftonline.us"",
-                                ""login.usgovcloudapi.net""]},
-                            {
-                            ""preferred_network"":""login-us.microsoftonline.com"",
-                            ""preferred_cache"":""login-us.microsoftonline.com"",
-                            ""aliases"":[
-                                ""login-us.microsoftonline.com""]}
-                        ]
-                }");
-        }
-
-        public static HttpMessageHandler CreateInstanceDiscoveryMockHandler(string url, string content)
+        public static HttpMessageHandler CreateInstanceDiscoveryMockHandler(
+            string discoveryEndpoint, 
+            string content = MsalTestConstants.DiscoveryJsonResponse)
         {
             return new MockHttpMessageHandler()
             {
-                ExpectedUrl = url,
+                ExpectedUrl = discoveryEndpoint,
                 ExpectedMethod = HttpMethod.Get,
                 ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
                 {
@@ -389,5 +351,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 }
             };
         }
+
+       
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Test.Unit;
 
 namespace Microsoft.Identity.Test.Common.Core.Mocks
@@ -17,10 +18,19 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             AddInstanceDiscoveryMockHandler(httpManager, MsalTestConstants.AuthorityCommonTenant);
         }
 
-        public static void AddInstanceDiscoveryMockHandler(this MockHttpManager httpManager, string url)
+        public static void AddInstanceDiscoveryMockHandler(this MockHttpManager httpManager, string authority)
         {
-            httpManager.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler(MsalTestConstants.GetDiscoveryEndpoint(url)));
+            string host = new Uri(authority).Host;
+            string discoveryHost = AadAuthority.IsInTrustedHostList(host)
+                                       ? host
+                                       : AadAuthority.DefaultTrustedHost;
+
+            string discoveryEndpoint = $"https://{discoveryHost}/common/discovery/instance";
+
+            httpManager.AddMockHandler(
+                MockHelpers.CreateInstanceDiscoveryMockHandler(discoveryEndpoint));
         }
+
 
         public static void AddResponseMockHandlerForPost(
             this MockHttpManager httpManager,

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Test.Unit;
 
 namespace Microsoft.Identity.Test.Common.Core.Mocks
@@ -21,7 +22,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public static void AddInstanceDiscoveryMockHandler(this MockHttpManager httpManager, string authority)
         {
             string host = new Uri(authority).Host;
-            string discoveryHost = AadAuthority.IsInTrustedHostList(host)
+            string discoveryHost = KnownMetadataProvider.IsKnownEnvironment(host)
                                        ? host
                                        : AadAuthority.DefaultTrustedHost;
 

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -33,10 +33,11 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             ITokenCacheAccessor accessor,
             string uid = MsalTestConstants.Uid,
             string utid = MsalTestConstants.Utid,
-            string clientId = MsalTestConstants.ClientId)
+            string clientId = MsalTestConstants.ClientId, 
+            string environment = MsalTestConstants.ProductionPrefCacheEnvironment)
         {
             MsalAccessTokenCacheItem atItem = new MsalAccessTokenCacheItem(
-                MsalTestConstants.ProductionPrefCacheEnvironment,
+                environment,
                 clientId,
                 MsalTestConstants.Scope.AsSingleString(),
                 utid,
@@ -49,7 +50,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             accessor.SaveAccessToken(atItem);
 
             var idTokenCacheItem = new MsalIdTokenCacheItem(
-                MsalTestConstants.ProductionPrefCacheEnvironment,
+                environment,
                 clientId,
                 MockHelpers.CreateIdToken(MsalTestConstants.UniqueId + "more", MsalTestConstants.DisplayableId),
                 MockHelpers.CreateClientInfo(uid, utid),
@@ -58,7 +59,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             accessor.SaveIdToken(idTokenCacheItem);
 
             var accountCacheItem = new MsalAccountCacheItem(
-                MsalTestConstants.ProductionPrefCacheEnvironment,
+                environment,
                 null,
                 MockHelpers.CreateClientInfo(uid, utid),
                 null,
@@ -70,7 +71,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             accessor.SaveAccount(accountCacheItem);
 
             atItem = new MsalAccessTokenCacheItem(
-                MsalTestConstants.ProductionPrefCacheEnvironment,
+                environment,
                 clientId,
                 MsalTestConstants.ScopeForAnotherResource.AsSingleString(),
                 utid,
@@ -82,11 +83,11 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             // add another access token
             accessor.SaveAccessToken(atItem);
 
-            AddRefreshTokenToCache(accessor,uid, utid, clientId);
+            AddRefreshTokenToCache(accessor,uid, utid, clientId, environment);
 
             var appMetadataItem = new MsalAppMetadataCacheItem(
                 clientId,
-                MsalTestConstants.ProductionPrefCacheEnvironment,
+                environment,
                 null);
 
             accessor.SaveAppMetadata(appMetadataItem);
@@ -137,10 +138,11 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             ITokenCacheAccessor accessor,
             string uid,
             string utid,
-            string clientId = MsalTestConstants.ClientId)
+            string clientId = MsalTestConstants.ClientId, 
+            string environment = MsalTestConstants.ProductionPrefCacheEnvironment)
         {
             var rtItem = new MsalRefreshTokenCacheItem
-                (MsalTestConstants.ProductionPrefCacheEnvironment, clientId, "someRT", MockHelpers.CreateClientInfo(uid, utid));
+                (environment, clientId, "someRT", MockHelpers.CreateClientInfo(uid, utid));
 
             accessor.SaveRefreshToken(rtItem);
         }

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -173,8 +173,8 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         public const string BrokerExtraQueryParameters = "extra=qp&key1=value1%20with%20encoded%20space&key2=value2";
         public const string BrokerClaims = "testClaims";
 
-        public static readonly ClientCredentialWrapper OnPremiseCredentialWithSecret = new ClientCredentialWrapper(ClientSecret);
-        public static readonly ClientCredentialWrapper CredentialWithSecret = new ClientCredentialWrapper(ClientSecret);
+        public static readonly ClientCredentialWrapper OnPremiseCredentialWithSecret = ClientCredentialWrapper.CreateWithSecret(ClientSecret);
+        public static readonly ClientCredentialWrapper CredentialWithSecret = ClientCredentialWrapper.CreateWithSecret(ClientSecret);
 
         public const string DiscoveryJsonResponse = @"{
                         ""tenant_discovery_endpoint"":""https://login.microsoftonline.com/tenant/.well-known/openid-configuration"",

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Identity.Test.Unit
         public const string ProductionPrefCacheEnvironment = "login.windows.net";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
 
+        public const string AuthorityNotKnownCommon = "https://sts.access.edu/common/";
+        public const string AuthorityNotKnownTenanted = "https://sts.access.edu/" + Utid + "/";
+
         public const string SovereignNetworkEnvironment = "login.microsoftonline.de";
         public const string AuthorityHomeTenant = "https://" + ProductionPrefNetworkEnvironment + "/home/";
         public const string AuthorityUtidTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + Utid + "/";
@@ -122,10 +125,7 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
 
         public static readonly string UserIdentifier = CreateUserIdentifier();
 
-        public static string GetDiscoveryEndpoint(string authority)
-        {
-            return authority + DiscoveryEndPoint;
-        }
+       
 
         public static string CreateUserIdentifier()
         {
@@ -173,10 +173,45 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         public const string BrokerExtraQueryParameters = "extra=qp&key1=value1%20with%20encoded%20space&key2=value2";
         public const string BrokerClaims = "testClaims";
 
-#if !ANDROID && !iOS && !WINDOWS_APP
-        public static readonly ClientCredentialWrapper OnPremiseCredentialWithSecret = ClientCredentialWrapper.CreateWithSecret(ClientSecret);
-        public static readonly ClientCredentialWrapper CredentialWithSecret = ClientCredentialWrapper.CreateWithSecret(ClientSecret);
-#endif
+        public static readonly ClientCredentialWrapper OnPremiseCredentialWithSecret = new ClientCredentialWrapper(ClientSecret);
+        public static readonly ClientCredentialWrapper CredentialWithSecret = new ClientCredentialWrapper(ClientSecret);
+
+        public const string DiscoveryJsonResponse = @"{
+                        ""tenant_discovery_endpoint"":""https://login.microsoftonline.com/tenant/.well-known/openid-configuration"",
+                        ""api-version"":""1.1"",
+                        ""metadata"":[
+                            {
+                            ""preferred_network"":""login.microsoftonline.com"",
+                            ""preferred_cache"":""login.windows.net"",
+                            ""aliases"":[
+                                ""login.microsoftonline.com"", 
+                                ""login.windows.net"",
+                                ""login.microsoft.com"",
+                                ""sts.windows.net""]},
+                            {
+                            ""preferred_network"":""login.partner.microsoftonline.cn"",
+                            ""preferred_cache"":""login.partner.microsoftonline.cn"",
+                            ""aliases"":[
+                                ""login.partner.microsoftonline.cn"",
+                                ""login.chinacloudapi.cn""]},
+                            {
+                            ""preferred_network"":""login.microsoftonline.de"",
+                            ""preferred_cache"":""login.microsoftonline.de"",
+                            ""aliases"":[
+                                    ""login.microsoftonline.de""]},
+                            {
+                            ""preferred_network"":""login.microsoftonline.us"",
+                            ""preferred_cache"":""login.microsoftonline.us"",
+                            ""aliases"":[
+                                ""login.microsoftonline.us"",
+                                ""login.usgovcloudapi.net""]},
+                            {
+                            ""preferred_network"":""login-us.microsoftonline.com"",
+                            ""preferred_cache"":""login-us.microsoftonline.com"",
+                            ""aliases"":[
+                                ""login-us.microsoftonline.com""]}
+                        ]
+                }";
     }
 
     internal static class Adfs2019LabConstants

--- a/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/AuthorityTests.cs
@@ -1,14 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Test.Common.Core.Helpers;
-using Microsoft.Identity.Test.LabInfrastructure;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Instance.Discovery;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.LabInfrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
 {
@@ -20,8 +24,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         [TestMethod]
         public async Task AuthorityMigrationAsync()
         {
-            var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
-            var user = labResponse.User;
+            LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
+            LabUser user = labResponse.User;
 
             IPublicClientApplication pca = PublicClientApplicationBuilder
                 .Create(labResponse.AppId)
@@ -52,8 +56,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         [TestMethod]
         public async Task FailedAuthorityValidationTestAsync()
         {
-            var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
-            var user = labResponse.User;
+            LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
+            LabUser user = labResponse.User;
 
             IPublicClientApplication pca = PublicClientApplicationBuilder
                 .Create(labResponse.AppId)
@@ -72,6 +76,56 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             Assert.IsTrue(exception.Message.Contains("AADSTS50049"));
             Assert.AreEqual("invalid_instance", exception.ErrorCode);
+        }
+
+        /// <summary>
+        /// If this test fails, please update the <see cref="KnownMetadataProvider"/> to 
+        /// use whatever Evo uses (i.e. the aliases, preferred network / metadata from the url below).
+        /// </summary>
+        [TestMethod]
+        public async Task KnownInstanceMetadataIsUpToDateAsync()
+        {
+            string validDiscoveryUri = @"https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize";
+            HttpClient httpClient = new HttpClient();
+            HttpResponseMessage discoveryResponse = await httpClient.SendAsync(
+                new HttpRequestMessage(
+                    HttpMethod.Get,
+                    validDiscoveryUri)).ConfigureAwait(false);
+            string discoveryJson = await discoveryResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            InstanceDiscoveryMetadataEntry[] actualMetadata = JsonHelper.DeserializeFromJson<InstanceDiscoveryResponse>(discoveryJson).Metadata;
+            var processedMetadata = new Dictionary<string, InstanceDiscoveryMetadataEntry>();
+            foreach (InstanceDiscoveryMetadataEntry entry in actualMetadata)
+            {
+                foreach (var alias in entry.Aliases)
+                {
+                    processedMetadata[alias] = entry;
+                }
+            }
+
+            IDictionary<string, InstanceDiscoveryMetadataEntry> expectedMetadata =
+                KnownMetadataProvider.GetAllEntriesForTest();
+
+            CoreAssert.AssertDictionariesAreEqual(
+                expectedMetadata,
+                processedMetadata,
+                new InstanceDiscoveryMetadataEntryComparer());
+        }
+    }
+
+    internal class InstanceDiscoveryMetadataEntryComparer : IEqualityComparer<InstanceDiscoveryMetadataEntry>
+    {
+        public bool Equals(InstanceDiscoveryMetadataEntry x, InstanceDiscoveryMetadataEntry y)
+        {
+            return
+                 string.Equals(x.PreferredCache, y.PreferredCache, System.StringComparison.OrdinalIgnoreCase) &&
+                 string.Equals(x.PreferredNetwork, y.PreferredNetwork, System.StringComparison.OrdinalIgnoreCase) &&
+                 Enumerable.SequenceEqual(x.Aliases, y.Aliases);
+        }
+
+        public int GetHashCode(InstanceDiscoveryMetadataEntry obj)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/AuthorityAliasesTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/AuthorityAliasesTests.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Identity.Test.Unit
 
             using (var httpManager = new MockHttpManager())
             {
-                httpManager.AddInstanceDiscoveryMockHandler();
 
                 var authorityUri = new Uri(
                     string.Format(
@@ -47,7 +46,9 @@ namespace Microsoft.Identity.Test.Unit
                         "https://{0}/common",
                         MsalTestConstants.ProductionNotPrefEnvironmentAlias));
 
-                var app = PublicClientApplicationBuilder
+                httpManager.AddInstanceDiscoveryMockHandler(authorityUri.AbsoluteUri);
+
+                PublicClientApplication app = PublicClientApplicationBuilder
                     .Create(MsalTestConstants.ClientId)
                           .WithAuthority(authorityUri, true)
                           .WithHttpManager(httpManager)
@@ -152,27 +153,27 @@ namespace Microsoft.Identity.Test.Unit
 
         private async Task ValidateCacheEntitiesEnvironmentAsync(ITokenCacheInternal cache, string expectedEnvironment)
         {
-            var logger = Substitute.For<ICoreLogger>();
-            var accessTokens = await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false);
-            foreach (var at in accessTokens)
+            ICoreLogger logger = Substitute.For<ICoreLogger>();
+            IEnumerable<Client.Cache.Items.MsalAccessTokenCacheItem> accessTokens = await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false);
+            foreach (Client.Cache.Items.MsalAccessTokenCacheItem at in accessTokens)
             {
                 Assert.AreEqual(expectedEnvironment, at.Environment);
             }
 
-            var refreshTokens = await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false);
-            foreach (var rt in refreshTokens)
+            IEnumerable<Client.Cache.Items.MsalRefreshTokenCacheItem> refreshTokens = await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false);
+            foreach (Client.Cache.Items.MsalRefreshTokenCacheItem rt in refreshTokens)
             {
                 Assert.AreEqual(expectedEnvironment, rt.Environment);
             }
 
-            var idTokens = await cache.GetAllIdTokensAsync(true).ConfigureAwait(false);
-            foreach (var id in idTokens)
+            IEnumerable<Client.Cache.Items.MsalIdTokenCacheItem> idTokens = await cache.GetAllIdTokensAsync(true).ConfigureAwait(false);
+            foreach (Client.Cache.Items.MsalIdTokenCacheItem id in idTokens)
             {
                 Assert.AreEqual(expectedEnvironment, id.Environment);
             }
 
-            var accounts = await cache.GetAllAccountsAsync().ConfigureAwait(false);
-            foreach (var account in accounts)
+            IEnumerable<Client.Cache.Items.MsalAccountCacheItem> accounts = await cache.GetAllAccountsAsync().ConfigureAwait(false);
+            foreach (Client.Cache.Items.MsalAccountCacheItem account in accounts)
             {
                 Assert.AreEqual(expectedEnvironment, account.Environment);
             }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheTests.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
                 var atItem = new MsalAccessTokenCacheItem(
                     MsalTestConstants.ProductionPrefNetworkEnvironment,
@@ -71,7 +70,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -109,7 +107,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -149,7 +146,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -180,7 +176,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness(isExtendedTokenLifetimeEnabled: true))
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -215,7 +210,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -246,7 +240,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var rtItem = new MsalRefreshTokenCacheItem(
@@ -281,7 +274,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
                 var rtItem = new MsalRefreshTokenCacheItem(
                     MsalTestConstants.SovereignNetworkEnvironment,
@@ -309,7 +301,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -381,7 +372,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -422,7 +412,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -463,7 +452,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
 
                 var atItem = new MsalAccessTokenCacheItem(
@@ -931,7 +919,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // Arrange
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
                 AuthenticationRequestParameters requestParams = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityTestTenant,
@@ -969,7 +956,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // Arrange
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
                 AuthenticationRequestParameters requestParams = harness.CreateAuthenticationRequestParameters(
                     MsalTestConstants.AuthorityTestTenant,
@@ -1012,7 +998,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         private void AddHostToInstanceCache(IServiceBundle serviceBundle, string host)
         {
             (serviceBundle.InstanceDiscoveryManager as InstanceDiscoveryManager)
-                .AddTestValue(
+                .AddTestValueToStaticProvider(
                     host,
                     new InstanceDiscoveryMetadataEntry
                     {

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheFormatTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/UnifiedCacheFormatTests.cs
@@ -33,9 +33,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
     {
         private void Init(MockHttpManager httpManager)
         {
-            httpManager.AddMockHandler(
-            MockHelpers.CreateInstanceDiscoveryMockHandler(
-                MsalTestConstants.GetDiscoveryEndpoint(MsalTestConstants.AuthorityCommonTenant)));
+            httpManager.AddInstanceDiscoveryMockHandler();
         }
 
         private string _clientId;

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/CacheTests/MsalTokenCacheKeysTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/CacheTests/MsalTokenCacheKeysTests.cs
@@ -51,6 +51,10 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.CacheTests
             Assert.AreEqual("accesstoken-clientid-contoso.com-user.read user.write", key.iOSService);
             Assert.AreEqual("accesstoken-clientid-contoso.com", key.iOSGeneric);
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.AccessToken, key.iOSType);
+
+            Assert.AreEqual(
+                key,
+                new MsalAccessTokenCacheKey("login.microsoftonline.com", "contoso.com", "uid.utid", "clientid", "user.read user.write"));
         }
 
         [TestMethod]
@@ -64,6 +68,10 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.CacheTests
             Assert.AreEqual("refreshtoken-clientid--", key.iOSService);
             Assert.AreEqual("refreshtoken-clientid-", key.iOSGeneric);
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.RefreshToken, key.iOSType);
+
+            Assert.AreEqual(
+                key,
+                new MsalRefreshTokenCacheKey("login.microsoftonline.com", "clientid", "uid.utid", ""));
         }
 
         [TestMethod]
@@ -77,6 +85,10 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.CacheTests
             Assert.AreEqual("refreshtoken-1--", key.iOSService);
             Assert.AreEqual("refreshtoken-1-", key.iOSGeneric);
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.RefreshToken, key.iOSType);
+
+            Assert.AreEqual(
+                key,
+                new MsalRefreshTokenCacheKey("login.microsoftonline.com", "CLIENT_ID_NOT_USED", "uid.utid", "1"));
         }
 
         [TestMethod]
@@ -90,6 +102,10 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.CacheTests
             Assert.AreEqual("idtoken-clientid-contoso.com-", key.iOSService);
             Assert.AreEqual("idtoken-clientid-contoso.com", key.iOSGeneric);
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.IdToken, key.iOSType);
+
+            Assert.AreEqual(
+                key,
+                new MsalIdTokenCacheKey("login.microsoftonline.com", "contoso.com", "uid.utid", "clientid"));
         }
 
         [TestMethod]
@@ -109,6 +125,12 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.CacheTests
             Assert.AreEqual("localid", key.iOSGeneric);
             Assert.AreEqual(MsalCacheKeys.iOSAuthorityTypeToAttrType["AAD"], key.iOSType);
 
+            Assert.AreEqual(key, new MsalAccountCacheKey(
+                "login.microsoftonline.com",
+                "contoso.com",
+                "uid.utid",
+                "localId",
+                "AAD"));
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceDiscoveryManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceDiscoveryManagerTests.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Instance.Discovery;
-using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -15,6 +14,48 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
     [TestClass]
     public class InstanceDiscoveryManagerTests : TestBase
     {
+        private const string Authority = "https://some_env.com/tid";
+        private INetworkMetadataProvider _networkMetadataProvider;
+        private IKnownMetadataProvider _knownMetadataProvider;
+        private IStaticMetadataProvider _staticMetadataProvider;
+        private InstanceDiscoveryMetadataEntry _expectedResult;
+        private MockHttpAndServiceBundle _harness;
+        private RequestContext _testRequestContext;
+        private InstanceDiscoveryManager _discoveryManager;
+
+        [TestInitialize]
+        public override void TestInitialize()
+        {
+            base.TestInitialize();
+
+            _networkMetadataProvider = Substitute.For<INetworkMetadataProvider>();
+            _knownMetadataProvider = Substitute.For<IKnownMetadataProvider>();
+            _staticMetadataProvider = Substitute.For<IStaticMetadataProvider>();
+            _expectedResult = new InstanceDiscoveryMetadataEntry()
+            {
+                Aliases = new[] { "some_env.com", "some_env2.com" },
+                PreferredCache = "env",
+                PreferredNetwork = "env"
+            };
+
+            _harness = base.CreateTestHarness();
+            _testRequestContext = new RequestContext(_harness.ServiceBundle, Guid.NewGuid());
+            _discoveryManager = new InstanceDiscoveryManager(
+                _harness.HttpManager,
+                _harness.ServiceBundle.TelemetryManager,
+                false,
+                _knownMetadataProvider,
+                _staticMetadataProvider,
+                _networkMetadataProvider);
+        }
+
+        [TestCleanup]
+        public override void TestCleanup()
+        {
+            _harness?.Dispose();
+            base.TestCleanup();
+        }
+
         [TestMethod]
         public async Task B2C_GetMetadataAsync()
         {
@@ -29,19 +70,122 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 .ConfigureAwait(false);
         }
 
+        [TestMethod]
+        public async Task StaticProviderIsUsedFirst_Async()
+        {
+            // Arrange
+            _staticMetadataProvider.GetMetadata("some_env.com").Returns(_expectedResult);
+
+            // Act
+            InstanceDiscoveryMetadataEntry actualResult1 = await _discoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
+                Authority,
+                new[] { "env1", "env2" },
+                _testRequestContext)
+                .ConfigureAwait(false);
+            _staticMetadataProvider.Received(1).GetMetadata("some_env.com");
+
+            InstanceDiscoveryMetadataEntry actualResult2 = await _discoveryManager.GetMetadataEntryAsync(
+                "https://some_env.com/tid",
+                _testRequestContext)
+                .ConfigureAwait(false);
+            _staticMetadataProvider.Received(2).GetMetadata("some_env.com");
+            _staticMetadataProvider.AddMetadata(null, null);
+
+            // Assert
+            Assert.AreSame(_expectedResult, actualResult1, "The static provider should be queried first");
+            Assert.AreSame(_expectedResult, actualResult2, "The static provider should be queried first");
+        }
+
+        [TestMethod]
+        public async Task KnownMetadataProviderIsCheckedSecondAsync()
+        {
+            // Arrange
+            var otherEnvs = new[] { "env1", "env2" };
+
+            // No response from the static provider
+            _staticMetadataProvider.GetMetadata("some_env.com").Returns((InstanceDiscoveryMetadataEntry)null);
+            _knownMetadataProvider.GetMetadata("some_env.com", otherEnvs).Returns(_expectedResult);
+
+            // Act
+            InstanceDiscoveryMetadataEntry actualResult = await _discoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
+                "https://some_env.com/tid",
+                otherEnvs,
+                _testRequestContext)
+                .ConfigureAwait(false);
+
+            // Assert
+            Assert.AreSame(_expectedResult, actualResult, "The known metadata provider should be queried second");
+            _staticMetadataProvider.Received(1).GetMetadata("some_env.com");
+            _knownMetadataProvider.Received(1).GetMetadata("some_env.com", otherEnvs);
+        }
+
+        [TestMethod]
+        public async Task NetworkProviderIsCalledLastAsync()
+        {
+            // Arrange
+            _staticMetadataProvider = new StaticMetadataProvider();
+
+            _discoveryManager = new InstanceDiscoveryManager(
+                _harness.HttpManager,
+                _harness.ServiceBundle.TelemetryManager,
+                false,
+                _knownMetadataProvider,
+                _staticMetadataProvider,
+                _networkMetadataProvider);
+
+            var otherEnvs = new[] { "env1", "env2" };
+            InstanceDiscoveryResponse discoveryResponse = new InstanceDiscoveryResponse
+            {
+                Metadata = new[] { _expectedResult }
+            };
+            var authorityUri = new Uri(Authority);
+
+            // No response from the static and known provider
+            _knownMetadataProvider
+                .GetMetadata("some_env.com", otherEnvs)
+                .Returns((InstanceDiscoveryMetadataEntry)null);
+            _networkMetadataProvider
+                .FetchAllDiscoveryMetadataAsync(authorityUri, _testRequestContext)
+                .Returns(discoveryResponse);
+
+            // Act
+            InstanceDiscoveryMetadataEntry actualResult = await _discoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
+                "https://some_env.com/tid",
+                otherEnvs,
+                _testRequestContext)
+                .ConfigureAwait(false);
+
+            // Assert
+            Assert.AreSame(_expectedResult, actualResult, "The known metadata provider should be queried second");
+            _knownMetadataProvider.Received(1).GetMetadata("some_env.com", otherEnvs);
+            _ = _networkMetadataProvider.Received(1).FetchAllDiscoveryMetadataAsync(authorityUri, _testRequestContext);
+        }
+
         private async Task ValidateSelfEntryAsync(Uri authority)
         {
-            using (var harness = CreateTestHarness())
+            using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
-                var entry = await harness.ServiceBundle.InstanceDiscoveryManager
+                InstanceDiscoveryMetadataEntry entry = await harness.ServiceBundle.InstanceDiscoveryManager
                     .GetMetadataEntryAsync(
-                        authority,
+                        authority.AbsoluteUri,
+                        new RequestContext(harness.ServiceBundle, Guid.NewGuid()))
+                    .ConfigureAwait(false);
+
+                InstanceDiscoveryMetadataEntry entry2 = await harness.ServiceBundle.InstanceDiscoveryManager
+                    .GetMetadataEntryTryAvoidNetworkAsync(
+                        authority.AbsoluteUri,
+                        new[] { "some_env" },
                         new RequestContext(harness.ServiceBundle, Guid.NewGuid()))
                     .ConfigureAwait(false);
 
                 Assert.AreEqual(authority.Host, entry.PreferredCache);
                 Assert.AreEqual(authority.Host, entry.PreferredNetwork);
                 Assert.AreEqual(authority.Host, entry.Aliases.Single());
+
+                Assert.AreEqual(authority.Host, entry2.PreferredCache);
+                Assert.AreEqual(authority.Host, entry2.PreferredNetwork);
+                Assert.AreEqual(authority.Host, entry2.Aliases.Single());
+
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceProviderTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 
             result = knownMetadataProvider.GetMetadata(
                 "login.microsoftonline.com", new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
-                Assert.IsNotNull(result);
+            Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
                 "login.partner.microsoftonline.cn", new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
@@ -69,6 +69,17 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             result = knownMetadataProvider.GetMetadata(
                 "bogus", new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
             Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void KnownMetadataProvider_IsKnown()
+        {
+            Assert.IsFalse(KnownMetadataProvider.IsKnownEnvironment(null));
+            Assert.IsFalse(KnownMetadataProvider.IsKnownEnvironment(""));
+            Assert.IsFalse(KnownMetadataProvider.IsKnownEnvironment("bogus"));
+
+            Assert.IsTrue(KnownMetadataProvider.IsKnownEnvironment("login.microsoftonline.de"));
+            Assert.IsTrue(KnownMetadataProvider.IsKnownEnvironment("LOGIN.microsoftonline.de"));
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceProviderTests.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
     [TestClass]
     public class InstanceProviderTests : TestBase
     {
+        private const string LoginMicrosoftOnlineCom = "login.microsoftonline.com";
+
         [TestMethod]
         public void StaticProviderPreservesStateAcrossInstances()
         {
@@ -39,23 +41,23 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             KnownMetadataProvider knownMetadataProvider = new KnownMetadataProvider();
 
             var result = knownMetadataProvider.GetMetadata(
-                 "login.microsoftonline.com", null);
+                 LoginMicrosoftOnlineCom, null);
             Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
-                "login.microsoftonline.com", Enumerable.Empty<string>());
+                LoginMicrosoftOnlineCom, Enumerable.Empty<string>());
             Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
-                "login.microsoftonline.com", new[] { "login.microsoftonline.com" });
+                LoginMicrosoftOnlineCom, new[] { LoginMicrosoftOnlineCom });
             Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
-                "login.microsoftonline.com", new[] { "login.microsoftonline.com" });
+                LoginMicrosoftOnlineCom, new[] { LoginMicrosoftOnlineCom });
             Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
-                "login.microsoftonline.com", new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
+                LoginMicrosoftOnlineCom, new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
             Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
@@ -63,7 +65,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
-               "login.microsoftonline.com", new[] { "login.windows.net", "bogus", "login.partner.microsoftonline.cn" });
+               LoginMicrosoftOnlineCom, new[] { "login.windows.net", "bogus", "login.partner.microsoftonline.cn" });
             Assert.IsNull(result);
 
             result = knownMetadataProvider.GetMetadata(

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/InstanceProviderTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Instance.Discovery;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
+{
+    [TestClass]
+    public class InstanceProviderTests : TestBase
+    {
+        [TestMethod]
+        public void StaticProviderPreservesStateAcrossInstances()
+        {
+            // Arrange
+            StaticMetadataProvider staticMetadataProvider1 = new StaticMetadataProvider();
+            StaticMetadataProvider staticMetadataProvider2 = new StaticMetadataProvider();
+            staticMetadataProvider1.AddMetadata("env", new InstanceDiscoveryMetadataEntry());
+
+            // Act
+            var result = staticMetadataProvider2.GetMetadata("env");
+            staticMetadataProvider2.Clear();
+            var result2 = staticMetadataProvider2.GetMetadata("env");
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNull(result2);
+        }
+
+        [TestMethod]
+        public void KnownMetadataProvider_RespondsIfEnvironmentsAreKnown()
+        {
+            // Arrange
+            KnownMetadataProvider knownMetadataProvider = new KnownMetadataProvider();
+
+            var result = knownMetadataProvider.GetMetadata(
+                 "login.microsoftonline.com", null);
+            Assert.IsNotNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
+                "login.microsoftonline.com", Enumerable.Empty<string>());
+            Assert.IsNotNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
+                "login.microsoftonline.com", new[] { "login.microsoftonline.com" });
+            Assert.IsNotNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
+                "login.microsoftonline.com", new[] { "login.microsoftonline.com" });
+            Assert.IsNotNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
+                "login.microsoftonline.com", new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
+                Assert.IsNotNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
+                "login.partner.microsoftonline.cn", new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
+            Assert.IsNotNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
+               "login.microsoftonline.com", new[] { "login.windows.net", "bogus", "login.partner.microsoftonline.cn" });
+            Assert.IsNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
+                "bogus", new[] { "login.windows.net", "login.microsoft.com", "login.partner.microsoftonline.cn" });
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AccountTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AccountTests.cs
@@ -134,7 +134,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             await ValidateGetAccountsWithDiscoveryAsync(tokenCacheAsString).ConfigureAwait(false);
         }
 
-
         [TestMethod]
         [DeploymentItem(@"Resources\MultiCloudTokenCache.json")]
         public async Task GetAccounts_PerformsNetworkInstanceDiscovery_IfUnknownRtEnvironment_Async()
@@ -162,7 +161,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
             await ValidateGetAccountsWithDiscoveryAsync(tokenCacheAsString).ConfigureAwait(false);
         }
-
 
         // Bug https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1030
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AccountTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AccountTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
@@ -10,6 +11,7 @@ using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Json.Linq;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -77,7 +79,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.IsTrue(accounts.All(a => a.Environment == "login.microsoftonline.com"));
         }
 
-
         // Bug https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1030
         [TestMethod]
         [DeploymentItem(@"Resources\MultiCloudTokenCache.json")]
@@ -86,12 +87,12 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             using (var httpManager = new MockHttpManager())
             {
                 // Arrange
-                httpManager.AddInstanceDiscoveryMockHandler();
+                // no discovery made because all environments are known
 
                 const string TokenCacheFile = "MultiCloudTokenCache.json";
-                var pcaGlobal = InitPcaForCloud(AzureCloudInstance.AzurePublic, httpManager, TokenCacheFile);
-                var pcaDe = InitPcaForCloud(AzureCloudInstance.AzureGermany, httpManager, TokenCacheFile);
-                var pcaCn = InitPcaForCloud(AzureCloudInstance.AzureChina, httpManager, TokenCacheFile);
+                var pcaGlobal = InitPcaFromCacheFile(AzureCloudInstance.AzurePublic, httpManager, TokenCacheFile);
+                var pcaDe = InitPcaFromCacheFile(AzureCloudInstance.AzureGermany, httpManager, TokenCacheFile);
+                var pcaCn = InitPcaFromCacheFile(AzureCloudInstance.AzureChina, httpManager, TokenCacheFile);
 
                 // Act
                 var accountsGlobal = await pcaGlobal.GetAccountsAsync().ConfigureAwait(false);
@@ -104,6 +105,64 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual("login.chinacloudapi.cn", accountsCn.Single().Environment);
             }
         }
+
+        [TestMethod]
+        [DeploymentItem(@"Resources\MultiCloudTokenCache.json")]
+        public async Task GetAccounts_PerformsNetworkInstanceDiscovery_IfUnknownAccountEnvironment_Async()
+        {
+            // Arrange - modify an existing account to have an unknown environment
+            string tokenCacheAsString = File.ReadAllText(
+                ResourceHelper.GetTestResourceRelativePath("MultiCloudTokenCache.json"));
+            var cacheJson = JObject.Parse(tokenCacheAsString);
+
+            JEnumerable<JToken> tokens = cacheJson["Account"].Children();
+            foreach (JToken token in tokens)
+            {
+                var obj = token.Children().Single() as JObject;
+
+                if (string.Equals(
+                    obj["environment"].ToString(),
+                    "login.microsoftonline.de",
+                    StringComparison.InvariantCulture))
+                {
+                    obj["environment"] = new Uri(MsalTestConstants.AuthorityNotKnownTenanted).Host;
+                }
+            }
+
+            tokenCacheAsString = cacheJson.ToString();
+
+            await ValidateGetAccountsWithDiscoveryAsync(tokenCacheAsString).ConfigureAwait(false);
+        }
+
+
+        [TestMethod]
+        [DeploymentItem(@"Resources\MultiCloudTokenCache.json")]
+        public async Task GetAccounts_PerformsNetworkInstanceDiscovery_IfUnknownRtEnvironment_Async()
+        {
+            // Arrange - modify an existing account to have an unknown environment
+            string tokenCacheAsString = File.ReadAllText(
+                ResourceHelper.GetTestResourceRelativePath("MultiCloudTokenCache.json"));
+            var cacheJson = JObject.Parse(tokenCacheAsString);
+
+            JEnumerable<JToken> tokens = cacheJson["RefreshToken"].Children();
+            foreach (JToken token in tokens)
+            {
+                var obj = token.Children().Single() as JObject;
+
+                if (string.Equals(
+                    obj["environment"].ToString(),
+                    "login.microsoftonline.de",
+                    StringComparison.InvariantCulture))
+                {
+                    obj["environment"] = new Uri(MsalTestConstants.AuthorityNotKnownTenanted).Host;
+                }
+            }
+
+            tokenCacheAsString = cacheJson.ToString();
+
+            await ValidateGetAccountsWithDiscoveryAsync(tokenCacheAsString).ConfigureAwait(false);
+        }
+
 
         // Bug https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1030
         [TestMethod]
@@ -134,8 +193,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             // Assert
             Assert.AreEqual("login.microsoftonline.de", accountsDe.Single().Environment);
         }
-
-     
 
         [TestMethod]
         public void TestGetAccounts()
@@ -291,10 +348,44 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.AreEqual(0, app.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count());
             Assert.AreEqual(0, app.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Count());
         }
+        private async Task ValidateGetAccountsWithDiscoveryAsync(string tokenCacheAsString)
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
 
+                var pcaGlobal = InitPcaFromCacheString(AzureCloudInstance.AzurePublic, httpManager, tokenCacheAsString);
+                var pcaDe = InitPcaFromCacheString(AzureCloudInstance.AzureGermany, httpManager, tokenCacheAsString);
+                var pcaCn = InitPcaFromCacheString(AzureCloudInstance.AzureChina, httpManager, tokenCacheAsString);
 
+                // Act
+                var accountsGlobal = await pcaGlobal.GetAccountsAsync().ConfigureAwait(false);
+                var accountsDe = await pcaDe.GetAccountsAsync().ConfigureAwait(false);
+                var accountsCn = await pcaCn.GetAccountsAsync().ConfigureAwait(false);
 
-        private PublicClientApplication InitPcaForCloud(AzureCloudInstance cloud, HttpManager httpManager, string tokenCacheFile)
+                // Assert
+                Assert.AreEqual("login.microsoftonline.com", accountsGlobal.Single().Environment);
+                Assert.IsTrue(!accountsDe.Any());
+                Assert.AreEqual("login.chinacloudapi.cn", accountsCn.Single().Environment);
+            }
+        }
+
+        private PublicClientApplication InitPcaFromCacheFile(
+            AzureCloudInstance cloud, 
+            HttpManager httpManager,
+            string tokenCacheFile)
+        {
+            return InitPcaFromCacheString(
+                cloud,
+                httpManager,
+                File.ReadAllText(
+                    ResourceHelper.GetTestResourceRelativePath(tokenCacheFile)));
+        }
+
+        private PublicClientApplication InitPcaFromCacheString(
+            AzureCloudInstance cloud,
+            HttpManager httpManager,
+            string tokenCacheString)
         {
             PublicClientApplication pca = PublicClientApplicationBuilder
                   .Create(ClientIdInFile)
@@ -303,7 +394,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                   .WithTelemetry(new TraceTelemetryConfig())
                   .BuildConcrete();
 
-            pca.InitializeTokenCacheFromFile(ResourceHelper.GetTestResourceRelativePath(tokenCacheFile));
+            pca.InitializeTokenCacheFromString(tokenCacheString);
             pca.UserTokenCacheInternal.Accessor.AssertItemCount(3, 3, 3, 3, 1);
 
             return pca;

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AcquireTokenSilentTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AcquireTokenSilentTests.cs
@@ -5,6 +5,7 @@
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache.Keys;
 using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Constants;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.Utils;
@@ -233,7 +234,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 if (expectNetworkDiscovery)
                 {
                     string host = new Uri(authority).Host;
-                    string discoveryHost = AadAuthority.IsInTrustedHostList(host)
+                    string discoveryHost = KnownMetadataProvider.IsKnownEnvironment(host)
                                                ? host
                                                : AadAuthority.DefaultTrustedHost;
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -722,8 +722,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             using (var httpManager = new MockHttpManager())
             {
-                httpManager.AddInstanceDiscoveryMockHandler();
-
                 var app = ConfidentialClientApplicationBuilder
                     .Create(MsalTestConstants.ClientId)
                     .WithAuthority(new Uri(MsalTestConstants.AuthorityTestTenant), true)

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -1004,8 +1004,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             using (var httpManager = new MockHttpManager())
             {
                 // Arrange
-                httpManager.AddInstanceDiscoveryMockHandler();
-
                 PublicClientApplication pca = CreatePcaFromFileWithAuthority(httpManager);
 
                 // Act
@@ -1053,8 +1051,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             using (var httpManager = new MockHttpManager())
             {
                 // Arrange
-                httpManager.AddInstanceDiscoveryMockHandler();
-
                 PublicClientApplication pca = CreatePcaFromFileWithAuthority(httpManager, tenantedAuthority1);
 
                 // Act

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
@@ -147,8 +147,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             using (var harness = new MockHttpTestHarness(MsalTestConstants.AuthorityHomeTenant))
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
-
                 var parameters = harness.CreateRequestParams(
                     harness.Cache,
                     ScopeHelper.CreateSortedSetFromEnumerable(

--- a/tests/Microsoft.Identity.Test.Unit.net45/TestBase.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/TestBase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestCleanup]
-        public void TestCleanup()
+        public virtual void TestCleanup()
         {
             Trace.WriteLine("Test finished " + TestContext.TestName);
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/TestExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/TestExtensions.cs
@@ -33,10 +33,14 @@ namespace Microsoft.Identity.Test.Unit
         public static void InitializeTokenCacheFromFile(this IPublicClientApplication pca, string resourceFile, bool updateATExpiry = false)
         {
             string tokenCacheAsString = File.ReadAllText(resourceFile);
+            InitializeTokenCacheFromString(pca, tokenCacheAsString, updateATExpiry);
+        }
 
+        public static void InitializeTokenCacheFromString(this IPublicClientApplication pca, string content, bool updateATExpiry = false)
+        {
             if (updateATExpiry)
             {
-                var cacheJson = JObject.Parse(tokenCacheAsString);
+                var cacheJson = JObject.Parse(content);
 
                 JEnumerable<JToken> tokens = cacheJson["AccessToken"].Children();
                 foreach (JToken token in tokens)
@@ -47,14 +51,13 @@ namespace Microsoft.Identity.Test.Unit
                     obj["extended_expires_on"] = CoreHelpers.DateTimeToUnixTimestamp(DateTimeOffset.Now.AddMinutes(100));
                 }
 
-                tokenCacheAsString = cacheJson.ToString();
-            
+                content = cacheJson.ToString();
+
             }
 
 
-            byte[] tokenCacheBlob = new UTF8Encoding().GetBytes(tokenCacheAsString);
+            byte[] tokenCacheBlob = new UTF8Encoding().GetBytes(content);
             ((ITokenCacheSerializer)pca.UserTokenCache).DeserializeMsalV3(tokenCacheBlob);
         }
-
     }
 }


### PR DESCRIPTION
I tried to split this into 3 commits which can be reviewed individually.

This work can be commited as is, but there are still a few things remaining: 

1. refactor AadAuthority.IsInTrustedHostList
2. regression test against known metadata becoming obsolete
3. Review Validate Authority - try a real test and see if we have Integration test around this
4. Telemetry when discovery is made vs not made (or better yet, which provider)