### PR TITLE
[Instance Metadata] If network discovery fails, use well-known or aut…

### DIFF
--- a/src/Microsoft.Identity.Client/MsalError.cs
+++ b/src/Microsoft.Identity.Client/MsalError.cs
@@ -590,6 +590,10 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string ClientCredentialAuthenticationTypesAreMutuallyExclusive = "Client_Credential_Authentication_Types_Are_Mutually_Exclusive";
 
+        /// <summary>
+        /// AAD service error indicating that the configured authority does not exist
+        /// </summary>
+        public const string InvalidInstance = "invalid_instance";
 #if iOS
         /// <summary>
         /// Xamarin.iOS specific. This error indicates that keychain access has not be enabled for the application.

--- a/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Identity.Test.Unit
         {
             using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
                     {


### PR DESCRIPTION
…hority

This will improve the reliablity of MSAL - if we can't perform an actual network instance discovery, then fall back to well-known aliases. If those fail, fall back to use only the provided authority. 

Does not impact authority validation, which will still propagate the failure. 