### PR TITLE
Adding an aka.ms link (for first party partners) to the XML doc for WithSendX5C.

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation)
+        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation)
+        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation)
+        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation)
+        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation)
+        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>


### PR DESCRIPTION
This is solving https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1568