### PR TITLE
Stop custom handling network down error

### DIFF
--- a/src/Microsoft.Identity.Client/MsalError.cs
+++ b/src/Microsoft.Identity.Client/MsalError.cs
@@ -470,6 +470,7 @@ namespace Microsoft.Identity.Client
         /// <para>Mitigation [App development]</para> In the application you could either inform the user that there are network issues
         /// or retry later
         /// </summary>
+        [Obsolete("MSAL no longer throws this error - it will allow the HttpClient exceptions to propagate. App developers may write their own logic for detecting access to the network issues, for example by using Xamarin.Essentials. ")]
         public const string NetworkNotAvailableError = "network_not_available";
 
         /// <summary>

--- a/src/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Identity.Client
         public const string MultipleTokensMatched =
             "The cache contains multiple tokens satisfying the requirements. Try to clear token cache";
 
-        public const string NetworkNotAvailable = "The network is down so authentication cannot proceed";
         public const string NoDataFromSTS = "No data received from security token service";
         public const string NullParameterTemplate = "Parameter '{0}' cannot be null";
         public const string ParsingMetadataDocumentFailed = "Parsing WS metadata exchange failed";

--- a/src/Microsoft.Identity.Client/Platforms/net45/WebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/WebUI.cs
@@ -92,16 +92,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
             RequestUri = requestUri;
             CallbackUri = callbackUri;
 
-            ThrowOnNetworkDown();
             return OnAuthenticate();
-        }
-
-        private static void ThrowOnNetworkDown()
-        {
-            if (!NetworkInterface.GetIsNetworkAvailable())
-            {
-                throw new MsalClientException(MsalError.NetworkNotAvailableError, MsalErrorMessage.NetworkNotAvailable);
-            }
         }
 
         protected abstract AuthorizationResult OnAuthenticate();

--- a/src/Microsoft.Identity.Client/Platforms/uap/WebUI.cs
+++ b/src/Microsoft.Identity.Client/Platforms/uap/WebUI.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Identity.Client.Platforms.uap
                 ? WebAuthenticationOptions.UseCorporateNetwork
                 : WebAuthenticationOptions.None;
 
-            ThrowOnNetworkDown();
             if (_silentMode)
             {
                 options |= WebAuthenticationOptions.SilentMode;
@@ -77,25 +76,12 @@ namespace Microsoft.Identity.Client.Platforms.uap
                     ex);
             }
 
-            AuthorizationResult result = ProcessAuthorizationResult(webAuthenticationResult, requestContext);
+            AuthorizationResult result = ProcessAuthorizationResult(webAuthenticationResult);
 
             return result;
         }
 
-        private void ThrowOnNetworkDown()
-        {
-            var profile = NetworkInformation.GetInternetConnectionProfile();
-            var isConnected = (profile != null
-                               && profile.GetNetworkConnectivityLevel() ==
-                               NetworkConnectivityLevel.InternetAccess);
-            if (!isConnected)
-            {
-                throw new MsalClientException(MsalError.NetworkNotAvailableError, MsalErrorMessage.NetworkNotAvailable);
-            }
-        }
-
-        private static AuthorizationResult ProcessAuthorizationResult(WebAuthenticationResult webAuthenticationResult,
-            RequestContext requestContext)
+        private static AuthorizationResult ProcessAuthorizationResult(WebAuthenticationResult webAuthenticationResult)
         {
             AuthorizationResult result;
             switch (webAuthenticationResult.ResponseStatus)


### PR DESCRIPTION
…Essentials for that.

Fixes bug https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/592 by providing a **consistent** approach to HTTP errors. See more details in the bug.

Note that this is theoretically a breaking change because we are changing exception logic, but in practice it should not make a difference, because if the network is down, MSAL will fail with an Http exception when making a discovery call. 