### PR TITLE
use previous clientId w/mobile apps

### DIFF
--- a/tests/devapps/XamarinDev/XamarinDev/App.xaml.cs
+++ b/tests/devapps/XamarinDev/XamarinDev/App.xaml.cs
@@ -14,7 +14,7 @@ namespace XamarinDev
 
         public static object RootViewController { get; set; }
 
-        public const string DefaultClientId = "16dab2ba-145d-4b1b-8569-bf4b9aed4dc8"; // in msidentity-samples-testing tenant -> PublicClientSample
+        public const string DefaultClientId = "4a1aa1d5-c567-49d0-ad0b-cd957a47f842"; // in msidentity-samples-testing tenant -> PublicClientSample
 
         public const string B2cClientId = "e3b9ad76-9763-4827-b088-80c7a7888f79";
 


### PR DESCRIPTION
This default clientId will not work w/any non-broker flow, as it doesn't have the correct redirect uri registered and the android manifest was not updated. I have added the android broker redirect uri to this client Id in the portal, so everything should work with this one client id.