### PR TITLE
change client exception back to service

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -259,6 +259,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     UiRequiredExceptionClassification.PromptNeverFailed);
             }
 
+            if(_authorizationResult.Status == AuthorizationStatus.UserCancel)
+            {
+                throw new MsalClientException(_authorizationResult.Error, _authorizationResult.ErrorDescription ?? "User cancelled authentication.");
+            }
+
             if (_authorizationResult.Status != AuthorizationStatus.Success)
             {
                 throw new MsalServiceException(_authorizationResult.Error, _authorizationResult.ErrorDescription ?? "Unknown error.");

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             if (_authorizationResult.Status != AuthorizationStatus.Success)
             {
-                throw new MsalClientException(_authorizationResult.Error, _authorizationResult.ErrorDescription ?? "Unknown error.");
+                throw new MsalServiceException(_authorizationResult.Error, _authorizationResult.ErrorDescription ?? "Unknown error.");
             }
         }
         internal /* internal for test only */ bool IsBrokerInvocationRequired()

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -259,13 +259,17 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     UiRequiredExceptionClassification.PromptNeverFailed);
             }
 
-            if(_authorizationResult.Status == AuthorizationStatus.UserCancel)
+            if (_authorizationResult.Status == AuthorizationStatus.UserCancel)
             {
+                ServiceBundle.DefaultLogger.Info(LogMessages.UserCancelledAuthentication);
                 throw new MsalClientException(_authorizationResult.Error, _authorizationResult.ErrorDescription ?? "User cancelled authentication.");
             }
 
             if (_authorizationResult.Status != AuthorizationStatus.Success)
             {
+                ServiceBundle.DefaultLogger.InfoPii(
+                    LogMessages.AuthorizationResultWasNotSuccessful + _authorizationResult.ErrorDescription ?? "Unknown error.", 
+                    LogMessages.AuthorizationResultWasNotSuccessful);
                 throw new MsalServiceException(_authorizationResult.Error, _authorizationResult.ErrorDescription ?? "Unknown error.");
             }
         }

--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -273,6 +273,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 throw new MsalServiceException(_authorizationResult.Error, _authorizationResult.ErrorDescription ?? "Unknown error.");
             }
         }
+
         internal /* internal for test only */ bool IsBrokerInvocationRequired()
         {
             if (_authorizationResult.Code != null &&

--- a/src/Microsoft.Identity.Client/LogMessages.cs
+++ b/src/Microsoft.Identity.Client/LogMessages.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Identity.Client
         public const string CanInvokeBrokerAcquireTokenWithBroker = "Can invoke broker. Will attempt to acquire token with broker. ";
         public const string AuthenticationWithBrokerDidNotSucceed = "Broker authentication did not succeed, or the broker install failed. " +
             "See https://aka.ms/msal-net-brokers for more information. ";
+        public const string UserCancelledAuthentication = "Authorization result status returned user cancelled authentication. ";
+        public const string AuthorizationResultWasNotSuccessful = "Authorization result was not successful. See error message for more details. ";
 
         public static string ErrorReturnedInBrokerResponse(string error)
         {

--- a/src/Microsoft.Identity.Client/UI/AuthorizationResult.cs
+++ b/src/Microsoft.Identity.Client/UI/AuthorizationResult.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Identity.Client.UI
                         : null);
             }
 
-
             var result = new AuthorizationResult();
             result.Status = AuthorizationStatus.Success;
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -801,7 +801,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                         .ExecuteAsync(CancellationToken.None)
                         .ConfigureAwait(false);
                 }
-                catch (MsalServiceException exc)
+                catch (MsalClientException exc)
                 {
                     Assert.IsNotNull(exc);
                     Assert.AreEqual("authentication_canceled", exc.ErrorCode);

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -801,7 +801,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                         .ExecuteAsync(CancellationToken.None)
                         .ConfigureAwait(false);
                 }
-                catch (MsalClientException exc)
+                catch (MsalServiceException exc)
                 {
                     Assert.IsNotNull(exc);
                     Assert.AreEqual("authentication_canceled", exc.ErrorCode);
@@ -810,6 +810,47 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                             anEvent => // Expect finding such an event
                                 anEvent[EventBase.EventNameKey].EndsWith("ui_event") &&
                                 anEvent[UiEvent.UserCancelledKey] == "true"));
+                    return;
+                }
+            }
+
+            Assert.Fail("Should not reach here. Exception was not thrown.");
+        }
+
+        [TestMethod]
+        [Description("Test for AcquireToken with user resetting password")]
+        public async Task B2CAcquireTokenWithResetPasswordTestAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                            .WithB2CAuthority(TestConstants.B2CLoginAuthority)
+                                                                            .WithHttpManager(httpManager)
+                                                                            .WithDebugLoggingCallback(logLevel: LogLevel.Verbose)
+                                                                            .BuildConcrete();
+
+                // Interactive call and user wants to reset password
+                var ui = new MockWebUI()
+                {
+                    MockResult = AuthorizationResult.FromUri(TestConstants.B2CLoginAuthority +
+                    "?error=access_denied&error_description=AADB2C90091%3a+The+user+has+cancelled+entering+self-asserted+information.")
+                };
+
+                httpManager.AddMockHandlerForTenantEndpointDiscovery(TestConstants.B2CLoginAuthority);
+                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+
+                try
+                {
+                    AuthenticationResult result = await app
+                        .AcquireTokenInteractive(TestConstants.s_scope)
+                        .ExecuteAsync(CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (MsalServiceException exc)
+                {
+                    Assert.IsNotNull(exc);
+                    Assert.AreEqual("access_denied", exc.ErrorCode);
+                    Assert.AreEqual("AADB2C90091: The user has cancelled entering self-asserted information.", exc.Message);
                     return;
                 }
             }
@@ -850,7 +891,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                         .ExecuteAsync(CancellationToken.None)
                         .ConfigureAwait(false);
                 }
-                catch (MsalClientException exc)
+                catch (MsalServiceException exc)
                 {
                     Assert.IsNotNull(exc);
                     Assert.AreEqual("access_denied", exc.ErrorCode);


### PR DESCRIPTION
[1276](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1276)

@jmprieur and @henrik-me we need to discuss this change and versioning. 