### PR TITLE
Part 1: iOS 13 broker support

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerParameter.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerParameter.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Identity.Client.Internal.Broker
         public const string Force = "force";
 
         public const string BrokerInstallUrl = "broker_install_url";
-        public const string BrokerV2 = "msauthv2://";
-        public const string BrokerV3 = "msauthv3://";
+        public const string UriSchemeBrokerV2 = "msauthv2://";
+        public const string UriSchemeBrokerV3 = "msauthv3://";
         public const string AuthCodePrefixForEmbeddedWebviewBrokerInstallRequired = "msauth://";
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerParameter.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerParameter.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
 
         public const string BrokerInstallUrl = "broker_install_url";
         public const string BrokerV2 = "msauthv2://";
+        public const string BrokerV3 = "msauthv3://";
         public const string AuthCodePrefixForEmbeddedWebviewBrokerInstallRequired = "msauth://";
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerResponseConst.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerResponseConst.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
         public const string ErrorMetadata = "error_metadata";
         public const string BrokerErrorDomain = "broker_error_domain";
         public const string BrokerErrorCode = "broker_error_code";
+        public const string BrokerErrorDescription = "error_description";
 
         public const string Authority = "authority";
         public const string AccessToken = "access_token";

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerResponseConst.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerResponseConst.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
         public const string Scope = "scope";
         public const string ExpiresOn = "expires_on";
         public const string ClientInfo = "client_info";
+
+        public const string iOSBrokerNonce = "broker_nonce"; //in response from iOS Broker
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -394,6 +394,11 @@ namespace Microsoft.Identity.Client
         public const string BrokerResponseReturnedError = "broker_response_returned_error";
 
         /// <summary>
+        /// Broker response nonce does not match the request nonce sent by MSAL.NET for iOS broker >= v6.3.19
+        /// </summary>
+        public const string BrokerNonceMismatch = "broker_nonce_mismatch";
+
+        /// <summary>
         /// MSAL is not able to invoke the broker. Possible reasons are the broker is not installed on the user's device,
         /// or there were issues with the UiParent or CallerViewController being null. See https://aka.ms/msal-brokers
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -59,6 +59,9 @@ namespace Microsoft.Identity.Client
         public const string BrokerResponseHashMismatch =
             "Unencrypted broker response hash did not match the expected hash";
 
+        public const string BrokerNonceMismatch = "Broker response nonce does not match the request nonce sent by MSAL.NET." +
+            "Please see https://aka.ms/msal-net-ios-13-broker for more details. ";
+
         public const string StsMetadataRequestFailed =
             "Metadata request to Access Control service failed. Check InnerException for more details";
 

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -101,12 +101,13 @@ namespace Microsoft.Identity.Client.OAuth2
 
         internal static MsalTokenResponse CreateFromBrokerResponse(Dictionary<string, string> responseDictionary)
         {
-            if (responseDictionary.ContainsKey(BrokerResponseConst.ErrorMetadata))
+            if (responseDictionary.ContainsKey(BrokerResponseConst.BrokerErrorCode) ||
+                responseDictionary.ContainsKey(BrokerResponseConst.BrokerErrorDescription))
             {
                 return new MsalTokenResponse
                 {
                     Error = responseDictionary[BrokerResponseConst.BrokerErrorCode],
-                    ErrorDescription = CoreHelpers.UrlDecode(responseDictionary[BrokerResponseConst.ErrorMetadata])
+                    ErrorDescription = CoreHelpers.UrlDecode(responseDictionary[BrokerResponseConst.BrokerErrorDescription])
                 };
             }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -24,14 +24,33 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Returns if the response is from the broker app
+        /// Returns if the response is from the broker app. See https://aka.ms/msal-net-ios-13-broker
+        /// for more details.
         /// </summary>
         /// <param name="sourceApplication">application bundle id of the broker</param>
         /// <returns>True if the response is from broker, False otherwise.</returns>
         public static bool IsBrokerResponse(string sourceApplication)
         {
-            Debug.WriteLine("IsBrokerResponse Called with sourceApplication {0}", sourceApplication);
-            return sourceApplication != null && sourceApplication.Equals("com.microsoft.azureauthenticator", StringComparison.OrdinalIgnoreCase);
+            Debug.WriteLine("IsBrokerResponse called with sourceApplication {0}", sourceApplication);
+
+            if (sourceApplication != null && sourceApplication.Equals("com.microsoft.azureauthenticator", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            else if (string.IsNullOrEmpty(sourceApplication))
+            {
+                // For iOS 13+, SourceApplication will not be returned
+                // Customers will need to install iOS broker >= 6.3.19
+                // MSAL.NET will generate a nonce (guid), which broker will
+                // return in the response. MSAL.NET will validate a match in iOSBroker.cs
+                // So if SourceApplication is null, just return, MSAL.NET will throw a 
+                // specific error message if the nonce does not match.
+                return true; 
+            }
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Client
             {
                 return true;
             }
-            else if (string.IsNullOrEmpty(sourceApplication))
+            if (string.IsNullOrEmpty(sourceApplication))
             {
                 // For iOS 13+, SourceApplication will not be returned
                 // Customers will need to install iOS broker >= 6.3.19

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -45,12 +45,10 @@ namespace Microsoft.Identity.Client
                 // return in the response. MSAL.NET will validate a match in iOSBroker.cs
                 // So if SourceApplication is null, just return, MSAL.NET will throw a 
                 // specific error message if the nonce does not match.
-                return true; 
+                return true;
             }
-            else
-            {
-                return false;
-            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
@@ -186,16 +186,13 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             byte[] rawHash = Convert.FromBase64String(responseActualHash);
             string hash = BitConverter.ToString(rawHash);
 
-            if (!string.IsNullOrEmpty(_brokerRequestNonce))
+            if (!ValidateBrokerResponseNonceWithRequestNonce(responseDictionary))
             {
-                if (!ValidateBrokerResponseNonceWithRequestNonce(responseDictionary))
+                return new MsalTokenResponse
                 {
-                    return new MsalTokenResponse
-                    {
-                        Error = MsalError.BrokerNonceMismatch,
-                        ErrorDescription = MsalErrorMessage.BrokerNonceMismatch
-                    };
-                }
+                    Error = MsalError.BrokerNonceMismatch,
+                    ErrorDescription = MsalErrorMessage.BrokerNonceMismatch
+                };
             }
 
             if (expectedHash.Equals(hash.Replace("-", ""), StringComparison.OrdinalIgnoreCase))
@@ -222,11 +219,15 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
         private bool ValidateBrokerResponseNonceWithRequestNonce(Dictionary<string, string> brokerResponseDictionary)
         {
-            string brokerResponseNonce = brokerResponseDictionary.ContainsKey(BrokerResponseConst.iOSBrokerNonce)
+            if (!string.IsNullOrEmpty(_brokerRequestNonce))
+            {
+                string brokerResponseNonce = brokerResponseDictionary.ContainsKey(BrokerResponseConst.iOSBrokerNonce)
                    ? brokerResponseDictionary[BrokerResponseConst.iOSBrokerNonce]
                    : null;
 
-            return string.Equals(brokerResponseNonce, _brokerRequestNonce);
+                return string.Equals(brokerResponseNonce, _brokerRequestNonce);
+            }
+            return false;
         }
 
         public static void SetBrokerResponse(NSUrl responseUrl)

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
@@ -154,11 +154,6 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         {
             MsalTokenResponse brokerTokenResponse;
 
-            if (responseDictionary.ContainsKey(iOSBrokerConstants.Error) || responseDictionary.ContainsKey(iOSBrokerConstants.ErrorDescription))
-            {
-                return MsalTokenResponse.CreateFromBrokerResponse(responseDictionary);
-            }
-
             string expectedHash = responseDictionary[iOSBrokerConstants.ExpectedHash];
             string encryptedResponse = responseDictionary[iOSBrokerConstants.EncryptedResponsed];
             string decryptedResponse = BrokerKeyHelper.DecryptBrokerResponse(encryptedResponse, _logger);

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         public const string ErrorDescription = "error_description";
         public const string ExpectedHash = "hash";
         public const string EncryptedResponsed = "response";
+        public const string BrokerNonce = "broker_nonce";
 
         public const string BrokerKeyService = "Broker Key Service";
         public const string BrokerKeyAccount = "Broker Key Account";
@@ -45,6 +46,8 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         public const string CanInvokeBroker = "Can invoke broker? ";
         public const string CanInvokeBrokerReturnsFalseMessage = " - returned from CanOpenUrl. Msauthv2 needs to be included " +
                     "in LSApplicationQueriesSchemes in Info.plist. See aka.ms/iosBroker for more information. ";
+        public const string iOSBrokerv2Installed = "iOS broker msauthv2:// installed on device: ";
+        public const string iOSBrokerv3Installed = "iOS broker msauthv3:// installed on device: ";
         public const string BrokerPayloadContainsInstallUrl = "iOS Broker - broker payload contains install url. ";
         public const string StartingActionViewActivity = "iOS Broker - Starting ActionView activity to ";
         public const string BrokerResponseContainsError = "Broker response contains an error. ";

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         public const string UiParentIsNullCannotInvokeBroker = "UIParent is null cannot invoke broker. ";
         public const string CallerViewControllerIsNullCannotInvokeBroker = "The CallerViewController is null. See https://aka.ms/msal-net-ios-Broker for details. ";
         public const string CanInvokeBroker = "Can invoke broker? ";
-        public const string CanInvokeBrokerReturnsFalseMessage = " - returned from CanOpenUrl. Msauthv2 needs to be included " +
+        public const string CanInvokeBrokerReturnsFalseMessage = "Cannot invoke the iOS broker. Returned from CanOpenUrl. msauthv2 and msauthv3 need to be included " +
                     "in LSApplicationQueriesSchemes in Info.plist. See aka.ms/iosBroker for more information. ";
         public const string iOSBrokerv2Installed = "iOS broker msauthv2:// installed on device: ";
         public const string iOSBrokerv3Installed = "iOS broker msauthv3:// installed on device: ";

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -28,15 +28,10 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
         private string _keychainGroup;
         private readonly RequestContext _requestContext;
-
-        private string GetBundleId()
-        {
-            return NSBundle.MainBundle.BundleIdentifier;
-        }
-
+        
         public void SetiOSKeychainSecurityGroup(string keychainSecurityGroup)
         {
-            if (String.IsNullOrEmpty(keychainSecurityGroup))
+            if (string.IsNullOrEmpty(keychainSecurityGroup))
             {
                 _keychainGroup = GetTeamId() + '.' + DefaultKeychainAccessGroup;
             }

--- a/tests/devapps/XamarinDev/XamarinDev.iOS/Info.plist
+++ b/tests/devapps/XamarinDev/XamarinDev.iOS/Info.plist
@@ -23,6 +23,7 @@
     <key>LSApplicationQueriesSchemes</key>
     <array>
         <string>msauthv2</string>
+        <string>msauthv3</string>
     </array>
     
     <key>MinimumOSVersion</key>


### PR DESCRIPTION
**Part 1: iOS 13 broker support**
- Generate a nonce to send in the broker request, only if msauthv3 (iOS broker 6.3.19+) is installed on the device
- Check that the nonce in the broker response matches the nonce sent in the request
- Update info.plist in dev app for msauthv3

More info on these required changes [here](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki/iOS-13-and-macOS-10.15-support-in-MSAL)

**Tested w/:**
- msauthv3 (iOS broker 6.3.19+)
- msauthv2 (iOS broker 6.3.12)

**TODO**: 
- Test w/iOS 13 and XCode 11 where source application returns null
- Create aka.ms link
- Update wiki and/or link to iOS team's docs

**Part 2:** Will include handling an application token, storing it in keychain and sending in the broker responses, but will do ADAL.NET work first and then come back to Part 2. Part 2 is not as urgent.

[issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1357)