### PR TITLE
Adding broker support check to silent requests

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             var logger = AuthenticationRequestParameters.RequestContext.Logger;
             MsalAccessTokenCacheItem cachedAccessTokenItem = null;
-            if (AuthenticationRequestParameters.IsBrokerEnabled)
+            if (ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth() && AuthenticationRequestParameters.IsBrokerEnabled)
             {
                 var msalTokenResponse = await ExecuteBrokerAsync(cancellationToken).ConfigureAwait(false);
                 return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);


### PR DESCRIPTION
Adding broker support check to silent requests so that iOS will use the internal MSAL cache rather than trying to use the broker silently.