### PR TITLE
On WsTrust parse error, return body

### DIFF
--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Identity.Client
         public const string PlatformNotSupported = "Platform Not Supported";
 
         public const string FederatedServiceReturnedErrorTemplate = "Federated service at {0} returned error: {1}";
-        public const string FederatedServiceParseErrorTemplate = "Federated service at {0} parse error: Body {1}";
+        public const string ParsingWsTrustResponseFailedErrorTemplate = "Federated service at {0} parse error: Body {1}";
         public const string UnknownUserType = "Unknown User Type";
 
         public const string InternalErrorCacheEmptyUsername =

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Identity.Client
         public const string PlatformNotSupported = "Platform Not Supported";
 
         public const string FederatedServiceReturnedErrorTemplate = "Federated service at {0} returned error: {1}";
+        public const string FederatedServiceParseErrorTemplate = "Federated service at {0} parse error: Body {1}";
         public const string UnknownUserType = "Unknown User Type";
 
         public const string InternalErrorCacheEmptyUsername =

--- a/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Identity.Client.WsTrust
             {
                 string message = string.Format(
                         CultureInfo.CurrentCulture,
-                        MsalErrorMessage.FederatedServiceParseErrorTemplate,
+                        MsalErrorMessage.ParsingWsTrustResponseFailedErrorTemplate,
                         wsTrustEndpoint.Uri,
                         resp.Body);
 

--- a/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -101,8 +101,14 @@ namespace Microsoft.Identity.Client.WsTrust
             }
             catch (System.Xml.XmlException ex)
             {
+                string message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        MsalErrorMessage.FederatedServiceParseErrorTemplate,
+                        wsTrustEndpoint.Uri,
+                        resp.Body);
+
                 throw new MsalClientException(
-                    MsalError.ParsingWsTrustResponseFailed, MsalError.ParsingWsTrustResponseFailed, ex);
+                    MsalError.ParsingWsTrustResponseFailed, message, ex);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Identity.Client.WsTrust;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Identity.Test.Common;
+using System.Globalization;
 
 namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
 {
@@ -72,6 +73,46 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
                 catch (MsalException ex)
                 {
                     Assert.AreEqual(MsalError.FederatedServiceReturnedError, ex.ErrorCode);
+                }
+            }
+        }
+
+        [TestMethod]
+        [Description("WsTrustRequest encounters a non parseable response from the wsTrust endpoint")]
+        public async Task WsTrustRequestParseErrorTestAsync()
+        {
+            const string body = "Non-Parsable";
+            const string uri = "https://some/address/usernamemixed";
+            string expectedMessage = string.Format(CultureInfo.CurrentCulture, MsalErrorMessage.ParsingWsTrustResponseFailedErrorTemplate, uri, body);
+
+            var endpoint = new WsTrustEndpoint(new Uri(uri), WsTrustVersion.WsTrust13);
+
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddMockHandler(
+                    new MockHttpMessageHandler()
+                    {
+                        ExpectedUrl = uri,
+                        ExpectedMethod = HttpMethod.Post,
+                        ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent(body)
+                        }
+                    });
+
+                var requestContext = new RequestContext(harness.ServiceBundle, Guid.NewGuid());
+                try
+                {
+                    var message = endpoint.BuildTokenRequestMessageWindowsIntegratedAuth("urn:federation:SomeAudience");
+
+                    WsTrustResponse wstResponse =
+                        await harness.ServiceBundle.WsTrustWebRequestManager.GetWsTrustResponseAsync(endpoint, message, requestContext).ConfigureAwait(false);
+                    Assert.Fail("We expect an exception to be thrown here");
+                }
+                catch (MsalException ex)
+                {
+                    Assert.AreEqual(MsalError.ParsingWsTrustResponseFailed, ex.ErrorCode);
+                    Assert.AreEqual(ex.Message, expectedMessage);
                 }
             }
         }


### PR DESCRIPTION
This returns the body of the response if there is a parse error. It would have been really helpful to realize what this issue was. Instead I had to compile the library from source and debug it.

This drove me crazy. I kept getting an error attempting to Seamless SSO that spawned this issue here: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1825

Turns out our firewall was intercepting the traffic and categorizing the SSSO site as "uncategorized" which requires a manual step to approve. It was basically impossible for me to determine this was an issue because the body was not being returned when there was a parse error. 