### PR TITLE
Add .WithDefaultRedirectUri() method to the PublicClientApplicationBuilder

### DIFF
--- a/src/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client
         public LogCallback LoggingCallback { get; internal set; }
         public string Component { get; internal set; }
         public IDictionary<string, string> ExtraQueryParameters { get; internal set; } = new Dictionary<string, string>();
-        public bool UseNewDefaultRedirectUri { get; internal set; }
+        public bool UseRecommendedDefaultRedirectUri { get; internal set; }
 
         internal ILegacyCachePersistence UserTokenLegacyCachePersistenceForTest { get; set; }
         internal ILegacyCachePersistence AppTokenLegacyCachePersistenceForTest { get; set; }

--- a/src/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Identity.Client
         public LogCallback LoggingCallback { get; internal set; }
         public string Component { get; internal set; }
         public IDictionary<string, string> ExtraQueryParameters { get; internal set; } = new Dictionary<string, string>();
+        public bool UseNewDefaultRedirectUri { get; internal set; }
 
         internal ILegacyCachePersistence UserTokenLegacyCachePersistenceForTest { get; set; }
         internal ILegacyCachePersistence AppTokenLegacyCachePersistenceForTest { get; set; }

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -67,10 +67,12 @@ namespace Microsoft.Identity.Client
         /// <term>value of <c>WebAuthenticationBroker.GetCurrentApplicationCallbackUri()</c></term>
         /// </item>
         /// <item>
-        /// <term>.NET Core</term>
+        /// <term>For system browser on .NET Core</term>
         /// <term><c>https://localhost</c></term>
         /// </item>
         /// </list>
+        /// NOTE:There will be an update to the default rediect uri in the future to accomodate for system browsers on the 
+        /// .NET desktop and .NET Core platforms.
         /// </summary>
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a public client application instance</returns>

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Identity.Client
         /// .NET Classic app - https://login.microsoftonline.com/common/oauth2/nativeclient
         /// UWP - value of WebAuthenticationBroker.GetCurrentApplicationCallbackUri()
         /// .NET Core - https://localhost
+        /// See https://aka.ms/msal-net-default-reply-uri.
         /// </summary>
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a public client application instance</returns>

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Configures the pca to use the recommended redirect Uri for the platform. 
+        /// Configures the public client application to use the recommended reply URI for the platform. 
         /// If you are calling your API from a 
         /// .NET Classic app - https://login.microsoftonline.com/common/oauth2/nativeclient
         /// UWP - value of WebAuthenticationBroker.GetCurrentApplicationCallbackUri()

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -51,13 +51,14 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Sets the public client application to use the latest default redirect URI. 
+        /// Sets the public client application to use the latest default redirect URI as opposed to urn:ietf:wg:oauth:2.0:oob. 
         /// This URI is platform specific: 
         /// Desktop = https://login.microsoftonline.com/common/oauth2/nativeclient
         /// UWP = value of WebAuthenticationBroker.GetCurrentApplicationCallbackUri()
         /// .NET Core = https://localhost
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
+        /// parameters, and to create a public client application instance</returns>
         public PublicClientApplicationBuilder WithDefaultRedirectUri()
         {
             Config.UseNewDefaultRedirectUri = true;

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -52,11 +52,25 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Configures the public client application to use the recommended reply URI for the platform. 
-        /// If you are calling your API from a 
-        /// .NET Classic app - https://login.microsoftonline.com/common/oauth2/nativeclient
-        /// UWP - value of WebAuthenticationBroker.GetCurrentApplicationCallbackUri()
-        /// .NET Core - https://localhost
         /// See https://aka.ms/msal-net-default-reply-uri.
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Platform</term>
+        /// <term>Default Reply URI</term>
+        /// </listheader>
+        /// <item>
+        /// <term>.NET desktop</term>
+        /// <term><c>https://login.microsoftonline.com/common/oauth2/nativeclient</c></term>
+        /// </item>
+        /// <item>
+        /// <term>UWP</term>
+        /// <term>value of <c>WebAuthenticationBroker.GetCurrentApplicationCallbackUri()</c></term>
+        /// </item>
+        /// <item>
+        /// <term>.NET Core</term>
+        /// <term><c>https://localhost</c></term>
+        /// </item>
+        /// </list>
         /// </summary>
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a public client application instance</returns>

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -51,17 +51,17 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Sets the public client application to use the latest default redirect URI as opposed to urn:ietf:wg:oauth:2.0:oob. 
-        /// This URI is platform specific: 
-        /// Desktop = https://login.microsoftonline.com/common/oauth2/nativeclient
-        /// UWP = value of WebAuthenticationBroker.GetCurrentApplicationCallbackUri()
-        /// .NET Core = https://localhost
+        /// Configures the pca to use the recommended redirect Uri for the platform. 
+        /// If you are calling your API from a 
+        /// .NET Classic app - https://login.microsoftonline.com/common/oauth2/nativeclient
+        /// UWP - value of WebAuthenticationBroker.GetCurrentApplicationCallbackUri()
+        /// .NET Core - https://localhost
         /// </summary>
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a public client application instance</returns>
         public PublicClientApplicationBuilder WithDefaultRedirectUri()
         {
-            Config.UseNewDefaultRedirectUri = true;
+            Config.UseRecommendedDefaultRedirectUri = true;
             return this;
         }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Client
             if (string.IsNullOrWhiteSpace(Config.RedirectUri))
             {
                 Config.RedirectUri = PlatformProxyFactory.CreatePlatformProxy(null)
-                                                         .GetDefaultRedirectUri(Config.ClientId, Config.UseNewDefaultRedirectUri);
+                                                         .GetDefaultRedirectUri(Config.ClientId, Config.UseRecommendedDefaultRedirectUri);
             }
 
             if (!Uri.TryCreate(Config.RedirectUri, UriKind.Absolute, out Uri uriResult))

--- a/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -50,6 +50,20 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+        /// <summary>
+        /// Sets the public client application to use the latest default redirect URI. 
+        /// This URI is platform specific: 
+        /// Desktop = https://login.microsoftonline.com/common/oauth2/nativeclient
+        /// UWP = value of WebAuthenticationBroker.GetCurrentApplicationCallbackUri()
+        /// .NET Core = https://localhost
+        /// </summary>
+        /// <returns></returns>
+        public PublicClientApplicationBuilder WithDefaultRedirectUri()
+        {
+            Config.UseNewDefaultRedirectUri = true;
+            return this;
+        }
+
 #if !ANDROID_BUILDTIME && !WINDOWS_APP_BUILDTIME && !NET_CORE_BUILDTIME && !DESKTOP_BUILDTIME && !MAC_BUILDTIME
         /// <summary>
         ///
@@ -116,7 +130,7 @@ namespace Microsoft.Identity.Client
             if (string.IsNullOrWhiteSpace(Config.RedirectUri))
             {
                 Config.RedirectUri = PlatformProxyFactory.CreatePlatformProxy(null)
-                                                         .GetDefaultRedirectUri(Config.ClientId);
+                                                         .GetDefaultRedirectUri(Config.ClientId, Config.UseNewDefaultRedirectUri);
             }
 
             if (!Uri.TryCreate(Config.RedirectUri, UriKind.Absolute, out Uri uriResult))

--- a/src/Microsoft.Identity.Client/Core/Constants.cs
+++ b/src/Microsoft.Identity.Client/Core/Constants.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Identity.Client.Core
 
         public const string UapWEBRedirectUri = "https://sso"; // only ADAL supports WEB
         public const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
+        public const string DefaultDesktopRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        public const string DefaultNetCoreRedirectUri = "https://localhost";
         public const string DefaultConfidentialClientRedirectUri = "https://replyUrlNotSet";
 
         public const string DefaultRealm = "http://schemas.microsoft.com/rel/trusted-realm";

--- a/src/Microsoft.Identity.Client/Core/Constants.cs
+++ b/src/Microsoft.Identity.Client/Core/Constants.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Identity.Client.Core
 
         public const string UapWEBRedirectUri = "https://sso"; // only ADAL supports WEB
         public const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
-        public const string DefaultDesktopRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
-        public const string DefaultNetCoreRedirectUri = "https://localhost";
+        public const string NativeClientRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        public const string LocalHostRedirectUri = "http://localhost";
         public const string DefaultConfidentialClientRedirectUri = "https://replyUrlNotSet";
 
         public const string DefaultRealm = "http://schemas.microsoft.com/rel/trusted-realm";

--- a/src/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId)
+        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
         {
             return string.Format(CultureInfo.InvariantCulture, AndroidDefaultRedirectUriTemplate, clientId);
         }

--- a/src/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
             return string.Format(CultureInfo.InvariantCulture, AndroidDefaultRedirectUriTemplate, clientId);
         }

--- a/src/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
         {
             return string.Format(CultureInfo.InvariantCulture, AndroidDefaultRedirectUriTemplate, clientId);
         }

--- a/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Client.Platforms.Mac
         {
             if (useRecommendedRedirectUri)
             {
-                return Constants.DefaultDesktopRedirectUri;
+                return Constants.NativeClientRedirectUri;
             }
 
             return Constants.DefaultRedirectUri;

--- a/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client.Platforms.Mac
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
         {
             return Constants.DefaultRedirectUri;
         }

--- a/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
@@ -78,8 +78,13 @@ namespace Microsoft.Identity.Client.Platforms.Mac
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
+            if (useRecommendedRedirectUri)
+            {
+                return Constants.DefaultDesktopRedirectUri;
+            }
+
             return Constants.DefaultRedirectUri;
         }
 

--- a/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/Mac/MacPlatformProxy.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client.Platforms.Mac
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId)
+        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
         {
             return Constants.DefaultRedirectUri;
         }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
             return string.Format(CultureInfo.InvariantCulture, IosDefaultRedirectUriTemplate, clientId);
         }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
         {
             return string.Format(CultureInfo.InvariantCulture, IosDefaultRedirectUriTemplate, clientId);
         }

--- a/src/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId)
+        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
         {
             return string.Format(CultureInfo.InvariantCulture, IosDefaultRedirectUriTemplate, clientId);
         }

--- a/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -146,9 +146,9 @@ namespace Microsoft.Identity.Client.Platforms.net45
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
-            if (useRecommendedRedirectURI)
+            if (useRecommendedRedirectUri)
             {
                 return Constants.DefaultDesktopRedirectUri;
             }

--- a/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
         {
             if (useRecommendedRedirectUri)
             {
-                return Constants.DefaultDesktopRedirectUri;
+                return Constants.NativeClientRedirectUri;
             }
 
             return Constants.DefaultRedirectUri;

--- a/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -146,9 +146,9 @@ namespace Microsoft.Identity.Client.Platforms.net45
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
         {
-            if (useNewRedirectURI)
+            if (useRecommendedRedirectURI)
             {
                 return Constants.DefaultDesktopRedirectUri;
             }

--- a/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -146,8 +146,13 @@ namespace Microsoft.Identity.Client.Platforms.net45
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId)
+        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
         {
+            if (useNewRedirectURI)
+            {
+                return Constants.DefaultDesktopRedirectUri;
+            }
+
             return Constants.DefaultRedirectUri;
         }
 

--- a/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
         {
             if (useRecommendedRedirectUri)
             {
-                return Constants.DefaultNetCoreRedirectUri;
+                return Constants.LocalHostRedirectUri;
             }
 
             return Constants.DefaultRedirectUri;

--- a/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -77,9 +77,9 @@ namespace Microsoft.Identity.Client.Platforms.netcore
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
         {
-            if (useNewRedirectURI)
+            if (useRecommendedRedirectURI)
             {
                 return Constants.DefaultNetCoreRedirectUri;
             }

--- a/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -77,9 +77,9 @@ namespace Microsoft.Identity.Client.Platforms.netcore
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
-            if (useRecommendedRedirectURI)
+            if (useRecommendedRedirectUri)
             {
                 return Constants.DefaultNetCoreRedirectUri;
             }

--- a/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -77,8 +77,13 @@ namespace Microsoft.Identity.Client.Platforms.netcore
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId)
+        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
         {
+            if (useNewRedirectURI)
+            {
+                return Constants.DefaultNetCoreRedirectUri;
+            }
+
             return Constants.DefaultRedirectUri;
         }
 

--- a/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
         {
             return Constants.DefaultRedirectUri;
         }

--- a/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
         {
             if (useRecommendedRedirectUri)
             {
-                return Constants.DefaultDesktopRedirectUri;
+                return Constants.NativeClientRedirectUri;
             }
 
             return Constants.DefaultRedirectUri;

--- a/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId)
+        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
         {
             return Constants.DefaultRedirectUri;
         }

--- a/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
@@ -43,8 +43,13 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
+            if (useRecommendedRedirectUri)
+            {
+                return Constants.DefaultDesktopRedirectUri;
+            }
+
             return Constants.DefaultRedirectUri;
         }
 

--- a/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
@@ -20,6 +20,7 @@ using Microsoft.Identity.Client.PlatformsCommon.Shared;
 using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
+using Windows.Security.Authentication.Web;
 
 namespace Microsoft.Identity.Client.Platforms.uap
 {
@@ -140,8 +141,12 @@ namespace Microsoft.Identity.Client.Platforms.uap
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string correlationId)
+        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
         {
+            if (useNewRedirectURI)
+            {
+                return WebAuthenticationBroker.GetCurrentApplicationCallbackUri().ToString();
+            }
             return Constants.DefaultRedirectUri;
         }
 

--- a/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
@@ -141,9 +141,9 @@ namespace Microsoft.Identity.Client.Platforms.uap
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
         {
-            if (useNewRedirectURI)
+            if (useRecommendedRedirectURI)
             {
                 return WebAuthenticationBroker.GetCurrentApplicationCallbackUri().ToString();
             }

--- a/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
@@ -141,9 +141,9 @@ namespace Microsoft.Identity.Client.Platforms.uap
         }
 
         /// <inheritdoc />
-        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false)
+        public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
-            if (useRecommendedRedirectURI)
+            if (useRecommendedRedirectUri)
             {
                 return WebAuthenticationBroker.GetCurrentApplicationCallbackUri().ToString();
             }

--- a/src/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
         /// <summary>
         /// Gets the default redirect uri for the platform, which sometimes includes the clientId
         /// </summary>
-        string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false);
+        string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false);
 
         string GetProductName();
 

--- a/src/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
         /// <summary>
         /// Gets the default redirect uri for the platform, which sometimes includes the clientId
         /// </summary>
-        string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false);
+        string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false);
 
         string GetProductName();
 

--- a/src/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
         /// <summary>
         /// Gets the default redirect uri for the platform, which sometimes includes the clientId
         /// </summary>
-        string GetDefaultRedirectUri(string clientId);
+        string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false);
 
         string GetProductName();
 

--- a/src/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public abstract string GetBrokerOrRedirectUri(Uri redirectUri);
 
         /// <inheritdoc />
-        public abstract string GetDefaultRedirectUri(string clientId);
+        public abstract string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false);
 
         /// <inheritdoc />
         public string GetProductName()

--- a/src/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public abstract string GetBrokerOrRedirectUri(Uri redirectUri);
 
         /// <inheritdoc />
-        public abstract string GetDefaultRedirectUri(string clientId, bool useNewRedirectURI = false);
+        public abstract string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false);
 
         /// <inheritdoc />
         public string GetProductName()

--- a/src/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
+++ b/src/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public abstract string GetBrokerOrRedirectUri(Uri redirectUri);
 
         /// <inheritdoc />
-        public abstract string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectURI = false);
+        public abstract string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false);
 
         /// <inheritdoc />
         public string GetProductName()

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                                             .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                                             .BuildConcrete();
-                //Validate legacy default URI
+                //Validate legacy default uri
                 Assert.AreEqual(app.AppConfig.RedirectUri, "urn:ietf:wg:oauth:2.0:oob");
 
                 app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
@@ -345,7 +345,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithDefaultRedirectUri()
                                                                             .BuildConcrete();
 
-                //Validate redirect uri
+                //Validate new default redirect uri
 #if DESKTOP
                 Assert.AreEqual(app.AppConfig.RedirectUri, "https://login.microsoftonline.com/common/oauth2/nativeclient");
 #elif NET_CORE

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                //harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                                             .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                                             .BuildConcrete();

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -351,19 +351,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 #elif NET_CORE
                 Assert.AreEqual(app.AppConfig.RedirectUri, "https://localhost");
 #endif
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
-
-                harness.HttpManager.AddMockHandlerForTenantEndpointDiscovery(MsalTestConstants.AuthorityCommonTenant);
-                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(MsalTestConstants.AuthorityCommonTenant);
-
-                AuthenticationResult result = app
-                    .AcquireTokenInteractive(MsalTestConstants.Scope)
-                    .ExecuteAsync(CancellationToken.None)
-                    .Result;
-
-                Assert.IsNotNull(result);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 #if DESKTOP
                 Assert.AreEqual(app.AppConfig.RedirectUri, "https://login.microsoftonline.com/common/oauth2/nativeclient");
 #elif NET_CORE
-                Assert.AreEqual(app.AppConfig.RedirectUri, "https://localhost");
+                Assert.AreEqual(app.AppConfig.RedirectUri, "http://localhost");
 #endif
             }
         }


### PR DESCRIPTION
implementation of .WithDefaultRedirectUri() [#1186](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1186)