### PR TITLE
fix for null ref during interactive flow w/out android broker

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
                 _logger.Verbose("User is specified for silent token request. Starting silent broker request");
                 string silentResult = _brokerHelper.GetBrokerAuthTokenSilently(brokerPayload, _activity);
                 _androidBrokerTokenResponse = CreateMsalTokenResponseFromResult(silentResult);
-                _readyForResponse.Release();
+                _readyForResponse?.Release();
                 return;
             }
             else
@@ -130,7 +130,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
         {
             if (data == null)
             {
-                _readyForResponse.Release();
+                _readyForResponse?.Release();
                 return;
             }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
                 _androidBrokerTokenResponse = CreateMsalTokenResponseFromResult(data.GetStringExtra(BrokerConstants.BrokerResultV2));
             }
 
-            _readyForResponse.Release();
+            _readyForResponse?.Release();
         }
 
         private static MsalTokenResponse CreateMsalTokenResponseFromResult(string brokerResult)


### PR DESCRIPTION
@bgavrilMS this resolves the null ref during interactive without broker. i know you want to do more refactoring, but wasn't sure if we wanted a quick fix or something more long term. here is a quick fix.
- tested w/system browser and embedded webview. I don't have the v2 android broker on my device, so didn't test any broker related flows.