### PR TITLE
Ignore reserved OIDC scopes when searching the token cache

### DIFF
--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
@@ -90,12 +90,14 @@ namespace Microsoft.Identity.Client.OAuth2
 
     internal static class OAuth2Value
     {
-        public static readonly SortedSet<string> ReservedScopes = 
-            new SortedSet<string> { ScopeOpenId, ScopeProfile, ScopeOfflineAccess };
         public const string CodeChallengeMethodValue = "S256";
+
         public const string ScopeOpenId = "openid";
         public const string ScopeOfflineAccess = "offline_access";
         public const string ScopeProfile = "profile";
+
+        public static readonly SortedSet<string> ReservedScopes =
+          new SortedSet<string> { ScopeOpenId, ScopeProfile, ScopeOfflineAccess };
     }
 
     internal class PromptValue

--- a/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Identity.Client.Utils
 {
     internal static class ScopeHelper
     {
-        public static bool ScopeContains(SortedSet<string> outerSet, SortedSet<string> possibleContainedSet)
+        public static bool ScopeContains(ISet<string> outerSet, IEnumerable<string> possibleContainedSet)
         {
             foreach (string key in possibleContainedSet)
             {

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
 
         public AuthenticationRequestParameters CreateAuthenticationRequestParameters(
             string authority,
-            SortedSet<string> scopes,
+            IEnumerable<string> scopes,
             ITokenCacheInternal tokenCache,
             IAccount account = null,
             IDictionary<string, string> extraQueryParameters = null,


### PR DESCRIPTION
Fix for #1548 