### PR TITLE
Send claims as query param to /authorize endpoint as per OIDC spec

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -209,6 +209,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 [OAuth2Parameter.RedirectUri] = redirectUriOverride?.OriginalString ?? AuthenticationRequestParameters.RedirectUri.OriginalString
             };
 
+            if (!string.IsNullOrWhiteSpace(AuthenticationRequestParameters.Claims))
+            {
+                authorizationRequestParameters[OAuth2Parameter.Claims] = AuthenticationRequestParameters.Claims;
+            }
+
             if (!string.IsNullOrWhiteSpace(_interactiveParameters.LoginHint))
             {
                 authorizationRequestParameters[OAuth2Parameter.LoginHint] = _interactiveParameters.LoginHint;

--- a/tests/Microsoft.Identity.Test.Common/Mocks/MsalMockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Mocks/MsalMockHelpers.cs
@@ -14,20 +14,20 @@ namespace Microsoft.Identity.Test.Common.Mocks
 {
     internal static class MsalMockHelpers
     {
-        public static void ConfigureMockWebUI(IPlatformProxy platformProxy, AuthorizationResult authorizationResult)
+        public static MockWebUI ConfigureMockWebUI(IPlatformProxy platformProxy, AuthorizationResult authorizationResult)
         {
-            ConfigureMockWebUI(platformProxy, authorizationResult, new Dictionary<string, string>());
+            return ConfigureMockWebUI(platformProxy, authorizationResult, new Dictionary<string, string>());
         }
 
-        public static void ConfigureMockWebUI(
+        public static MockWebUI ConfigureMockWebUI(
             IPlatformProxy platformProxy,
             AuthorizationResult authorizationResult,
             Dictionary<string, string> queryParamsToValidate)
         {
-            ConfigureMockWebUI(platformProxy, authorizationResult, queryParamsToValidate, null);
+            return ConfigureMockWebUI(platformProxy, authorizationResult, queryParamsToValidate, null);
         }
 
-        public static void ConfigureMockWebUI(
+        public static MockWebUI ConfigureMockWebUI(
             IPlatformProxy platformProxy,
             AuthorizationResult authorizationResult,
             Dictionary<string, string> queryParamsToValidate,
@@ -41,6 +41,8 @@ namespace Microsoft.Identity.Test.Common.Mocks
             };
 
             ConfigureMockWebUI(platformProxy, webUi);
+
+            return webUi;
         }
 
         public static void ConfigureMockWebUI(IPlatformProxy platformProxy, MockWebUI webUi)


### PR DESCRIPTION
Fix for #1328 