### PR TITLE
Fix for #1708 - use token_endpoint as issuer and x5t in header

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
@@ -79,10 +79,11 @@ namespace Microsoft.Identity.Client.Instance
             string authorizationEndpoint = ReplaceTenantToken(edr.AuthorizationEndpoint, tenantId);
             string tokenEndpoint = ReplaceTenantToken(edr.TokenEndpoint, tenantId);
 
+            //string issuer = edr.Issuer; // not used
             endpoints = new AuthorityEndpoints(
                 authorizationEndpoint,
                 tokenEndpoint,
-                GetSelfSignedJwtAudience(edr.Issuer, tokenEndpoint, tenantId, authorityInfo.AuthorityType));
+                tokenEndpoint);
 
             Add(authorityInfo, userPrincipalName, endpoints);
             return endpoints;

--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
@@ -79,7 +79,6 @@ namespace Microsoft.Identity.Client.Instance
             string authorizationEndpoint = ReplaceTenantToken(edr.AuthorizationEndpoint, tenantId);
             string tokenEndpoint = ReplaceTenantToken(edr.TokenEndpoint, tenantId);
 
-            //string issuer = edr.Issuer; // not used
             endpoints = new AuthorityEndpoints(
                 authorizationEndpoint,
                 tokenEndpoint,

--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityEndpointResolutionManager.cs
@@ -89,19 +89,6 @@ namespace Microsoft.Identity.Client.Instance
             return endpoints;
         }
 
-        // Used in WithCertificate to create an audience claim in JWT sent by MSAL to EVO
-        // ADAL uses the token endpoint as audience (tenanted or not)
-        // MSAL had been using the issuer, which does not work when tenantnless. But continue to use issuer for ADFS and B2C.
-        private static string GetSelfSignedJwtAudience(string issuer, string tokenEndpoint, string tenantId, AuthorityType authorityType)
-        {
-            if (authorityType == AuthorityType.Aad)
-            {
-                return tokenEndpoint;
-            }
-
-            return ReplaceTenantToken(issuer, tenantId);
-        }
-
         private static string ReplaceTenantToken(string template, string tenantId)
         {
             // some templates use {tenant}, some {tenantid}

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Identity.Client.Internal
 #endif
             }
 
-            [JsonProperty(PropertyName = JsonWebTokenConstants.ReservedHeaderParameters.X5T)]
+            [JsonProperty(PropertyName = JsonWebTokenConstants.ReservedHeaderParameters.X509CertificateThumbprint)]
             public string X509CertificateThumbprint { get; set; }
 
             [JsonProperty(

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -191,6 +191,11 @@ namespace Microsoft.Identity.Client.Internal
                 : base(credential)
             {
                 X509CertificateThumbprint = Credential.Thumbprint;
+                if (Credential?.Certificate?.Thumbprint != null)
+                {
+                    X509CertificateKeyId = Credential.Certificate.Thumbprint;
+                }
+
                 X509CertificatePublicCertValue = null;
 
                 if (!sendCertificate)
@@ -205,8 +210,24 @@ namespace Microsoft.Identity.Client.Internal
 #endif
             }
 
+            /// <summary>
+            /// x5t = base64 url encoded cert thumbprint 
+            /// </summary>
+            /// <remarks>
+            /// Mandatory for ADFS 2019
+            /// </remarks>
             [JsonProperty(PropertyName = JsonWebTokenConstants.ReservedHeaderParameters.X509CertificateThumbprint)]
             public string X509CertificateThumbprint { get; set; }
+
+            /// <summary>
+            /// kid (key id) = cert thumbprint
+            /// </summary>
+            /// <remarks>
+            /// Key Id is an optional param, but recommended. Wilson adds both kid and x5t to JWT header
+            /// </remarks>
+            [JsonProperty(PropertyName = JsonWebTokenConstants.ReservedHeaderParameters.KeyId, 
+                DefaultValueHandling = DefaultValueHandling.Ignore)]
+            public string X509CertificateKeyId { get; set; }
 
             [JsonProperty(
                 PropertyName = JsonWebTokenConstants.ReservedHeaderParameters.X509CertificatePublicCertValue, 

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Identity.Client.Internal
 #endif
             }
 
-            [JsonProperty(PropertyName = JsonWebTokenConstants.ReservedHeaderParameters.KeyId)]
+            [JsonProperty(PropertyName = JsonWebTokenConstants.ReservedHeaderParameters.X5T)]
             public string X509CertificateThumbprint { get; set; }
 
             [JsonProperty(

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebTokenConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebTokenConstants.cs
@@ -45,10 +45,7 @@ namespace Microsoft.Identity.Client.Internal
             /// </summary>
             public const string KeyId = "kid";
 
-            /// <summary>
-            /// 
-            /// </summary>
-            public const string X5T = "x5t";
+            public const string X509CertificateThumbprint = "x5t";
 
             public const string X509CertificatePublicCertValue = "x5c";
         }

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebTokenConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebTokenConstants.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Identity.Client.Internal
             /// </summary>
             public const string KeyId = "kid";
 
+            /// <summary>
+            /// 
+            /// </summary>
+            public const string X5T = "x5t";
+
             public const string X509CertificatePublicCertValue = "x5c";
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/B2cAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/InstanceTests/B2cAuthorityTests.cs
@@ -99,7 +99,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 Assert.AreEqual(
                     "https://sometenantid.b2clogin.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/policy/oauth2/v2.0/token",
                     endpoints.TokenEndpoint);
-                Assert.AreEqual("https://sometenantid.b2clogin.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/v2.0/", endpoints.SelfSignedJwtAudience);
+                Assert.AreEqual("https://sometenantid.b2clogin.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/policy/oauth2/v2.0/token", 
+                    endpoints.SelfSignedJwtAudience);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/UtilTests/JsonHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/UtilTests/JsonHelperTests.cs
@@ -177,7 +177,8 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
             string expectedHeader = @"{
                                        ""alg"": ""RS256"",
                                        ""typ"": ""JWT"",
-                                       ""kid"": ""lJjBuRyk8s_-oQxT3MgwH5qNS94"",
+                                       ""x5t"": ""lJjBuRyk8s_-oQxT3MgwH5qNS94"",
+                                       ""kid"": ""9498C1B91CA4F2CFFEA10C53DCC8301F9A8D4BDE"",
                                        ""x5c"": ""MIIDJDCCAgygAwIBAgIQK4SCZgh/R5anP05v4z6VLjANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE5MDgxNTE3MjY1M1oXDTIwMDgxNTE3MzY1M1owDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIxSuzLrpxnq44CSux3l2UMvIBwBXnh4tmmZtju4qCNJzVmCrhyC9i5jH7YCicXeFQChWfbZpyo2TpDD/cTw+Rpi9QLhhGvDnMF+uk1pqSp5Fdh11YacX7w76Wc7Er+FM2PiKtyDX6+nFzUvV3SfjfdcAadConDAWOdmpd34UNZ/DzM6dRKynWuaE+0kD843Tr+pCXlMGQBAQatWyROK+rgOKhnv1/vMAZ90SCjxAhnjxj+9GRIGYzonuTa+EOqXRn1XQ+j54Ux953Oq0zGCNbXndGjGKH1U1JP/nAemFsh0h2DcdAdEkxOS3+QrdiZEkPPfe8x5BLJmvoRWJ9eCAT0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFB03ltXqrZeIzolZQj8w98DG8HCIMB0GA1UdDgQWBBQdN5bV6q2XiM6JWUI/MPfAxvBwiDANBgkqhkiG9w0BAQsFAAOCAQEAiXAQHHWiJ+8wLk0evDZSXDfQ0brYsKLimxJSrVOzpz4BnHTIr86ZEYA6jCKNfhRnrPU9HQ43CUSU1MRX03ovdJMoYjuWCGAFlZrYMC9PhPwt2B0a3DRl0wsl3jxOYYrFHonBWvjDFdWEP2Nr2T8iWPgpS5uIdgU1GqN9EbI+3B46qH4rTH3vAwpeF38XDjBO8DYycotwG34zgD2zQ2ZoPmQG07Y8rjBo+JW56ri3RfeMu3kZVfM359JXzQhw+L8PDY8MVhltiZ1ufvKS6F5vAZYLUXUGtVmlS7mLgNJKvJN9fxd1BlZdqfD3+o4xBUGVCjS3HR/7NJBl/pPHZtKckQ==""
                                     }";
 


### PR DESCRIPTION
This fixes the ADFS + confidential client scenario

Tested on an Azure Stack env which uses ADFS 2019. 

Needs an integration test, for which I am discussing with the lab team. Will follow up separately. 