### PR TITLE
[iOS] Support UINavigationController with empty stack

### DIFF
--- a/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
+++ b/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
@@ -65,10 +65,9 @@ namespace Microsoft.Identity.Client.UI
                 UITabBarController tabBarController = (UITabBarController)callerViewController;
                 return FindCurrentViewController(tabBarController.SelectedViewController);
             }
-            else if (callerViewController is UINavigationController)
+            else if (callerViewController is UINavigationController uiNavigationController && uiNavigationController.VisibleViewController != null)
             {
-                UINavigationController navigationController = (UINavigationController)callerViewController;
-                return FindCurrentViewController(navigationController.VisibleViewController);
+                return FindCurrentViewController(uiNavigationController.VisibleViewController);
             }
             else if (callerViewController.PresentedViewController != null)
             {


### PR DESCRIPTION
This change permits calling AcquireAuthorizationAsync() with an app RootViewController that is a UINavigationController with an empty navigation stack.

The top-level view controller will now be returned, rather than trying to recursively call FindCurrentViewController() on a null VisibleViewController (which causes a NullReferenceException).

## How to reproduce the bug
Build the solution at https://github.com/davidjohnoliver/active-directory-Uno and run the iOS head.