### PR TITLE
Update test projects to netcore 3.1

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.netcore.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.netcore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Microsoft.Identity.Test.Unit.netcore/Microsoft.Identity.Test.Unit.netcore.csproj
+++ b/tests/Microsoft.Identity.Test.Unit.netcore/Microsoft.Identity.Test.Unit.netcore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/tests/devapps/NetCoreTestApp/NetCoreTestApp.csproj
+++ b/tests/devapps/NetCoreTestApp/NetCoreTestApp.csproj
@@ -2,27 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Configurations>Debug;Release</Configurations>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-    <ApplicationIcon />
-    <StartupObject />
-  </PropertyGroup>
-
-  <!-- Set this env variable locally to enable Telemetry on developer applications-->
-  <PropertyGroup Condition="'$(ARIA_TELEMETRY_ENABLED)' != ''">
-    <DefineConstants>$(DefineConstants);ARIA_TELEMETRY_ENABLED</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Legacy2CPSWorkaround" Version="1.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
-    <ProjectReference Condition="'$(ARIA_TELEMETRY_ENABLED)' != ''" Include="..\AriaTelemetryProvider\AriaTelemetryProvider.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This should improve team experience, as .net core 2.1 SDK is no longer installed by default with VS and people cannot easily run netcore tests locally.