### PR TITLE
Fix for #1384 - do not allow /common authorities on client creds

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Internal.Requests;
 
 namespace Microsoft.Identity.Client.ApiConfig.Executors
@@ -52,6 +53,13 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 commonParameters,
                 requestContext,
                 _confidentialClientApplication.AppTokenCacheInternal);
+
+            if (requestParams.Authority is AadAuthority aadAuthority && aadAuthority.IsTenantless()) 
+            {
+                throw new MsalClientException(
+                    MsalError.ClientCredentialExplicitTenantId, 
+                    MsalErrorMessage.ClientCredentialExplicitTenantId);
+            }
 
             requestParams.SendX5C = clientParameters.SendX5C;
             requestParams.IsClientCredentialRequest = true;

--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -61,6 +61,10 @@ namespace Microsoft.Identity.Client
             TokenType = tokenType;
         }
 
+        /// <summary>
+        /// Create an authentication result from an AccessToken item and optionally from an IdToken item. 
+        /// IdToken can be null, for example in client credential grant.
+        /// </summary>
         internal AuthenticationResult(
             MsalAccessTokenCacheItem msalAccessTokenCacheItem,
             MsalIdTokenCacheItem msalIdTokenCacheItem,
@@ -82,7 +86,7 @@ namespace Microsoft.Identity.Client
             UniqueId = msalIdTokenCacheItem?.IdToken?.GetUniqueId();
             ExpiresOn = msalAccessTokenCacheItem.ExpiresOn;
             ExtendedExpiresOn = msalAccessTokenCacheItem.ExtendedExpiresOn;
-            TenantId = msalIdTokenCacheItem?.IdToken?.TenantId;
+            TenantId = msalIdTokenCacheItem?.IdToken?.TenantId ?? msalAccessTokenCacheItem.TenantId;
             IdToken = msalIdTokenCacheItem?.Secret;
             Scopes = msalAccessTokenCacheItem.ScopeSet;
             IsExtendedLifeTimeToken = msalAccessTokenCacheItem.IsExtendedLifeTimeToken;

--- a/src/client/Microsoft.Identity.Client/Instance/AadAuthority.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AadAuthority.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client.Instance
 
             if (!string.IsNullOrEmpty(tenantId) &&
                 !string.IsNullOrEmpty(currentTenantId) &&
-                TenantlessTenantNames.Contains(currentTenantId))
+                IsInTenantlessSet(currentTenantId))
             {
                 var authorityUri = new Uri(AuthorityInfo.CanonicalAuthority);
 
@@ -41,6 +41,17 @@ namespace Microsoft.Identity.Client.Instance
             }
 
             return AuthorityInfo.CanonicalAuthority;
+        }
+
+        private static bool IsInTenantlessSet(string tenantId)
+        {
+            return TenantlessTenantNames.Contains(tenantId);
+        }
+
+        internal bool IsTenantless()
+        {
+            string currentTenantId = this.GetTenantId();
+            return IsInTenantlessSet(currentTenantId);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -679,18 +679,25 @@ namespace Microsoft.Identity.Client
         public const string ClientIdMustBeAGuid = "client_id_must_be_guid";
 
         /// <summary>
-        /// <para>What happens?</para>You have configured both a telememtry callback and a telemetry config. 
-        /// <para>Mitigation</para>Only one telememtry mechanism can be configured.
+        /// <para>What happens?</para>You have configured both a telemetry callback and a telemetry config. 
+        /// <para>Mitigation</para>Only one telemetry mechanism can be configured.
         /// </summary>
         public const string TelemetryConfigOrTelemetryCallback = "telemetry_config_or_telemetry_callback";
 
         /// <summary>
         /// AAD service error indicating that the configured client is not valid
-        /// <para>Migigation</para>In the AAD app registration portal, make sure the correct client (Public or
+        /// <para>Mitigation</para>In the AAD app registration portal, make sure the correct client (Public or
         /// Confidential) is selected for the respective authentication flow.
         /// See https://aka.ms/msal-net-invalid-client for details.
         /// </summary>
         public const string InvalidClient = "invalid_client";
+
+        /// <summary>
+        /// <para>What happens?</para>You didn't specify an authority or you are trying to use 
+        /// an AAD authority with a general audience (`common`, `organizations` or `consumers`). 
+        /// <para>Mitigation</para>Specify the tenant id with your authority. You can get tenant id from the app registration portal. Use a method like .WithAuthority(audience, tenantID) to specify the authority.
+        /// </summary>
+        public const string ClientCredentialExplicitTenantId = "client_credential_explicit_tenant_id";
 
 #if iOS
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -278,6 +278,10 @@ namespace Microsoft.Identity.Client
             " Potential issue: the redirect URI is valid, but it has been configured for the wrong app type." +
             " Check the configuration of the app being used in the app registration portal." +
             " See https://aka.ms/msal-net-invalid-client for details. ";
+        
+        internal const string ClientCredentialExplicitTenantId =
+            "You're using the client credential flow (for a daemon app) and you didn't configure an authority or you are trying to use an AAD authority with a general audience (`common`, `organizations` or `consumers`). " +
+            "Specify the tenant id with your authority. You can get tenant id from the app registration portal. Use a method such as .WithAuthority(audience, tenantID) to specify the authority. See https://aka.ms/msal-net-client-credentials";
 
         public static string NoUserInstanceMetadataEntry(string environment)
         {

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Test.Unit
         private void SetupMocks(MockHttpManager httpManager)
         {
             httpManager.AddInstanceDiscoveryMockHandler();
-            httpManager.AddMockHandlerForTenantEndpointDiscovery(TestConstants.AuthorityCommonTenant);
+            httpManager.AddMockHandlerForTenantEndpointDiscovery(TestConstants.AuthorityUtidTenant);
         }
 
         private void SetupMocks(MockHttpManager httpManager, string authority)
@@ -102,7 +102,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var app = ConfidentialClientApplicationBuilder
                     .Create(TestConstants.ClientId)
-                    .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
                     .WithCertificate(certificate)
@@ -152,7 +152,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var app = ConfidentialClientApplicationBuilder
                     .Create(TestConstants.ClientId)
-                    .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
                     .WithCertificate(certificate)
@@ -276,7 +276,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var app = ConfidentialClientApplicationBuilder
                     .Create(TestConstants.ClientId)
-                    .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
                     .WithCertificate(certificate)


### PR DESCRIPTION
Fix for #1384 
Can be reviewed but do not commit this before it goes through API governance.