### PR TITLE
Fixing another instance of the certificate thumbprint

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Test.Unit
         public static readonly string[] s_graphScopes = new[] { "user.read" };
         public const uint JwtToAadLifetimeInSeconds = 60 * 10; // Ten minutes
         public const string ClientCredentialAudience = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0";
-        public const string AutomationTestThumbprint = "79fbcbeb5cd28994e50daff8035bacf764b14306";
+        public const string AutomationTestThumbprint = "3051A5BE699BC4596EE47E9FEBBF48DBA85BE67B";
         public const string RSATestCertThumbprint = "9498C1B91CA4F2CFFEA10C53DCC8301F9A8D4BDE";
 
         public static readonly SortedSet<string> s_scopeForAnotherResource = new SortedSet<string>(new[] { "r2/scope1", "r2/scope2" });


### PR DESCRIPTION
Same as https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/commit/11326f0e4145a04e5ed33f9a3af1bcdcef1c862c

but for different tests