### PR TITLE
remove use of wrong default redirect uri in tests urn:ietf:wg:oauth:2…

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Identity.Client
         /// This redirect URI needs to be registered in the app registration (https://aka.ms/msal-net-register-app).
         /// In MSAL.NET, <c>IPublicClientApplication</c> defines the following default RedirectUri values:
         /// <list type="bullet">
-        /// <item><description><c>urn:ietf:wg:oauth:2.0:oob</c> for desktop (.NET Framework and .NET Core) applications</description></item>
+        /// <item><description><c>https://login.microsoftonline.com/common/oauth2/nativeclient</c> for desktop (.NET Framework and .NET Core) applications</description></item>
         /// <item><description><c>msal{ClientId}</c> for Xamarin iOS and Xamarin Android without broker (as this will be used by the system web browser by default on these
         /// platforms to call back the application)
         /// </description></item>

--- a/src/client/Microsoft.Identity.Client/Core/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Core/Constants.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Client.Core
         public const int CodeVerifierByteSize = 32;
 
         public const string UapWEBRedirectUri = "https://sso"; // only ADAL supports WEB
-        public const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
+        public const string DefaultRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
         public const string NativeClientRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
         public const string LocalHostRedirectUri = "http://localhost";
         public const string DefaultConfidentialClientRedirectUri = "https://replyUrlNotSet";

--- a/src/client/Microsoft.Identity.Client/Core/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Core/Constants.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Client.Core
         public const int CodeVerifierByteSize = 32;
 
         public const string UapWEBRedirectUri = "https://sso"; // only ADAL supports WEB
-        public const string DefaultRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        public const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
         public const string NativeClientRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
         public const string LocalHostRedirectUri = "http://localhost";
         public const string DefaultConfidentialClientRedirectUri = "https://replyUrlNotSet";

--- a/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Client
         /// This redirect URI needs to be registered in the app registration (https://aka.ms/msal-net-register-app)
         /// In MSAL.NET, <see cref="T:PublicClientApplication"/> define the following default RedirectUri values:
         /// <list type="bullet">
-        /// <item><description><c>urn:ietf:wg:oauth:2.0:oob</c> for desktop (.NET Framework and .NET Core) applications</description></item>
+        /// <item><description><c>https://login.microsoftonline.com/common/oauth2/nativeclient</c> for desktop (.NET Framework and .NET Core) applications</description></item>
         /// <item><description><c>msal{ClientId}</c> for Xamarin iOS and Xamarin Android (as this will be used by the system web browser by default on these
         /// platforms to call back the application)
         /// </description></item>
@@ -283,7 +283,7 @@ namespace Microsoft.Identity.Client
         /// This redirect URI needs to be registered in the app registration (https://aka.ms/msal-net-register-app).
         /// In MSAL.NET, <see cref="T:PublicClientApplication"/> define the following default RedirectUri values:
         /// <list type="bullet">
-        /// <item><description><c>urn:ietf:wg:oauth:2.0:oob</c> for desktop (.NET Framework and .NET Core) applications</description></item>
+        /// <item><description><c>https://login.microsoftonline.com/common/oauth2/nativeclient</c> for desktop (.NET Framework and .NET Core) applications</description></item>
         /// <item><description><c>msal{ClientId}</c> for Xamarin iOS and Xamarin Android (as this will be used by the system web browser by default on these
         /// platforms to call back the application)
         /// </description></item>

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string Name = "First Last";
         public const string Claims = "claim1claim2";
         public const string DisplayableId = "displayable@id.com";
-        public const string RedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        public const string RedirectUri = "urn:ietf:wg:oauth:2.0:oob";
         public const string ClientSecret = "client_secret";
         public const string DefaultPassword = "password";
         public const string AuthorityTestTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + Utid + "/";

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string Name = "First Last";
         public const string Claims = "claim1claim2";
         public const string DisplayableId = "displayable@id.com";
-        public const string RedirectUri = "urn:ietf:wg:oauth:2.0:oob";
+        public const string RedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
         public const string ClientSecret = "client_secret";
         public const string DefaultPassword = "password";
         public const string AuthorityTestTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + Utid + "/";
@@ -179,7 +179,7 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         public const string FabrikamDisplayableId = "displayable@fabrikam.com";
         public const string OnPremiseHomeObjectId = OnPremiseUniqueId;
         public const string OnPremisePolicy = "on_premise_policy";
-        public const string OnPremiseRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
+        public const string OnPremiseRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
         public const string OnPremiseClientSecret = "on_premise_client_secret";
         public const string OnPremiseUid = "my-OnPremise-UID";
         public const string OnPremiseUtid = "my-OnPremise-UTID";

--- a/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Integration.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
+using Microsoft.Identity.Test.UIAutomation.Infrastructure;
 using Microsoft.Identity.Test.Unit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -390,7 +391,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             SecureString securePassword = new NetworkCredential("", user.GetOrFetchPassword()).SecurePassword;
 
-            var msalPublicClient = PublicClientApplicationBuilder.Create(publicClientID).WithAuthority(TestConstants.AuthorityOrganizationsTenant).WithRedirectUri("urn:ietf:wg:oauth:2.0:oob").Build();
+            var msalPublicClient = PublicClientApplicationBuilder.Create(publicClientID).WithAuthority(TestConstants.AuthorityOrganizationsTenant).WithRedirectUri(TestConstants.RedirectUri).Build();
 
             AuthenticationResult authResult = await msalPublicClient
                 .AcquireTokenByUsernamePassword(s_oboServiceScope, user.Upn, securePassword)

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 //Validate new default redirect uri
 #if DESKTOP
-                Assert.AreEqual(TestConstants.RedirectUri, app.AppConfig.RedirectUri);
+                Assert.AreEqual(Constants.NativeClientRedirectUri, app.AppConfig.RedirectUri);
 #elif NET_CORE
                 Assert.AreEqual(app.AppConfig.RedirectUri, "http://localhost");
 #endif

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.IsNotNull(app);
             Assert.AreEqual("https://fs.contoso.com/adfs/", app.Authority);
             Assert.AreEqual(TestConstants.ClientId, app.AppConfig.ClientId);
-            Assert.AreEqual("urn:ietf:wg:oauth:2.0:oob", app.AppConfig.RedirectUri);
+            Assert.AreEqual(TestConstants.RedirectUri, app.AppConfig.RedirectUri);
         }
 
         [TestMethod]
@@ -450,7 +450,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                                                             .BuildConcrete();
                 //Validate legacy default uri
-                Assert.AreEqual(app.AppConfig.RedirectUri, "urn:ietf:wg:oauth:2.0:oob");
+                Assert.AreEqual(TestConstants.RedirectUri, app.AppConfig.RedirectUri);
 
                 app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
                                                                             .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
@@ -461,7 +461,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 //Validate new default redirect uri
 #if DESKTOP
-                Assert.AreEqual(app.AppConfig.RedirectUri, "https://login.microsoftonline.com/common/oauth2/nativeclient");
+                Assert.AreEqual(TestConstants.RedirectUri, app.AppConfig.RedirectUri);
 #elif NET_CORE
                 Assert.AreEqual(app.AppConfig.RedirectUri, "http://localhost");
 #endif


### PR DESCRIPTION
….0:oob