### PR TITLE
updating telemetry schema from v1 to v2

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -128,6 +128,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         apiEvent.TenantId = authenticationResult.TenantId;
                         apiEvent.AccountId = authenticationResult.UniqueId;
                         apiEvent.WasSuccessful = true;
+                        if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.AcquireTokenSilent)
+                        {
+                            AuthenticationRequestParameters.RequestContext.ServiceBundle.TelemetryManager.SuccessfulSilentCallCount ++;
+                        }
                         return authenticationResult;
                     }
                     catch (MsalException ex)

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/ITelemetryManager.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/ITelemetryManager.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
     internal interface ITelemetryManager
     {
         TelemetryCallback Callback { get; }
-
+        int SuccessfulSilentCallCount { get; set; }
         TelemetryHelper CreateTelemetryHelper(EventBase eventBase);
 
         void StartEvent(EventBase eventToStart);

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/HttpTelemetryContent.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/HttpTelemetryContent.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client.Core;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Constants;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 
@@ -18,35 +20,66 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal
                 evt.TryGetValue(MsalTelemetryBlobEventNames.ApiErrorCodeConstStrKey, out string errorCode);
                 evt.TryGetValue(MsalTelemetryBlobEventNames.ForceRefreshId, out string forceRefresh);
 
-                ApiId = apiId ?? string.Empty;
-                CorrelationId = correlationId ?? string.Empty;
-                LastErrorCode = errorCode ?? string.Empty;
+                ApiId.Add(apiId ?? string.Empty);
+                CorrelationId.Add(correlationId ?? string.Empty);
+                LastErrorCode.Add(errorCode ?? string.Empty);
                 ForceRefresh = forceRefresh ?? string.Empty;
             }
         }
 
-        public string LastErrorCode { get; set; } = string.Empty;
-        public string ApiId { get; set; } = string.Empty;
-        public string CorrelationId { get; set; } = string.Empty;
-        public string ForceRefresh { get; set; } = string.Empty;
-
-        public string GetCsvAsPrevious()
+        public /*For testing*/ HttpTelemetryContent(bool shouldClearCache)
         {
-            if (string.IsNullOrWhiteSpace(ApiId))
+            if (shouldClearCache)
+            {
+                ApiId?.Clear();
+                CorrelationId?.Clear();
+                LastErrorCode?.Clear();
+            }
+        }
+
+        public string ForceRefresh { get; set; } = string.Empty;
+        public static List<string> ApiId { get; set; } = new List<string>();
+        public static List<string> CorrelationId { get; set; } = new List<string>();
+        public static List<string> LastErrorCode { get; set; } = new List<string>();
+
+        public string GetCsvAsPrevious(int successfulSilentCallCount)
+        {
+            if (ApiId == null)
             {
                 return string.Empty;
             }
 
             // csv expected format:
-            // 1|api_id,correlation_id,last_error_code|platform_config
-            string[] myValues = new string[] {
-                ApiId,
-                CorrelationId,
-                LastErrorCode};
+            // 2|silent_successful_count|failed_requests|errors|platform_fields
+            // failed_request can be further expanded to include:
+            // api_id_1,correlation_id_1,api_id_2,correlation_id_2|error_1,error_2
+            string apiIdCorIdData = CreateApiIdAndCorrelationIdContent();
+            string data = string.Format(CultureInfo.InvariantCulture,
+                $"{TelemetryConstants.HttpTelemetrySchemaVersion2}{TelemetryConstants.HttpTelemetryPipe}{successfulSilentCallCount}{TelemetryConstants.HttpTelemetryPipe}" +
+                $"{CreateFailedRequestsContent(apiIdCorIdData)}" +
+                $"{TelemetryConstants.HttpTelemetryPipe}");
 
-            string csvString = string.Join(",", myValues);
-            csvString = $"{TelemetryConstants.HttpTelemetrySchemaVersion1}{TelemetryConstants.HttpTelemetryPipe}{csvString}{TelemetryConstants.HttpTelemetryPipe}";
-            return csvString;
+            if (data.Length <= 3800)
+            {
+                return data;
+            }
+            else
+            {
+                return data.Substring(0, length: 3800);
+            }                
+        }
+
+        private string CreateApiIdAndCorrelationIdContent()
+        {
+            var apiIdAndCorId = ApiId.Concat(CorrelationId)
+                                        .ToList();
+            return string.Join(",", apiIdAndCorId);
+        }
+
+        private string CreateFailedRequestsContent(string apiIdAndCorIdCsv)
+        {
+            string errorCodeCsv = string.Join(",", LastErrorCode);
+            return $"{apiIdAndCorIdCsv}{TelemetryConstants.HttpTelemetryPipe}{errorCodeCsv}";
         }
 
         public string GetCsvAsCurrent()
@@ -54,13 +87,11 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal
             // csv expected format:
             // 1|api_id,force_refresh|platform_config
             string[] myValues = new string[] {
-                ApiId,
-                ConvertFromStringToBitwise(ForceRefresh),
-                };
+                ApiId.FirstOrDefault(),
+                ConvertFromStringToBitwise(ForceRefresh)};
 
             string csvString = string.Join(",", myValues);
-            csvString = $"{TelemetryConstants.HttpTelemetrySchemaVersion1}{TelemetryConstants.HttpTelemetryPipe}{csvString}{TelemetryConstants.HttpTelemetryPipe}";
-            return csvString;
+            return $"{TelemetryConstants.HttpTelemetrySchemaVersion2}{TelemetryConstants.HttpTelemetryPipe}{csvString}{TelemetryConstants.HttpTelemetryPipe}";
         }
 
         private string ConvertFromStringToBitwise(string value)

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/HttpTelemetryContent.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/HttpTelemetryContent.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal
         }
 
         public string ForceRefresh { get; set; } = string.Empty;
-        public static List<string> ApiId { get; set; } = new List<string>();
-        public static List<string> CorrelationId { get; set; } = new List<string>();
-        public static List<string> LastErrorCode { get; set; } = new List<string>();
+        public List<string> ApiId { get; set; } = new List<string>();
+        public List<string> CorrelationId { get; set; } = new List<string>();
+        public List<string> LastErrorCode { get; set; } = new List<string>();
 
         public string GetCsvAsPrevious(int successfulSilentCallCount)
         {
@@ -65,7 +65,10 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal
             }
             else
             {
-                return data.Substring(0, length: 3800);
+                ApiId?.Clear();
+                CorrelationId?.Clear();
+                LastErrorCode?.Clear();
+                return string.Empty;
             }                
         }
 
@@ -85,7 +88,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal
         public string GetCsvAsCurrent()
         {
             // csv expected format:
-            // 1|api_id,force_refresh|platform_config
+            // 2|api_id,force_refresh|platform_config
             string[] myValues = new string[] {
                 ApiId.FirstOrDefault(),
                 ConvertFromStringToBitwise(ForceRefresh)};

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
 
     internal static class TelemetryConstants
     {
-        public const string HttpTelemetrySchemaVersion1 = "1";
+        public const string HttpTelemetrySchemaVersion2 = "2";
         public const string HttpTelemetryPipe = "|";
         public const string XClientCurrentTelemetry = "x-client-current-telemetry";
         public const string XClientLastTelemetry = "x-client-last-telemetry";
@@ -27,5 +27,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
         public const string True = "true";
         public const string One = "1";
         public const string Zero = "0";
+        public const string CommaDelimiter = ",";
+        public const string PlatformFields = "platform_fields";
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryManager.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryManager.cs
@@ -32,12 +32,13 @@ namespace Microsoft.Identity.Client.TelemetryCore
         private readonly bool _onlySendFailureTelemetry;
         private readonly IPlatformProxy _platformProxy;
         private readonly IApplicationConfiguration _applicationConfiguration;
+        public int SuccessfulSilentCallCount { get; set; } = 0;
 
         public TelemetryManager(
             IApplicationConfiguration applicationConfiguration,
             IPlatformProxy platformProxy,
             TelemetryCallback telemetryCallback,
-            bool onlySendFailureTelemetry = false)
+            bool onlySendFailureTelemetry = false)        
         {
             _mostRecentStoppedApiEvent = null;
             _applicationConfiguration = applicationConfiguration;
@@ -137,7 +138,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
             {
                 var httpTelemetryContent = new HttpTelemetryContent(_mostRecentStoppedApiEvent);
                 _mostRecentStoppedApiEvent = null;
-                return httpTelemetryContent.GetCsvAsPrevious();
+                return httpTelemetryContent.GetCsvAsPrevious(SuccessfulSilentCallCount);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.net45/Infrastructure/HttpTelemetryRecorder.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/Infrastructure/HttpTelemetryRecorder.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Identity.Client.TelemetryCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Integration.net45.Infrastructure
+{
+    public class HttpTelemetryRecorder
+    {
+        public List<string> ApiId { get; set; } = new List<string>();
+        public List<string> CorrelationIdPrevious { get; set; } = new List<string>();
+        public List<string> ApiIdPrevious { get; set; } = new List<string>();
+        public List<string> ErrorCode { get; set; } = new List<string>();
+        public string ForceRefresh { get; set; }
+        public string SilentCallSuccessfulCount { get; set; }
+
+        public void CheckSchemaVersion(string telemetryCsv)
+        {
+            Assert.AreEqual(
+                TelemetryConstants.HttpTelemetrySchemaVersion2,
+                 telemetryCsv.StartsWith(TelemetryConstants.HttpTelemetrySchemaVersion2));
+        }
+
+        public void SplitCurrentCsv(string telemetryCsv)
+        {
+            string[] splitCsv = telemetryCsv.Split('|');
+            string[] splitApiIdAndForceRefresh = splitCsv[1].Split(',');
+            ApiId.Add(splitApiIdAndForceRefresh[0]);
+            string forceRefresh = splitApiIdAndForceRefresh[1];
+            ForceRefresh = forceRefresh;
+        }
+
+        public void SplitPreviousCsv(string telemetryCsv)
+        {
+            string[] splitCsv = telemetryCsv.Split('|');
+            SilentCallSuccessfulCount = splitCsv[1];
+
+            if (splitCsv[2] == string.Empty)
+            {
+                return;
+            }
+
+            string[] splitFailedRequests = splitCsv[2].Split(',');
+            ApiIdPrevious.Add(splitFailedRequests[1]);
+            CorrelationIdPrevious.Add(splitFailedRequests[2]);
+            ErrorCode.Add(splitCsv[2]);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Integration.net45/Infrastructure/RecordingHandler.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/Infrastructure/RecordingHandler.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Test.Integration.net45.Infrastructure
+{
+    public class RecordingHandler : DelegatingHandler
+    {
+        private readonly Action<HttpRequestMessage, HttpResponseMessage> _recordingAction;
+
+        public RecordingHandler(Action<HttpRequestMessage, HttpResponseMessage> recordingAction)
+        {
+            _recordingAction = recordingAction;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            _recordingAction.Invoke(request, response);
+            return response;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Integration.net45/Infrastructure/TestHttpClientFactory.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/Infrastructure/TestHttpClientFactory.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Identity.Test.Integration.net45.Infrastructure
+{
+    public class TestHttpClientFactory : IMsalHttpClientFactory
+    {
+        HttpClient _httpClient;
+
+        public IList<(HttpRequestMessage, HttpResponseMessage)> RequestsAndResponses { get; }
+
+        public TestHttpClientFactory()
+        {
+            RequestsAndResponses = new List<(HttpRequestMessage, HttpResponseMessage)>();
+
+            var recordingHandler = new RecordingHandler((req, res) => RequestsAndResponses.Add((req, res)));
+            recordingHandler.InnerHandler = new HttpClientHandler();
+            _httpClient = new HttpClient(recordingHandler);
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return _httpClient;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/LabAuthenticationHelper.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/LabAuthenticationHelper.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Identity.Test.LabInfrastructure
                 authority,
                 scopes,
                 s_defaultAuthType,
-                String.Empty,
-                String.Empty,
-                String.Empty).ConfigureAwait(false);
+                string.Empty,
+                string.Empty,
+                string.Empty).ConfigureAwait(false);
         }
 
         public static async Task<string> GetLabAccessTokenAsync(string authority, string[] scopes, LabAccessAuthenticationType authType, string clientId, string certThumbprint, string clientSecret)
@@ -71,8 +71,8 @@ namespace Microsoft.Identity.Test.LabInfrastructure
             switch (authType)
             {
                 case LabAccessAuthenticationType.ClientCertificate:
-                    var clientIdForCertAuth = String.IsNullOrEmpty(clientId) ? LabAccessConfidentialClientId : clientId;
-                    var certThumbprintForLab = String.IsNullOrEmpty(clientId) ? LabAccessThumbPrint : certThumbprint;
+                    var clientIdForCertAuth = string.IsNullOrEmpty(clientId) ? LabAccessConfidentialClientId : clientId;
+                    var certThumbprintForLab = string.IsNullOrEmpty(clientId) ? LabAccessThumbPrint : certThumbprint;
 
                     cert = CertificateHelper.FindCertificateByThumbprint(certThumbprintForLab);
                     if (cert == null)
@@ -95,8 +95,8 @@ namespace Microsoft.Identity.Test.LabInfrastructure
                         .ConfigureAwait(false);
                     break;
                 case LabAccessAuthenticationType.ClientSecret:
-                    var clientIdForSecretAuth = String.IsNullOrEmpty(clientId) ? LabAccessConfidentialClientId : clientId;
-                    var clientSecretForLab = String.IsNullOrEmpty(clientId) ? s_secret : clientSecret;
+                    var clientIdForSecretAuth = string.IsNullOrEmpty(clientId) ? LabAccessConfidentialClientId : clientId;
+                    var clientSecretForLab = string.IsNullOrEmpty(clientId) ? s_secret : clientSecret;
 
                     confidentialApp = ConfidentialClientApplicationBuilder
                         .Create(clientIdForSecretAuth)
@@ -111,7 +111,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
                         .ConfigureAwait(false);
                     break;
                 case LabAccessAuthenticationType.UserCredential:
-                    var clientIdForPublicClientAuth = String.IsNullOrEmpty(clientId) ? LabAccessPublicClientId : clientId;
+                    var clientIdForPublicClientAuth = string.IsNullOrEmpty(clientId) ? LabAccessPublicClientId : clientId;
                     var publicApp = PublicClientApplicationBuilder
                         .Create(clientIdForPublicClientAuth)
                         .WithAuthority(new Uri(authority), true)

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/HttpTests/HttpManagerTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
     {
         readonly Dictionary<string, string> _httpTelemetryHeaders = new Dictionary<string, string>
         {
-            {TelemetryConstants.XClientLastTelemetry, TelemetryConstants.HttpTelemetrySchemaVersion1},
-            {TelemetryConstants.XClientCurrentTelemetry, TelemetryConstants.HttpTelemetrySchemaVersion1}
+            {TelemetryConstants.XClientLastTelemetry, TelemetryConstants.HttpTelemetrySchemaVersion2},
+            {TelemetryConstants.XClientCurrentTelemetry, TelemetryConstants.HttpTelemetrySchemaVersion2}
         };
 
         [TestInitialize]

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/Telemetry/TelemetryHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/Telemetry/TelemetryHelperTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.Telemetry
     {
         private const string CorrelationId = "thetelemetrycorrelationid";
         private const string ClientId = "theclientid";
-        private _TestEvent _trackingEvent;
+        internal _TestEvent _trackingEvent;
         private TelemetryManager _telemetryManager;
         private _TestReceiver _testReceiver;
 
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.Telemetry
             }
         }
 
-        private class _TestEvent : EventBase
+        internal class _TestEvent : EventBase
         {
             public _TestEvent(string eventName, string correlationId) : base(eventName, correlationId)
             {

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/HttpTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/HttpTelemetryTests.cs
@@ -7,10 +7,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.TelemetryCore;
+using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Test.Common.Mocks;
+using Microsoft.Identity.Test.Unit.CoreTests.Telemetry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.PublicApiTests
@@ -20,12 +23,14 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
     {
         private TokenCacheHelper _tokenCacheHelper;
         private Guid _correlationId;
+        private const string Comma = ",";
 
         [TestInitialize]
         public override void TestInitialize()
         {
             base.TestInitialize();
             _tokenCacheHelper = new TokenCacheHelper();
+            new HttpTelemetryContent(true);
         }
 
         [TestMethod]
@@ -64,35 +69,142 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             await CreateFailedAndThenSuccessfulResponseToVerifyErrorCodesInHttpTelemetryDataAsync(MsalError.UnknownError).ConfigureAwait(false);
         }
 
+        [TestMethod]
+        public void CheckCurrentHttpTelemetryHeaderContent()
+        {
+            const string csvString = "2|,1|";
+            HttpTelemetryContent httpTelemetryContent = CreateHttpTelemetryContent();
+            Assert.AreEqual(csvString, httpTelemetryContent.GetCsvAsCurrent());
+        }
+
+        [TestMethod]
+        public void CheckPreviousHttpTelemetryHeaderContentWithAuthFailed()
+        {
+            const string csvString =
+                "2|0|" +
+                ",1005,1005" +
+                ",d3adb33f-c0de-ed0c-c0de-deadb33fc0d3,0a69ff54-3e00-4244-a6c8-09ccc1efa707|" +
+                ",authentication_failed|";
+
+            HttpTelemetryContent httpTelemetryContent = CreateHttpTelemetryContent();
+            List<string> errorCodes = new List<string>(new string[] { MsalError.AuthenticationFailed });
+            PopulateHttpTelemetryContent(errorCodes);
+
+            Assert.AreEqual(csvString, httpTelemetryContent.GetCsvAsPrevious(0));
+        }
+
+        [TestMethod]
+        public void CheckPreviousHttpTelemetryHeaderContentWithTwoFailures()
+        {
+            const string csvString =
+                "2|0|" +
+                ",1005,1005" +
+                ",d3adb33f-c0de-ed0c-c0de-deadb33fc0d3,0a69ff54-3e00-4244-a6c8-09ccc1efa707|" +
+                ",authentication_failed,user_mismatch|";
+
+            HttpTelemetryContent httpTelemetryContent = CreateHttpTelemetryContent();
+            List<string> errorCodes = new List<string>(new string[] { MsalError.AuthenticationFailed, MsalError.UserMismatch });
+            PopulateHttpTelemetryContent(errorCodes);
+
+            Assert.AreEqual(csvString, httpTelemetryContent.GetCsvAsPrevious(0));
+        }
+
+        [TestMethod]
+        public void CheckPreviousHttpTelemetryHeaderContentWithThreeFailures()
+        {
+            const string csvString =
+                "2|1|" +
+                ",1005,1005,1005" +
+                ",d3adb33f-c0de-ed0c-c0de-deadb33fc0d3,0a69ff54-3e00-4244-a6c8-09ccc1efa707,b1e662cf-8efb-4e13-b89a-71e845bbb62f|" +
+                ",authentication_failed,user_mismatch,invalid_grant|";
+
+            HttpTelemetryContent httpTelemetryContent = CreateHttpTelemetryContent();
+            List<string> errorCodes = new List<string>(new string[] { MsalError.AuthenticationFailed, MsalError.UserMismatch, MsalError.InvalidGrantError });
+            PopulateHttpTelemetryContent(errorCodes);
+            HttpTelemetryContent.ApiId.Add("1005");
+            HttpTelemetryContent.CorrelationId.Add("b1e662cf-8efb-4e13-b89a-71e845bbb62f");
+
+            Assert.AreEqual(csvString, httpTelemetryContent.GetCsvAsPrevious(1));
+        }
+
+        [TestMethod]
+        public void CheckHttpPreviousTelemetryHeaderSize()
+        {
+            string hugeString = new string('*', 3757);
+            HttpTelemetryContent.ApiId.Add(hugeString);
+            HttpTelemetryContent httpTelemetryContent = CreateHttpTelemetryContent();
+            string previousCsvString = httpTelemetryContent.GetCsvAsPrevious(0);
+
+            Assert.IsTrue(previousCsvString.Length <= 3800);
+        }
+
+        private HttpTelemetryContent CreateHttpTelemetryContent()
+        {
+            HttpTelemetryContent httpTelemetryContent = new HttpTelemetryContent(
+                new TelemetryHelperTests._TestEvent("tracking event", TestConstants.ClientId));
+            httpTelemetryContent.ForceRefresh = "1";
+            return httpTelemetryContent;
+        }
+
+        private void PopulateHttpTelemetryContent(List<string> errorCodes)
+        {
+            HttpTelemetryContent.ApiId.Add("1005");
+            HttpTelemetryContent.ApiId.Add("1005");
+            HttpTelemetryContent.CorrelationId.Add("0a69ff54-3e00-4244-a6c8-09ccc1efa707");
+            HttpTelemetryContent.LastErrorCode.AddRange(errorCodes);
+        }
+
         public static IDictionary<string, string> CreateHttpTelemetryHeaders(
            Guid correlationId,
            string apiId,
            string errorCode,
+           string errorCode2,
            string forceRefresh)
         {
-            const string comma = ",";
+            string repeatedCorrelationId = CreateRepeatInTelemetryHeader(correlationId.ToString());
+            string corrIdSection = repeatedCorrelationId.Trim(',');
 
             IDictionary<string, string> httpTelemetryHeaders = new Dictionary<string, string>
                 {
                     { TelemetryConstants.XClientLastTelemetry,
-                        TelemetryConstants.HttpTelemetrySchemaVersion1 +
+                        TelemetryConstants.HttpTelemetrySchemaVersion2 +
                         TelemetryConstants.HttpTelemetryPipe +
-                        apiId +
-                        comma +
-                        correlationId.ToString() +
-                        comma +
-                        errorCode +
+                        "0" +
+                        TelemetryConstants.HttpTelemetryPipe +
+                        CreateRepeatInTelemetryHeader(apiId) +
+                        corrIdSection +
+                        TelemetryConstants.HttpTelemetryPipe +
+                        CreateErrorCodeRepeatHeader(errorCode, errorCode2) +
                         TelemetryConstants.HttpTelemetryPipe
                         },
                     { TelemetryConstants.XClientCurrentTelemetry,
-                        TelemetryConstants.HttpTelemetrySchemaVersion1 +
+                        TelemetryConstants.HttpTelemetrySchemaVersion2 +
                         TelemetryConstants.HttpTelemetryPipe +
                         apiId +
-                        comma +
+                        Comma +
                         forceRefresh +
                         TelemetryConstants.HttpTelemetryPipe}
                 };
             return httpTelemetryHeaders;
+        }
+
+        private static string CreateRepeatInTelemetryHeader(
+            string stringToRepeat)
+        {
+            return stringToRepeat + Comma + stringToRepeat + Comma + stringToRepeat + Comma;
+        }
+
+        private static string CreateErrorCodeRepeatHeader(
+            string errorCode1,
+            string errorCode2)
+        {
+            string DoubleComma = ",,";
+
+            if (!string.IsNullOrEmpty(errorCode2))
+            {
+                return DoubleComma + errorCode1 + Comma + errorCode2;
+            }
+            return DoubleComma + errorCode1;
         }
 
         private async Task CreateFailedAndThenSuccessfulResponseToVerifyErrorCodesInHttpTelemetryDataAsync(string errorCode)
@@ -101,26 +213,27 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             {
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
-                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                                            .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
-                                                                            .WithHttpManager(harness.HttpManager)
-                                                                            .WithTelemetry(new TraceTelemetryConfig())
-                                                                            .BuildConcrete();
                 // Interactive call and authentication fails
                 var ui = new MockWebUI()
                 {
                     MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?error=" + errorCode)
                 };
 
+                PublicClientApplication pca = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                    .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                                                                    .WithTelemetry(new TraceTelemetryConfig())
+                                                                    .WithHttpManager(harness.HttpManager)
+                                                                    .BuildConcrete();
+
                 harness.HttpManager.AddMockHandlerForTenantEndpointDiscovery(TestConstants.AuthorityCommonTenant);
-                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+                MsalMockHelpers.ConfigureMockWebUI(pca.ServiceBundle.PlatformProxy, ui);
 
                 _correlationId = new Guid();
                 AuthenticationResult result = null;
 
                 try
                 {
-                    result = await app
+                    result = await pca
                         .AcquireTokenInteractive(TestConstants.s_scope)
                         .WithCorrelationId(_correlationId)
                         .ExecuteAsync(CancellationToken.None)
@@ -133,9 +246,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                     // Try authentication again...
                     MsalMockHelpers.ConfigureMockWebUI(
-                        app.ServiceBundle.PlatformProxy,
-                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
-                    var userCacheAccess = app.UserTokenCache.RecordAccess();
+                        pca.ServiceBundle.PlatformProxy,
+                        AuthorizationResult.FromUri(pca.AppConfig.RedirectUri + "?code=some-code"));
+                    var userCacheAccess = pca.UserTokenCache.RecordAccess();
 
                     harness.HttpManager.AddSuccessfulTokenResponseWithHttpTelemetryMockHandlerForPost(
                         TestConstants.AuthorityCommonTenant,
@@ -145,9 +258,10 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                             _correlationId,
                             TestConstants.InteractiveRequestApiId,
                             exc.ErrorCode,
+                            null,
                             TelemetryConstants.Zero));
 
-                    result = app
+                    result = pca
                          .AcquireTokenInteractive(TestConstants.s_scope)
                          .WithCorrelationId(_correlationId)
                          .ExecuteAsync(CancellationToken.None)

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
                 Guid correlationId = Guid.NewGuid();
-
+                
                 AuthenticationResult result = app
                     .AcquireTokenInteractive(TestConstants.s_scope)
                     .WithCorrelationId(correlationId)
@@ -259,15 +259,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     app.ServiceBundle.PlatformProxy,
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
-                harness.HttpManager.AddSuccessfulTokenResponseWithHttpTelemetryMockHandlerForPost(
-                    TestConstants.AuthorityCommonTenant,
-                    null,
-                    null,
-                    HttpTelemetryTests.CreateHttpTelemetryHeaders(
-                        correlationId,
-                        TestConstants.InteractiveRequestApiId,
-                        null,
-                        TelemetryConstants.Zero));
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
                 result = app
                     .AcquireTokenInteractive(TestConstants.s_scope)


### PR DESCRIPTION
Updating the telemetry schema from v1 to v2 - here is a link to the [internal pr doc](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/995?isPreview=true&path=%2FTelemetry%2FMSALServerSideTelemetry.md&_a=files&fullScreen=true)

Main change is in the previous requests, we now need to keep all the previous requests (api_id and correlation_id plus any corresponding error codes) up to 4kb for telemetry.

@bgavrilMS and I will discuss this tomorrow.