### PR TITLE
Enabling the Remove account api on MSAL for andorid broker

### DIFF
--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Identity.Client
             if (AppConfig.IsBrokerEnabled && ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth())
             {
                 var broker = ServiceBundle.PlatformProxy.CreateBroker(null);
-                broker.RemoveAccountAsync(AppConfig.ClientId, account);
+                await broker.RemoveAccountAsync(AppConfig.ClientId, account).ConfigureAwait(false);
                 return;
             }
 

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -88,7 +88,6 @@ namespace Microsoft.Identity.Client
             RequestContext requestContext = CreateRequestContext(Guid.NewGuid());
             IEnumerable<IAccount> accounts = Enumerable.Empty<IAccount>();
 
-
             if (AppConfig.IsBrokerEnabled && ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth())
             {
                 var broker = ServiceBundle.PlatformProxy.CreateBroker(null);
@@ -137,6 +136,13 @@ namespace Microsoft.Identity.Client
         /// <param name="account">Instance of the account that needs to be removed</param>
         public async Task RemoveAsync(IAccount account)
         {
+            if (AppConfig.IsBrokerEnabled && ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth())
+            {
+                var broker = ServiceBundle.PlatformProxy.CreateBroker(null);
+                broker.RemoveAccountAsync(AppConfig.ClientId, account);
+                return;
+            }
+
             RequestContext requestContext = CreateRequestContext(Guid.NewGuid());
             if (account != null && UserTokenCacheInternal != null)
             {

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
@@ -14,7 +14,11 @@ namespace Microsoft.Identity.Client.Internal.Broker
 
         Task<MsalTokenResponse> AcquireTokenUsingBrokerAsync(Dictionary<string, string> brokerPayload);
 
-        //This method is only available to brokers that have the BrokerSupportsSilentFlow flag enabled
+        //These methods are only available to brokers that have the BrokerSupportsSilentFlow flag enabled
+        #region Silent Flow Methods
         Task<IEnumerable<IAccount>> GetAccountsAsync(string clientID);
+
+        void RemoveAccountAsync(string clientID, IAccount account);
+        #endregion Silent Flow Methods
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
         #region Silent Flow Methods
         Task<IEnumerable<IAccount>> GetAccountsAsync(string clientID);
 
-        void RemoveAccountAsync(string clientID, IAccount account);
+        Task RemoveAccountAsync(string clientID, IAccount account);
         #endregion Silent Flow Methods
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             throw new PlatformNotSupportedException(MsalErrorMessage.BrokerNotSupportedOnThisPlatform);
         }
 
-        public void RemoveAccountAsync(string clientID, IAccount account)
+        public Task RemoveAccountAsync(string clientID, IAccount account)
         {
             throw new NotImplementedException(MsalErrorMessage.BrokerNotSupportedOnThisPlatform);
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
@@ -28,5 +28,10 @@ namespace Microsoft.Identity.Client.Internal.Broker
         {
             throw new PlatformNotSupportedException(MsalErrorMessage.BrokerNotSupportedOnThisPlatform);
         }
+
+        public void RemoveAccountAsync(string clientID, IAccount account)
+        {
+            throw new NotImplementedException(MsalErrorMessage.BrokerNotSupportedOnThisPlatform);
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
@@ -254,6 +254,33 @@ namespace Microsoft.Identity.Client.Platforms.Android
             }
         }
 
+        public async void RemoveAccountAsync(string clientID, IAccount account)
+        {
+            if (!CanInvokeBroker())
+            {
+                _logger.Error("Android broker is not installed so no accounts will be removed.");
+                return;
+            }
+
+            Dictionary<string, string> brokerPayload = new Dictionary<string, string>();
+            brokerPayload.Add(BrokerParameter.ClientId, clientID);
+            brokerPayload.Add(BrokerConstants.Environment, account.Environment);
+            brokerPayload.Add(BrokerParameter.HomeAccountId, account.HomeAccountId.Identifier);
+
+            try
+            {
+                await _brokerHelper.InitiateBrokerHandshakeAsync(_activity).ConfigureAwait(false);
+
+                _brokerHelper.RemoveBrokerAccountInAccountManager(brokerPayload);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Failed to remove Android broker account from the broker.");
+                HandleBrokerOperationError(ex);
+                throw;
+            }
+        }
+
         private void HandleBrokerOperationError(Exception ex)
         {
             _logger.Error(MsalErrorMessage.AndroidBrokerCannotBeInvoked);

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBroker.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
             }
         }
 
-        public async void RemoveAccountAsync(string clientID, IAccount account)
+        public async Task RemoveAccountAsync(string clientID, IAccount account)
         {
             if (!CanInvokeBroker())
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
@@ -274,8 +274,6 @@ namespace Microsoft.Identity.Client.Platforms.Android
                 null,
                 null,
                 GetPreferredLooper(null));
-
-            Bundle bundleResult = (Bundle)result?.Result;
         }
 
         //Inorder for broker to use the V2 endpoint during authentication, MSAL must initiate a handshake with broker to specify what endpoint should be used for the request.

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
@@ -262,6 +262,22 @@ namespace Microsoft.Identity.Client.Platforms.Android
             return brokerAccounts;
         }
 
+        public void RemoveBrokerAccountInAccountManager(IDictionary<string, string> brokerPayload)
+        {
+            Bundle removeAccountBundle = GetRemoveBrokerAccountBundle(brokerPayload);
+            removeAccountBundle.PutString(BrokerConstants.BrokerAccountManagerOperationKey, BrokerConstants.RemoveAccount);
+
+            var result = _androidAccountManager.AddAccount(BrokerConstants.BrokerAccountType,
+                BrokerConstants.AuthtokenType,
+                null,
+                removeAccountBundle,
+                null,
+                null,
+                GetPreferredLooper(null));
+
+            Bundle bundleResult = (Bundle)result?.Result;
+        }
+
         //Inorder for broker to use the V2 endpoint during authentication, MSAL must initiate a handshake with broker to specify what endpoint should be used for the request.
         public async Task InitiateBrokerHandshakeAsync(Activity callerActivity)
         {
@@ -437,6 +453,17 @@ namespace Microsoft.Identity.Client.Platforms.Android
             bundle.PutString(BrokerConstants.AccountClientIdKey, GetValueFromBrokerPayload(brokerPayload, BrokerParameter.ClientId));
             bundle.PutString(BrokerConstants.AccountRedirect, GetValueFromBrokerPayload(brokerPayload, BrokerParameter.ClientId));
             bundle.PutInt(BrokerConstants.CallerInfoUID, Binder.CallingUid);
+
+            return bundle;
+        }
+
+        private Bundle GetRemoveBrokerAccountBundle(IDictionary<string, string> brokerPayload)
+        {
+            Bundle bundle = new Bundle();
+
+            bundle.PutString(BrokerConstants.AccountClientIdKey, GetValueFromBrokerPayload(brokerPayload, BrokerParameter.ClientId));
+            bundle.PutString(BrokerConstants.Environment, GetValueFromBrokerPayload(brokerPayload, BrokerConstants.Environment));
+            bundle.PutString(BrokerConstants.HomeAccountIDKey, GetValueFromBrokerPayload(brokerPayload, BrokerParameter.HomeAccountId));
 
             return bundle;
         }

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/BrokerConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/BrokerConstants.cs
@@ -109,7 +109,12 @@ namespace Microsoft.Identity.Client.Platforms.Android
         public const string ChallangeResponseVersion = "Version";
 
         public const string ResponseErrorCode = "com.microsoft.aad.adal:BrowserErrorCode";
+
         public const string ResponseErrorMessage = "com.microsoft.aad.adal:BrowserErrorMessage";
+
+        public const string HomeAccountIDKey = "account.home.account.id";
+
+        public const string Environment = "environment";
 
 
         /**
@@ -160,6 +165,8 @@ namespace Microsoft.Identity.Client.Platforms.Android
         public const string BrokerAccounts = "broker_accounts";
 
         public const string CommonProtocolVersion = "common.protocol.version";
+
+        public const string RemoveAccount = "REMOVE_ACCOUNT";
 
         // Claims step-up. Skip cache look up
         public const string SkipCache = "skip.cache";

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             throw new NotImplementedException();
         }
 
-        public void RemoveAccountAsync(string clientID, IAccount account)
+        public Task RemoveAccountAsync(string clientID, IAccount account)
         {
             throw new NotImplementedException();
         }

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSBroker.cs
@@ -308,5 +308,10 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         {
             throw new NotImplementedException();
         }
+
+        public void RemoveAccountAsync(string clientID, IAccount account)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
@@ -167,7 +167,18 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        public async Task GetAccountsAsync()
+        public void BrokerRemoveAccountAsyncOnUnsupportedPlatformTest()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                IBroker broker = harness.ServiceBundle.PlatformProxy.CreateBroker(null);
+
+                AssertException.TaskThrowsAsync<PlatformNotSupportedException>(() => broker.RemoveAccountAsync(TestConstants.ClientId, new Account("test", "test", "test"))).ConfigureAwait(false);
+            }
+        }
+
+        [TestMethod]
+        public async Task BrokerGetAccountsTestAsync()
         {
             // Arrange
             var mockBroker = Substitute.For<IBroker>();


### PR DESCRIPTION
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1676

