### PR TITLE
[WIP] fix possible null ref in non-broker related calls when source applica…

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using Foundation;
 using Microsoft.Identity.Client.Platforms.iOS;
 
@@ -57,8 +58,21 @@ namespace Microsoft.Identity.Client
         /// <param name="url"></param>
         public static void SetBrokerContinuationEventArgs(NSUrl url)
         {
+            // url should always be present
+            // if coming from broker, will be the broker response
+            // check to prevent null ref later
+            if (url == null)
+            {
+                return;
+            }
+
             Debug.WriteLine("SetBrokercontinuationEventArgs Called with Url {0}", url);
-            iOSBroker.SetBrokerResponse(url);
+
+            string urlString = string.Format(CultureInfo.CurrentCulture, url.ToString());
+            if (urlString.Contains(iOSBrokerConstants.IdentifyiOSBrokerFromResponseUrl))
+            {
+                iOSBroker.SetBrokerResponse(url);
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Client
         {
             Debug.WriteLine("IsBrokerResponse called with sourceApplication {0}", sourceApplication);
 
-            if (sourceApplication != null && sourceApplication.Equals("com.microsoft.azureauthenticator", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(sourceApplication) && sourceApplication.Equals("com.microsoft.azureauthenticator", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -58,17 +58,10 @@ namespace Microsoft.Identity.Client
         /// <param name="url"></param>
         public static void SetBrokerContinuationEventArgs(NSUrl url)
         {
-            // url should always be present
-            // if coming from broker, will be the broker response
-            // check to prevent null ref later
-            if (url == null)
-            {
-                return;
-            }
-
             Debug.WriteLine("SetBrokercontinuationEventArgs Called with Url {0}", url);
 
-            string urlString = string.Format(CultureInfo.CurrentCulture, url.ToString());
+            string urlString = url.AbsoluteString;
+            
             if (urlString.Contains(iOSBrokerConstants.IdentifyiOSBrokerFromResponseUrl))
             {
                 iOSBroker.SetBrokerResponse(url);

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         public static void SetBrokerResponse(NSUrl responseUrl)
         {
             s_brokerResponse = responseUrl;
-            s_brokerResponseReady.Release();
+            s_brokerResponseReady?.Release();
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBrokerConstants.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         public const string ExpectedHash = "hash";
         public const string EncryptedResponsed = "response";
         public const string BrokerNonce = "broker_nonce";
+        public const string IdentifyiOSBrokerFromResponseUrl = "broker";
 
         public const string BrokerKeyService = "Broker Key Service";
         public const string BrokerKeyAccount = "Broker Key Account";


### PR DESCRIPTION
…tion is null

first reported in [ADAL](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1673)
now w/ios 13, sourceApplication can be null, and if null, we are throwing a null ref later in the code for non broker responses, as the SemaphoreSlim was never created during the creation of the ios broker object.

still need to test this scenario w/msal