### PR TITLE
Make correlationID available only on RequestContext

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Validation/AdfsAuthorityValidator.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Validation/AdfsAuthorityValidator.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client.Instance.Validation
                         httpResponse);
                 }
 
-                AdfsWebFingerResponse wfr = OAuth2Client.CreateResponse<AdfsWebFingerResponse>(httpResponse, requestContext, false);
+                AdfsWebFingerResponse wfr = OAuth2Client.CreateResponse<AdfsWebFingerResponse>(httpResponse, requestContext);
                 if (wfr.Links.FirstOrDefault(
                         a => a.Rel.Equals(Constants.DefaultRealm, StringComparison.OrdinalIgnoreCase) &&
                              a.Href.Equals(resource)) == null)

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
 
             BrokerPayload.Add(BrokerParameter.Scope, scopes);
             BrokerPayload.Add(BrokerParameter.ClientId, _authenticationRequestParameters.ClientId);
-            BrokerPayload.Add(BrokerParameter.CorrelationId, _logger.CorrelationId.ToString());
+            BrokerPayload.Add(BrokerParameter.CorrelationId, _authenticationRequestParameters.RequestContext.CorrelationId.ToString());
             BrokerPayload.Add(BrokerParameter.ClientVersion, MsalIdHelper.GetMsalVersion());
             BrokerPayload.Add(BrokerParameter.Force, "NO");
             BrokerPayload.Add(BrokerParameter.RedirectUri, _serviceBundle.Config.RedirectUri);

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerSilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerSilentRequest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             string scopes = EnumerableExtensions.AsSingleString(_authenticationRequestParameters.Scope);
             BrokerPayload.Add(BrokerParameter.Scope, scopes);
             BrokerPayload.Add(BrokerParameter.ClientId, _authenticationRequestParameters.ClientId);
-            BrokerPayload.Add(BrokerParameter.CorrelationId, _logger.CorrelationId.ToString());
+            BrokerPayload.Add(BrokerParameter.CorrelationId, _authenticationRequestParameters.RequestContext.CorrelationId.ToString());
             BrokerPayload.Add(BrokerParameter.ClientVersion, MsalIdHelper.GetMsalVersion());
             BrokerPayload.Add(BrokerParameter.RedirectUri, _serviceBundle.Config.RedirectUri);
             string extraQP = string.Join("&", _authenticationRequestParameters.ExtraQueryParameters.Select(x => x.Key + "=" + x.Value));

--- a/src/client/Microsoft.Identity.Client/Internal/Logger/ICoreLogger.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Logger/ICoreLogger.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Identity.Client.Core
 {
     internal interface ICoreLogger
     {
-        Guid CorrelationId { get; }
         string ClientName { get; }
         string ClientVersion { get; }
         bool PiiLoggingEnabled { get; }
@@ -28,7 +27,7 @@ namespace Microsoft.Identity.Client.Core
         void InfoPiiWithPrefix(Exception exWithPii, string prefix);
         void Verbose(string messageScrubbed);
         void VerbosePii(string messageWithPii, string messageScrubbed);
-        void Log(LogLevel msalLogLevel, string messageWithPii, string messageScrubbed);
+        void Log(LogLevel logLevel, string messageWithPii, string messageScrubbed);
         DurationLogHelper LogBlockDuration(string measuredBlockName, LogLevel logLevel = LogLevel.Verbose);
         DurationLogHelper LogMethodDuration(LogLevel logLevel = LogLevel.Verbose, [CallerMemberName] string methodName = null);
     }

--- a/src/client/Microsoft.Identity.Client/Internal/Logger/MsalLogger.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Logger/MsalLogger.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Client.Internal.Logger
             bool isDefaultPlatformLoggingEnabled,
             LogCallback loggingCallback)
         {
-            CorrelationId = correlationId;
+            _correlationId = correlationId;
             PiiLoggingEnabled = enablePiiLogging;
             _loggingCallback = loggingCallback;
             _minLogLevel = logLevel;
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Client.Internal.Logger
 
         public static ICoreLogger NullLogger => s_nullLogger.Value;
 
-        public Guid CorrelationId { get; }
+        private readonly Guid _correlationId;
 
         public bool PiiLoggingEnabled { get; }
 
@@ -134,11 +134,7 @@ namespace Microsoft.Identity.Client.Internal.Logger
             Log(LogLevel.Error, string.Empty, messageScrubbed);
         }
 
-        public void ErrorPii(Exception exWithPii)
-        {
-            Log(LogLevel.Error, exWithPii.ToString(), GetPiiScrubbedExceptionDetails(exWithPii));
-        }
-
+     
         public void ErrorPiiWithPrefix(Exception exWithPii, string prefix)
         {
             Log(LogLevel.Error, prefix + exWithPii.ToString(), prefix + GetPiiScrubbedExceptionDetails(exWithPii));
@@ -149,6 +145,11 @@ namespace Microsoft.Identity.Client.Internal.Logger
             Log(LogLevel.Error, messageWithPii, messageScrubbed);
         }
 
+        public void ErrorPii(Exception exWithPii)
+        {
+            Log(LogLevel.Error, exWithPii.ToString(), GetPiiScrubbedExceptionDetails(exWithPii));
+        }
+
         public void Log(LogLevel logLevel, string messageWithPii, string messageScrubbed)
         {
             if (_loggingCallback == null || logLevel > _minLogLevel)
@@ -156,10 +157,9 @@ namespace Microsoft.Identity.Client.Internal.Logger
                 return;
             }
 
-            // format log message;
-            string correlationId = CorrelationId.Equals(Guid.Empty)
+            string correlationId = _correlationId.Equals(Guid.Empty)
                 ? string.Empty
-                : " - " + CorrelationId;
+                : " - " + _correlationId;
 
             var msalIdParameters = MsalIdHelper.GetMsalIdParameters(this);
             string os = "N/A";

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -165,10 +165,10 @@ namespace Microsoft.Identity.Client.Internal
                 authorizationRequestParameters[OAuth2Parameter.LoginHint] = _interactiveParameters.LoginHint;
             }
 
-            if (_requestParams.RequestContext?.Logger?.CorrelationId != Guid.Empty)
+            if (_requestParams.RequestContext.CorrelationId != Guid.Empty)
             {
                 authorizationRequestParameters[OAuth2Parameter.CorrelationId] =
-                    _requestParams.RequestContext.Logger.CorrelationId.ToString();
+                    _requestParams.RequestContext.CorrelationId.ToString();
             }
 
             foreach (KeyValuePair<string, string> kvp in MsalIdHelper.GetMsalIdParameters(_requestParams.RequestContext.Logger))

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client.OAuth2
             {
                 _bodyParameters[key] = value;
             }
-        }        
+        }
 
         internal void AddHeader(string key, string value)
         {
@@ -80,12 +80,10 @@ namespace Microsoft.Identity.Client.OAuth2
 
         internal async Task<T> ExecuteRequestAsync<T>(Uri endPoint, HttpMethod method, RequestContext requestContext, bool expectErrorsOn200OK = false, bool addCommonHeaders = true)
         {
-            bool addCorrelationId = requestContext != null && !string.IsNullOrEmpty(requestContext.Logger.CorrelationId.ToString());
-            
             //Requests that are replayed by PKeyAuth do not need to have headers added because they already exist
             if (addCommonHeaders)
             {
-                AddCommonHeaders(requestContext, addCorrelationId);
+                AddCommonHeaders(requestContext);
             }
 
             HttpResponse response = null;
@@ -140,16 +138,13 @@ namespace Microsoft.Identity.Client.OAuth2
                 }
             }
 
-            return CreateResponse<T>(response, requestContext, addCorrelationId);
-        }   
+            return CreateResponse<T>(response, requestContext);
+        }
 
-        private bool AddCommonHeaders(RequestContext requestContext, bool addCorrelationId)
+        private void AddCommonHeaders(RequestContext requestContext)
         {
-            if (addCorrelationId)
-            {
-                _headers.Add(OAuth2Header.CorrelationId, requestContext.Logger.CorrelationId.ToString());
-                _headers.Add(OAuth2Header.RequestCorrelationIdInResponse, "true");
-            }
+            _headers.Add(OAuth2Header.CorrelationId, requestContext.CorrelationId.ToString());
+            _headers.Add(OAuth2Header.RequestCorrelationIdInResponse, "true");
 
             if (!string.IsNullOrWhiteSpace(requestContext.Logger.ClientName))
             {
@@ -160,8 +155,6 @@ namespace Microsoft.Identity.Client.OAuth2
             {
                 _headers.Add(OAuth2Header.AppVer, requestContext.Logger.ClientVersion);
             }
-
-            return addCorrelationId;
         }
 
         private void DecorateHttpEvent(HttpMethod method, RequestContext requestContext, HttpResponse response, HttpEvent httpEvent)
@@ -194,17 +187,14 @@ namespace Microsoft.Identity.Client.OAuth2
             }
         }
 
-        public static T CreateResponse<T>(HttpResponse response, RequestContext requestContext, bool addCorrelationId)
+        public static T CreateResponse<T>(HttpResponse response, RequestContext requestContext)
         {
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 ThrowServerException(response, requestContext);
             }
 
-            if (addCorrelationId)
-            {
-                VerifyCorrelationIdHeaderInResponse(response.HeadersAsDictionary, requestContext);
-            }
+            VerifyCorrelationIdHeaderInResponse(response.HeadersAsDictionary, requestContext);
 
             return JsonHelper.DeserializeFromJson<T>(response.Body);
         }
@@ -312,7 +302,7 @@ namespace Microsoft.Identity.Client.OAuth2
                     string correlationIdHeader = headers[trimmedKey].Trim();
                     if (string.Compare(
                             correlationIdHeader,
-                            requestContext.Logger.CorrelationId.ToString(),
+                            requestContext.CorrelationId.ToString(),
                             StringComparison.OrdinalIgnoreCase) != 0)
                     {
                         requestContext.Logger.WarningPii(
@@ -320,7 +310,7 @@ namespace Microsoft.Identity.Client.OAuth2
                                 CultureInfo.InvariantCulture,
                                 "Returned correlation id '{0}' does not match the sent correlation id '{1}'",
                                 correlationIdHeader,
-                                requestContext.Logger.CorrelationId),
+                                requestContext.CorrelationId),
                             "Returned correlation id does not match the sent correlation id");
                     }
 


### PR DESCRIPTION
There should be only 1 place to get the CorrelationId from - the RequestContext. 