### PR TITLE
Enabling Device Code flow with personal accounts

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
@@ -49,15 +49,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
             client.AddBodyParameter(OAuth2Parameter.Scope, deviceCodeScopes.AsSingleString());
             client.AddQueryParameter(OAuth2Parameter.Claims, AuthenticationRequestParameters.Claims);
 
-
-            // Talked with Shiung, devicecode will be added to the discovery endpoint "soon".
-            // Fow now, the string replace is correct.
-            // TODO: We should NOT be talking to common, need to work with henrik/bogdan on why /common is being set
-            // as default for msal.
             string deviceCodeEndpoint = AuthenticationRequestParameters.Endpoints.TokenEndpoint
-                                                                       .Replace("token", "devicecode").Replace(
-                                                                           "common",
-                                                                           "organizations");
+                                                                       .Replace("token", "devicecode");
 
             var builder = new UriBuilder(deviceCodeEndpoint);
             builder.AppendQueryParameters(AuthenticationRequestParameters.ExtraQueryParameters);


### PR DESCRIPTION
Removes the restriction common => organizations that was set up when Device Code flow did not work yet for Microsoft personal accounts.

When this PR is in, we also need to:
- Update https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Device-Code-Flow#constraints
- Update the following page in docs.ms: scenario-desktop-acquire-token.md (several locations in the page)
- remove references to AADSTS90133
- update docs.ms: scenario-desktop-app-registration.md
- update v2-supported-account-types.md
- update https://github.com/Azure-Samples/active-directory-dotnetcore-devicecodeflow-v2/blob/master/device-code-flow-console/appsettings.json#L16