### PR TITLE
circumvent cache look up for OBO

### DIFF
--- a/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 
@@ -29,20 +28,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         internal override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
             await ResolveAuthorityEndpointsAsync().ConfigureAwait(false);
-
-            // look for access token in the cache first.
-            // no access token is found, then it means token does not exist
-            // or new assertion has been passed. We should not use Refresh Token
-            // for the user because the new incoming token may have updated claims
-            // like mfa etc.
-
-            MsalAccessTokenCacheItem msalAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
-            if (msalAccessTokenItem != null)
-            {
-                return new AuthenticationResult(msalAccessTokenItem, null, AuthenticationRequestParameters.RequestContext.CorrelationId);
-            }
-
-
+            
             var msalTokenResponse = await SendTokenRequestAsync(GetBodyParameters(), cancellationToken).ConfigureAwait(false);
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -173,7 +173,9 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.IsNotNull(result.AccessToken);
 
                 appCacheAccess.AssertAccessCounts(0, 0);
-                userCacheAccess.AssertAccessCounts(1, 1);
+                userCacheAccess.AssertAccessCounts(0, 1);
+
+                harness.HttpManager.AddMockHandler(CreateTokenResponseHttpHandler(false));
 
                 result = await app
                     .AcquireTokenOnBehalfOf(TestConstants.s_scope, userAssertion)
@@ -185,7 +187,7 @@ namespace Microsoft.Identity.Test.Unit
                 //Check user cache
                 Assert.AreEqual(1, app.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count());
                 appCacheAccess.AssertAccessCounts(0, 0);
-                userCacheAccess.AssertAccessCounts(2, 1);
+                userCacheAccess.AssertAccessCounts(0, 2);
             }
         }
 


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1349