### PR TITLE
Allowing android broker flow to return accounts from local MSAL cache when broker is not installed and WithBroker() is true

### DIFF
--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -91,8 +91,11 @@ namespace Microsoft.Identity.Client
             if (AppConfig.IsBrokerEnabled && ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth())
             {
                 var broker = ServiceBundle.PlatformProxy.CreateBroker(null);
-                accounts = await broker.GetAccountsAsync(AppConfig.ClientId).ConfigureAwait(false);
-                return accounts;
+                if (broker.CanInvokeBroker())
+                {
+                    accounts = await broker.GetAccountsAsync(AppConfig.ClientId).ConfigureAwait(false);
+                    return accounts;
+                }
             }
 
             if (UserTokenCache == null)

--- a/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/RequestsTests/BrokerRequestTests.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             var mockBroker = Substitute.For<IBroker>();
             var expectedAccount = Substitute.For<IAccount>();
             mockBroker.GetAccountsAsync(TestConstants.ClientId).Returns(new[] { expectedAccount });
+            mockBroker.CanInvokeBroker().Returns(true);
 
             var platformProxy = Substitute.For<IPlatformProxy>();
             platformProxy.CanBrokerSupportSilentAuth().Returns(true);


### PR DESCRIPTION
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1775

Validated with manual testing.
Adding a new manual test for this to the spreadsheet

I also verified that this is the same behavior on MSAL Andorid