### PR TITLE
fix sso on uap and update uwp test app

### DIFF
--- a/src/client/Microsoft.Identity.Client/Core/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Core/Constants.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Client.Core
         public const int CodeVerifierLength = 128;
         public const int CodeVerifierByteSize = 32;
 
-        public const string UapWEBRedirectUri = "https://sso"; // only ADAL supports WEB
+        public const string UapWEBRedirectUri = "https://sso"; // for WEB
         public const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
         public const string NativeClientRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
         public const string LocalHostRedirectUri = "http://localhost";

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 {
                     // Hack: STS does not yet send back the suberror on these platforms because they are not in an allowed list,
                     // so the best thing we can do is to consider all errors as client_mismatch.
-#if NETSTANDARD || UAP || MAC
+#if NETSTANDARD || WINDOWS_APP || MAC
                     ex?.GetType();  // avoid the "variable 'ex' is declared but never used" in this code path.
                     return null;
 #else

--- a/tests/devapps/UWP standalone/MainPage.xaml
+++ b/tests/devapps/UWP standalone/MainPage.xaml
@@ -15,10 +15,9 @@
         <Button Content="Clear Cache" HorizontalAlignment="Left" Margin="636,354,0,0" VerticalAlignment="Top" Click="ClearCacheAsync"/>
         <Button Content="Clear First Account" HorizontalAlignment="Left" Margin="750,354,0,0" VerticalAlignment="Top" Click="ClearFirstAccountAsync"/>
 
-        <Button Content="Show Cache Size" HorizontalAlignment="Center" Margin="0,407,0,0" VerticalAlignment="Top" Click="ShowCacheCountAsync"/>
-        <TextBlock HorizontalAlignment="Center" Margin="0,469,0,0" Height="450" Width="800" TextWrapping="Wrap" Text="" VerticalAlignment="Top" TextAlignment="Center" Name="AccessToken"/>
         <Button Content="Acquire Token Integrated Windows Auth" HorizontalAlignment="Center" Margin="0,200,0,0" VerticalAlignment="Top" Click="AcquireTokenIWA_ClickAsync"/>
-
+        <ComboBox PlaceholderText="RedirectURI" x:Name="redirectUriCbx" ItemsSource="{x:Bind _redirectUris}" HorizontalAlignment="Center" Margin="0,468,0,0" VerticalAlignment="Top"/>
+        <TextBlock HorizontalAlignment="Center" Margin="0,520,0,0" Height="450" Width="800" TextWrapping="Wrap" Text="" VerticalAlignment="Top" TextAlignment="Center" Name="AccessToken"/>
     </Grid>
 
 </Page>

--- a/tests/devapps/UWP standalone/MainPage.xaml.cs
+++ b/tests/devapps/UWP standalone/MainPage.xaml.cs
@@ -17,6 +17,7 @@ using Windows.UI.Xaml.Navigation;
 using Windows.Storage;
 using Windows.Storage.Streams;
 using System.Threading;
+using System.Collections.ObjectModel;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -27,17 +28,30 @@ namespace UWP_standalone
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private readonly IPublicClientApplication _pca;
-        private static readonly string s_clientID = "9058d700-ccd7-4dd4-a029-aec31995add0";
+        private IPublicClientApplication _pca;
+        private static readonly string s_clientID = "4a1aa1d5-c567-49d0-ad0b-cd957a47f842"; //"9058d700-ccd7-4dd4-a029-aec31995add0";
+        //private static readonly string s_clientID = "9058d700-ccd7-4dd4-a029-aec31995add0";
         private static readonly string s_authority = "https://login.microsoftonline.com/common/";
         private static readonly IEnumerable<string> s_scopes = new[] { "user.read" };
         private const string CacheFileName = "msal_user_cache.json";
 
+        private const string NullRedirectUri = "None - WEB redirect uri";
+        private readonly ObservableCollection<string> _redirectUris = new ObservableCollection<string>();
+
         public MainPage()
         {
-            this.InitializeComponent();
+            InitializeComponent();
+            _redirectUris.Add(NullRedirectUri);
+            _redirectUris.Add("https://MyDirectorySearcherApp");
+        }
 
-            _pca = PublicClientApplicationBuilder.Create(s_clientID).WithAuthority(s_authority).Build();
+        private void CreatePublicClient()
+        {
+            _pca = PublicClientApplicationBuilder.Create(s_clientID)
+                .WithAuthority(s_authority)
+                //.WithRedirectUri(GetRedirectUri())
+                //.WithDefaultRedirectUri()
+                .Build();
 
             // custom serialization - this is very similar to what MSAL is doing
             // but extenders can implement their own cache.
@@ -71,8 +85,25 @@ namespace UWP_standalone
             });
         }
 
+        private string GetRedirectUri()
+        {
+            if (redirectUriCbx.SelectedValue == null)
+            {
+                return null;
+            }
+
+            string selectedRedirectUri = redirectUriCbx.SelectedValue.ToString();
+            if (selectedRedirectUri == NullRedirectUri)
+            {
+                return null;
+            }
+
+            return selectedRedirectUri;
+        }
+
         private async void AcquireTokenIWA_ClickAsync(object sender, RoutedEventArgs e)
         {
+            CreatePublicClient();
             AuthenticationResult result = null;
             try
             {
@@ -85,7 +116,6 @@ namespace UWP_standalone
             }
 
             await DisplayResultAsync(result).ConfigureAwait(false);
-
         }
 
         private async void ShowCacheCountAsync(object sender, RoutedEventArgs e)
@@ -97,8 +127,6 @@ namespace UWP_standalone
                 string.Join(", ", accounts.Select(a => a.Username));
 
             await DisplayMessageAsync(message).ConfigureAwait(false);
-            ;
-
         }
 
         private async void ClearCacheAsync(object sender, RoutedEventArgs e)
@@ -121,27 +149,35 @@ namespace UWP_standalone
 
         private async void AccessTokenSilentButton_ClickAsync(object sender, RoutedEventArgs e)
         {
-            IEnumerable<IAccount> accounts = await _pca.GetAccountsAsync().ConfigureAwait(false);
-
-            AuthenticationResult result = null;
-            try
+            if (_pca == null)
             {
-                result = await _pca
-                    .AcquireTokenSilent(s_scopes, accounts.FirstOrDefault())
-                    .ExecuteAsync(CancellationToken.None)
-                    .ConfigureAwait(false);
+                await DisplayMessageAsync("No PCA created yet. Call acquire token interactive first. ").ConfigureAwait(false);
             }
-            catch (Exception ex)
+            else
             {
-                await DisplayErrorAsync(ex).ConfigureAwait(false);
-                return;
-            }
+                IEnumerable<IAccount> accounts = await _pca.GetAccountsAsync().ConfigureAwait(false);
 
-            await DisplayResultAsync(result).ConfigureAwait(false);
+                AuthenticationResult result = null;
+                try
+                {
+                    result = await _pca
+                        .AcquireTokenSilent(s_scopes, accounts.FirstOrDefault())
+                        .ExecuteAsync(CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    await DisplayErrorAsync(ex).ConfigureAwait(false);
+                    return;
+                }
+
+                await DisplayResultAsync(result).ConfigureAwait(false);
+            }
         }
 
         private async void AccessTokenButton_ClickAsync(object sender, RoutedEventArgs e)
         {
+            CreatePublicClient();
             AuthenticationResult result = null;
             try
             {
@@ -151,6 +187,13 @@ namespace UWP_standalone
                 result = await _pca.AcquireTokenInteractive(s_scopes)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
+
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal,
+                    () =>
+                    {
+                        AccessToken.Text = "\nAccessToken: \n" + result.AccessToken;
+                    });
+
             }
             catch (Exception ex)
             {

--- a/tests/devapps/UWP standalone/MainPage.xaml.cs
+++ b/tests/devapps/UWP standalone/MainPage.xaml.cs
@@ -29,8 +29,7 @@ namespace UWP_standalone
     public sealed partial class MainPage : Page
     {
         private IPublicClientApplication _pca;
-        private static readonly string s_clientID = "4a1aa1d5-c567-49d0-ad0b-cd957a47f842"; //"9058d700-ccd7-4dd4-a029-aec31995add0";
-        //private static readonly string s_clientID = "9058d700-ccd7-4dd4-a029-aec31995add0";
+        private static readonly string s_clientID = "4a1aa1d5-c567-49d0-ad0b-cd957a47f842";
         private static readonly string s_authority = "https://login.microsoftonline.com/common/";
         private static readonly IEnumerable<string> s_scopes = new[] { "user.read" };
         private const string CacheFileName = "msal_user_cache.json";
@@ -49,8 +48,7 @@ namespace UWP_standalone
         {
             _pca = PublicClientApplicationBuilder.Create(s_clientID)
                 .WithAuthority(s_authority)
-                //.WithRedirectUri(GetRedirectUri())
-                //.WithDefaultRedirectUri()
+                .WithRedirectUri(GetRedirectUri())
                 .Build();
 
             // custom serialization - this is very similar to what MSAL is doing

--- a/tests/devapps/UWP standalone/Package.appxmanifest
+++ b/tests/devapps/UWP standalone/Package.appxmanifest
@@ -45,5 +45,7 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <uap:Capability Name="enterpriseAuthentication"/>
+    <Capability Name="privateNetworkClientServer"/>
   </Capabilities>
 </Package>


### PR DESCRIPTION
Using the test app, select the null redirect uri, which will use https://sso and then WEB auth to handle "sso". I signed in w/corp account and cloud account, and both show as previously signed in accounts using the UWP stand-alone test app. Similar to how we handle this in ADAL.