### PR TITLE
[1245] Add framework and version to MsalException ToString()

### DIFF
--- a/src/Microsoft.Identity.Client/MsalException.cs
+++ b/src/Microsoft.Identity.Client/MsalException.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.PlatformsCommon.Factories;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Json.Linq;
 
@@ -103,7 +105,22 @@ namespace Microsoft.Identity.Client
         /// <returns>A string representation of the current exception.</returns>
         public override string ToString()
         {
-            return base.ToString() + string.Format(CultureInfo.InvariantCulture, "\n\tErrorCode: {0}", ErrorCode);
+            string msalProductName = PlatformProxyFactory.CreatePlatformProxy(null).GetProductName();
+            string msalVersion = MsalIdHelper.GetMsalVersion();
+
+            string innerExceptionContents = InnerException == null 
+                ? string.Empty 
+                : string.Format(CultureInfo.InvariantCulture, "\nInner Excception: {0}", InnerException.ToString());
+
+            return string.Format(
+                CultureInfo.InvariantCulture, 
+                "{0}.{1}.{2}: \n\tErrorCode: {3}\n{4}{5}", 
+                msalProductName, 
+                msalVersion, 
+                GetType().Name,
+                ErrorCode, 
+                base.ToString(), 
+                innerExceptionContents);
         }
 
         #region SERIALIZATION


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1245

Exception example now looks like this (from a unit test):

MSAL.Desktop.4.0.0.0.MsalUiRequiredException: 
	ErrorCode: exCode
Microsoft.Identity.Client.MsalUiRequiredException: exMessage
	StatusCode: 400 
	ResponseBody: { "error":"invalid_grant", "suberror":"some_suberror",
            "claims":"some_claims",
            "error_description":"AADSTS90002: Tenant 'x' not found. ", "error_codes":[90002],"timestamp":"2019-01-28 14:16:04Z",
            "trace_id":"43f14373-8d7d-466e-a5f1-6e3889291e00",
            "correlation_id":"6347d33d-941a-4c35-9912-a9cf54fb1b3e"} 
	Headers: Retry-After: 0
