### PR TITLE
Fix jwtAudience value having {tenantid} instead of common during clie…

### DIFF
--- a/src/Microsoft.Identity.Client/Core/Constants.cs
+++ b/src/Microsoft.Identity.Client/Core/Constants.cs
@@ -36,14 +36,15 @@ namespace Microsoft.Identity.Client.Core
 
         public const string WellKnownOpenIdConfigurationPath = ".well-known/openid-configuration";
         public const string OpenIdConfigurationEndpoint = "v2.0/" + WellKnownOpenIdConfigurationPath;
-
+        public const string Tenant = "{tenant}";
+        public const string TenantId = "{tenantid}";
         public static string FormatAdfsWebFingerUrl(string host, string resource)
         {
             return string.Format(
                 CultureInfo.InvariantCulture,
                 "https://{0}/.well-known/webfinger?rel={1}&resource={2}",
                 host,
-                Constants.DefaultRealm,
+                DefaultRealm,
                 resource);
         }
     }

--- a/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
@@ -78,13 +78,13 @@ namespace Microsoft.Identity.Client.Instance
             endpoints = new AuthorityEndpoints(
                 edr.AuthorizationEndpoint.Replace(Constants.Tenant, tenant),
                 edr.TokenEndpoint.Replace(Constants.Tenant, tenant),
-                ReplaceNonTenantSpecificValueWithCorrectTenant(edr, tenant));
+                ReplaceNonTenantSpecificValueWithTenant(edr, tenant));
 
             Add(authorityInfo, userPrincipalName, endpoints);
             return endpoints;
         }
 
-        internal string ReplaceNonTenantSpecificValueWithCorrectTenant(TenantDiscoveryResponse endpoints, string tenant)
+        internal string ReplaceNonTenantSpecificValueWithTenant(TenantDiscoveryResponse endpoints, string tenant)
         {
             string selfSignedJwtAudience = endpoints.Issuer;
 

--- a/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
+++ b/src/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
@@ -34,11 +34,11 @@ namespace Microsoft.Identity.Client.Instance
         {
             if (TryGetCacheValue(authorityInfo, userPrincipalName, out var endpoints))
             {
-                requestContext.Logger.Info("Resolving authority endpoints... Already resolved? - TRUE");
+                requestContext.Logger.Info(LogMessages.ResolvingAuthorityEndpointsTrue);
                 return endpoints;
             }
 
-            requestContext.Logger.Info("Resolving authority endpoints... Already resolved? - FALSE");
+            requestContext.Logger.Info(LogMessages.ResolvingAuthorityEndpointsFalse);
 
             var authorityUri = new Uri(authorityInfo.CanonicalAuthority);
             string path = authorityUri.AbsolutePath.Substring(1);
@@ -58,30 +58,50 @@ namespace Microsoft.Identity.Client.Instance
             {
                 throw new MsalClientException(
                     MsalError.TenantDiscoveryFailedError,
-                    "Authorize endpoint was not found in the openid configuration");
+                    MsalErrorMessage.AuthorizeEndpointWasNotFoundInTheOpenIdConfiguration);
             }
 
             if (string.IsNullOrEmpty(edr.TokenEndpoint))
             {
                 throw new MsalClientException(
                     MsalError.TenantDiscoveryFailedError,
-                    "Token endpoint was not found in the openid configuration");
+                    MsalErrorMessage.TokenEndpointWasNotFoundInTheOpenIdConfiguration);
             }
 
             if (string.IsNullOrEmpty(edr.Issuer))
             {
                 throw new MsalClientException(
                     MsalError.TenantDiscoveryFailedError,
-                    "Issuer was not found in the openid configuration");
+                    MsalErrorMessage.IssuerWasNotFoundInTheOpenIdConfiguration);
             }
 
             endpoints = new AuthorityEndpoints(
-                edr.AuthorizationEndpoint.Replace("{tenant}", tenant),
-                edr.TokenEndpoint.Replace("{tenant}", tenant),
-                edr.Issuer.Replace("{tenant}", tenant));
+                edr.AuthorizationEndpoint.Replace(Constants.Tenant, tenant),
+                edr.TokenEndpoint.Replace(Constants.Tenant, tenant),
+                ReplaceNonTenantSpecificValueWithCorrectTenant(edr, tenant));
 
             Add(authorityInfo, userPrincipalName, endpoints);
             return endpoints;
+        }
+
+        internal string ReplaceNonTenantSpecificValueWithCorrectTenant(TenantDiscoveryResponse endpoints, string tenant)
+        {
+            string selfSignedJwtAudience = endpoints.Issuer;
+
+            if (selfSignedJwtAudience.Contains(Constants.TenantId))
+            {
+                selfSignedJwtAudience = selfSignedJwtAudience.Replace(Constants.TenantId, tenant);
+                return selfSignedJwtAudience;
+            }
+            else if (selfSignedJwtAudience.Contains(Constants.Tenant))
+            {
+                selfSignedJwtAudience = selfSignedJwtAudience.Replace(Constants.Tenant, tenant);
+                return selfSignedJwtAudience;
+            }
+            else
+            {
+                return selfSignedJwtAudience;
+            }            
         }
 
         private bool TryGetCacheValue(AuthorityInfo authorityInfo, string userPrincipalName, out AuthorityEndpoints endpoints)
@@ -99,13 +119,13 @@ namespace Microsoft.Identity.Client.Instance
                 return true;
             }
 
-            if( !string.IsNullOrEmpty(userPrincipalName))
+            if (!string.IsNullOrEmpty(userPrincipalName))
             {
                 if (!cacheEntry.ValidForDomainsList.Contains(AdfsUpnHelper.GetDomainFromUpn(userPrincipalName)))
                 {
                     return false;
                 }
-            }           
+            }
 
             endpoints = cacheEntry.Endpoints;
             return true;
@@ -127,18 +147,18 @@ namespace Microsoft.Identity.Client.Instance
                     }
                 }
 
-                if(!string.IsNullOrEmpty(userPrincipalName))
+                if (!string.IsNullOrEmpty(userPrincipalName))
                 {
                     updatedCacheEntry.ValidForDomainsList.Add(AdfsUpnHelper.GetDomainFromUpn(userPrincipalName));
-                }    
+                }
             }
 
             s_endpointCacheEntries.TryAdd(authorityInfo.CanonicalAuthority, updatedCacheEntry);
         }
 
         private async Task<TenantDiscoveryResponse> DiscoverEndpointsAsync(
-            string openIdConfigurationEndpoint,
-            RequestContext requestContext)
+             string openIdConfigurationEndpoint,
+             RequestContext requestContext)
         {
             var client = new OAuth2Client(requestContext.Logger, _serviceBundle.HttpManager, _serviceBundle.TelemetryManager);
             return await client.ExecuteRequestAsync<TenantDiscoveryResponse>(

--- a/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             get
             {
-                if (String.IsNullOrEmpty(_loginHint) && Account != null)
+                if (string.IsNullOrEmpty(_loginHint) && Account != null)
                 {
                     return Account.Username;
                 }

--- a/src/Microsoft.Identity.Client/Internal/Requests/ClientCredentialHelper.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/ClientCredentialHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.OAuth2;
@@ -64,7 +63,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     {
                         if (!ValidateClientAssertion(clientCredential, endpoints, sendX5C))
                         {
-                            logger.Info("Client Assertion does not exist or near expiry.");
+                            logger.Info(LogMessages.ClientAssertionDoesNotExistOrNearExpiry);
+                           
                             JsonWebToken jwtToken;
                             
                             if (clientCredential.AuthenticationType == ConfidentialClientAuthenticationType.ClientCertificateWithClaims)
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         }
                         else
                         {
-                            logger.Info("Reusing the unexpired Client Assertion...");
+                            logger.Info(LogMessages.ReusingTheUnexpiredClientAssertion);
                         }
                     }
 

--- a/src/Microsoft.Identity.Client/LogMessages.cs
+++ b/src/Microsoft.Identity.Client/LogMessages.cs
@@ -9,27 +9,20 @@ namespace Microsoft.Identity.Client
     internal static class LogMessages
     {
         public const string BeginningAcquireByRefreshToken = "Begin acquire token by refresh token...";
-        public const string NoScopesProvidedForRefreshTokenRequest = "No scopes provided for acquire token by refresh token request. Using default scope instead.";
-
-        public static string UsingXScopesForRefreshTokenRequest(int numScopes)
-        {
-            return string.Format(CultureInfo.InvariantCulture, "Using {0} scopes for acquire token by refresh token request", numScopes);
-        }
+        public const string NoScopesProvidedForRefreshTokenRequest = "No scopes provided for acquire token by refresh token request. " +
+            "Using default scope instead.";      
 
         public const string CustomWebUiAcquiringAuthorizationCode = "Using CustomWebUi to acquire the authorization code";
         public const string CustomWebUiRedirectUriMatched = "Redirect Uri was matched.  Returning success from CustomWebUiHandler.";
         public const string CustomWebUiOperationCancelled = "CustomWebUi AcquireAuthorizationCode was canceled";
 
-        public static string CustomWebUiCallingAcquireAuthorizationCodePii(Uri authorizationUri, Uri redirectUri)
-        {
-            return string.Format(
-                CultureInfo.InvariantCulture,
-                "calling CustomWebUi.AcquireAuthorizationCode authUri({0}) redirectUri({1})",
-                authorizationUri,
-                redirectUri);
-        }
-
         public const string CustomWebUiCallingAcquireAuthorizationCodeNoPii = "Calling CustomWebUi.AcquireAuthorizationCode";
+
+        public const string ClientAssertionDoesNotExistOrNearExpiry = "Client Assertion does not exist or near expiry. ";
+        public const string ReusingTheUnexpiredClientAssertion = "Reusing the unexpired Client Assertion...";
+
+        public const string ResolvingAuthorityEndpointsTrue = "Resolving authority endpoints... Already resolved? - TRUE";
+        public const string ResolvingAuthorityEndpointsFalse = "Resolving authority endpoints... Already resolved? - FALSE";
 
         public const string CheckMsalTokenResponseReturnedFromBroker = "Checking MsalTokenResponse returned from broker. ";
         public const string BrokerResponseContainsAccessToken = "Broker response contains access token. Access token count: ";
@@ -42,10 +35,22 @@ namespace Microsoft.Identity.Client
         public const string AuthenticationWithBrokerDidNotSucceed = "Broker authentication did not succeed, or the broker install failed. " +
             "See https://aka.ms/msal-net-brokers for more information. ";
 
-
         public static string ErrorReturnedInBrokerResponse(string error)
         {
             return string.Format(CultureInfo.InvariantCulture, "Error {0} returned in broker response. ", error);
+        }
+
+        public static string UsingXScopesForRefreshTokenRequest(int numScopes)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "Using {0} scopes for acquire token by refresh token request", numScopes);
+        }
+        public static string CustomWebUiCallingAcquireAuthorizationCodePii(Uri authorizationUri, Uri redirectUri)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "calling CustomWebUi.AcquireAuthorizationCode authUri({0}) redirectUri({1})",
+                authorizationUri,
+                redirectUri);
         }
     }
 }

--- a/src/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -269,5 +269,9 @@ namespace Microsoft.Identity.Client
 
         public const string EmbeddedWebviewDefaultBrowser = "You configured MSAL interactive authentication to use an embedded WebView " +
             "and you also configured system WebView options. These are mutually exclusive. See https://aka.ms/msal-net-os-browser";
+
+        public const string AuthorizeEndpointWasNotFoundInTheOpenIdConfiguration = "Authorize endpoint was not found in the openid configuration";
+        public const string TokenEndpointWasNotFoundInTheOpenIdConfiguration = "Token endpoint was not found in the openid configuration";
+        public const string IssuerWasNotFoundInTheOpenIdConfiguration = "Issuer was not found in the openid configuration";
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -10,7 +10,6 @@ using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.Utils;
-using Microsoft.Identity.Json.Serialization;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 
 namespace Microsoft.Identity.Test.Unit
@@ -29,6 +28,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string ScopeForAnotherResourceStr = "r2/scope1 r2/scope2";
         public const string Uid = "my-uid";
         public const string Utid = "my-utid";
+        public const string Common = "common";
+        public const string TenantId = "e56cat29e-b008-4cea-b6f0-48facatsd64a";
         public static readonly IDictionary<string, string> ClientAssertionClaims = new Dictionary<string, string> {{ "client_ip", "some_ip" }, { "aud", "some_audience" }};
 
         public const string HomeAccountId = Uid + "." + Utid;

--- a/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -23,8 +20,8 @@ using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Test.Unit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IdentityModel.Tokens.Jwt;
-using NSubstitute;
 using System.Security.Claims;
+using System.Linq;
 
 namespace Microsoft.Identity.Test.Integration.net45.HeadlessTests
 {

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             TenantDiscoveryResponse tenantDiscoveryResponse = new TenantDiscoveryResponse();
 
             tenantDiscoveryResponse.Issuer = issuer;
-            string selfSignedJwtAudience = resolver.ReplaceNonTenantSpecificValueWithCorrectTenant(tenantDiscoveryResponse, tenantId);
+            string selfSignedJwtAudience = resolver.ReplaceNonTenantSpecificValueWithTenant(tenantDiscoveryResponse, tenantId);
             Assert.AreEqual(expectedJwtAudience, selfSignedJwtAudience);
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit.net45/Resources/OpenidConfigurationCommon.json
+++ b/tests/Microsoft.Identity.Test.Unit.net45/Resources/OpenidConfigurationCommon.json
@@ -1,0 +1,14 @@
+﻿{
+  "authorization_endpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  "token_endpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+  "token_endpoint_auth_methods_supported": [ "client_secret_post", "private_key_jwt", "client_secret_basic" ],
+  "jwks_uri": "https://login.microsoftonline.com/common/discovery/keys",
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "pairwise" ],
+  "id_token_signing_alg_values_supported": [ "RS256" ],
+  "http_logout_supported": true,
+  "response_types_supported": [ "code", "id_token", "code id_token", "token id_token", "token" ],
+  "scopes_supported": [ "openid" ],
+  "issuer": "https://login.microsoftonline.com/{tenantid}/v2.0",
+  "claims_supported": [ "sub", "iss", "cloud_instance_name", "aud", "exp", "iat", "auth_time", "acr", "amr", "nonce", "email", "given_name", "family_name", "nickname" ]
+}

--- a/tests/Microsoft.Identity.Test.Unit.net45/TestBase.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/TestBase.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
@@ -61,7 +59,7 @@ namespace Microsoft.Identity.Test.Unit
         {
             string traceFile = Environment.GetEnvironmentVariable("MsalTracePath");
 
-            if (!String.IsNullOrEmpty(traceFile))
+            if (!string.IsNullOrEmpty(traceFile))
             {
                 Trace.Listeners.Add(new TextWriterTraceListener(traceFile, "testListener"));
             }


### PR DESCRIPTION
Fix jwtAudience value having {tenantid} instead of common during clie…nt credential w/certificate flow

- add some consts and move log messages to const
- add u tests

[Issue 891](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/891)