### PR TITLE
cleanup for presentationContext

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
@@ -65,21 +65,19 @@ namespace Microsoft.Identity.Client.Platforms.iOS.SystemWebview
                             }
                         });
 
-                    // iOS 13 requires a PresentationContextProvider
-                    if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+                    asWebAuthenticationSession.BeginInvokeOnMainThread(() =>
                     {
-                        asWebAuthenticationSession.BeginInvokeOnMainThread(() =>
+                        if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
                         {
+                            // If the presentationContext is missing from the session,
+                            // MSAL.NET will pick up an "authentication cancelled" error
+                            // With the addition of the presentationContext, .Start() must
+                            // be called on the main UI thread
                             asWebAuthenticationSession.PresentationContextProvider =
                             new ASWebAuthenticationPresentationContextProviderWindow();
-                            asWebAuthenticationSession.Start();
-                        });
-                    }
-
-                    else
-                    {
+                        }
                         asWebAuthenticationSession.Start();
-                    }
+                    });
                 }
 
                 else if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))


### PR DESCRIPTION
i could not find any official documentation on .Start() and the main ui thread...also, Xamarin has not come out w/docs yet for the presentationContext and iOS 13 methods.