### PR TITLE
fix encoding the redirecturi when a "/" is present for android broker…

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
@@ -363,8 +363,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
         private string GetEncodedRedirectUri(string redirectUri)
         {
             Uri uri = new Uri(redirectUri);
-            var test = "msauth://" + uri.Host + "/" + System.Net.WebUtility.UrlEncode(uri.AbsolutePath.Split('/')[1]);
-            return "msauth://" + uri.Host + "/" + System.Net.WebUtility.UrlEncode(uri.AbsolutePath.Split('/')[1]);
+            return "msauth://" + uri.Host + "/" + System.Net.WebUtility.UrlEncode(uri.AbsolutePath.Substring(1));
         }
 
         private Bundle GetBrokerAccountBundle(IDictionary<string, string> brokerPayload)


### PR DESCRIPTION
… scenarios

I didn't write a test because it's in the android code, so i made a little console app to test it.

```csharp
static void Main(string[] args)
{
    Console.WriteLine("Cats rule the world.\n");

    string redirectUrlWithSlash = "msauth://com.companyname.xamarindev/t+Bk/nrTiK6yhmUDgd80TS5ZZT8=";

    string redirectUriWithoutSlash = "msauth://com.companyname.xamarindev/t+BsfnrTiK6yhmUDgd80TS5ZZT8=";

    Console.WriteLine("These are the redirect URIs before URLEncoding:\n{0}\n{1}\n\n", redirectUrlWithSlash, redirectUriWithoutSlash);

    Console.WriteLine("This Method does not work:\nThis RedirectUri has a slash:\n {0}\n" +
        "This one does not:\n {1}\n\n", GetEncodedRedirectUriDoesNotWork(redirectUrlWithSlash), GetEncodedRedirectUriDoesNotWork(redirectUriWithoutSlash));
           
    Console.WriteLine("This Method does work:\nThis RedirectUri has a slash:\n {0}\n" +
        "This one does not:\n {1}", GetEncodedRedirectUri(redirectUrlWithSlash), GetEncodedRedirectUri(redirectUriWithoutSlash));
    Console.ReadLine();
}

private static string GetEncodedRedirectUriDoesNotWork(string redirectUri)
{
    Uri uri = new Uri(redirectUri);
    return "msauth://" + uri.Host + "/" + System.Net.WebUtility.UrlEncode(uri.AbsolutePath.Split('/')[1]);
}

private static string GetEncodedRedirectUri(string redirectUri)
{
    Uri uri = new Uri(redirectUri);
    return "msauth://" + uri.Host + "/" + System.Net.WebUtility.UrlEncode(uri.AbsolutePath.Substring(1));
}
```