### PR TITLE
fix error message for invalid_client

### DIFF
--- a/src/Microsoft.Identity.Client/MsalError.cs
+++ b/src/Microsoft.Identity.Client/MsalError.cs
@@ -682,6 +682,14 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string TelemetryConfigOrTelemetryCallback = "telemetry_config_or_telemetry_callback";
 
+        /// <summary>
+        /// AAD service error indicating that the configured client is not valid
+        /// <para>Migigation</para>In the AAD app registration portal, make sure the correct client (Public or
+        /// Confidential) is selected for the respective authentication flow.
+        /// See https://aka.ms/msal-net-invalid-client for details.
+        /// </summary>
+        public const string InvalidClient = "invalid_client";
+
 #if iOS
         /// <summary>
         /// Xamarin.iOS specific. This error indicates that keychain access has not be enabled for the application.

--- a/src/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -278,6 +278,10 @@ namespace Microsoft.Identity.Client
         public const string UIViewControllerIsRequiredToInvokeiOSBroker = "UIViewController is null, so MSAL.NET cannot invoke the iOS broker. See https://aka.ms/msal-net-ios-broker";
         public const string ValidateAuthorityOrCustomMetadata = "You have configured custom instance metadata, but the validateAuthority flag is set to true. These are mutually exclusive. Set the validateAuthority flag to false. See https://aka.ms/msal-net-custom-instance-metadata for more details.";
 
+        public const string InvalidClient = "The wrong application (public or confidential) is being used with this authentication flow." +
+            " Check the configuration of the app being used in the app registration portal." +
+            " See https://aka.ms/msal-net-invalid-client for details. ";
+
         public static string NoUserInstanceMetadataEntry(string environment)
         {
             return string.Format(

--- a/src/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
+++ b/src/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
@@ -32,6 +32,13 @@ namespace Microsoft.Identity.Client
                 }
             }
 
+            if (string.Equals(oAuth2Response?.Error, MsalError.InvalidClient, StringComparison.OrdinalIgnoreCase))
+            {
+                ex = new MsalServiceException(
+                    MsalError.InvalidClient,
+                    MsalErrorMessage.InvalidClient + " Original exception: " + oAuth2Response?.ErrorDescription);
+            }
+
             if (ex == null)
             {
                 ex = new MsalServiceException(errorCode, errorMessage, innerException);

--- a/src/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
+++ b/src/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Identity.Client
             {
                 ex = new MsalServiceException(
                     MsalError.InvalidClient,
-                    MsalErrorMessage.InvalidClient + " Original exception: " + oAuth2Response?.ErrorDescription);
+                    MsalErrorMessage.InvalidClient + " Original exception: " + oAuth2Response?.ErrorDescription, 
+                    innerException);
             }
 
             if (ex == null)

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -155,6 +155,20 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 "\"f11508ab-067f-40d4-83cb-ccc67bf57e45\"}");
         }
 
+        public static HttpResponseMessage CreateInvalidClientResponseMessage()
+        {
+            return CreateFailureMessage(HttpStatusCode.BadRequest,
+                "{\"error\":\"invalid_client\",\"error_description\":\"AADSTS7000218: " +
+                "The request body must contain the following parameter: " +
+                "'client_assertion' or 'client_secret'." +
+                "Trace ID: 21c3e4db - d2fd - 44f7 - a3e0 - 5939f84e6000" +
+                "Correlation ID: 3d483b09 - 1198 - 4acb - 929f - c648674e32bd" +
+                "Timestamp: 2019 - 07 - 12 19:24:42Z\"," +
+                "\"error_codes\":[7000218],\"timestamp\":\"2019-07-12 19:24:42Z\"," +
+                "\"trace_id\":\"21c3e4db-d2fd-44f7-a3e0-5939f84e6000\",\"correlation_id\":" +
+                "\"3d483b09-1198-4acb-929f-c648674e32bd\"}");
+        }
+
         public static HttpResponseMessage CreateNoErrorFieldResponseMessage()
         {
             return CreateFailureMessage(HttpStatusCode.BadRequest,

--- a/tests/Microsoft.Identity.Test.Unit.net45/ExceptionTests/MsalExceptionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/ExceptionTests/MsalExceptionTests.cs
@@ -155,6 +155,26 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         }
 
         [TestMethod]
+        public void InvalidClientException_IsRepackaged()
+        {
+            // Arrange
+            HttpResponse httpResponse = new HttpResponse()
+            {
+                Body =  JsonError.Replace("invalid_grant", "invalid_client"),
+                StatusCode = HttpStatusCode.BadRequest, // 400
+            };
+
+            // Act
+            var msalException = MsalServiceExceptionFactory.FromHttpResponse(ExCode, ExMessage, httpResponse);
+
+            // Assert
+            var msalServiceException = msalException as MsalServiceException;
+            Assert.AreEqual(MsalError.InvalidClient, msalServiceException.ErrorCode);
+            Assert.IsTrue(msalServiceException.Message.Contains(MsalErrorMessage.InvalidClient));
+            ValidateExceptionProductInformation(msalException);
+        }
+
+        [TestMethod]
         public void MsalServiceException_HttpResponse_OAuthResponse()
         {
             // Arrange

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Test.Common;
-using Microsoft.Identity.Test.Common.Core.Helpers;
-using Microsoft.Identity.Test.Common.Core.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,6 +10,12 @@ using System.Net.Http;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
@@ -177,7 +177,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         public async Task AcquireTokenByIntegratedWindowsAuthTest_ManagedUserAsync()
         {
             // Arrange
@@ -188,14 +187,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 httpManager.AddMockHandlerForTenantEndpointDiscovery(MsalTestConstants.AuthorityCommonTenant);
                 AddMockHandlerDefaultUserRealmDiscovery_ManagedUser(httpManager);
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Act
-                var exception = await AssertException.TaskThrowsAsync<MsalClientException>(
+                MsalClientException exception = await AssertException.TaskThrowsAsync<MsalClientException>(
                     async () => await app
                         .AcquireTokenByIntegratedWindowsAuth(MsalTestConstants.Scope)
                         .WithUsername(MsalTestConstants.User.Username)
@@ -208,7 +207,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         public async Task AcquireTokenByIntegratedWindowsAuthTest_UnknownUserAsync()
         {
             // Arrange
@@ -230,14 +228,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         }
                     });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Act
-                var exception = await AssertException.TaskThrowsAsync<MsalClientException>(
+                MsalClientException exception = await AssertException.TaskThrowsAsync<MsalClientException>(
                     async () => await app
                         .AcquireTokenByIntegratedWindowsAuth(MsalTestConstants.Scope)
                         .WithUsername(MsalTestConstants.User.Username)
@@ -250,7 +248,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
+
         [DeploymentItem(@"Resources\TestMex.xml")]
         [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
         public async Task AcquireTokenByIntegratedWindowsAuthTestAsync()
@@ -267,17 +265,17 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 MockHttpMessageHandler realmDiscoveryHandler = AddMockHandlerDefaultUserRealmDiscovery(httpManager);
                 AddMockHandlerMex(httpManager);
                 AddMockHandlerWsTrustWindowsTransport(httpManager);
-                var mockTokenRequestHttpHandler = AddMockHandlerAadSuccess(httpManager, MsalTestConstants.AuthorityCommonTenant);
+                MockHttpMessageHandler mockTokenRequestHttpHandler = AddMockHandlerAadSuccess(httpManager, MsalTestConstants.AuthorityCommonTenant);
                 mockTokenRequestHttpHandler.ExpectedQueryParams = extraQueryParamsAndClaims;
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithExtraQueryParameters(MsalTestConstants.ExtraQueryParams)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
-                var result = await app
+                AuthenticationResult result = await app
                     .AcquireTokenByIntegratedWindowsAuth(MsalTestConstants.Scope)
                                                         .WithClaims(MsalTestConstants.Claims)
                                                         .WithUsername(MsalTestConstants.User.Username)
@@ -298,7 +296,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         [DeploymentItem(@"Resources\TestMex.xml")]
         [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
         public async Task AcquireTokenByIntegratedWindowsAuthInvalidClientTestAsync()
@@ -323,14 +320,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                        ResponseMessage = MockHelpers.CreateInvalidClientResponseMessage()
                    });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithExtraQueryParameters(MsalTestConstants.ExtraQueryParams)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
-                var result = await AssertException.TaskThrowsAsync<MsalServiceException>(
+                MsalServiceException result = await AssertException.TaskThrowsAsync<MsalServiceException>(
                     async () => await app.AcquireTokenByIntegratedWindowsAuth(MsalTestConstants.Scope)
                                                         .WithClaims(MsalTestConstants.Claims)
                                                         .WithUsername(MsalTestConstants.User.Username)
@@ -346,7 +343,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
 #if !WINDOWS_APP // U/P flow not enabled on UWP
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         [DeploymentItem(@"Resources\TestMex.xml")]
         [DeploymentItem(@"Resources\WsTrustResponse.xml")]
         public async Task FederatedUsernamePasswordWithSecureStringAcquireTokenTestAsync()
@@ -356,13 +352,13 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 httpManager.AddInstanceDiscoveryMockHandler();
                 MockHttpMessageHandler realmDiscoveryHandler = AddMockResponseForFederatedAccounts(httpManager);
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
-                var result = await app.AcquireTokenByUsernamePassword(
+                AuthenticationResult result = await app.AcquireTokenByUsernamePassword(
                     MsalTestConstants.Scope,
                     MsalTestConstants.User.Username,
                     _secureString).ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
@@ -382,7 +378,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         [DeploymentItem(@"Resources\TestMex.xml")]
         public async Task MexEndpointFailsToResolveTestAsync()
         {
@@ -406,14 +401,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         }
                     });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Call acquire token, Mex parser fails
-                var result = await AssertException.TaskThrowsAsync<MsalClientException>(
+                MsalClientException result = await AssertException.TaskThrowsAsync<MsalClientException>(
                     async () => await app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
@@ -429,7 +424,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         [DeploymentItem(@"Resources\TestMex.xml")]
         public async Task MexDoesNotReturnAuthEndpointTestAsync()
         {
@@ -444,14 +438,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 httpManager.AddMockHandlerContentNotFound(HttpMethod.Post,
                     "https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport");
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Call acquire token, endpoint not found
-                var result = await AssertException.TaskThrowsAsync<MsalClientException>(
+                MsalClientException result = await AssertException.TaskThrowsAsync<MsalClientException>(
                     async () => await app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
@@ -466,7 +460,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         public async Task MexParsingFailsTestAsync()
         {
             using (var httpManager = new MockHttpManager())
@@ -479,14 +472,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 httpManager.AddMockHandlerContentNotFound(HttpMethod.Get,
                     "https://msft.sts.microsoft.com/adfs/services/trust/mex");
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Call acquire token
-                var result = await AssertException.TaskThrowsAsync<MsalServiceException>(
+                MsalServiceException result = await AssertException.TaskThrowsAsync<MsalServiceException>(
                     async () => await app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
@@ -501,7 +494,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         [DeploymentItem(@"Resources\TestMex.xml")]
         [DeploymentItem(@"Resources\WsTrustResponse.xml")]
         public async Task FederatedUsernameNullPasswordTestAsync()
@@ -517,7 +509,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 httpManager.AddMockHandlerContentNotFound(HttpMethod.Post,
                     "https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport");
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
@@ -526,7 +518,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 SecureString str = null;
 
                 // Call acquire token
-                var result = await AssertException.TaskThrowsAsync<MsalClientException>(
+                MsalClientException result = await AssertException.TaskThrowsAsync<MsalClientException>(
                     async () => await app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
@@ -541,7 +533,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordWithCommonTests")]
         [DeploymentItem(@"Resources\TestMex.xml")]
         [DeploymentItem(@"Resources\WsTrustResponse.xml")]
         public async Task FederatedUsernamePasswordCommonAuthorityTestAsync()
@@ -563,14 +554,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         ResponseMessage = MockHelpers.CreateInvalidRequestTokenResponseMessage()
                     });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Call acquire token
-                var result = await AssertException.TaskThrowsAsync<MsalServiceException>(
+                MsalServiceException result = await AssertException.TaskThrowsAsync<MsalServiceException>(
                     async () => await app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
@@ -585,7 +576,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordWithCommonTests")]
         public async Task ManagedUsernamePasswordCommonAuthorityTestAsync()
         {
             using (var httpManager = new MockHttpManager())
@@ -616,14 +606,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         ResponseMessage = MockHelpers.CreateInvalidRequestTokenResponseMessage()
                     });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Call acquire token
-                var result = await AssertException.TaskThrowsAsync<MsalServiceException>(
+                MsalServiceException result = await AssertException.TaskThrowsAsync<MsalServiceException>(
                     async () => await app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
@@ -638,7 +628,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
+
         public async Task ManagedUsernameSecureStringPasswordAcquireTokenTestAsync()
         {
             using (var httpManager = new MockHttpManager())
@@ -659,13 +649,13 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         }
                     });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
-                var result = await app.AcquireTokenByUsernamePassword(
+                AuthenticationResult result = await app.AcquireTokenByUsernamePassword(
                     MsalTestConstants.Scope,
                     MsalTestConstants.User.Username,
                     _secureString).ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
@@ -678,7 +668,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         public async Task ManagedUsernameNoPasswordAcquireTokenTestAsync()
         {
             using (var httpManager = new MockHttpManager())
@@ -686,7 +675,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 httpManager.AddInstanceDiscoveryMockHandler();
                 AddMockResponseforManagedAccounts(httpManager);
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
@@ -695,7 +684,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 SecureString str = null;
 
                 // Call acquire token
-                var result = await AssertException.TaskThrowsAsync<MsalClientException>(
+                MsalClientException result = await AssertException.TaskThrowsAsync<MsalClientException>(
                     async () => await app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
@@ -710,7 +699,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         public async Task ManagedUsernameIncorrectPasswordAcquireTokenTestAsync()
         {
             using (var httpManager = new MockHttpManager())
@@ -735,18 +723,18 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         }
                     });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Call acquire token
-                var result = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(
-                    async () => await app.AcquireTokenByUsernamePassword(
+                MsalUiRequiredException result = await Assert.ThrowsExceptionAsync<MsalUiRequiredException>(
+                    () => app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
-                        str).ExecuteAsync(CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
+                        str).ExecuteAsync(CancellationToken.None)).ConfigureAwait(false);
 
                 // Check error code
                 Assert.AreEqual(MsalError.InvalidGrantError, result.ErrorCode);
@@ -757,7 +745,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        [TestCategory("IntegratedWindowsAuthAndUsernamePasswordTests")]
         public async Task UsernamePasswordInvalidClientTestAsync()
         {
             using (var httpManager = new MockHttpManager())
@@ -790,18 +777,18 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         ResponseMessage = MockHelpers.CreateInvalidClientResponseMessage()
                     });
 
-                var app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                         .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                         .WithHttpManager(httpManager)
                                                         .WithTelemetry(new TraceTelemetryConfig())
                                                         .BuildConcrete();
 
                 // Call acquire token
-                var result = await AssertException.TaskThrowsAsync<MsalServiceException>(
-                    async () => await app.AcquireTokenByUsernamePassword(
+                MsalServiceException result = await Assert.ThrowsExceptionAsync<MsalServiceException>(
+                    () => app.AcquireTokenByUsernamePassword(
                         MsalTestConstants.Scope,
                         MsalTestConstants.User.Username,
-                        _secureString).ExecuteAsync(CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
+                        _secureString).ExecuteAsync()).ConfigureAwait(false);
 
                 // Check inner exception
                 Assert.AreEqual(MsalError.InvalidClient, result.ErrorCode);


### PR DESCRIPTION
fix for [making iwa/up/device code error better](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1249)

I tried it out w/a conf client i made in the portal. For all three auth flows (device code, iwa, u/p), i always got the same error:
 {"error":"invalid_client","error_description":"AADSTS7000218: The request body must contain the following parameter: 'client_assertion' or 'client_secret'.\r\nTrace ID: 3859ae12-01bc-4f57-9fd8-0bee7ec87b00\r\nCorrelation ID: 5467e70d-2025-43a8-92e9-758a143c0319\r\nTimestamp: 2019-07-12 23:33:09Z","error_codes":[7000218],"timestamp":"2019-07-12 23:33:09Z","trace_id":"3859ae12-01bc-4f57-9fd8-0bee7ec87b00","correlation_id":"5467e70d-2025-43a8-92e9-758a143c0319"}

So, @bgavrilMS  not sure how you got something else for u/p.

@jmprieur Feel free to edit the wiki info: https://aka.ms/msal-net-invalid-client

