### PR TITLE
Convert YAML builds into templates to share build steps

### DIFF
--- a/build/pipeline-pullrequest.yaml
+++ b/build/pipeline-pullrequest.yaml
@@ -18,78 +18,24 @@ variables:
   BuildConfiguration: 'debug'
 
 steps:
-- task: AzureKeyVault@1
-  displayName: 'Azure Key Vault: BuildAutomation'
-  inputs:
-    azureSubscription: 'MSID MSAL.NET Automation KeyVault'
-    KeyVaultName: BuildAutomation
-    SecretsFilter: 'AzureADIdentityDivisionTestAgent, RSATestCertDotNet'
+# Install keyvault secrets
+- template: template-install-keyvault-secrets.yaml
 
-- powershell: |
-   $kvSecretBytes = [System.Convert]::FromBase64String('$(AzureADIdentityDivisionTestAgent)')
-   $certCollection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-   $certCollection.Import($kvSecretBytes, $null, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
+# Configure Python
+- template: template-python-config.yaml
 
-   $protectedCertificateBytes = $certCollection.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pkcs12)
-   $pfxPath = '$(Build.SourcesDirectory)' + "\TestCert.pfx"
-   [System.IO.File]::WriteAllBytes($pfxPath, $protectedCertificateBytes)
+# Nuget Restore and Build LibsAndSamples.sln
+- template: template-restore-build-libsandsamples.yaml
+  parameters:
+    BuildPlatform: '$(BuildPlatform)'
+    BuildConfiguration: '$(BuildConfiguration)'
 
-   Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\LocalMachine\My
+# Run Unit Tests
+- template: template-run-unit-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
 
-   $kvSecretBytes = [System.Convert]::FromBase64String('$(RSATestCertDotNet)')
-   $certCollection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-   $certCollection.Import($kvSecretBytes, $null, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
-
-   $protectedCertificateBytes = $certCollection.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pkcs12)
-   $pfxPath = '$(Build.SourcesDirectory)' + "\TestCert.pfx"
-   [System.IO.File]::WriteAllBytes($pfxPath, $protectedCertificateBytes)
-
-   Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\LocalMachine\My
-  displayName: 'Install Keyvault Secrets'
-
-- task: stevedower.python.PythonScript.PythonScript@1
-  displayName: 'Update PIP'
-  inputs:
-    arguments: '-m pip install --upgrade pip'
-
-- task: stevedower.python.PythonScript.PythonScript@1
-  displayName: 'Install MSAL.Python PIP'
-  inputs:
-    arguments: '-m pip install msal'
-
-- task: VSBuild@1
-  displayName: 'NuGet restore LibsAndSamples.sln'
-  inputs:
-    solution: LibsAndSamples.sln
-    vsVersion: "15.0"
-    msbuildArgs: '/t:restore'
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-
-- task: VSBuild@1
-  displayName: 'Build solution LibsAndSamples.sln'
-  inputs:
-    solution: LibsAndSamples.sln
-    vsVersion: "15.0"
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-    clean: true
-
-- task: DotNetCoreCLI@2
-  displayName: 'Run unit tests'
-  inputs:
-    command: test
-    projects: |
-     tests/Microsoft.Identity.Test.Unit.*/*.csproj
-     tests/CacheCompat/CommonCache.Test.Unit/*.csproj
-    arguments: '-c $(BuildConfiguration) --no-build --no-restore --collect "Code coverage"'
-
-- task: DotNetCoreCLI@2
-  displayName: 'Run integration Tests'
-  inputs:
-    command: test
-    projects: |
-     tests/Microsoft.Identity.Test.Integration.net45/Microsoft.Identity.Test.Integration.net45.csproj
-     tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.netcore.csproj
-     tests/CacheCompat/CommonCache.Test.Unit/*.csproj
-    arguments: '-c $(BuildConfiguration) --no-build --no-restore --collect "Code coverage"'
+# Run Integration Tests
+- template: template-run-integration-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'

--- a/build/pipeline-pullrequest.yaml
+++ b/build/pipeline-pullrequest.yaml
@@ -18,11 +18,8 @@ variables:
   BuildConfiguration: 'debug'
 
 steps:
-# Install keyvault secrets
-- template: template-install-keyvault-secrets.yaml
-
-# Configure Python
-- template: template-python-config.yaml
+# Bootstrap the build
+- template: template-bootstrap-build.yaml
 
 # Nuget Restore and Build LibsAndSamples.sln
 - template: template-restore-build-libsandsamples.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -21,299 +21,49 @@ variables:
   BuildConfiguration: 'release'
 
 steps:
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-  displayName: 'Run PoliCheck'
-  inputs:
-    targetType: F
-    optionsFTPATH: 'build/policheck_filetypes.xml'
-  continueOnError: true
+# Run pre-build code analysis (policheck, credscan, etc)
+- template: template-prebuild-code-analysis.yaml
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: 'Run CredScan'
-  inputs:
-    suppressionsFile: 'build/credscan-exclusion.json'
-    debugMode: false
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-  displayName: 'Post Analysis'
-  inputs:
-    CredScan: true
-    PoliCheck: true
-
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.6.2'
-  inputs:
-    versionSpec: 4.6.2
-
-#Your build pipeline references an undefined variable named ‘TestSecret’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+# Run Nuget Tool Installer
+- template: template-install-nuget.yaml
 
 - powershell: |
    $secret = '$(TestSecret)'
    $secret | Out-File $(Build.SourcesDirectory)/tests/Microsoft.Identity.Test.LabInfrastructure/data.txt
   displayName: 'Install Keyvault Secrets'
 
-- task: stevedower.python.PythonScript.PythonScript@1
-  displayName: 'Install MSAL.Python PIP'
-  inputs:
-    arguments: '-m pip install msal'
+# Configure Python
+- template: template-python-config.yaml
 
-- task: VSBuild@1
-  displayName: 'NuGet restore LibsAndSamples.sln'
-  inputs:
-    solution: LibsAndSamples.sln
-    vsVersion: '16.0'
-    msbuildArgs: '/t:restore'
-    configuration: '$(BuildConfiguration)'
+# Nuget Restore and Build LibsAndSamples.sln
+- template: template-restore-build-libsandsamples.yaml
+  parameters:
+    BuildPlatform: '$(BuildPlatform)'
+    BuildConfiguration: '$(BuildConfiguration)'
 
-- task: VSBuild@1
-  displayName: 'Build solution LibsAndSamples.sln'
-  inputs:
-    solution: LibsAndSamples.sln
-    msbuildArgs: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+# Nuget Restore and Build LibsAndSamples.sln
+- template: template-restore-build-libsandsamples.yaml
+  parameters:
+    BuildPlatform: '$(BuildPlatform)'
+    BuildConfiguration: '$(BuildConfiguration)'
+    MsBuildArguments: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
 
-- task: DotNetCoreCLI@2
-  displayName: 'Run MSAL unit tests'
-  inputs:
-    command: test
-    projects: 'tests/Microsoft.Identity.Test.Unit.*/*.csproj'
-    arguments: '-c $(BuildConfiguration) --no-build --no-restore'
+# Run Unit Tests
+- template: template-run-unit-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
-  displayName: 'Run Roslyn Analyzers'
-  continueOnError: true
+# TODO: run integration tests?
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-  displayName: 'Check Roslyn Results '
-  inputs:
-    RoslynAnalyzers: true
+# Run Post-build code analysis (e.g. Roslyn)
+- template: template-postbuild-code-analysis.yaml
 
-- task: VSBuild@1
-  displayName: 'Pack MSAL'
-  inputs:
-    solution: 'src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
-    vsVersion: 15.0
-    msbuildArgs: '/t:pack /p:nobuild=true '
-    configuration: '$(BuildConfiguration)'
+# Pack and sign all of the nuget packages
+- template: template-pack-and-sign-all-nugets.yaml
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'Sign MSAL Binaries'
-  inputs:
-    ConnectedServiceName: 'IDDP Code Signing'
-    FolderPath: '$(Build.SourcesDirectory)\src\client\Microsoft.Identity.Client'
-    Pattern: '**\bin\**\Microsoft.Identity.Client.dll'
-    UseMinimatch: true
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolSign",
-         "parameters": [
-         {
-           "parameterName": "OpusName",
-           "parameterValue": "TestSign"
-         },
-         {
-           "parameterName": "OpusInfo",
-           "parameterValue": "http://test"
-         },
-         {
-           "parameterName": "PageHash",
-           "parameterValue": "/NPH"
-         },
-         {
-           "parameterName": "FileDigest",
-           "parameterValue": "/fd sha256"
-         },
-         {
-           "parameterName": "TimeStamp",
-           "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-         }
-         ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       },
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolVerify",
-         "parameters": [ ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       }
-     ]
-    SessionTimeout: 20
-    VerboseLogin: true
-  timeoutInMinutes: 10
+# Publish nuget packages and symbols
+- template: template-publish-packages-and-symbols.yaml
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'Sign MSAL Ref Binaries '
-  inputs:
-    ConnectedServiceName: 'IDDP Code Signing'
-    FolderPath: '$(Build.SourcesDirectory)\src\client\Microsoft.Identity.Client.Ref'
-    Pattern: '**\ref\Microsoft.Identity.Client.dll'
-    UseMinimatch: true
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolSign",
-         "parameters": [
-         {
-           "parameterName": "OpusName",
-           "parameterValue": "TestSign"
-         },
-         {
-           "parameterName": "OpusInfo",
-           "parameterValue": "http://test"
-         },
-         {
-           "parameterName": "PageHash",
-           "parameterValue": "/NPH"
-         },
-         {
-           "parameterName": "FileDigest",
-           "parameterValue": "/fd sha256"
-         },
-         {
-           "parameterName": "TimeStamp",
-           "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-         }
-         ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       },
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolVerify",
-         "parameters": [ ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       }
-     ]
-    SessionTimeout: 20
-    VerboseLogin: true
-  timeoutInMinutes: 10
+# Publish analysis and cleanup
+- template: template-publish-analysis-and-cleanup.yaml
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-  displayName: 'Run BinSkim '
-  inputs:
-    InputType: Basic
-    AnalyzeTarget: '$(Build.SourcesDirectory)\**\bin\**\Microsoft.Identity.Client.dll'
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-  displayName: 'Check BinSkim Results'
-  inputs:
-    BinSkim: true
-
-- task: VSBuild@1
-  displayName: 'Pack MSAL'
-  inputs:
-    solution: 'src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
-    vsVersion: 15.0
-    msbuildArgs: '/t:pack /p:nobuild=true /p:IncludeSymbols=true'
-    configuration: '$(BuildConfiguration)'
-
-- task: CopyFiles@2
-  displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\packages'
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)'
-    Contents: '**\*nupkg'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\packages'
-    flattenFolders: true
-
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'Sign Packages'
-  inputs:
-    ConnectedServiceName: 'IDDP Code Signing'
-    FolderPath: '$(Build.ArtifactStagingDirectory)\packages'
-    Pattern: '*nupkg'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-401405",
-             "operationSetCode": "NuGetSign",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-401405",
-             "operationSetCode": "NuGetVerify",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    SessionTimeout: 20
-    VerboseLogin: true
-  timeoutInMinutes: 5
-
-- task: NuGetCommand@2
-  displayName: 'Verify packages are signed'
-  inputs:
-    command: custom
-    arguments: 'verify -Signature $(Build.ArtifactStagingDirectory)\packages\*.nupkg'
-  continueOnError: true
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-  displayName: 'Publish Security Analysis Logs'
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: packages'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\packages'
-    ArtifactName: packages
-
-- task: NuGetCommand@2
-  displayName: 'Publish packages to MyGet'
-  inputs:
-    command: push
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/packages/**/*.nupkg'
-    nuGetFeedType: external
-    publishFeedCredentials: 'Wilson MyGet feed'
-  continueOnError: true
-
-- task: NuGetCommand@2
-  displayName: 'Publish packages to VSTS feed'
-  inputs:
-    command: push
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/packages/**/*.nupkg'
-    publishVstsFeed: '46419298-b96c-437f-bd4c-12c8df7f868d'
-    allowPackageConflicts: true
-  continueOnError: true
-
-- task: PublishSymbols@2
-  displayName: 'Publish symbols'
-  inputs:
-    SearchPattern: '**/bin/**/microsoft.identity.client.*'
-    IndexSources: false
-    SymbolServerType: TeamServices
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
-  displayName: 'TSA upload to Codebase: Unified .NET Core Stamp: Azure'
-  inputs:
-    tsaVersion: TsaV2
-    codebase: NewOrUpdate
-    codeBaseName: 'Unified .NET Core'
-    notificationAlias: 'IdentityDevExDotnet@microsoft.com'
-    codeBaseAdmins: 'EUROPE\\aadidagt'
-    instanceUrlForTsaV2: IDENTITYDIVISION
-    projectNameIDENTITYDIVISION: IDDP
-    areaPath: 'IDDP\DevEx-Client-SDK\DotNet'
-    iterationPath: 'IDDP\Unscheduled'
-    uploadAPIScan: false
-    uploadFortifySCA: false
-    uploadFxCop: false
-    uploadModernCop: false
-    uploadPREfast: false
-    uploadTSLint: false
-  continueOnError: true
-
-- task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-  displayName: 'Clean Agent Directories'

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -30,11 +30,6 @@ steps:
 # Install keyvault secrets
 - template: template-install-keyvault-secrets.yaml
 
-- powershell: |
-   $secret = '$(TestSecret)'
-   $secret | Out-File $(Build.SourcesDirectory)/tests/Microsoft.Identity.Test.LabInfrastructure/data.txt
-  displayName: 'Install Keyvault Secrets'
-
 # Configure Python
 - template: template-python-config.yaml
 

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -40,6 +40,7 @@ steps:
   parameters:
     BuildPlatform: '$(BuildPlatform)'
     BuildConfiguration: '$(BuildConfiguration)'
+    MsalClientSemVer: '$(MsalClientSemVer)'
     # MsBuildArguments: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
 
 # Run Unit Tests

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -50,7 +50,7 @@ steps:
 # Pack and sign all of the nuget packages
 - template: template-pack-and-sign-all-nugets.yaml
 
-# Publish nuget packages and symbols
+# Publish nuget packages and symbols to VSTS package manager.
 - template: template-publish-packages-and-symbols.yaml
 
 # Publish analysis and cleanup

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -27,6 +27,9 @@ steps:
 # Run Nuget Tool Installer
 - template: template-install-nuget.yaml
 
+# Install keyvault secrets
+- template: template-install-keyvault-secrets.yaml
+
 - powershell: |
    $secret = '$(TestSecret)'
    $secret | Out-File $(Build.SourcesDirectory)/tests/Microsoft.Identity.Test.LabInfrastructure/data.txt

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -40,7 +40,7 @@ steps:
   parameters:
     BuildPlatform: '$(BuildPlatform)'
     BuildConfiguration: '$(BuildConfiguration)'
-    MsBuildArguments: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
+    # MsBuildArguments: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
 
 # Run Unit Tests
 - template: template-run-unit-tests.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -40,7 +40,7 @@ steps:
   parameters:
     BuildPlatform: '$(BuildPlatform)'
     BuildConfiguration: '$(BuildConfiguration)'
-    MsalClientSemVer: '$(MsalClientSemVer)'
+    MsalClientSemVer: $(MsalClientSemVer)
     # MsBuildArguments: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
 
 # Run Unit Tests

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -24,14 +24,8 @@ steps:
 # Run pre-build code analysis (policheck, credscan, etc)
 - template: template-prebuild-code-analysis.yaml
 
-# Run Nuget Tool Installer
-- template: template-install-nuget.yaml
-
-# Install keyvault secrets
-- template: template-install-keyvault-secrets.yaml
-
-# Configure Python
-- template: template-python-config.yaml
+# Bootstrap the build
+- template: template-bootstrap-build.yaml
 
 # Nuget Restore and Build LibsAndSamples.sln
 - template: template-restore-build-libsandsamples.yaml
@@ -39,14 +33,16 @@ steps:
     BuildPlatform: '$(BuildPlatform)'
     BuildConfiguration: '$(BuildConfiguration)'
     MsalClientSemVer: $(MsalClientSemVer)
-    # MsBuildArguments: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
 
 # Run Unit Tests
 - template: template-run-unit-tests.yaml
   parameters:
     BuildConfiguration: '$(BuildConfiguration)'
 
-# TODO: run integration tests?
+# Run Integration Tests
+- template: template-run-integration-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
 
 # Run Post-build code analysis (e.g. Roslyn)
 - template: template-postbuild-code-analysis.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -40,12 +40,6 @@ steps:
   parameters:
     BuildPlatform: '$(BuildPlatform)'
     BuildConfiguration: '$(BuildConfiguration)'
-
-# Nuget Restore and Build LibsAndSamples.sln
-- template: template-restore-build-libsandsamples.yaml
-  parameters:
-    BuildPlatform: '$(BuildPlatform)'
-    BuildConfiguration: '$(BuildConfiguration)'
     MsBuildArguments: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
 
 # Run Unit Tests

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -40,9 +40,9 @@ steps:
     BuildConfiguration: '$(BuildConfiguration)'
 
 # Run Integration Tests
-- template: template-run-integration-tests.yaml
-  parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
+# - template: template-run-integration-tests.yaml
+#   parameters:
+#     BuildConfiguration: '$(BuildConfiguration)'
 
 # Run Post-build code analysis (e.g. Roslyn)
 - template: template-postbuild-code-analysis.yaml

--- a/build/pipeline-uiautomation.yaml
+++ b/build/pipeline-uiautomation.yaml
@@ -36,6 +36,9 @@ stages:
         - visualstudio
     steps:
 
+    # Bootstrap the build
+    - template: template-bootstrap-build.yaml
+
     # Nuget Restore and Build LibsAndSamples.sln
     - template: template-restore-build-libsandsamples.yaml
       parameters:

--- a/build/pipeline-uiautomation.yaml
+++ b/build/pipeline-uiautomation.yaml
@@ -4,6 +4,8 @@ trigger:
   branches:
     include:
     - master
+    exclude:
+    - markzuber/*
 
 pr:
 - master
@@ -15,7 +17,7 @@ schedules:
   branches:
     include:
     - master
-    
+
 variables:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'debug'
@@ -33,24 +35,12 @@ stages:
         - msbuild
         - visualstudio
     steps:
-    - task: VSBuild@1
-      displayName: 'NuGet restore LibsAndSamples.sln'
-      inputs:
-        solution: LibsAndSamples.sln
-        vsVersion: '15.0'
-        msbuildArgs: '/t:restore'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-      condition: succeededOrFailed()
 
-    - task: VSBuild@1
-      displayName: 'Build solution LibsAndSamples.sln'
-      inputs:
-        solution: LibsAndSamples.sln
-        vsVersion: '15.0'
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        clean: true
+    # Nuget Restore and Build LibsAndSamples.sln
+    - template: template-restore-build-libsandsamples.yaml
+      parameters:
+        BuildPlatform: '$(BuildPlatform)'
+        BuildConfiguration: '$(BuildConfiguration)'
 
     - task: DownloadSecureFile@1
       displayName: 'Download Xamarin Ui Test Tools'

--- a/build/template-bootstrap-build.yaml
+++ b/build/template-bootstrap-build.yaml
@@ -4,7 +4,7 @@
 steps:
 
 # Run Dotnet Tool Installer
-- template: template-install-dotnet-core.yaml
+# - template: template-install-dotnet-core.yaml
 
 # Run Nuget Tool Installer
 - template: template-install-nuget.yaml

--- a/build/template-bootstrap-build.yaml
+++ b/build/template-bootstrap-build.yaml
@@ -1,0 +1,14 @@
+# template-bootstrap-build.yaml
+# Basic bootstraps for any build (nuget, dotnet, secrets)
+
+# Run Dotnet Tool Installer
+- template: template-install-dotnet-core.yaml
+
+# Run Nuget Tool Installer
+- template: template-install-nuget.yaml
+
+# Install keyvault secrets
+- template: template-install-keyvault-secrets.yaml
+
+# Configure Python
+- template: template-python-config.yaml

--- a/build/template-bootstrap-build.yaml
+++ b/build/template-bootstrap-build.yaml
@@ -1,6 +1,8 @@
 # template-bootstrap-build.yaml
 # Basic bootstraps for any build (nuget, dotnet, secrets)
 
+steps:
+
 # Run Dotnet Tool Installer
 - template: template-install-dotnet-core.yaml
 

--- a/build/template-install-dotnet-core.yaml
+++ b/build/template-install-dotnet-core.yaml
@@ -1,0 +1,8 @@
+# template-install-dotnet-core.yaml
+# install the version of dotnet core we need on the machine
+
+steps:
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 2.2.401'
+  inputs:
+    version: 2.2.401

--- a/build/template-install-keyvault-secrets.yaml
+++ b/build/template-install-keyvault-secrets.yaml
@@ -1,0 +1,32 @@
+# template-install-keyvault-secrets.yaml
+# Install all secrets needed from KeyVault onto the build machine.
+
+steps:
+- task: AzureKeyVault@1
+  displayName: 'Azure Key Vault: BuildAutomation'
+  inputs:
+    azureSubscription: 'MSID MSAL.NET Automation KeyVault'
+    KeyVaultName: BuildAutomation
+    SecretsFilter: 'AzureADIdentityDivisionTestAgent, RSATestCertDotNet'
+
+- powershell: |
+   $kvSecretBytes = [System.Convert]::FromBase64String('$(AzureADIdentityDivisionTestAgent)')
+   $certCollection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+   $certCollection.Import($kvSecretBytes, $null, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
+
+   $protectedCertificateBytes = $certCollection.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pkcs12)
+   $pfxPath = '$(Build.SourcesDirectory)' + "\TestCert.pfx"
+   [System.IO.File]::WriteAllBytes($pfxPath, $protectedCertificateBytes)
+
+   Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\LocalMachine\My
+
+   $kvSecretBytes = [System.Convert]::FromBase64String('$(RSATestCertDotNet)')
+   $certCollection = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+   $certCollection.Import($kvSecretBytes, $null, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
+
+   $protectedCertificateBytes = $certCollection.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pkcs12)
+   $pfxPath = '$(Build.SourcesDirectory)' + "\TestCert.pfx"
+   [System.IO.File]::WriteAllBytes($pfxPath, $protectedCertificateBytes)
+
+   Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\LocalMachine\My
+  displayName: 'Install Keyvault Secrets'

--- a/build/template-install-nuget.yaml
+++ b/build/template-install-nuget.yaml
@@ -1,0 +1,8 @@
+# template-install-nuget.yaml
+# Run Nuget Tool Installer
+
+steps:
+- task: NuGetToolInstaller@0
+  displayName: 'Use NuGet 4.6.2'
+  inputs:
+    versionSpec: 4.6.2

--- a/build/template-nuget-pack.yaml
+++ b/build/template-nuget-pack.yaml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
 - task: VSBuild@1
-  displayName: 'Pack $(ProjectPath)'
+  displayName: 'Pack ${{ parameters.ProjectPath }}'
   inputs:
-    solution: 'src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
-    vsVersion: 15.0
+    solution: ${{ parameters.ProjectPath }}
+    vsVersion: '15.0'
     msbuildArgs: '/t:pack /p:nobuild=true /p:IncludeSymbols=true'
-    configuration: '$(BuildConfiguration)'
+    configuration: ${{ parameters.BuildConfiguration }}

--- a/build/template-nuget-pack.yaml
+++ b/build/template-nuget-pack.yaml
@@ -1,0 +1,13 @@
+
+parameters:
+  BuildConfiguration: 'release'
+  ProjectPath: ''
+
+steps:
+- task: VSBuild@1
+  displayName: 'Pack $(ProjectPath)'
+  inputs:
+    solution: 'src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
+    vsVersion: 15.0
+    msbuildArgs: '/t:pack /p:nobuild=true /p:IncludeSymbols=true'
+    configuration: '$(BuildConfiguration)'

--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -2,7 +2,7 @@
 # Pack and sign all nuget packages needed for our builds
 
 parameters:
-  BuildConfiguration: 'debug'
+  BuildConfiguration: 'release'
 
 steps:
 

--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -1,0 +1,67 @@
+# template-pack-and-sign-all-nugets.yaml
+# Pack and sign all nuget packages needed for our builds
+
+parameters:
+  BuildConfiguration: 'debug'
+
+steps:
+
+# Pack and sign Microsoft.Identity.Client
+- template: template-pack-and-sign-nuget.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+    ProjectRootPath: '$(Build.SourcesDirectory)\src\client'
+    AssemblyName: 'Microsoft.Identity.Client'
+    HasRefAssembly: 'true'
+
+# Pack and sign Microsoft.Identity.Client.Extensions.Msal
+- template: template-pack-and-sign-nuget.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+    ProjectRootPath: '$(Build.SourcesDirectory)\src\extensions.msal'
+    AssemblyName: 'Microsoft.Identity.Client.Extensions.Msal'
+
+# Pack and sign Microsoft.Identity.Client.Extensions.Web
+- template: template-pack-and-sign-nuget.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+    ProjectRootPath: '$(Build.SourcesDirectory)\src\extensions.web'
+    AssemblyName: 'Microsoft.Identity.Client.Extensions.Web'
+
+# Copy all packages out to staging
+- task: CopyFiles@2
+  displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\packages'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: '**\*nupkg'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\packages'
+    flattenFolders: true
+
+# Sign all final nuget packages in the staging directory
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'Sign Packages'
+  inputs:
+    ConnectedServiceName: 'IDDP Code Signing'
+    FolderPath: '$(Build.ArtifactStagingDirectory)\packages'
+    Pattern: '*nupkg'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+         {
+             "keyCode": "CP-401405",
+             "operationSetCode": "NuGetSign",
+             "parameters": [ ],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         },
+         {
+             "keyCode": "CP-401405",
+             "operationSetCode": "NuGetVerify",
+             "parameters": [ ],
+             "toolName": "sign",
+             "toolVersion": "1.0"
+         }
+     ]
+    SessionTimeout: 20
+    VerboseLogin: true
+  timeoutInMinutes: 5

--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -9,7 +9,7 @@ steps:
 # Pack and sign Microsoft.Identity.Client
 - template: template-pack-and-sign-nuget.yaml
   parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
     ProjectRootPath: '$(Build.SourcesDirectory)\src\client'
     AssemblyName: 'Microsoft.Identity.Client'
     HasRefAssembly: 'true'
@@ -17,14 +17,14 @@ steps:
 # Pack and sign Microsoft.Identity.Client.Extensions.Msal
 - template: template-pack-and-sign-nuget.yaml
   parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
     ProjectRootPath: '$(Build.SourcesDirectory)\src\extensions.msal'
     AssemblyName: 'Microsoft.Identity.Client.Extensions.Msal'
 
 # Pack and sign Microsoft.Identity.Client.Extensions.Web
 - template: template-pack-and-sign-nuget.yaml
   parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
     ProjectRootPath: '$(Build.SourcesDirectory)\src\extensions.web'
     AssemblyName: 'Microsoft.Identity.Client.Extensions.Web'
 

--- a/build/template-pack-and-sign-nuget.yaml
+++ b/build/template-pack-and-sign-nuget.yaml
@@ -1,6 +1,6 @@
 
 parameters:
-  BuildConfiguration: 'debug'
+  BuildConfiguration: 'release'
   ProjectRootPath: ''
   AssemblyName: ''
   HasRefAssembly: 'false'

--- a/build/template-pack-and-sign-nuget.yaml
+++ b/build/template-pack-and-sign-nuget.yaml
@@ -8,21 +8,21 @@ parameters:
 steps:
 - template: template-nuget-pack.yaml
   parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
-    ProjectPath: '$(ProjectRootPath)\$(AssemblyName)\$(AssemblyName).csproj'
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    ProjectPath: '${{ parameters.ProjectRootPath }}\${{ parameters.AssemblyName }}\${{ parameters.AssemblyName }}.csproj'
 
 - template: template-sign-binary.yaml
   parameters:
-    FolderPath: '$(ProjectRootPath)\$(AssemblyName)'
-    Pattern: '**\bin\**\$(AssemblyName).dll'
+    FolderPath: '${{ parameters.ProjectRootPath }}\${{ parameters.AssemblyName }}'
+    Pattern: '**\bin\**\${{ parameters.AssemblyName }}.dll'
 
 - ${{ if eq(parameters.HasRefAssembly, 'true') }}:
   - template: template-sign-binary.yaml
     parameters:
-      FolderPath: '$(ExtensionsMsalProjPath)\$(AssemblyName).Ref'
-      Pattern: '**\ref\**\$(AssemblyName).dll'
+      FolderPath: '${{ parameters.ProjectRootPath }}\${{ parameters.AssemblyName }}.Ref'
+      Pattern: '**\ref\**\${{ parameters.AssemblyName }}.dll'
 
 - template: template-nuget-pack.yaml
   parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
-    ProjectPath: '$(ProjectRootPath)\$(AssemblyName)\$(AssemblyName).csproj'
+    BuildConfiguration: ${{ parameters.BuildConfiguration }}
+    ProjectPath: '${{ parameters.ProjectRootPath }}\${{ parameters.AssemblyName }}\${{ parameters.AssemblyName }}.csproj'

--- a/build/template-pack-and-sign-nuget.yaml
+++ b/build/template-pack-and-sign-nuget.yaml
@@ -1,0 +1,28 @@
+
+parameters:
+  BuildConfiguration: 'debug'
+  ProjectRootPath: ''
+  AssemblyName: ''
+  HasRefAssembly: 'false'
+
+steps:
+- template: template-nuget-pack.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+    ProjectPath: '$(ProjectRootPath)\$(AssemblyName)\$(AssemblyName).csproj'
+
+- template: template-sign-binary.yaml
+  parameters:
+    FolderPath: '$(ProjectRootPath)\$(AssemblyName)'
+    Pattern: '**\bin\**\$(AssemblyName).dll'
+
+- ${{ if eq(parameters.HasRefAssembly, 'true') }}:
+  - template: template-sign-binary.yaml
+    parameters:
+      FolderPath: '$(ExtensionsMsalProjPath)\$(AssemblyName).Ref'
+      Pattern: '**\ref\**\$(AssemblyName).dll'
+
+- template: template-nuget-pack.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+    ProjectPath: '$(ProjectRootPath)\$(AssemblyName)\$(AssemblyName).csproj'

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -1,0 +1,12 @@
+# template-postbuild-code-analysis.yaml
+# Run post-build code analysis (e.g. Roslyn analyzers)
+
+steps:
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+  displayName: 'Run Roslyn Analyzers'
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: 'Check Roslyn Results '
+  inputs:
+    RoslynAnalyzers: true

--- a/build/template-prebuild-code-analysis.yaml
+++ b/build/template-prebuild-code-analysis.yaml
@@ -1,0 +1,22 @@
+# template-prebuild-code-analysis.yaml
+# Run pre-build code analysis (e.g. credscan, policheck)
+
+steps:
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    optionsFTPATH: 'build/policheck_filetypes.xml'
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    suppressionsFile: 'build/credscan-exclusion.json'
+    debugMode: false
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: 'Post Analysis'
+  inputs:
+    CredScan: true
+    PoliCheck: true

--- a/build/template-publish-analysis-and-cleanup.yaml
+++ b/build/template-publish-analysis-and-cleanup.yaml
@@ -1,0 +1,30 @@
+# template-publish-analysis-and-cleanup.yaml
+# Publish any security analysis logs (e.g. TSA) and perform post-build cleanup
+# Should be LAST step of any build it's used in.
+
+steps:
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  displayName: 'Publish Security Analysis Logs'
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+  displayName: 'TSA upload to Codebase: Unified .NET Core Stamp: Azure'
+  inputs:
+    tsaVersion: TsaV2
+    codebase: NewOrUpdate
+    codeBaseName: 'Unified .NET Core'
+    notificationAlias: 'IdentityDevExDotnet@microsoft.com'
+    codeBaseAdmins: 'EUROPE\\aadidagt'
+    instanceUrlForTsaV2: IDENTITYDIVISION
+    projectNameIDENTITYDIVISION: IDDP
+    areaPath: 'IDDP\DevEx-Client-SDK\DotNet'
+    iterationPath: 'IDDP\Unscheduled'
+    uploadAPIScan: false
+    uploadFortifySCA: false
+    uploadFxCop: false
+    uploadModernCop: false
+    uploadPREfast: false
+    uploadTSLint: false
+  continueOnError: true
+
+- task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+  displayName: 'Clean Agent Directories'

--- a/build/template-publish-packages-and-symbols.yaml
+++ b/build/template-publish-packages-and-symbols.yaml
@@ -1,0 +1,47 @@
+# template-publish-packages-and-symbols.yaml
+# Publishes all nuget packages and symbols to appropriate destinations.
+
+parameters:
+  NugetPackagesWildcard: '$(Build.ArtifactStagingDirectory)\packages\*.nupkg'
+  ArtifactPublishPath: '$(Build.ArtifactStagingDirectory)\packages'
+  SymbolPublishWildcard: '**/bin/**/microsoft.identity.client.*'
+  DropArtifactName: 'packages'
+
+steps:
+- task: NuGetCommand@2
+  displayName: 'Verify packages are signed'
+  inputs:
+    command: custom
+    arguments: 'verify -Signature $(NugetPackagesWildcard)'
+  continueOnError: true
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: packages'
+  inputs:
+    PathtoPublish: '$(ArtifactPublishPath)'
+    ArtifactName: $(DropArtifactName)
+
+- task: NuGetCommand@2
+  displayName: 'Publish packages to MyGet'
+  inputs:
+    command: push
+    packagesToPush: '$(NugetPackagesWildcard)'
+    nuGetFeedType: external
+    publishFeedCredentials: 'Wilson MyGet feed'
+  continueOnError: true
+
+- task: NuGetCommand@2
+  displayName: 'Publish packages to VSTS feed'
+  inputs:
+    command: push
+    packagesToPush: '$(NugetPackagesWildcard)'
+    publishVstsFeed: '46419298-b96c-437f-bd4c-12c8df7f868d'
+    allowPackageConflicts: true
+  continueOnError: true
+
+- task: PublishSymbols@2
+  displayName: 'Publish symbols'
+  inputs:
+    SearchPattern: '$(SymbolPublishWildcard)'
+    IndexSources: false
+    SymbolServerType: TeamServices

--- a/build/template-publish-packages-and-symbols.yaml
+++ b/build/template-publish-packages-and-symbols.yaml
@@ -12,20 +12,20 @@ steps:
   displayName: 'Verify packages are signed'
   inputs:
     command: custom
-    arguments: 'verify -Signature $(NugetPackagesWildcard)'
+    arguments: 'verify -Signature ${{ parameters.NugetPackagesWildcard }}'
   continueOnError: true
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: packages'
   inputs:
-    PathtoPublish: '$(ArtifactPublishPath)'
-    ArtifactName: $(DropArtifactName)
+    PathtoPublish: '${{ parameters.ArtifactPublishPath }}'
+    ArtifactName: ${{ parameters.DropArtifactName }}''
 
 - task: NuGetCommand@2
   displayName: 'Publish packages to MyGet'
   inputs:
     command: push
-    packagesToPush: '$(NugetPackagesWildcard)'
+    packagesToPush: '${{ parameters.NugetPackagesWildcard }}'
     nuGetFeedType: external
     publishFeedCredentials: 'Wilson MyGet feed'
   continueOnError: true
@@ -34,7 +34,7 @@ steps:
   displayName: 'Publish packages to VSTS feed'
   inputs:
     command: push
-    packagesToPush: '$(NugetPackagesWildcard)'
+    packagesToPush: '${{ parameters.NugetPackagesWildcard }}'
     publishVstsFeed: '46419298-b96c-437f-bd4c-12c8df7f868d'
     allowPackageConflicts: true
   continueOnError: true
@@ -42,6 +42,6 @@ steps:
 - task: PublishSymbols@2
   displayName: 'Publish symbols'
   inputs:
-    SearchPattern: '$(SymbolPublishWildcard)'
+    SearchPattern: '${{ parameters.SymbolPublishWildcard }}'
     IndexSources: false
     SymbolServerType: TeamServices

--- a/build/template-python-config.yaml
+++ b/build/template-python-config.yaml
@@ -1,0 +1,13 @@
+# template-python-config.yaml
+# Installs and updates PIP and ensures MSAL.Python PIP is properly installed on build machine.
+
+steps:
+- task: stevedower.python.PythonScript.PythonScript@1
+  displayName: 'Update PIP'
+  inputs:
+    arguments: '-m pip install --upgrade pip'
+
+- task: stevedower.python.PythonScript.PythonScript@1
+  displayName: 'Install MSAL.Python PIP'
+  inputs:
+    arguments: '-m pip install msal'

--- a/build/template-restore-build-libsandsamples.yaml
+++ b/build/template-restore-build-libsandsamples.yaml
@@ -4,7 +4,6 @@
 parameters:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'debug'
-  MsBuildArguments: '/p:RunCodeAnalysis=false '
 
 steps:
 - task: VSBuild@1
@@ -21,7 +20,7 @@ steps:
   inputs:
     solution: LibsAndSamples.sln
     vsVersion: '15.0'
-    msbuildArgs: '$(MsBuildArguments)'
+    msbuildArgs: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
     clean: true

--- a/build/template-restore-build-libsandsamples.yaml
+++ b/build/template-restore-build-libsandsamples.yaml
@@ -21,7 +21,7 @@ steps:
   inputs:
     solution: LibsAndSamples.sln
     vsVersion: '15.0'
-    msbuildArgs: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=${{ parameters.MsalClientSemVer }}) /p:SourceLinkCreate=true'
+    msbuildArgs: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=${{ parameters.MsalClientSemVer }} /p:SourceLinkCreate=true'
     platform: ${{ parameters.BuildPlatform }}
     configuration: ${{ parameters.BuildConfiguration }}
     clean: true

--- a/build/template-restore-build-libsandsamples.yaml
+++ b/build/template-restore-build-libsandsamples.yaml
@@ -1,0 +1,27 @@
+# template-restore-build-libsandsamples.yaml
+# Performs Nuget Restore and Build of LibsAndSamples.sln based on BuildPlatform and BuildConfiguration
+
+parameters:
+  BuildPlatform: 'any cpu'
+  BuildConfiguration: 'debug'
+  MsBuildArguments: ''
+
+steps:
+- task: VSBuild@1
+  displayName: 'NuGet restore LibsAndSamples.sln'
+  inputs:
+    solution: LibsAndSamples.sln
+    vsVersion: "15.0"
+    msbuildArgs: '/t:restore'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+
+- task: VSBuild@1
+  displayName: 'Build solution LibsAndSamples.sln'
+  inputs:
+    solution: LibsAndSamples.sln
+    msbuildargs: '$(MsBuildArguments)'
+    vsVersion: "15.0"
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    clean: true

--- a/build/template-restore-build-libsandsamples.yaml
+++ b/build/template-restore-build-libsandsamples.yaml
@@ -4,6 +4,7 @@
 parameters:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'debug'
+  MsalClientSemVer: '4.0.0-devopsbuild'
 
 steps:
 - task: VSBuild@1

--- a/build/template-restore-build-libsandsamples.yaml
+++ b/build/template-restore-build-libsandsamples.yaml
@@ -11,7 +11,7 @@ steps:
   displayName: 'NuGet restore LibsAndSamples.sln'
   inputs:
     solution: LibsAndSamples.sln
-    vsVersion: "15.0"
+    vsVersion: '15.0'
     msbuildArgs: '/t:restore'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
@@ -20,8 +20,8 @@ steps:
   displayName: 'Build solution LibsAndSamples.sln'
   inputs:
     solution: LibsAndSamples.sln
-    msbuildargs: '$(MsBuildArguments)'
-    vsVersion: "15.0"
+    vsVersion: '15.0'
+    msbuildArgs: '$(MsBuildArguments)'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
     clean: true

--- a/build/template-restore-build-libsandsamples.yaml
+++ b/build/template-restore-build-libsandsamples.yaml
@@ -13,15 +13,15 @@ steps:
     solution: LibsAndSamples.sln
     vsVersion: '15.0'
     msbuildArgs: '/t:restore'
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+    platform: ${{ parameters.BuildPlatform }}
+    configuration: ${{ parameters.BuildConfiguration }}
 
 - task: VSBuild@1
   displayName: 'Build solution LibsAndSamples.sln'
   inputs:
     solution: LibsAndSamples.sln
     vsVersion: '15.0'
-    msbuildArgs: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=$(MsalClientSemVer) /p:SourceLinkCreate=true'
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+    msbuildArgs: '/p:RunCodeAnalysis=false /p:ReferencedBinsPathRoot=$(Build.BinariesDirectory)\FxCopRefAssemblies /p:MsalClientSemVer=${{ parameters.MsalClientSemVer }}) /p:SourceLinkCreate=true'
+    platform: ${{ parameters.BuildPlatform }}
+    configuration: ${{ parameters.BuildConfiguration }}
     clean: true

--- a/build/template-restore-build-libsandsamples.yaml
+++ b/build/template-restore-build-libsandsamples.yaml
@@ -4,7 +4,7 @@
 parameters:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'debug'
-  MsBuildArguments: ''
+  MsBuildArguments: '/p:RunCodeAnalysis=false '
 
 steps:
 - task: VSBuild@1

--- a/build/template-run-integration-tests.yaml
+++ b/build/template-run-integration-tests.yaml
@@ -13,4 +13,4 @@ steps:
      tests/Microsoft.Identity.Test.Integration.net45/Microsoft.Identity.Test.Integration.net45.csproj
      tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.netcore.csproj
      tests/CacheCompat/CommonCache.Test.Unit/*.csproj
-    arguments: '-c $(BuildConfiguration) --no-build --no-restore --collect "Code coverage"'
+    arguments: '-c ${{ parameters.BuildConfiguration }} --no-build --no-restore --collect "Code coverage"'

--- a/build/template-run-integration-tests.yaml
+++ b/build/template-run-integration-tests.yaml
@@ -1,0 +1,17 @@
+# template-run-integration-tests.yaml
+# Run all integration tests across the LibsAndSamples.sln project
+
+parameters:
+  BuildPlatform: 'any cpu'
+  BuildConfiguration: 'debug'
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: 'Run integration Tests'
+  inputs:
+    command: test
+    projects: |
+     tests/Microsoft.Identity.Test.Integration.net45/Microsoft.Identity.Test.Integration.net45.csproj
+     tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.netcore.csproj
+     tests/CacheCompat/CommonCache.Test.Unit/*.csproj
+    arguments: '-c $(BuildConfiguration) --no-build --no-restore --collect "Code coverage"'

--- a/build/template-run-integration-tests.yaml
+++ b/build/template-run-integration-tests.yaml
@@ -2,7 +2,6 @@
 # Run all integration tests across the LibsAndSamples.sln project
 
 parameters:
-  BuildPlatform: 'any cpu'
   BuildConfiguration: 'debug'
 
 steps:

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -1,0 +1,15 @@
+# template-run-unit-tests.yaml
+# Run all unit tests across the LibsAndSamples.sln project
+
+parameters:
+  BuildConfiguration: 'debug'
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: 'Run unit tests'
+  inputs:
+    command: test
+    projects: |
+     tests/Microsoft.Identity.Test.Unit.*/*.csproj
+     tests/CacheCompat/CommonCache.Test.Unit/*.csproj
+    arguments: '-c $(BuildConfiguration) --no-build --no-restore --collect "Code coverage"'

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -12,4 +12,4 @@ steps:
     projects: |
      tests/Microsoft.Identity.Test.Unit.*/*.csproj
      tests/CacheCompat/CommonCache.Test.Unit/*.csproj
-    arguments: '-c $(BuildConfiguration) --no-build --no-restore --collect "Code coverage"'
+    arguments: '-c ${{ parameters.BuildConfiguration }} --no-build --no-restore --collect "Code coverage"'

--- a/build/template-sign-binary.yaml
+++ b/build/template-sign-binary.yaml
@@ -7,11 +7,11 @@ parameters:
 
 steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'Sign Binary: $(Pattern)'
+  displayName: 'Sign Binary: ${{ parameters.Pattern }}'
   inputs:
     ConnectedServiceName: 'IDDP Code Signing'
-    FolderPath: '$(FolderPath)'
-    Pattern: '$(Pattern)'
+    FolderPath: ${{ parameters.FolderPath }}
+    Pattern: ${{ parameters.Pattern }}
     UseMinimatch: true
     signConfigType: inlineSignParams
     inlineOperation: |
@@ -57,10 +57,10 @@ steps:
   timeoutInMinutes: 10
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-  displayName: 'Run BinSkim $(Pattern)'
+  displayName: 'Run BinSkim ${{ parameters.Pattern }}'
   inputs:
     InputType: Basic
-    AnalyzeTarget: '$(Pattern)'
+    AnalyzeTarget: ${{ parameters.Pattern }}
     AnalyzeVerbose: true
     AnalyzeHashes: true
 

--- a/build/template-sign-binary.yaml
+++ b/build/template-sign-binary.yaml
@@ -1,0 +1,70 @@
+# template-sign-binary.yaml
+# Signs a binary via ESRP
+
+parameters:
+  FolderPath: ''
+  Pattern: ''
+
+steps:
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'Sign Binary: $(Pattern)'
+  inputs:
+    ConnectedServiceName: 'IDDP Code Signing'
+    FolderPath: '$(FolderPath)'
+    Pattern: '$(Pattern)'
+    UseMinimatch: true
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolSign",
+         "parameters": [
+         {
+           "parameterName": "OpusName",
+           "parameterValue": "TestSign"
+         },
+         {
+           "parameterName": "OpusInfo",
+           "parameterValue": "http://test"
+         },
+         {
+           "parameterName": "PageHash",
+           "parameterValue": "/NPH"
+         },
+         {
+           "parameterName": "FileDigest",
+           "parameterValue": "/fd sha256"
+         },
+         {
+           "parameterName": "TimeStamp",
+           "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+         }
+         ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       },
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolVerify",
+         "parameters": [ ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       }
+     ]
+    SessionTimeout: 20
+    VerboseLogin: true
+  timeoutInMinutes: 10
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  displayName: 'Run BinSkim $(Pattern)'
+  inputs:
+    InputType: Basic
+    AnalyzeTarget: '$(Pattern)'
+    AnalyzeVerbose: true
+    AnalyzeHashes: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: 'Check BinSkim Results'
+  inputs:
+    BinSkim: true

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -9,6 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 
+    <!-- We use SemVer 2.0, and this removes the warning when building nuget packages that 2.0 semver is not compatible with semver 1.0 tools. -->
     <NoWarn>NU5105</NoWarn>
 
   </PropertyGroup>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -8,6 +8,9 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)/../build/SolutionWideAnalyzerConfig.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+
+    <NoWarn>NU5105</NoWarn>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/extensions.msal/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
+++ b/src/extensions.msal/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
@@ -25,11 +25,11 @@
   <PropertyGroup>
 
     <!--This should be passed from the VSTS build-->
-    <ClientSemVer Condition="'$(ClientSemVer)' == ''">4.0.0-localbuild</ClientSemVer>
+    <ClientSemVer Condition="'$(MsalClientSemVer)' == ''">4.0.0-localbuild</ClientSemVer>
     <!-- For now, the Extensions.Msal libraries are ALWAYS in preview mode -->
     <MsalClientSemVer Condition="'$(MsalClientSemVer)' != ''">$(MsalClientSemVer)-preview</MsalClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
-    <Version>$(ClientSemVer)</Version>
+    <Version>$(MsalClientSemVer)</Version>
 
     <DefineConstants>$(DefineConstants);MSAL</DefineConstants>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
Main thing I still need to fix is the warning on release builds around SemVer 2.0.  If folks know how to disable this warning, that would be helpful.


C:\Program   Files\dotnet\sdk\2.2.105\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(202,5):   Error NU5105: The package version '4.3.1-internal20190906.4yamltemplates'   uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on   legacy clients. Change the package version to a SemVer 1.0.0 string. If the   version contains a release label it must start with a letter. This message   can be ignored if the package is not intended for older clients.
--


