### PR TITLE
fix enum default value for `ConfidentialClientAuthenticationType`

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
@@ -143,6 +143,13 @@ namespace Microsoft.Identity.Client.Internal
             {
                 AuthenticationType = ConfidentialClientAuthenticationType.SignedClientAssertion;
             }
+
+            if (AuthenticationType == ConfidentialClientAuthenticationType.None)
+            {
+                throw new MsalClientException(
+                    MsalError.ClientCredentialAuthenticationTypeMustBeDefined,
+                    MsalErrorMessage.ClientCredentialAuthenticationTypeMustBeDefined);
+            }
         }
 
         internal byte[] Sign(ICryptographyManager cryptographyManager, string message)
@@ -168,6 +175,7 @@ namespace Microsoft.Identity.Client.Internal
 
     internal enum ConfidentialClientAuthenticationType
     {
+        None,
         ClientCertificate,
         ClientCertificateWithClaims,
         ClientSecret,

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -614,6 +614,11 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string ClientCredentialAuthenticationTypesAreMutuallyExclusive = "Client_Credential_Authentication_Types_Are_Mutually_Exclusive";
 
+        /// <summary>
+        /// <para>What happens?</para>You configured MSAL confidential client authentication without an authentication type (Certificate, Secret, Client Assertion)
+        /// </summary>
+        public const string ClientCredentialAuthenticationTypeMustBeDefined = "Client_Credential_Authentication_Type_Must_Be_Defined";
+
         #region InvalidGrant suberrors
         /// <summary>
         /// Issue can be resolved by user interaction during the interactive authentication flow.

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -616,7 +616,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// <para>What happens?</para>You configured MSAL confidential client authentication without an authentication type (Certificate, Secret, Client Assertion)
-        /// <para>Mitigation>/para>Either call <see cref="ConfidentialClientApplicationBuilder.WithClientSecret">, <see cref="ConfidentialClientApplicationBuilder.WithCertificate"> or <see cref="ConfidentialClientApplicationBuilder.WithClientAssertion">.
+        /// <para>Mitigation</para>Either call <see cref="ConfidentialClientApplicationBuilder.WithClientSecret"/>, <see cref="ConfidentialClientApplicationBuilder.WithCertificate"/> or <see cref="ConfidentialClientApplicationBuilder.WithClientAssertion"/>.
         /// </summary>
         public const string ClientCredentialAuthenticationTypeMustBeDefined = "Client_Credential_Authentication_Type_Must_Be_Defined";
 

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -616,6 +616,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// <para>What happens?</para>You configured MSAL confidential client authentication without an authentication type (Certificate, Secret, Client Assertion)
+        /// <para>Mitigation>/para>Either call <see cref="ConfidentialClientApplicationBuilder.WithClientSecret">, <see cref="ConfidentialClientApplicationBuilder.WithCertificate"> or <see cref="ConfidentialClientApplicationBuilder.WithClientAssertion">.
         /// </summary>
         public const string ClientCredentialAuthenticationTypeMustBeDefined = "Client_Credential_Authentication_Type_Must_Be_Defined";
 

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -618,7 +618,7 @@ namespace Microsoft.Identity.Client
         /// <para>What happens?</para>You configured MSAL confidential client authentication without an authentication type (Certificate, Secret, Client Assertion)
         /// <para>Mitigation</para>Either call <see cref="ConfidentialClientApplicationBuilder.WithClientSecret"/>, <see cref="ConfidentialClientApplicationBuilder.WithCertificate"/> or <see cref="ConfidentialClientApplicationBuilder.WithClientAssertion"/>.
         /// </summary>
-        public const string ClientCredentialAuthenticationTypeMustBeDefined = "Client_Credential_Authentication_Type_Must_Be_Defined";
+        public const string ClientCredentialAuthenticationTypeMustBeDefined = "Client_Credentials_Required_In_Confidential_Client_Application";
 
         #region InvalidGrant suberrors
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -616,7 +616,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// <para>What happens?</para>You configured MSAL confidential client authentication without an authentication type (Certificate, Secret, Client Assertion)
-        /// <para>Mitigation</para>Either call <see cref="ConfidentialClientApplicationBuilder.WithClientSecret"/>, <see cref="ConfidentialClientApplicationBuilder.WithCertificate"/> or <see cref="ConfidentialClientApplicationBuilder.WithClientAssertion"/>.
+        /// <para>Mitigation</para>Either call ConfidentialClientApplicationBuilder.WithClientSecret, ConfidentialClientApplicationBuilder.WithCertificate, ConfidentialClientApplicationBuilder.WithClientAssertion
         /// </summary>
         public const string ClientCredentialAuthenticationTypeMustBeDefined = "Client_Credentials_Required_In_Confidential_Client_Application";
 

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Identity.Client
             "ConfidentialClientApplication implementation does not implement IConfidentialClientApplicationExecutor.";
 
         public const string ClientCredentialAuthenticationTypesAreMutuallyExclusive = "ClientSecret, Certificate and ClientAssertion are mutually exclusive properties. Only specify one. See https://aka.ms/msal-net-client-credentials";
-        public const string ClientCredentialAuthenticationTypeMustBeDefined = "One authentication type either: ClientSecret, Certificate OR ClientAssertion must be defined when creating a Confidential Client. Only specify one. See https://aka.ms/msal-net-client-credentials";
+        public const string ClientCredentialAuthenticationTypeMustBeDefined = "One client credential type required either: ClientSecret, Certificate OR ClientAssertion must be defined when creating a Confidential Client. Only specify one. See https://aka.ms/msal-net-client-credentials";
         public const string ClientIdMustBeAGuid = "Error: ClientId is not a Guid.";
 
         public static string InvalidRedirectUriReceived(string invalidRedirectUri)

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Identity.Client
             "ConfidentialClientApplication implementation does not implement IConfidentialClientApplicationExecutor.";
 
         public const string ClientCredentialAuthenticationTypesAreMutuallyExclusive = "ClientSecret, Certificate and ClientAssertion are mutually exclusive properties. Only specify one. See https://aka.ms/msal-net-client-credentials";
+        public const string ClientCredentialAuthenticationTypeMustBeDefined = "One authentication type either: ClientSecret, Certificate OR ClientAssertion must be defined when creating a Confidential Client. Only specify one. See https://aka.ms/msal-net-client-credentials";
         public const string ClientIdMustBeAGuid = "Error: ClientId is not a Guid.";
 
         public static string InvalidRedirectUriReceived(string invalidRedirectUri)

--- a/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         {
             var cca = ConfidentialClientApplicationBuilder
                .Create(PublicCloudConfidentialClientID)
+               .WithClientSecret(_publicCloudCcaSecret)
                .WithRedirectUri(RedirectUri)
                .WithTestLogging()
                .Build();

--- a/tests/Microsoft.Identity.Test.Unit.net45/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         [TestMethod]
         public void TestConstructor()
         {
-            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId).Build();
+            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                          .WithClientSecret("cats")
+                                                          .Build();
+
             Assert.AreEqual(TestConstants.ClientId, cca.AppConfig.ClientId);
             Assert.IsNotNull(cca.UserTokenCache);
 
@@ -56,22 +59,29 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
         private void TestBuildConfidentialClientFromOptions(ConfidentialClientApplicationOptions options)
         {
+            options.ClientSecret = "cats";
             var app = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(options).Build();
             var authorityInfo = ((ConfidentialClientApplication)app).ServiceBundle.Config.AuthorityInfo;
             Assert.AreEqual("https://login.microsoftonline.com/the_tenant_id/", authorityInfo.CanonicalAuthority);
         }
 
         [TestMethod]
+        [DeploymentItem(@"Resources\testCert.crtfile")]
         public void TestBuildWithNoClientSecretButUsingCert()
         {
             var options = new ConfidentialClientApplicationOptions()
             {
                 ClientId = TestConstants.ClientId,
                 TenantId = "the_tenant_id",
-                Instance = "https://login.microsoftonline.com"
+                Instance = "https://login.microsoftonline.com",
             };
 
-            var app = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(options).Build();
+            var cert = new X509Certificate2(
+               ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
+
+            var app = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(options)
+                                                          .WithCertificate(cert)
+                                                          .Build();
             var authorityInfo = ((ConfidentialClientApplication)app).ServiceBundle.Config.AuthorityInfo;
             Assert.AreEqual("https://login.microsoftonline.com/the_tenant_id/", authorityInfo.CanonicalAuthority);
         }
@@ -112,7 +122,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestWithDifferentClientId()
         {
             const string ClientId = "9340c42a-f5de-4a80-aea0-874adc2ca325";
-            var cca = ConfidentialClientApplicationBuilder.Create(ClientId).Build();
+            var cca = ConfidentialClientApplicationBuilder.Create(ClientId).WithClientSecret("cats").Build();
             Assert.AreEqual(ClientId, cca.AppConfig.ClientId);
         }
 
@@ -120,7 +130,10 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_ClientIdOverride()
         {
             const string ClientId = "73cc145e-798f-430c-8d6d-618f1a5802e9";
-            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId).WithClientId(ClientId).Build();
+            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                .WithClientId(ClientId)
+                                                                .WithClientSecret("cats")
+                                                                .Build();
             Assert.AreEqual(ClientId, cca.AppConfig.ClientId);
         }
 
@@ -130,7 +143,11 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
             const string ClientName = "my client name";
             const string ClientVersion = "1.2.3.4-prerelease";
             var cca =
-                ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId).WithClientName(ClientName).WithClientVersion(ClientVersion).Build();
+                ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                            .WithClientName(ClientName)
+                                                            .WithClientVersion(ClientVersion)
+                                                            .WithClientSecret("cats")
+                                                            .Build();
             Assert.AreEqual(ClientName, cca.AppConfig.ClientName);
             Assert.AreEqual(ClientVersion, cca.AppConfig.ClientVersion);
         }
@@ -138,7 +155,10 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         [TestMethod]
         public void TestConstructor_WithDebugLoggingCallback()
         {
-            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId).WithDebugLoggingCallback().Build();
+            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                .WithClientSecret("cats")
+                                                                .WithDebugLoggingCallback()
+                                                                .Build();
             Assert.IsNotNull(cca.AppConfig.LoggingCallback);
         }
 
@@ -146,7 +166,10 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_WithHttpClientFactory()
         {
             var httpClientFactory = NSubstitute.Substitute.For<IMsalHttpClientFactory>();
-            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId).WithHttpClientFactory(httpClientFactory).Build();
+            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                .WithHttpClientFactory(httpClientFactory)
+                                                                .WithClientSecret("cats")
+                                                                .Build();
             Assert.AreEqual(httpClientFactory, cca.AppConfig.HttpClientFactory);
         }
 
@@ -154,7 +177,9 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_WithLogging()
         {
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithLogging((level, message, pii) => { }).Build();
+                      .Create(TestConstants.ClientId)
+                            .WithClientSecret("cats")
+                            .WithLogging((level, message, pii) => { }).Build();
 
             Assert.IsNotNull(cca.AppConfig.LoggingCallback);
         }
@@ -164,7 +189,9 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         {
             const string RedirectUri = "http://some_redirect_uri/";
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithRedirectUri(RedirectUri).Build();
+                      .Create(TestConstants.ClientId)
+                      .WithClientSecret("cats")
+                      .WithRedirectUri(RedirectUri).Build();
 
             Assert.AreEqual(RedirectUri, cca.AppConfig.RedirectUri);
         }
@@ -173,7 +200,9 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_WithNullRedirectUri()
         {
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithRedirectUri(null).Build();
+                      .Create(TestConstants.ClientId)
+                      .WithClientSecret("cats")
+                      .WithRedirectUri(null).Build();
 
             Assert.AreEqual(Constants.DefaultConfidentialClientRedirectUri, cca.AppConfig.RedirectUri);
         }
@@ -182,7 +211,9 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_WithEmptyRedirectUri()
         {
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithRedirectUri(string.Empty).Build();
+                      .Create(TestConstants.ClientId)
+                      .WithClientSecret("cats")
+                      .WithRedirectUri(string.Empty).Build();
 
             Assert.AreEqual(Constants.DefaultConfidentialClientRedirectUri, cca.AppConfig.RedirectUri);
         }
@@ -191,7 +222,10 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_WithWhitespaceRedirectUri()
         {
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithRedirectUri("      ").Build();
+                      .Create(TestConstants.ClientId)
+                      .WithClientSecret("cats")
+                      .WithRedirectUri("      ")
+                      .Build();
 
             Assert.AreEqual(Constants.DefaultConfidentialClientRedirectUri, cca.AppConfig.RedirectUri);
         }
@@ -201,6 +235,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         {
             Assert.ThrowsException<InvalidOperationException>(() =>
                 ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                    .WithClientSecret("cats")
                                                     .WithRedirectUri("this is not a valid uri")
                                                     .Build());
         }
@@ -210,7 +245,10 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         {
             const string TenantId = "a_tenant id";
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithTenantId(TenantId).Build();
+                      .Create(TestConstants.ClientId)
+                      .WithClientSecret("cats")
+                      .WithTenantId(TenantId)
+                      .Build();
 
             Assert.AreEqual(TenantId, cca.AppConfig.TenantId);
         }
@@ -220,7 +258,9 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         {
             const string ClientSecret = "secret value here";
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithClientSecret(ClientSecret).Build();
+                      .Create(TestConstants.ClientId)
+                      .WithClientSecret(ClientSecret)
+                      .Build();
 
             Assert.IsNotNull(cca.AppConfig.ClientSecret);
             Assert.AreEqual(ClientSecret, cca.AppConfig.ClientSecret);
@@ -234,7 +274,8 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
                 ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
 
             var cca = ConfidentialClientApplicationBuilder
-                      .Create(TestConstants.ClientId).WithCertificate(cert).Build();
+                      .Create(TestConstants.ClientId)
+                      .WithCertificate(cert).Build();
 
             Assert.IsNotNull(cca.AppConfig.ClientCredentialCertificate);
         }
@@ -266,6 +307,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         {
             string instanceMetadataJson = File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("CustomInstanceMetadata.json"));
             var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                   .WithClientSecret("cats")
                                                    .WithInstanceDiscoveryMetadata(instanceMetadataJson)
                                                    .Build();
 
@@ -280,6 +322,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
             string instanceMetadataJson = File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("CustomInstanceMetadata.json"));
             var ex = AssertException.Throws<MsalClientException>(() => ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                   .WithInstanceDiscoveryMetadata(instanceMetadataJson)
+                                                  .WithClientSecret("cats")
                                                   .WithAuthority("https://some.authority/bogus/", true)
                                                   .Build());
             Assert.AreEqual(ex.ErrorCode, MsalError.ValidateAuthorityOrCustomMetadata);
@@ -290,6 +333,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         {
             var ex = AssertException.Throws<MsalClientException>(() => ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                   .WithInstanceDiscoveryMetadata("{bad_json_metadata")
+                                                  .WithClientSecret("cats")
                                                   .Build());
 
             Assert.AreEqual(ex.ErrorCode, MsalError.InvalidUserInstanceMetadata);

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1018,6 +1018,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         public void EnsurePublicApiSurfaceExistsOnInterface()
         {
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                                     .WithClientSecret("cats")
                                                                                      .Build();
 
             // This test is to ensure that the methods we want/need on the IConfidentialClientApplication exist and compile.  This isn't testing functionality, that's done elsewhere.


### PR DESCRIPTION
Fix for [issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1795) 
Also related to this issue in [ms identity web](https://github.com/AzureAD/microsoft-identity-web/pull/139)

Repro: 
- Create a confidential client using application options (or without, based on my testing), and do not include a client secret, certificate or assertion. 
- In `ClientCredentialWrapper` the default enum value is `ClientCertificate`, so when no value is provided in creating the cca, the default AuthenticationType is `ClientCertificate`. Later, in `ClientCredentialHelper`, we go the path of `ClientCertificate` and MSAL throws a null ref on line 80 when trying to sign something it doesn't have:
`clientCredential.CachedAssertion = jwtToken.Sign(clientCredential, sendX5C);`

MS.Identity.Web had customers reporting (see linked PR) that when forgetting to set the client secret in the web app, MS.Identity.Web relies on MSAL for getting the cca tokens, so we don't have a value in the `ClientSecret`, but successfully make the cca...later we try to do to `.AcquireTokenByAuthorizationCode` using the cca we made earlier and we get a null ref. 

I have a fix for us in Identity Web to make sure we send options without null or empty strings. Here's a fix for you as well, but another fix would be to ensure that one of the four authenticationType options are used for the cca. We check that not more than one are used, but not that at least one is used. 