### PR TITLE
Resolving issue with authority api adding an additional "/" to the authority.

### DIFF
--- a/src/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client
         internal static AuthorityInfo FromAadAuthority(Uri cloudInstanceUri, Guid tenantId, bool validateAuthority)
         {
 #pragma warning disable CA1305 // Specify IFormatProvider
-            return FromAuthorityUri(string.Format(CultureInfo.InvariantCulture, "{0}/{1}/", cloudInstanceUri, tenantId.ToString("D")), validateAuthority);
+            return FromAuthorityUri(string.Format(CultureInfo.InvariantCulture, "{0}{1}/", cloudInstanceUri, tenantId.ToString("D")), validateAuthority);
 #pragma warning restore CA1305 // Specify IFormatProvider
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Client
             {
                 return FromAadAuthority(cloudInstanceUri, tenantId, validateAuthority);
             }
-            return FromAuthorityUri(string.Format(CultureInfo.InvariantCulture, "{0}/{1}/", cloudInstanceUri, tenant), validateAuthority);
+            return FromAuthorityUri(string.Format(CultureInfo.InvariantCulture, "{0}{1}/", cloudInstanceUri, tenant), validateAuthority);
         }
 
         internal static AuthorityInfo FromAadAuthority(

--- a/src/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client
         internal static AuthorityInfo FromAadAuthority(Uri cloudInstanceUri, Guid tenantId, bool validateAuthority)
         {
 #pragma warning disable CA1305 // Specify IFormatProvider
-            return FromAuthorityUri(string.Format(CultureInfo.InvariantCulture, "{0}{1}/", cloudInstanceUri, tenantId.ToString("D")), validateAuthority);
+            return FromAuthorityUri(new Uri(cloudInstanceUri, tenantId.ToString("D")).ToString(), validateAuthority);
 #pragma warning restore CA1305 // Specify IFormatProvider
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Client
             {
                 return FromAadAuthority(cloudInstanceUri, tenantId, validateAuthority);
             }
-            return FromAuthorityUri(string.Format(CultureInfo.InvariantCulture, "{0}{1}/", cloudInstanceUri, tenant), validateAuthority);
+            return FromAuthorityUri(new Uri(cloudInstanceUri, tenant).ToString(), validateAuthority);
         }
 
         internal static AuthorityInfo FromAadAuthority(

--- a/src/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client
         internal static AuthorityInfo FromAadAuthority(Uri cloudInstanceUri, Guid tenantId, bool validateAuthority)
         {
 #pragma warning disable CA1305 // Specify IFormatProvider
-            return FromAuthorityUri(new Uri(cloudInstanceUri, tenantId.ToString("D")).ToString(), validateAuthority);
+            return FromAuthorityUri(new Uri(cloudInstanceUri, tenantId.ToString("D")).AbsoluteUri, validateAuthority);
 #pragma warning restore CA1305 // Specify IFormatProvider
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Client
             {
                 return FromAadAuthority(cloudInstanceUri, tenantId, validateAuthority);
             }
-            return FromAuthorityUri(new Uri(cloudInstanceUri, tenant).ToString(), validateAuthority);
+            return FromAuthorityUri(new Uri(cloudInstanceUri, tenant).AbsoluteUri, validateAuthority);
         }
 
         internal static AuthorityInfo FromAadAuthority(

--- a/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/MsalTestConstants.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string Uid = "my-uid";
         public const string Utid = "my-utid";
         public const string Common = "common";
-        public const string TenantId = "e56cat29e-b008-4cea-b6f0-48facatsd64a";
+        public const string TenantId = "751a212b-4003-416e-b600-e1f48e40db9f";
         public static readonly IDictionary<string, string> ClientAssertionClaims = new Dictionary<string, string> {{ "client_ip", "some_ip" }, { "aud", "some_audience" }};
         public const string RTSecret = "someRT";
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Identity.Test.Common.Core.Helpers;
 
 namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 {
@@ -322,25 +323,62 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         public void TenantSpecificAuthorityInitTest()
         {
             var host = String.Concat("https://", MsalTestConstants.ProductionPrefNetworkEnvironment);
-            var fullAuthority = String.Concat(host, "/" , MsalTestConstants.TenantId, "/");
+            var expectedAuthority = String.Concat(host, "/" , MsalTestConstants.TenantId, "/");
 
             var publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                              .WithAuthority(host, MsalTestConstants.TenantId)
                                                              .BuildConcrete();
 
-            Assert.AreEqual(publicClient.Authority, fullAuthority);
+            Assert.AreEqual(publicClient.Authority, expectedAuthority);
 
             publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                          .WithAuthority(host, new Guid(MsalTestConstants.TenantId))
                                                          .BuildConcrete();
 
-            Assert.AreEqual(publicClient.Authority, fullAuthority);
+            Assert.AreEqual(publicClient.Authority, expectedAuthority);
+
+            publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                                                         .WithAuthority(new Uri(expectedAuthority))
+                                                         .BuildConcrete();
+
+            Assert.AreEqual(publicClient.Authority, expectedAuthority);
+        }
+
+        [TestMethod]
+        public void MalformedAuthorityInitTest()
+        {
+            PublicClientApplication publicClient = null;
+            var expectedAuthority = String.Concat("https://", MsalTestConstants.ProductionPrefNetworkEnvironment, "/", MsalTestConstants.TenantId, "/");
+
+            //Check bad URI format
+            var host = String.Concat("test", MsalTestConstants.ProductionPrefNetworkEnvironment, "/");
+            var fullAuthority = String.Concat(host, MsalTestConstants.TenantId);
+
+            AssertException.Throws<UriFormatException>(() =>
+            {
+                publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                                                             .WithAuthority(fullAuthority)
+                                                             .BuildConcrete();
+            });
+
+            //Check empty path segments
+            host = String.Concat("https://", MsalTestConstants.ProductionPrefNetworkEnvironment, "/");
+            fullAuthority = String.Concat(host, MsalTestConstants.TenantId, "//");
+
+            publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                                                         .WithAuthority(host, new Guid(MsalTestConstants.TenantId))
+                                                         .BuildConcrete();
+
+            Assert.AreEqual(publicClient.Authority, expectedAuthority);
+
+            //Check additional path segments
+            fullAuthority = String.Concat(host , MsalTestConstants.TenantId, "/ABCD!@#$TEST//");
 
             publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
                                                          .WithAuthority(new Uri(fullAuthority))
                                                          .BuildConcrete();
 
-            Assert.AreEqual(publicClient.Authority, fullAuthority);
+            Assert.AreEqual(publicClient.Authority, expectedAuthority);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -319,6 +319,31 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         }
 
         [TestMethod]
+        public void TenantSpecificAuthorityInitTest()
+        {
+            var host = String.Concat("https://", MsalTestConstants.ProductionPrefNetworkEnvironment);
+            var fullAuthority = String.Concat(host, "/" , MsalTestConstants.TenantId, "/");
+
+            var publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                                                             .WithAuthority(host, MsalTestConstants.TenantId)
+                                                             .BuildConcrete();
+
+            Assert.AreEqual(publicClient.Authority, fullAuthority);
+
+            publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                                                         .WithAuthority(host, new Guid(MsalTestConstants.TenantId))
+                                                         .BuildConcrete();
+
+            Assert.AreEqual(publicClient.Authority, fullAuthority);
+
+            publicClient = PublicClientApplicationBuilder.Create(MsalTestConstants.ClientId)
+                                                         .WithAuthority(new Uri(fullAuthority))
+                                                         .BuildConcrete();
+
+            Assert.AreEqual(publicClient.Authority, fullAuthority);
+        }
+
+        [TestMethod]
         public void TenantAuthorityDoesNotChange()
         {
             // no change because initial authority is tenanted


### PR DESCRIPTION
Resolving issue with authority api adding an additional "/" to the end of the authority.

Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1270