### PR TITLE
[In Progress - Not ready to merge] iOS/Android broker refactor

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -116,6 +116,9 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+#endif // !ANDROID_BUILDTIME && !WINDOWS_APP_BUILDTIME && !NET_CORE_BUILDTIME && !DESKTOP_BUILDTIME && !MAC_BUILDTIME
+
+#if !WINDOWS_APP_BUILDTIME && !NET_CORE_BUILDTIME && !DESKTOP_BUILDTIME && !MAC_BUILDTIME
         /// <summary>
         /// On Android and iOS, brokers enable Single-Sign-On, device identification,
         /// and application identification verification. To enable one of these features,
@@ -127,12 +130,11 @@ namespace Microsoft.Identity.Client
         /// parameters, and to create a public client application instance</returns>
         public PublicClientApplicationBuilder WithBroker(bool enableBroker = true)
         {
-#if iOS
             Config.IsBrokerEnabled = enableBroker;
-#endif // iOS
+
             return this;
         }
-#endif // !ANDROID_BUILDTIME && !WINDOWS_APP_BUILDTIME && !NET_CORE_BUILDTIME && !DESKTOP_BUILDTIME && !MAC_BUILDTIME
+#endif //!WINDOWS_APP_BUILDTIME && !NET_CORE_BUILDTIME && !DESKTOP_BUILDTIME && !MAC_BUILDTIME
 
 #if WINDOWS_APP
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequest.cs
@@ -10,47 +10,85 @@ using Microsoft.Identity.Client.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client.Internal.Broker
 {
-    internal class BrokerInteractiveRequest
+    internal class BrokerInteractiveRequest : InteractiveRequest
     {
         internal Dictionary<string, string> BrokerPayload { get; set; } = new Dictionary<string, string>();
         internal IBroker Broker { get; }
         private readonly AcquireTokenInteractiveParameters _interactiveParameters;
-        private readonly AuthenticationRequestParameters _authenticationRequestParameters;
-        private readonly IServiceBundle _serviceBundle;
-        private readonly AuthorizationResult _authorizationResult;
 
         internal BrokerInteractiveRequest(
+            IServiceBundle serviceBundle,
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenInteractiveParameters acquireTokenInteractiveParameters,
-            IServiceBundle serviceBundle,
-            AuthorizationResult authorizationResult,
+            IWebUI webUI,
             IBroker broker)
+            : base(
+                  serviceBundle,
+                  authenticationRequestParameters,
+                  acquireTokenInteractiveParameters,
+                  webUI)
         {
-            _authenticationRequestParameters = authenticationRequestParameters;
             _interactiveParameters = acquireTokenInteractiveParameters;
-            _serviceBundle = serviceBundle;
-            _authorizationResult = authorizationResult;
             Broker = broker;
         }
 
-        public async Task<MsalTokenResponse> SendTokenRequestToBrokerAsync()
+        internal async Task<MsalTokenResponse> ExecuteBrokerAsync(CancellationToken cancellationToken)
+        {
+            return await SendTokenRequestToBrokerAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<MsalTokenResponse> SendTokenRequestToBrokerAsync(CancellationToken cancellationToken)
         {
             if (Broker.CanInvokeBroker())
             {
-                _authenticationRequestParameters.RequestContext.Logger.Info(LogMessages.CanInvokeBrokerAcquireTokenWithBroker);
-
+                AuthenticationRequestParameters.RequestContext.Logger.Info(LogMessages.CanInvokeBrokerAcquireTokenWithBroker);
+                BrokerPayload.Clear();
                 return await SendAndVerifyResponseAsync().ConfigureAwait(false);
             }
             else
             {
-                _authenticationRequestParameters.RequestContext.Logger.Info(LogMessages.AddBrokerInstallUrlToPayload);
-                BrokerPayload[BrokerParameter.BrokerInstallUrl] = _authorizationResult.Code;
+                if (!string.IsNullOrEmpty(AuthResult?.Code)) // The user has already signed in and auth code contains msauth
+                {
+                    AuthenticationRequestParameters.RequestContext.Logger.Info(LogMessages.UserPreviouslySignedInBrokerRequired);
+                    await BrokerRequiredToAcquireTokenAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    AuthenticationRequestParameters.RequestContext.Logger.Info("The developer set .WithBroker(true), but broker is not installed" +
+                        "on the device. Will take the user through the sign-in experience to generate the auth code...");
+                    await ExecuteAuthorizationAsync(cancellationToken).ConfigureAwait(false); // The user goes through the sign-in process
 
-                return await SendAndVerifyResponseAsync().ConfigureAwait(false);
+                    if (IsBrokerInvocationRequired()) // If auth code is prefixed w/msauth, broker is required due to conditional access policies
+                    {
+                        await BrokerRequiredToAcquireTokenAsync().ConfigureAwait(false);
+                    }
+                }
+
+                // broker not needed based on auth code result. Continue w/regular acquire token call
+                return await SendTokenRequestAsync(GetBodyParameters(), cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<MsalTokenResponse> BrokerRequiredToAcquireTokenAsync()
+        {
+            BrokerPayload.Clear();
+            AuthenticationRequestParameters.RequestContext.Logger.Info(LogMessages.AddBrokerInstallUrlToPayload);
+            BrokerPayload[BrokerParameter.BrokerInstallUrl] = AuthResult.Code;
+            return await SendAndVerifyResponseAsync().ConfigureAwait(false);
+        }
+
+        internal override async Task ExecuteAuthorizationAsync(CancellationToken cancellationToken)
+        {
+            await ResolveAuthorityEndpointsAsync().ConfigureAwait(false);
+            await AcquireAuthorizationAsync(cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(AuthResult.Code)) // something failed, make sure error message is returned
+            {
+                VerifyAuthorizationResult();
             }
         }
 
@@ -67,44 +105,43 @@ namespace Microsoft.Identity.Client.Internal.Broker
 
         internal void CreateRequestParametersForBroker()
         {
-            BrokerPayload.Clear();
-            BrokerPayload.Add(BrokerParameter.Authority, _authenticationRequestParameters.Authority.AuthorityInfo.CanonicalAuthority);
-            string scopes = EnumerableExtensions.AsSingleString(_authenticationRequestParameters.Scope);
+            BrokerPayload.Add(BrokerParameter.Authority, AuthenticationRequestParameters.Authority.AuthorityInfo.CanonicalAuthority);
+            string scopes = EnumerableExtensions.AsSingleString(AuthenticationRequestParameters.Scope);
 
             BrokerPayload.Add(BrokerParameter.Scope, scopes);
-            BrokerPayload.Add(BrokerParameter.ClientId, _authenticationRequestParameters.ClientId);
-            BrokerPayload.Add(BrokerParameter.CorrelationId, _authenticationRequestParameters.RequestContext.Logger.CorrelationId.ToString());
+            BrokerPayload.Add(BrokerParameter.ClientId, AuthenticationRequestParameters.ClientId);
+            BrokerPayload.Add(BrokerParameter.CorrelationId, AuthenticationRequestParameters.RequestContext.Logger.CorrelationId.ToString());
             BrokerPayload.Add(BrokerParameter.ClientVersion, MsalIdHelper.GetMsalVersion());
             BrokerPayload.Add(BrokerParameter.Force, "NO");
-            BrokerPayload.Add(BrokerParameter.RedirectUri, _serviceBundle.Config.RedirectUri); 
+            BrokerPayload.Add(BrokerParameter.RedirectUri, ServiceBundle.Config.RedirectUri);
 
-            string extraQP = string.Join("&", _authenticationRequestParameters.ExtraQueryParameters.Select(x => x.Key + "=" + x.Value));
+            string extraQP = string.Join("&", AuthenticationRequestParameters.ExtraQueryParameters.Select(x => x.Key + "=" + x.Value));
             BrokerPayload.Add(BrokerParameter.ExtraQp, extraQP);
 
-            BrokerPayload.Add(BrokerParameter.Username, _authenticationRequestParameters.Account?.Username ?? string.Empty);
+            BrokerPayload.Add(BrokerParameter.Username, AuthenticationRequestParameters.Account?.Username ?? string.Empty);
             BrokerPayload.Add(BrokerParameter.ExtraOidcScopes, BrokerParameter.OidcScopesValue);
             BrokerPayload.Add(BrokerParameter.Prompt, _interactiveParameters.Prompt.PromptValue);
         }
-        
+
         internal void ValidateResponseFromBroker(MsalTokenResponse msalTokenResponse)
         {
-            _authenticationRequestParameters.RequestContext.Logger.Info(LogMessages.CheckMsalTokenResponseReturnedFromBroker);
+            AuthenticationRequestParameters.RequestContext.Logger.Info(LogMessages.CheckMsalTokenResponseReturnedFromBroker);
             if (msalTokenResponse.AccessToken != null)
             {
-                _authenticationRequestParameters.RequestContext.Logger.Info(
+                AuthenticationRequestParameters.RequestContext.Logger.Info(
                     LogMessages.BrokerResponseContainsAccessToken +
                     msalTokenResponse.AccessToken.Count());
                 return;
             }
             else if (msalTokenResponse.Error != null)
             {
-                _authenticationRequestParameters.RequestContext.Logger.Info(
+                AuthenticationRequestParameters.RequestContext.Logger.Info(
                     LogMessages.ErrorReturnedInBrokerResponse(msalTokenResponse.Error));
                 throw new MsalServiceException(msalTokenResponse.Error, MsalErrorMessage.BrokerResponseError + msalTokenResponse.ErrorDescription);
             }
             else
             {
-                _authenticationRequestParameters.RequestContext.Logger.Info(LogMessages.UnknownErrorReturnedInBrokerResponse);
+                AuthenticationRequestParameters.RequestContext.Logger.Info(LogMessages.UnknownErrorReturnedInBrokerResponse);
                 throw new MsalServiceException(MsalError.BrokerResponseReturnedError, MsalErrorMessage.BrokerResponseReturnedError, null);
             }
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -16,8 +16,6 @@ using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Client.TelemetryCore.Internal;
-using Microsoft.Identity.Client.TelemetryCore;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {
@@ -38,7 +36,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenInteractiveParameters interactiveParameters,
             IWebUI webUi)
-            : base(serviceBundle, authenticationRequestParameters, interactiveParameters)
+            : base(
+                  serviceBundle,
+                  authenticationRequestParameters,
+                  interactiveParameters)
         {
             _webUi = webUi; // can be null just to generate the authorization uri 
 
@@ -70,7 +71,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             if (AuthenticationRequestParameters.IsBrokerEnabled) // set by developer
             {
-                await ExecuteBrokerInteractiveRequestAsync(cancellationToken).ConfigureAwait(false);
+                _msalTokenResponse = await ExecuteBrokerInteractiveRequestAsync(cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -78,7 +79,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
                 if (IsBrokerInvocationRequired()) // if auth code is prefixed w/msauth, broker is required due to conditional access policies
                 {
-                    await ExecuteBrokerInteractiveRequestAsync(cancellationToken).ConfigureAwait(false);
+                    _msalTokenResponse = await ExecuteBrokerInteractiveRequestAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -97,12 +98,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 ServiceBundle,
                 AuthenticationRequestParameters,
                 _interactiveParameters,
-                _webUi,
-                broker);
+                broker,
+                _webUi);
 
             return await brokerInteractiveRequest.ExecuteBrokerAsync(cancellationToken).ConfigureAwait(false);
         }
-
 
         internal virtual async Task ExecuteAuthorizationAsync(CancellationToken cancellationToken)
         {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -14,12 +14,8 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.Instance.Discovery;
-using Microsoft.Identity.Json.Linq;
-using System.Text;
-using Microsoft.Identity.Json;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {

--- a/src/client/Microsoft.Identity.Client/LogMessages.cs
+++ b/src/client/Microsoft.Identity.Client/LogMessages.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Identity.Client
         public const string BrokerInvocationRequired = "Based on auth code received from STS, broker invocation is required. ";
         public const string AddBrokerInstallUrlToPayload = "Broker is required for authentication and broker is not installed on the device. " +
             "Adding BrokerInstallUrl to broker payload. ";
+        public const string UserPreviouslySignedInBrokerRequired = "User previously signed in and is required to domain join their device. ";
         public const string BrokerInvocationNotRequired = "Based on auth code received from STS, broker invocation is not required. ";
         public const string CanInvokeBrokerAcquireTokenWithBroker = "Can invoke broker. Will attempt to acquire token with broker. ";
         public const string AuthenticationWithBrokerDidNotSucceed = "Broker authentication did not succeed, or the broker install failed. " +

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
             try
             {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                new TaskFactory().StartNew(() => AcquireTokenInternalAsync(brokerPayload));
+                Task.Run(() => AcquireTokenInternalAsync(brokerPayload)).ConfigureAwait(false);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
             catch (Exception ex)
@@ -134,7 +134,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
                 return;
             }
 
-            if (resultCode != BrokerResponseCode.ResponseReceived)
+            if (resultCode != (int)BrokerResponseCode.ResponseReceived)
             {
                 _androidBrokerTokenResponse = new MsalTokenResponse
                 {

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
@@ -254,8 +254,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
 
             if (!string.Equals(computedRedirectUri, GetValueFromBrokerPayload(brokerPayload, BrokerParameter.RedirectUri), StringComparison.OrdinalIgnoreCase))
             {
-                //ADD Broker Error for redirect URI on android
-                string msg = string.Format(CultureInfo.CurrentCulture, MsalError.CannotInvokeBroker, computedRedirectUri);
+                string msg = string.Format(CultureInfo.CurrentCulture, "The broker redirect URI is incorrect, it should be {0}. Please visit https://aka.ms/Brokered-Authentication-for-Android for more details.", computedRedirectUri);
                 _logger.Info(msg);
                 throw new MsalClientException(MsalError.CannotInvokeBroker, msg);
             }

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AuthenticationContinuationHelper.cs
@@ -32,13 +32,15 @@ namespace Microsoft.Identity.Client
             var logger = MsalLogger.Create(Guid.Empty, null);
             logger.Info(string.Format(CultureInfo.InvariantCulture, "Received Activity Result({0})", (int)resultCode));
 
-                    AndroidBroker.SetBrokerResult(data, (int)resultCode);
-
-
             AuthorizationResult authorizationResult;
             if (data.Action != null && data.Action.Equals("ReturnFromEmbeddedWebview", StringComparison.OrdinalIgnoreCase))
             {
                 authorizationResult = ProcessFromEmbeddedWebview(requestCode, resultCode, data);
+            }
+            else if (!String.IsNullOrEmpty(data.GetStringExtra(BrokerConstants.BrokerResultV2)))
+            {
+                AndroidBroker.SetBrokerResult(data, (int)resultCode);
+                return;
             }
             else
             {
@@ -52,20 +54,14 @@ namespace Microsoft.Identity.Client
         {
             switch ((int)resultCode)
             {
-            case (int)Result.Ok:
-                return AuthorizationResult.FromUri(data.GetStringExtra("ReturnedUrl"));
+                case (int)Result.Ok:
+                    return AuthorizationResult.FromUri(data.GetStringExtra("ReturnedUrl"));
 
-            case (int)Result.Canceled:
-                return AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel);
-
-                case BrokerResponseCode.ResponseReceived:
-                case BrokerResponseCode.BrowserCodeError:
-                case BrokerResponseCode.UserCancelled:
-                    AndroidBroker.SetBrokerResult(data, (int)resultCode);
-                    return null;
+                case (int)Result.Canceled:
+                    return AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel);
 
                 default:
-                return AuthorizationResult.FromStatus(AuthorizationStatus.UnknownError);
+                    return AuthorizationResult.FromStatus(AuthorizationStatus.UnknownError);
             }
         }
 
@@ -73,14 +69,14 @@ namespace Microsoft.Identity.Client
         {
             switch ((int)resultCode)
             {
-            case AndroidConstants.AuthCodeReceived:
-                return AuthorizationResult.FromUri(data.GetStringExtra("com.microsoft.identity.client.finalUrl"));
+                case AndroidConstants.AuthCodeReceived:
+                    return AuthorizationResult.FromUri(data.GetStringExtra("com.microsoft.identity.client.finalUrl"));
 
-            case AndroidConstants.Cancel:
-                return AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel);
+                case AndroidConstants.Cancel:
+                    return AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel);
 
-            default:
-                return AuthorizationResult.FromStatus(AuthorizationStatus.UnknownError);
+                default:
+                    return AuthorizationResult.FromStatus(AuthorizationStatus.UnknownError);
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/BrokerResponseCode.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/BrokerResponseCode.cs
@@ -3,10 +3,10 @@
 
 namespace Microsoft.Identity.Client.Platforms.Android
 {
-    internal static class BrokerResponseCode
+    internal enum BrokerResponseCode
     {
-        public const int UserCancelled = 2001;
-        public const int BrowserCodeError = 2002;
-        public const int ResponseReceived = 2004;
+        UserCancelled = 2001,
+        BrowserCodeError = 2002,
+        ResponseReceived = 2004
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Identity.Test.Unit
                 IBroker broker = harness.ServiceBundle.PlatformProxy.CreateBroker(null);
                 BrokerInteractiveRequest brokerInteractiveRequest = 
                     new BrokerInteractiveRequest(
+                        harness.ServiceBundle,
                         parameters,
-                        interactiveParameters, 
-                        harness.ServiceBundle, 
+                        interactiveParameters,
                         null,
                         broker);
 
@@ -64,8 +64,6 @@ namespace Microsoft.Identity.Test.Unit
 
                 //Assert.AreEqual(TestConstants.BrokerClaims, brokerInteractiveRequest._brokerPayload[BrokerParameter.Claims]); //TODO
                 Assert.AreEqual(BrokerParameter.OidcScopesValue, brokerInteractiveRequest.BrokerPayload[BrokerParameter.ExtraOidcScopes]);
-
-
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/BrokerParametersTest.cs
@@ -7,8 +7,9 @@ using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client;
 using System;
-using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Test.Common.Mocks;
+using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Test.Unit
 {
@@ -33,6 +34,11 @@ namespace Microsoft.Identity.Test.Unit
 
                 AcquireTokenInteractiveParameters interactiveParameters = new AcquireTokenInteractiveParameters();
 
+                MockWebUI ui = new MockWebUI()
+                {
+                    MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?code=some-code")
+                };
+
                 // Act
                 IBroker broker = harness.ServiceBundle.PlatformProxy.CreateBroker(null);
                 BrokerInteractiveRequest brokerInteractiveRequest = 
@@ -40,8 +46,8 @@ namespace Microsoft.Identity.Test.Unit
                         harness.ServiceBundle,
                         parameters,
                         interactiveParameters,
-                        null,
-                        broker);
+                        broker, 
+                        ui);
 
                 brokerInteractiveRequest.CreateRequestParametersForBroker();
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
@@ -3,20 +3,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Test.Common.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Test.Unit.RequestsTests
 {
@@ -98,6 +97,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
+
+
         public void BrokerInteractiveRequestTest()
         {
             string CanonicalizedAuthority = AuthorityInfo.CanonicalizeAuthorityUri(CoreHelpers.UrlDecode(TestConstants.AuthorityTestTenant));
@@ -116,9 +117,9 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 IBroker broker = harness.ServiceBundle.PlatformProxy.CreateBroker(null);
                 _brokerInteractiveRequest =
                     new BrokerInteractiveRequest(
-                        parameters,
-                        null,
                         harness.ServiceBundle,
+                        parameters,
+                        new AcquireTokenInteractiveParameters(),
                         null,
                         broker);
                 Assert.AreEqual(false, _brokerInteractiveRequest.Broker.CanInvokeBroker());
@@ -153,6 +154,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 AssertException.TaskThrowsAsync<PlatformNotSupportedException>(() => _brokerSilentRequest.Broker.AcquireTokenUsingBrokerAsync(new Dictionary<string, string>())).ConfigureAwait(false);
             }
         }
+
+        [TestMethod]
+        [Description(".WithBroker(true), but broker not installed on the device. Device auth required, but not work place joined")]
+        public void WithBrokerTrueButNotInstalled_DeviceAuthRequired_BrokerInstallInvoked()
+        {
+
+        }
+
 
         private void ValidateBrokerResponse(MsalTokenResponse msalTokenResponse, Action<Exception> validationHandler)
         {
@@ -206,9 +215,9 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 IBroker broker = harness.ServiceBundle.PlatformProxy.CreateBroker(null);
                 _brokerInteractiveRequest =
                     new BrokerInteractiveRequest(
+                        harness.ServiceBundle,
                         parameters,
                         interactiveParameters,
-                        harness.ServiceBundle,
                         null,
                         broker);
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
@@ -113,6 +113,11 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     null,
                     TestConstants.s_extraQueryParams);
 
+                MockWebUI ui = new MockWebUI()
+                {
+                    MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?code=some-code")
+                };
+
                 // Act
                 IBroker broker = harness.ServiceBundle.PlatformProxy.CreateBroker(null);
                 _brokerInteractiveRequest =
@@ -120,8 +125,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         harness.ServiceBundle,
                         parameters,
                         new AcquireTokenInteractiveParameters(),
-                        null,
-                        broker);
+                        broker,
+                        ui);
                 Assert.AreEqual(false, _brokerInteractiveRequest.Broker.CanInvokeBroker());
                 AssertException.TaskThrowsAsync<PlatformNotSupportedException>(() => _brokerInteractiveRequest.Broker.AcquireTokenUsingBrokerAsync(new Dictionary<string, string>())).ConfigureAwait(false);
             }
@@ -212,14 +217,19 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     interactiveParameters,
                     new MockWebUI());
 
+                MockWebUI ui = new MockWebUI()
+                {
+                    MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?code=some-code")
+                };
+
                 IBroker broker = harness.ServiceBundle.PlatformProxy.CreateBroker(null);
                 _brokerInteractiveRequest =
                     new BrokerInteractiveRequest(
                         harness.ServiceBundle,
                         parameters,
                         interactiveParameters,
-                        null,
-                        broker);
+                        broker,
+                        ui);
 
                 _brokerSilentRequest =
                     new BrokerSilentRequest(

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/InteractiveRequestTests.cs
@@ -201,19 +201,16 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
                 MockWebUI ui = new MockWebUI()
                 {
                     // When the auth code is returned from the authorization server prefixed with msauth:// 
                     // and then a url. MSAL will look for app_link, then go to the App Store to download the Authentiator App
-                    // The user who logged requires cert based auth and broker
+                    // The user who logged in requires cert based auth and broker
                     MockResult = AuthorizationResult.FromUri(
-                        TestConstants.AuthorityHomeTenant + 
-                        "?code=msauth://wpj?username=idlabmamca%40msidlab4.onmicrosoft.com&app_link=itms%3a%2f%2fitunes.apple.com%2fapp%2fazure-authenticator%2fid983156458%3fmt%3d8")
+                        "msauth://wpj?username=idlabmamca%40msidlab4.onmicrosoft.com&app_link=itms%3a%2f%2fitunes.apple.com%2fapp%2fazure-authenticator%2fid983156458%3fmt%3d8")
                 };
-
-                MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
-
-                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityHomeTenant);
 
                 harness.ServiceBundle.PlatformProxy.SetBrokerForTest(CreateMockBroker());
 
@@ -231,7 +228,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 AuthenticationResult result = await request.RunAsync(CancellationToken.None).ConfigureAwait(false);
                 Assert.IsNotNull(result);
-                Assert.AreEqual("some-access-token", result.AccessToken);
+                Assert.AreEqual("access-token", result.AccessToken);
             }
         }
 


### PR DESCRIPTION
fix null ref when .WithBroker(true) but broker not installed
fix wpj requirement from auth code

Mainly review these two classes:  `InteractiveRequest` and `BrokerInteractiveRequest` classes and `ExecuteAsync()` and `SendTokenRequestToBrokerAsync()` in the broker interactive request

**Test cases for iOS Broker:**
- Developer sets `.WithBroker(true)`
User logs in to app.
Broker is not installed on device.
User is presented with regular auth flow and signs in.

- WPJ requirement - broker not installed
User logs into app
User is presented with regular auth flow
Auth code is returned like this: `msauth://wpj?username=idlabmamca%40msidlab4.onmicrosoft.com&app_link=itms%3a%2f%2fitunes.apple.com%2fapp%2fazure-authenticator%2fid983156458%3fmt%3d8`
MSAL will open the broker in the AppStore
>This scenario does not work. ests does not have xamarin ios/android on it's list of supporting MAM, so you have to replace the auth code w/the above to test the experience, as we are currently presented with the wrong log-in screen

- WPJ requirement - broker installed
User logs into app
User is presented with regular auth flow
Auth code is returned like this: `msauth://wpj?username=idlabmamca%40msidlab4.onmicrosoft.com&app_link=itms%3a%2f%2fitunes.apple.com%2fapp%2fazure-authenticator%2fid983156458%3fmt%3d8`
User logs in via broker

- Interactive LogIn (no broker)
User logs in to app.
User is presented with regular auth flow and signs in.

**Test Cases for Android Broker (@trwalke to add them here):**
