### PR TITLE
Removing unneeded semaphore release

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
@@ -145,9 +145,6 @@ namespace Microsoft.Identity.Client.Platforms.Android
             catch (Exception ex)
             {
                 _logger.ErrorPiiWithPrefix(ex, "Broker invocation failed.");
-
-
-                s_readyForResponse.Release();
                 throw;
             }
 


### PR DESCRIPTION
Removing unneeded semaphore as it has the potential to cause threading issues in the future.