### PR TITLE
Update cache tests to enable the java to .net and python tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ msal/tests/dev apps/XForms/XForms.UWP/BundleArtifacts/x86.txt
 
 /msal/src/Microsoft.Identity.Client/docfx_project
 /msal/src/Microsoft.Identity.Client/_api
+/tests/CacheCompat/CommonCache.Test.MsalJava/target

--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,4 @@ msal/tests/dev apps/XForms/XForms.UWP/BundleArtifacts/x86.txt
 /msal/src/Microsoft.Identity.Client/docfx_project
 /msal/src/Microsoft.Identity.Client/_api
 /tests/CacheCompat/CommonCache.Test.MsalJava/target
+/tests/CacheCompat/CommonCache.Test.MsalPython/Properties/launchSettings.json

--- a/tests/CacheCompat/CommonCache.Test.Common/ProcessUtils.cs
+++ b/tests/CacheCompat/CommonCache.Test.Common/ProcessUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -23,6 +24,41 @@ namespace CommonCache.Test.Common
 
         public ProcessUtils()
         {
+
+        }
+
+        public async Task<string> FindProgramAsync(string findArgs, CancellationToken cancellationToken)
+        {
+            if (File.Exists(findArgs))
+            {
+                return findArgs;
+            }
+
+            var executable = findArgs;
+            try
+            {
+                Console.WriteLine($"Calling:  where {findArgs}");
+                ProcessRunResults whereResults = await RunProcessAsync("where", findArgs, cancellationToken).ConfigureAwait(false);
+                if (whereResults != null)
+                {
+                    Console.WriteLine($"Search result: {whereResults}");
+                    if (!string.IsNullOrEmpty(whereResults.StandardOut))
+                    {
+                        var results = whereResults.StandardOut.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                        if (results.Length > 0)
+                            executable = results[0].Trim();
+                        else
+                            executable = whereResults.StandardOut.Trim();
+                    }
+                }
+            }
+            catch (ProcessRunException ex)
+            {
+                Console.WriteLine(ex.ProcessStandardOutput);
+                throw;
+            }
+
+            return executable;
         }
 
         public void KillAllChildProcesses()

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
@@ -25,9 +25,23 @@ namespace CommonCache.Test.MsalJava
             CancellationToken cancellationToken)
         {
             var processUtils = new ProcessUtils();
-            string executablePath = "mvn.cmd";
+            string executablePath = @"C:\apache-maven-3.6.2\bin\mvn.cmd";
 
             string pomFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "pom.xml");
+
+            try
+            {
+                string findMavenArgs = $"mvn.cmd";
+                Console.WriteLine($"Calling:  where {findMavenArgs}");
+                var whereMavenResults = await processUtils.RunProcessAsync("where", findMavenArgs, cancellationToken).ConfigureAwait(false);
+                File.WriteAllText(@"C:\Users\henrikm\AppData\Local\Temp\adalcachecompattestdata\mvnishere.txt", whereMavenResults.ToString());
+
+            }
+            catch (ProcessRunException ex)
+            {
+                Console.WriteLine(ex.ProcessStandardOutput);
+                throw;
+            }
 
             try
             {

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
@@ -25,22 +25,31 @@ namespace CommonCache.Test.MsalJava
             CancellationToken cancellationToken)
         {
             var processUtils = new ProcessUtils();
-            string executablePath = @"C:\apache-maven-3.6.2\bin\mvn.cmd";
+            string executablePath = @"C:\apache-maven-3.6.2\bin\mvn.cmd"; // replace with std. devops build vm location
 
             string pomFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "pom.xml");
 
-            try
+            if (!File.Exists(executablePath))
             {
-                string findMavenArgs = $"mvn.cmd";
-                Console.WriteLine($"Calling:  where {findMavenArgs}");
-                var whereMavenResults = await processUtils.RunProcessAsync("where", findMavenArgs, cancellationToken).ConfigureAwait(false);
-                File.WriteAllText(@"C:\Users\henrikm\AppData\Local\Temp\adalcachecompattestdata\mvnishere.txt", whereMavenResults.ToString());
-
-            }
-            catch (ProcessRunException ex)
-            {
-                Console.WriteLine(ex.ProcessStandardOutput);
-                throw;
+                try
+                {
+                    string findMavenArgs = $"mvn.cmd";
+                    Console.WriteLine($"Calling:  where {findMavenArgs}");
+                    ProcessRunResults whereMavenResults = await processUtils.RunProcessAsync("where", findMavenArgs, cancellationToken).ConfigureAwait(false);
+                    if (whereMavenResults != null)
+                    {
+                        Console.WriteLine($"Maven search result: {whereMavenResults}");
+                        if (!string.IsNullOrEmpty(whereMavenResults.StandardOut))
+                        {
+                            executablePath = whereMavenResults.StandardOut.Trim();
+                        }
+                    }
+                }
+                catch (ProcessRunException ex)
+                {
+                    Console.WriteLine(ex.ProcessStandardOutput);
+                    throw;
+                }
             }
 
             try

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
@@ -25,32 +25,11 @@ namespace CommonCache.Test.MsalJava
             CancellationToken cancellationToken)
         {
             var processUtils = new ProcessUtils();
-            string executablePath = @"C:\apache-maven-3.6.2\bin\mvn.cmd"; // replace with std. devops build vm location
+            string executablePath = @"mvn.cmd"; // replace with std. devops build vm location
 
             string pomFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "pom.xml");
 
-            if (!File.Exists(executablePath))
-            {
-                try
-                {
-                    string findMavenArgs = $"mvn.cmd";
-                    Console.WriteLine($"Calling:  where {findMavenArgs}");
-                    ProcessRunResults whereMavenResults = await processUtils.RunProcessAsync("where", findMavenArgs, cancellationToken).ConfigureAwait(false);
-                    if (whereMavenResults != null)
-                    {
-                        Console.WriteLine($"Maven search result: {whereMavenResults}");
-                        if (!string.IsNullOrEmpty(whereMavenResults.StandardOut))
-                        {
-                            executablePath = whereMavenResults.StandardOut.Trim();
-                        }
-                    }
-                }
-                catch (ProcessRunException ex)
-                {
-                    Console.WriteLine(ex.ProcessStandardOutput);
-                    throw;
-                }
-            }
+            executablePath = await processUtils.FindProgramAsync(executablePath, cancellationToken).ConfigureAwait(false);
 
             try
             {

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/JavaLanguageExecutor.cs
@@ -25,7 +25,7 @@ namespace CommonCache.Test.MsalJava
             CancellationToken cancellationToken)
         {
             var processUtils = new ProcessUtils();
-            string executablePath = "mvn.exe";
+            string executablePath = "mvn.cmd";
 
             string pomFilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "pom.xml");
 

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/Properties/launchSettings.json
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "CommonCache.Test.MsalJava": {
+      "commandName": "Project",
+      "commandLineArgs": "--inputPath \"C:\\Users\\henrikm\\AppData\\Local\\Temp\\tmpDDB4.tmp\" "
+    }
+  }
+}

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>0.5.0-preview</version>
+            <version>0.6.0-preview</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/src/main/java/TestConsoleApp.java
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/src/main/java/TestConsoleApp.java
@@ -100,10 +100,10 @@ public class TestConsoleApp {
                             (new TestOutput.Result(user.upn, result.account().username(), false));
 
                     System.out.println("got token for (" + result.account().username() + ") by signing in with credentials");
-                } catch (AuthenticationException ex) {
+                } catch (MsalException ex) {
                     System.out.println("**TOKEN ACQUIRE FAILURE**");
                     System.out.println(ex.getMessage());
-                    System.out.println(ex.getErrorCode());
+                    System.out.println(ex.errorCode());
                     testOutput.results.add
                             (new TestOutput.Result(user.upn, null, false));
                 }

--- a/tests/CacheCompat/CommonCache.Test.MsalPython/PythonLanguageExecutor.cs
+++ b/tests/CacheCompat/CommonCache.Test.MsalPython/PythonLanguageExecutor.cs
@@ -29,9 +29,11 @@ namespace CommonCache.Test.MsalPython
 
             string executablePath = "python.exe";
 
-            Console.WriteLine($"Calling:  {executablePath} {finalArguments}");
             var processUtils = new ProcessUtils();
-            var processRunResults = await processUtils.RunProcessAsync(executablePath, finalArguments, cancellationToken).ConfigureAwait(false);
+            executablePath = await processUtils.FindProgramAsync(executablePath, cancellationToken).ConfigureAwait(false);
+
+            Console.WriteLine($"Calling:  {executablePath} {finalArguments}");
+            ProcessRunResults processRunResults = await processUtils.RunProcessAsync(executablePath, finalArguments, cancellationToken).ConfigureAwait(false);
             return processRunResults;
         }
     }

--- a/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
+++ b/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
@@ -152,14 +152,13 @@ namespace CommonCache.Test.Unit
             await executor.ExecuteAsync(interactiveType, silentType, CancellationToken.None).ConfigureAwait(false);
         }
 
-        //[Ignore("https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1286")]
         [DataTestMethod]
         [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalV3, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalV3 msal v3 cache")]
-        //[DataRow(CacheProgramType.MsalJava, CacheProgramType.AdalV5, CacheStorageType.MsalV3, DisplayName = "MsalJava->AdalV5 msal v3 cache")]
-        //[DataRow(CacheProgramType.MsalV3, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalV3->MsalJava msal v3 cache")]
-        //[DataRow(CacheProgramType.AdalV5, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "AdalV5->MsalJava msal v3 cache")]
-        //[DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
-        //[DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
+        [DataRow(CacheProgramType.MsalJava, CacheProgramType.AdalV5, CacheStorageType.MsalV3, DisplayName = "MsalJava->AdalV5 msal v3 cache")]
+        [DataRow(CacheProgramType.MsalV3, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalV3->MsalJava msal v3 cache")]
+        [DataRow(CacheProgramType.AdalV5, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "AdalV5->MsalJava msal v3 cache")]
+        [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
+        [DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
         public async Task TestMsalJavaCacheCompatibilityAsync(
             CacheProgramType interactiveType,
             CacheProgramType silentType,

--- a/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
+++ b/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
@@ -152,14 +152,14 @@ namespace CommonCache.Test.Unit
             await executor.ExecuteAsync(interactiveType, silentType, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Ignore("https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1286")]
+        //[Ignore("https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1286")]
         [DataTestMethod]
         [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalV3, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalV3 msal v3 cache")]
-        [DataRow(CacheProgramType.MsalJava, CacheProgramType.AdalV5, CacheStorageType.MsalV3, DisplayName = "MsalJava->AdalV5 msal v3 cache")]
-        [DataRow(CacheProgramType.MsalV3, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalV3->MsalJava msal v3 cache")]
-        [DataRow(CacheProgramType.AdalV5, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "AdalV5->MsalJava msal v3 cache")]
-        [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
-        [DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
+        //[DataRow(CacheProgramType.MsalJava, CacheProgramType.AdalV5, CacheStorageType.MsalV3, DisplayName = "MsalJava->AdalV5 msal v3 cache")]
+        //[DataRow(CacheProgramType.MsalV3, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalV3->MsalJava msal v3 cache")]
+        //[DataRow(CacheProgramType.AdalV5, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "AdalV5->MsalJava msal v3 cache")]
+        //[DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
+        //[DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
         public async Task TestMsalJavaCacheCompatibilityAsync(
             CacheProgramType interactiveType,
             CacheProgramType silentType,

--- a/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
+++ b/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
@@ -157,8 +157,8 @@ namespace CommonCache.Test.Unit
         [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalV3, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalV3 msal v3 cache")]
         [DataRow(CacheProgramType.MsalJava, CacheProgramType.AdalV5, CacheStorageType.MsalV3, DisplayName = "MsalJava->AdalV5 msal v3 cache")]
         [DataRow(CacheProgramType.AdalV5, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "AdalV5->MsalJava msal v3 cache")]
-        //[DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
-        //[DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
+        [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
+        [DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
         public async Task TestMsalJavaCacheCompatibilityAsync(
             CacheProgramType interactiveType,
             CacheProgramType silentType,

--- a/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
+++ b/tests/CacheCompat/CommonCache.Test.Unit/CacheExecutionTests.cs
@@ -153,12 +153,12 @@ namespace CommonCache.Test.Unit
         }
 
         [DataTestMethod]
+        [DataRow(CacheProgramType.MsalV3, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalV3->MsalJava msal v3 cache")]
         [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalV3, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalV3 msal v3 cache")]
         [DataRow(CacheProgramType.MsalJava, CacheProgramType.AdalV5, CacheStorageType.MsalV3, DisplayName = "MsalJava->AdalV5 msal v3 cache")]
-        [DataRow(CacheProgramType.MsalV3, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalV3->MsalJava msal v3 cache")]
         [DataRow(CacheProgramType.AdalV5, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "AdalV5->MsalJava msal v3 cache")]
-        [DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
-        [DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
+        //[DataRow(CacheProgramType.MsalJava, CacheProgramType.MsalPython, CacheStorageType.MsalV3, DisplayName = "MsalJava->MsalPython msal v3 cache")]
+        //[DataRow(CacheProgramType.MsalPython, CacheProgramType.MsalJava, CacheStorageType.MsalV3, DisplayName = "MsalPython->MsalJava msal v3 cache")]
         public async Task TestMsalJavaCacheCompatibilityAsync(
             CacheProgramType interactiveType,
             CacheProgramType silentType,


### PR DESCRIPTION
A few issues:
* Maven was not found as the process is a cmd, 
* The process runner was not able to run the cmd with-out a complete path to the cmd. 
* The latest Java library had introduced some updates to the public api
* Python executable location improved to enable local test runs (should not be needed but was not working locally on my box)

TODO:
* Lookup env var M2_HOME to find maven installation
* Add logging to the Java cache test