### PR TITLE
Jennyf/ios broker key fix

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/BrokerKeyHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/BrokerKeyHelper.cs
@@ -5,7 +5,6 @@ using Foundation;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Utils;
 using Security;
-using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
 
@@ -54,15 +53,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             {
                 brokerKey = key.ToArray();
             }
-            if (brokerKey == null)
-            {
-                logger.Info("broker key is null. ");                
-            }
-            else
-            {
-                logger.Info("broker key is not null. returning. ");
-               
-            }
+
             return brokerKey;
         }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/BrokerKeyHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/BrokerKeyHelper.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             byte[] brokerKey = null;
             SecRecord record = new SecRecord(SecKind.GenericPassword)
             {
-                Generic = NSData.FromString(iOSBrokerConstants.LocalSettingsContainerName),
+                Account = iOSBrokerConstants.BrokerKeyAccount,
                 Service = iOSBrokerConstants.BrokerKeyService
             };
 

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/BrokerKeyHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/BrokerKeyHelper.cs
@@ -19,16 +19,14 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             SecRecord record = new SecRecord(SecKind.GenericPassword)
             {
                 Generic = NSData.FromString(iOSBrokerConstants.LocalSettingsContainerName),
-                Service = iOSBrokerConstants.BrokerKeyService,
-                Account = iOSBrokerConstants.BrokerKeyAccount,
-                Label = iOSBrokerConstants.BrokerKeyLabel,
-                Comment = iOSBrokerConstants.BrokerKeyComment,
-                Description = iOSBrokerConstants.BrokerKeyStorageDescription
+                Service = iOSBrokerConstants.BrokerKeyService
             };
 
             NSData key = SecKeyChain.QueryAsData(record);
             if (key == null)
             {
+                logger.Info("Attempted to query the keychain returned a null NSData key. ");
+
                 AesManaged algo = new AesManaged();
                 algo.GenerateKey();
                 byte[] rawBytes = algo.Key;
@@ -56,7 +54,15 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             {
                 brokerKey = key.ToArray();
             }
-
+            if (brokerKey == null)
+            {
+                logger.Info("broker key is null. ");                
+            }
+            else
+            {
+                logger.Info("broker key is not null. returning. ");
+               
+            }
             return brokerKey;
         }
 


### PR DESCRIPTION
When migrating an app from ADAL to MSAL, customers can hit this issue:
```System.Security.Cryptography.CryptographicException: Bad PKCS7 padding. Invalid length 0.
  at Crimson.CommonCrypto.FastCryptorTransform.ThrowBadPaddingException (System.Security.Cryptography.PaddingMode padding, System.Int32 length, System.Int32 position) [0x00047] in /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/src/Xamarin.iOS/mcs/class/corlib/CommonCrypto/FastCryptorTransform.cs:198 
  at Crimson.CommonCrypto.FastCryptorTransform.FinalDecrypt (System.Byte[] 
```
Why? Because ADAL uses the Generic settings name: `LocalSettingsContainerName = "ActiveDirectoryAuthenticationLibrary"`

but MSAL uses `LocalSettingsContainerName = "MicrosoftIdentityClient";`, which means when querying the keychain in BrokerKeyHelper, the key is not valid, as it can't find the entry. 

Fix is to only query by Service and Account, which will find the ADAL entry. 