### PR TITLE
Fix regression from PR #1275

### DIFF
--- a/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopCryptographyManager.cs
+++ b/src/Microsoft.Identity.Client/Platforms/net45/NetDesktopCryptographyManager.cs
@@ -122,7 +122,9 @@ namespace Microsoft.Identity.Client.Platforms.net45
         /// <returns><see cref="RSACryptoServiceProvider"/> initialized with private key from <paramref name="certificate"/></returns>
         private static RSACryptoServiceProvider GetCryptoProviderForSha256(X509Certificate2 certificate)
         {
-            return (RSACryptoServiceProvider) certificate.PrivateKey;
+            // We need to call the other GetCryptoProviderForSha256 method in case certificate.PrivateKey is using
+            // one of the providers that doesn't support SHA256
+            return GetCryptoProviderForSha256((RSACryptoServiceProvider)certificate.PrivateKey);
         }
 
         // Copied from ACS code


### PR DESCRIPTION
Fix a regression from [PR#1275](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/1275) where if certificate.PrivateKey returns an instance of RSACryptoServiceProvider using a legacy CSP that doesn't support SHA256 the signature fails.  The fix is to use the existing helper method that checks for unsupported provider types and create a new instance of RSACryptoServiceProvider with a supported provider type.