### PR TITLE
Cleanup null cache non-used code paths

### DIFF
--- a/src/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -31,15 +31,13 @@ namespace Microsoft.Identity.Client.Cache
             AuthenticationRequestParameters requestParams, 
             ITelemetryManager telemetryManager)
         {
-            TokenCacheInternal = tokenCacheInternal;
+            TokenCacheInternal = tokenCacheInternal ?? throw new ArgumentNullException(nameof(requestParams));
             _requestParams = requestParams ?? throw new ArgumentNullException(nameof(requestParams));
             _telemetryManager = telemetryManager ?? throw new ArgumentNullException(nameof(telemetryManager));
         }
 
         #region ICacheSessionManager implementation
         public ITokenCacheInternal TokenCacheInternal { get; }
-
-        public bool HasCache => TokenCacheInternal != null; 
 
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {

--- a/src/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.Client.Cache
             AuthenticationRequestParameters requestParams, 
             ITelemetryManager telemetryManager)
         {
-            TokenCacheInternal = tokenCacheInternal ?? throw new ArgumentNullException(nameof(requestParams));
+            TokenCacheInternal = tokenCacheInternal ?? throw new ArgumentNullException(nameof(tokenCacheInternal));
             _requestParams = requestParams ?? throw new ArgumentNullException(nameof(requestParams));
             _telemetryManager = telemetryManager ?? throw new ArgumentNullException(nameof(telemetryManager));
         }

--- a/src/Microsoft.Identity.Client/Cache/ICacheSessionManager.cs
+++ b/src/Microsoft.Identity.Client/Cache/ICacheSessionManager.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Identity.Client.Cache
     internal interface ICacheSessionManager
     {
         ITokenCacheInternal TokenCacheInternal { get; }
-        bool HasCache { get; }
         Task<MsalAccessTokenCacheItem> FindAccessTokenAsync();
         Task<Tuple<MsalAccessTokenCacheItem, MsalIdTokenCacheItem>> SaveTokenResponseAsync(MsalTokenResponse tokenResponse);
         Task<MsalIdTokenCacheItem> GetIdTokenCacheItemAsync(MsalIdTokenCacheKey idTokenCacheKey);

--- a/src/Microsoft.Identity.Client/Internal/Requests/ByRefreshTokenRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/ByRefreshTokenRequest.cs
@@ -25,13 +25,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         internal override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (!CacheManager.HasCache)
-            {
-                throw new MsalUiRequiredException(
-                    MsalError.TokenCacheNullError,
-                    MsalErrorMessage.NullTokenCacheError);
-            }
-
             AuthenticationRequestParameters.RequestContext.Logger.Verbose(LogMessages.BeginningAcquireByRefreshToken);
             await ResolveAuthorityEndpointsAsync().ConfigureAwait(false);
             var msalTokenResponse = await SendTokenRequestAsync(

--- a/src/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         internal override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (!_clientParameters.ForceRefresh && CacheManager.HasCache)
+            if (!_clientParameters.ForceRefresh)
             {
                 var msalAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
                 if (msalAccessTokenItem != null)

--- a/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -36,14 +36,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
             // for the user because the new incoming token may have updated claims
             // like mfa etc.
 
-            if (CacheManager.HasCache)
+            MsalAccessTokenCacheItem msalAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
+            if (msalAccessTokenItem != null)
             {
-                MsalAccessTokenCacheItem msalAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
-                if (msalAccessTokenItem != null)
-                {
-                    return new AuthenticationResult(msalAccessTokenItem, null, AuthenticationRequestParameters.RequestContext.CorrelationId);
-                }
+                return new AuthenticationResult(msalAccessTokenItem, null, AuthenticationRequestParameters.RequestContext.CorrelationId);
             }
+
 
             var msalTokenResponse = await SendTokenRequestAsync(GetBodyParameters(), cancellationToken).ConfigureAwait(false);
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);

--- a/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -61,17 +61,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             string messageWithPii = string.Format(
                 CultureInfo.InvariantCulture,
-                "=== Token Acquisition ({4}) started:\n\tAuthority: {0}\n\tScope: {1}\n\tClientId: {2}\n\tCache Provided: {3}",
+                "=== Token Acquisition ({3}) started:\n\tAuthority: {0}\n\tScope: {1}\n\tClientId: {2}\n\t",
                 authenticationRequestParameters.AuthorityInfo?.CanonicalAuthority,
                 authenticationRequestParameters.Scope.AsSingleString(),
                 authenticationRequestParameters.ClientId,
-                CacheManager.HasCache,
                 GetType().Name);
 
             string messageWithoutPii = string.Format(
                 CultureInfo.InvariantCulture,
-                "=== Token Acquisition ({1}) started:\n\tCache Provided: {0}",
-                CacheManager.HasCache,
+                "=== Token Acquisition ({0}) started:\n\t",
                 GetType().Name);
 
             if (authenticationRequestParameters.AuthorityInfo != null &&
@@ -212,29 +210,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             AuthenticationRequestParameters.TenantUpdatedCanonicalAuthority =
                    AuthenticationRequestParameters.Authority.GetTenantedAuthority(idToken?.TenantId);
 
-            if (CacheManager.HasCache)
-            {
-                AuthenticationRequestParameters.RequestContext.Logger.Info("Saving Token Response to cache..");
+            AuthenticationRequestParameters.RequestContext.Logger.Info("Saving Token Response to cache..");
 
-                var tuple = await CacheManager.SaveTokenResponseAsync(msalTokenResponse).ConfigureAwait(false);
-                return new AuthenticationResult(tuple.Item1, tuple.Item2, AuthenticationRequestParameters.RequestContext.CorrelationId);
-            }
-            else
-            {
-                return new AuthenticationResult(
-                    new MsalAccessTokenCacheItem(
-                        AuthenticationRequestParameters.AuthorityInfo.Host,
-                        AuthenticationRequestParameters.ClientId,
-                        msalTokenResponse,
-                        idToken?.TenantId),
-                    new MsalIdTokenCacheItem(
-                        AuthenticationRequestParameters.AuthorityInfo.Host,
-                        AuthenticationRequestParameters.ClientId,
-                        msalTokenResponse,
-                        idToken?.TenantId),
-                        AuthenticationRequestParameters.RequestContext.CorrelationId
-                    );
-            }
+            var tuple = await CacheManager.SaveTokenResponseAsync(msalTokenResponse).ConfigureAwait(false);
+            return new AuthenticationResult(tuple.Item1, tuple.Item2, AuthenticationRequestParameters.RequestContext.CorrelationId);
+
         }
 
         private void ValidateAccountIdentifiers(ClientInfo fromServer)

--- a/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
@@ -85,13 +85,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         internal override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (!CacheManager.HasCache)
-            {
-                throw new MsalUiRequiredException(
-                    MsalError.TokenCacheNullError,
-                    MsalErrorMessage.NullTokenCacheForSilentError);
-            }
-
             // Look for access token
             if (!_silentParameters.ForceRefresh)
             {
@@ -105,6 +98,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 }
             }
 
+            return await RefreshRTAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<AuthenticationResult> RefreshRTAsync(CancellationToken cancellationToken)
+        {
             // Try FOCI first
             MsalTokenResponse msalTokenResponse = await TryGetTokenUsingFociAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Microsoft.Identity.Client/MsalError.cs
+++ b/src/Microsoft.Identity.Client/MsalError.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Identity.Client
         /// This error code comes back from <see cref="ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> calls when
         /// the user cache had not been set in the application constructor. This should never happen in MSAL.NET 3.x as the cache is created by the application
         /// </summary>
+        [Obsolete("This error code is not in use")]
         public const string TokenCacheNullError = "token_cache_null";
 
         /// <summary>

--- a/src/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -210,9 +210,6 @@ namespace Microsoft.Identity.Client
         public const string InstanceAndAzureCloudInstanceAreMutuallyExclusive = "Instance and AzureCloudInstance are both set but they're mutually exclusive.";
         public const string NoRefreshTokenProvided = "A refresh token must be provided.";
 
-        public const string NullTokenCacheError = "Token cache is set to null. Acquire by refresh token requests cannot be executed.";
-        public const string NullTokenCacheForSilentError = "Token cache is set to null. Silent requests cannot be executed.";
-
         public const string NoTokensFoundError = "No Refresh Token found in the cache";
         public const string NoRefreshTokenInResponse = "Acquire by refresh token request completed, but no refresh token was found";
 

--- a/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/Microsoft.Identity.Client/TokenCache.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Identity.Client
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         internal const string NullPreferredUsernameDisplayLabel = "Missing from the token response";
-        private const string AzurePublicEnv = "login.microsoftonline.com";
         private const int DefaultExpirationBufferInMinutes = 5;
 
         private readonly ITokenCacheBlobStorage _defaultTokenCacheBlobStorage;

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
@@ -43,11 +43,16 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public AuthenticationRequestParameters CreateAuthenticationRequestParameters(
             string authority,
             SortedSet<string> scopes,
-            ITokenCacheInternal tokenCache = null,
+            ITokenCacheInternal tokenCache,
             IAccount account = null,
             IDictionary<string, string> extraQueryParameters = null,
             string claims = null)
         {
+            if (tokenCache == null)
+            {
+                throw new ArgumentNullException(nameof(tokenCache));
+            }
+
             var commonParameters = new AcquireTokenCommonParameters
             {
                 Scopes = scopes ?? TestConstants.s_scope,

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Identity.Test.Unit
 {
     internal static class TestConstants
     {
-        public static readonly SortedSet<string> s_scope = new SortedSet<string>(new[] { "r1/scope1", "r1/scope2" });
+        public static SortedSet<string> s_scope
+        {
+            get
+            {
+                return new SortedSet<string>(new[] { "r1/scope1", "r1/scope2" });
+            }
+        }
+
         public const string ScopeStr = "r1/scope1 r1/scope2";
         public static readonly string[] s_graphScopes = new[] { "user.read" };
         public const uint JwtToAadLifetimeInSeconds = 60 * 10; // Ten minutes

--- a/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Identity.Test.Unit
                 // Arrange
                 var parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
-                    null,
-                    null,
-                    null,
+                    TestConstants.s_scope,
+                    new TokenCache(harness.ServiceBundle),
+                    null, 
                     TestConstants.s_extraQueryParams);
 
                 // Act

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/TokenCacheTests.cs
@@ -57,7 +57,11 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 cache.Accessor.SaveAccessToken(atItem);
                 var item = cache.FindAccessTokenAsync(
-                    harness.CreateAuthenticationRequestParameters(TestConstants.AuthorityTestTenant, TestConstants.s_scope, account: TestConstants.s_user)).Result;
+                    harness.CreateAuthenticationRequestParameters(
+                        TestConstants.AuthorityTestTenant, 
+                        TestConstants.s_scope,
+                        cache,
+                        account: TestConstants.s_user)).Result;
 
                 Assert.IsNotNull(item);
                 Assert.AreEqual(atKey, item.Secret);
@@ -91,6 +95,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var param = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
                     new SortedSet<string>(),
+                    cache,
                     account: TestConstants.s_user);
 
                 param.Scope.Add("r1/scope1");
@@ -129,6 +134,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var param = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
                     new SortedSet<string>(),
+                    cache,
                     account: new Account(TestConstants.s_userIdentifier, TestConstants.DisplayableId, null));
 
                 param.Scope.Add(TestConstants.s_scope.First());
@@ -164,6 +170,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var param = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
                     new SortedSet<string>(),
+                    cache, 
                     account: new Account(TestConstants.s_userIdentifier, TestConstants.DisplayableId, null));
 
                 Assert.IsNull(cache.FindAccessTokenAsync(param).Result);
@@ -194,6 +201,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var param = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
                     new SortedSet<string>(),
+                    cache,
                     account: new Account(TestConstants.s_userIdentifier, TestConstants.DisplayableId, null));
 
                 var cacheItem = cache.FindAccessTokenAsync(param).Result;
@@ -228,6 +236,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var param = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
                     new SortedSet<string>(),
+                    cache,
                     account: new Account(TestConstants.s_userIdentifier, TestConstants.DisplayableId, null));
 
                 Assert.IsNull(cache.FindAccessTokenAsync(param).Result);
@@ -254,6 +263,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var authParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
                     TestConstants.s_scope,
+                    cache,
                     account: TestConstants.s_user);
 
                 Assert.IsNotNull(cache.FindRefreshTokenAsync(authParams));
@@ -265,6 +275,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                                      harness.CreateAuthenticationRequestParameters(
                                          TestConstants.AuthorityHomeTenant + "more",
                                          TestConstants.s_scope,
+                                         cache,
                                          account: TestConstants.s_user)));
             }
         }
@@ -287,6 +298,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var authParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
                     TestConstants.s_scope,
+                    cache,
                     account: TestConstants.s_user);
 
                 var rt = cache.FindRefreshTokenAsync(authParams).Result;
@@ -320,7 +332,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 var authParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
-                    TestConstants.s_scope);
+                    TestConstants.s_scope, 
+                    cache);
                 authParams.ClientCredential = TestConstants.s_credentialWithSecret;
                 authParams.IsClientCredentialRequest = true;
 
@@ -393,7 +406,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 var authParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
-                    TestConstants.s_scope);
+                    TestConstants.s_scope, 
+                    cache);
                 authParams.UserAssertion = new UserAssertion(
                     harness.ServiceBundle.PlatformProxy.CryptographyManager.CreateBase64UrlEncodedSha256Hash(atKey));
 
@@ -435,7 +449,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 var authParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
-                    TestConstants.s_scope);
+                    TestConstants.s_scope, 
+                    cache);
                 authParams.UserAssertion = new UserAssertion(atItem.UserAssertionHash + "-random");
 
                 var item = cache.FindAccessTokenAsync(authParams).Result;
@@ -474,7 +489,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 var authParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
-                    TestConstants.s_scope);
+                    TestConstants.s_scope, 
+                    cache);
                 authParams.UserAssertion = new UserAssertion(atKey);
 
                 ((TokenCache)cache).AfterAccess = AfterAccessNoChangeNotification;
@@ -896,7 +912,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             return new AuthenticationRequestParameters(
                 serviceBundle,
-                null,
+                new TokenCache(serviceBundle),
                 commonParameters,
                 requestContext ?? new RequestContext(serviceBundle, Guid.NewGuid()))
             {
@@ -922,7 +938,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle);
                 AuthenticationRequestParameters requestParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
-                    TestConstants.s_scope,
+                    TestConstants.s_scope, 
+                    cache,
                     account: TestConstants.s_user);
 
                 // Act
@@ -960,6 +977,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 AuthenticationRequestParameters requestParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
                     TestConstants.s_scope,
+                    cache,
                     account: TestConstants.s_user);
 
                 cache.Accessor.SaveAppMetadata(

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheV2Tests/TokenCacheV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheV2Tests/TokenCacheV2Tests.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Identity.Test.Unit.CacheV2Tests
                 var cacheManager = new CacheManager(_storageManager, harness.CreateAuthenticationRequestParameters(
                                                         TestConstants.AuthorityTestTenant,
                                                         new SortedSet<string>(MsalCacheV2TestConstants.Scope),
+                                                        new TokenCache(harness.ServiceBundle),
                                                         account: TestConstants.s_user));
 
                 Assert.IsTrue(cacheManager.TryReadCache(out var tokenResponse, out var accountResponse));

--- a/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/OAuthClientTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Test.Unit
                     AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                         TestConstants.AuthorityHomeTenant,
                         TestConstants.s_scope,
-                        null,
+                        new TokenCache(harness.ServiceBundle),
                         extraQueryParameters: new Dictionary<string, string>
                         {
                             {"extra", "qp"}
@@ -179,7 +179,7 @@ namespace Microsoft.Identity.Test.Unit
                 AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
                     TestConstants.s_scope,
-                    null);
+                    new TokenCache(harness.ServiceBundle));
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = TestConstants.DisplayableId;
                 AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 // Arrange
                 var parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityTestTenant,
-                    null,
-                    null,
+                    TestConstants.s_scope,
+                    new TokenCache(harness.ServiceBundle),
                     null,
                     TestConstants.s_extraQueryParams);
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 AuthenticationRequestParameters requestParams = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
-                    TestConstants.s_scope);
+                    TestConstants.s_scope, 
+                    new TokenCache(harness.ServiceBundle));
 
                 var interactiveParameters = new AcquireTokenInteractiveParameters
                 {
@@ -213,7 +214,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
                     TestConstants.s_scope,
-                    null);
+                    new TokenCache(harness.ServiceBundle));
                 parameters.IsBrokerEnabled = false;
                 
                 InteractiveRequest request = new InteractiveRequest(
@@ -238,7 +239,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                         TestConstants.AuthorityHomeTenant,
                         TestConstants.s_scope,
-                        null,
+                        new TokenCache(harness.ServiceBundle),
                         extraQueryParameters: new Dictionary<string, string>
                         {
                             {"extra", "qp"}
@@ -281,7 +282,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
                     TestConstants.s_scope,
-                    null,
+                    new TokenCache(harness.ServiceBundle),
                     extraQueryParameters: new Dictionary<string, string> { { "extra", "qp" } });
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = TestConstants.DisplayableId;
@@ -351,7 +352,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
                     TestConstants.s_scope,
-                    null,
+                    new TokenCache(harness.ServiceBundle),
                     extraQueryParameters: new Dictionary<string, string> { { "extra", "qp" }, { "prompt", "login" } });
                 parameters.RedirectUri = new Uri("some://uri");
                 parameters.LoginHint = TestConstants.DisplayableId;

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 var parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
-                    TestConstants.s_scope);
+                    TestConstants.s_scope, 
+                    new TokenCache(harness.ServiceBundle));
                 parameters.RedirectUri = new Uri(ExpectedRedirectUri);
                 parameters.LoginHint = TestConstants.DisplayableId;
                 var interactiveParameters = new AcquireTokenInteractiveParameters

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/SilentRequestTests.cs
@@ -109,38 +109,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        public void SilentRefreshFailedNullCacheTest()
+        public void RequestParamsNullArg()
         {
             using (var harness = new MockHttpTestHarness(TestConstants.AuthorityHomeTenant))
             {
-                var parameters = harness.CreateRequestParams(
+                AssertException.Throws<ArgumentNullException>( () => harness.CreateRequestParams(
                     null,
-                    ScopeHelper.CreateSortedSetFromEnumerable(
-                        new[]
-                        {
-                            "some-scope1",
-                            "some-scope2"
-                        }),
-                    authorityOverride: AuthorityInfo.FromAuthorityUri(TestConstants.AuthorityHomeTenant, false));
-
-                var silentParameters = new AcquireTokenSilentParameters()
-                {
-                    Account = new Account(TestConstants.HomeAccountId, TestConstants.DisplayableId, TestConstants.ProductionPrefCacheEnvironment),
-                };
-
-                try
-                {
-                    var request = new SilentRequest(harness.ServiceBundle, parameters, silentParameters);
-                    Task<AuthenticationResult> task = request.RunAsync(CancellationToken.None);
-                    var authenticationResult = task.Result;
-                    Assert.Fail("MsalUiRequiredException should be thrown here");
-                }
-                catch (AggregateException ae)
-                {
-                    var exc = ae.InnerException as MsalUiRequiredException;
-                    Assert.IsNotNull(exc);
-                    Assert.AreEqual(MsalError.TokenCacheNullError, exc.ErrorCode);
-                }
+                    TestConstants.s_scope,
+                    authorityOverride: AuthorityInfo.FromAuthorityUri(TestConstants.AuthorityHomeTenant, false)));
             }
         }
 


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1345

This is leftover from ADAL. In MSAL, you cannot set the TokenCache to null. There is a bit of product code and quite a few tests that internally set it to null, but it not a valid scenario. 