### PR TITLE
Add CodeQL Analysis workflow

### DIFF
--- a/.github/workflows/workflows/codeql.yml
+++ b/.github/workflows/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "Code Scanning - Action"
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  CodeQL-Build:
+
+    strategy:
+      fail-fast: false
+
+
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # Override language selection by uncommenting this and choosing your languages
+      # with:
+      #   languages: go, javascript, csharp, python, cpp, java
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below).
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs CodeQL on every push, and on a daily schedule.

Code scanning looks for vulnerabilities, such as XSS, SQL injection, etc., in your code. If it finds any new vulnerabilities it surfaces them in the PR as check annotations, and blocks the build until they’re fixed or marked as false positives. If it finds any on the repo’s default branch it displays them in the [security tab](../security/code-scanning).

For now you also need to be feature flagged individually to see results in the security tab (as well as having write permission on this repo) - if you drop an email to jhutchings1@github.com I can get anyone you need added. 

Finally, this is an early access program that has not been released yet, so please don't share before May 6th when we’re unveiling it at GitHub Satellite.

Cc: @greysteil
