### PR TITLE
Adding sendX5C api to the acquire token by refresh token and auth code flows for confidential clients to enable SN+I.

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -66,6 +66,24 @@ namespace Microsoft.Identity.Client
         {
             return ConfidentialClientApplicationExecutor.ExecuteAsync(CommonParameters, Parameters, cancellationToken);
         }
+
+        /// <summary>
+        /// Specifies if the x5c claim (public key of the certificate) should be sent to the STS.
+        /// Sending the x5c enables application developers to achieve easy certificate roll-over in Azure AD:
+        /// this method will send the public certificate to Azure AD along with the token request,
+        /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
+        /// This saves the application admin from the need to explicitly manage the certificate rollover
+        /// (either via portal or powershell/CLI operation)
+        /// </summary>
+        /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
+        /// The default is <c>false</c></param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public AcquireTokenByAuthorizationCodeParameterBuilder WithSendX5C(bool withSendX5C)
+        {
+            CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);
+            Parameters.SendX5C = withSendX5C;
+            return this;
+        }
     }
 #endif
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
@@ -53,5 +53,26 @@ namespace Microsoft.Identity.Client
         {
             return ApiEvent.ApiIds.AcquireTokenByRefreshToken;
         }
+
+#if !ANDROID_BUILDTIME && !iOS_BUILDTIME && !WINDOWS_APP_BUILDTIME && !MAC_BUILDTIME // Hide on mobile platforms
+
+        /// <summary>
+        /// Specifies if the x5c claim (public key of the certificate) should be sent to the STS.
+        /// Sending the x5c enables application developers to achieve easy certificate roll-over in Azure AD:
+        /// this method will send the public certificate to Azure AD along with the token request,
+        /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
+        /// This saves the application admin from the need to explicitly manage the certificate rollover
+        /// (either via portal or powershell/CLI operation)
+        /// </summary>
+        /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
+        /// The default is <c>false</c></param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public AcquireTokenByRefreshTokenParameterBuilder WithSendX5C(bool withSendX5C)
+        {
+            CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);
+            Parameters.SendX5C = withSendX5C;
+            return this;
+        }
+#endif
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
 
             requestContext.Logger.Info(LogMessages.UsingXScopesForRefreshTokenRequest(commonParameters.Scopes.Count()));
 
+            requestParameters.SendX5C = refreshTokenParameters.SendX5C;
+
             var handler = new ByRefreshTokenRequest(ServiceBundle, requestParameters, refreshTokenParameters);
             return await handler.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 commonParameters,
                 requestContext,
                 _confidentialClientApplication.UserTokenCacheInternal);
+            requestParams.SendX5C = authorizationCodeParameters.SendX5C;
 
             var handler = new AuthorizationCodeRequest(
                 ServiceBundle,

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByAuthorizationCodeParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByAuthorizationCodeParameters.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     {
         public string AuthorizationCode { get; set; }
 
+        public bool SendX5C { get; set; }
+
         public void LogParameters(ICoreLogger logger)
         {
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByRefreshTokenParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByRefreshTokenParameters.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     {
         public string RefreshToken { get; set; }
 
+        public bool SendX5C { get; set; }
+
         public void LogParameters(ICoreLogger logger)
         {
         }


### PR DESCRIPTION
fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1490