### PR TITLE
iOS Broker Part II

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerResponseConst.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerResponseConst.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
 
         public const string Authority = "authority";
         public const string AccessToken = "access_token";
+        public const string ClientId = "client_id";
         public const string RefreshToken = "refresh_token";
         public const string IdToken = "id_token";
         public const string Bearer = "Bearer";
@@ -19,7 +20,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
         public const string Scope = "scope";
         public const string ExpiresOn = "expires_on";
         public const string ClientInfo = "client_info";
-
-        public const string iOSBrokerNonce = "broker_nonce"; //in response from iOS Broker
+       
+        public const string iOSBrokerNonce = "broker_nonce"; // included in request and response with iOS Broker v3
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -735,6 +735,14 @@ namespace Microsoft.Identity.Client
         /// <para>For more details</para> see https://aka.ms/msal-net-ios-broker
         /// </summary>
         public const string UIViewControllerRequiredForiOSBroker = "uiviewcontroller_required_for_ios_broker";
+
+        /// <summary>
+        /// Xamarin.iOS + broker specific. This error indidates that the writing of the application token from iOS broker
+        /// to the keychain threw an exception. No SecStatusCode was returned.
+        /// <para>Mitigation</para> Check the logs.
+        /// <para>For more details</para> see https://aka.ms/msal-net-ios-broker
+        /// </summary>
+        public const string WritingApplicationTokenToKeychainFailed = "writing_application_token_to_keychain_failed";
 #endif
 
 #if ANDROID

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -737,12 +737,20 @@ namespace Microsoft.Identity.Client
         public const string UIViewControllerRequiredForiOSBroker = "uiviewcontroller_required_for_ios_broker";
 
         /// <summary>
-        /// Xamarin.iOS + broker specific. This error indidates that the writing of the application token from iOS broker
+        /// Xamarin.iOS + broker specific. This error indicates that the writing of the application token from iOS broker
         /// to the keychain threw an exception. No SecStatusCode was returned.
         /// <para>Mitigation</para> Check the logs.
         /// <para>For more details</para> see https://aka.ms/msal-net-ios-broker
         /// </summary>
         public const string WritingApplicationTokenToKeychainFailed = "writing_application_token_to_keychain_failed";
+
+        /// <summary>
+        /// Xamarin.iOS + broker specific. This error indicates that the reading of the application token from 
+        /// the keychain threw an exception. No SecStatusCode was returned.
+        /// <para>Mitigation</para> Check the logs.
+        /// <para>For more details</para> see https://aka.ms/msal-net-ios-broker
+        /// </summary>
+        public const string ReadingApplicationTokenFromKeychainFailed = "reading_application_token_from_keychain_failed";
 #endif
 
 #if ANDROID

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -275,6 +275,8 @@ namespace Microsoft.Identity.Client
         public const string InvalidUserInstanceMetadata = "The json containing instance metadata could not be parsed. See https://aka.ms/msal-net-custom-instance-metadata for details.";
 
         public const string UIViewControllerIsRequiredToInvokeiOSBroker = "UIViewController is null, so MSAL.NET cannot invoke the iOS broker. See https://aka.ms/msal-net-ios-broker";
+        public const string WritingApplicationTokenToKeychainFailed = "This error indidates that the writing of the application token from iOS broker to the keychain threw an exception. No SecStatusCode was returned. ";
+
         public const string ValidateAuthorityOrCustomMetadata = "You have configured custom instance metadata, but the validateAuthority flag is set to true. These are mutually exclusive. Set the validateAuthority flag to false. See https://aka.ms/msal-net-custom-instance-metadata for more details.";
 
         public const string InvalidClient = "The wrong application (public or confidential) is being used with this authentication flow." +

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -276,6 +276,7 @@ namespace Microsoft.Identity.Client
 
         public const string UIViewControllerIsRequiredToInvokeiOSBroker = "UIViewController is null, so MSAL.NET cannot invoke the iOS broker. See https://aka.ms/msal-net-ios-broker";
         public const string WritingApplicationTokenToKeychainFailed = "This error indidates that the writing of the application token from iOS broker to the keychain threw an exception. No SecStatusCode was returned. ";
+        public const string ReadingApplicationTokenFromKeychainFailed = "This error indicates that the reading of the application token from the keychain threw an exception. No SecStatusCode was returned. ";
 
         public const string ValidateAuthorityOrCustomMetadata = "You have configured custom instance metadata, but the validateAuthority flag is set to true. These are mutually exclusive. Set the validateAuthority flag to false. See https://aka.ms/msal-net-custom-instance-metadata for more details.";
 

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
@@ -55,5 +55,9 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         public const string BrokerPayloadPii = "iOS Broker Payload: ";
         public const string BrokerPayloadNoPii = "iOS Broker Payload Count: ";
         public const string BrokerResponseValuesPii = "iOS Broker Response Values: ";
+        public const string AttemptToSaveBrokerApplicationToken = "Attempt to save iOS broker application token resulted in: ";
+        public const string SecStatusCodeFromTryGetBrokerApplicationToken = "The SecStatusCode from trying to get the broker application token is: ";
+        public const string iOSBroker = "iOS_broker";
+        public const string ApplicationToken = "application_token"; // included in request and response with v3 iOS broker
     }
 }


### PR DESCRIPTION
- get application token in broker response
- save in keychain
- send in subsequent requests to v3 broker

tested w/iOS v3 broker

@bgavrilMS maybe you'll have time to take a look at this. also one for [ADAL](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/1672), but the changes are the same, so whatever comments made here, i will update in ADAL as well. 
Am also going to confirm w/iOS team tomorrow that this works as expected and they see the right stuff on their end. Also, am not sure which specific use case or test should be run to ensure the expected behavior happens, so will find out tomorrow. wanted to give you time to review, if you have time. 😼 thx.