### PR TITLE
Uppercasing prompt parameters to avoid broker failures

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidBrokerHelper.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
                 ClientAppVersion = Application.Context.PackageManager.GetPackageInfo(Application.Context.PackageName, PackageInfoFlags.MatchAll).VersionName,
                 ClientVersion = GetValueFromBrokerPayload(brokerPayload, BrokerParameter.ClientVersion),
                 CorrelationId = GetValueFromBrokerPayload(brokerPayload, BrokerParameter.CorrelationId),
-                Prompt = "NONE"
+                Prompt = GetValueFromBrokerPayload(brokerPayload, BrokerParameter.Prompt).ToUpperInvariant()
             };
 
             brokerIntent.PutExtra(BrokerConstants.BrokerRequestV2, JsonHelper.SerializeToJson(request));


### PR DESCRIPTION
Found a bug in the android broker where if you send the prompt without making the text uppercase the json parsing will sometimes fail on the broker side and crash the broker app. It just so happened that adding claims to the json trigged this bug. They are going to fix in the next release.