### PR TITLE
Added try/catch around InternalGetDeviceId for NetDesktop

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -209,10 +209,18 @@ namespace Microsoft.Identity.Client.Platforms.net45
 
         /// <inheritdoc />
         protected override string InternalGetDeviceId()
-        {
-            // Considered PII, ensure that it is hashed.
-            return NetworkInterface.GetAllNetworkInterfaces().Where(nic => nic.OperationalStatus == OperationalStatus.Up)
-                            .Select(nic => nic.GetPhysicalAddress()?.ToString()).FirstOrDefault();
+        {            
+            try
+            {
+                // Considered PII, ensure that it is hashed.
+                return NetworkInterface.GetAllNetworkInterfaces().Where(nic => nic.OperationalStatus == OperationalStatus.Up)
+                                .Select(nic => nic.GetPhysicalAddress()?.ToString()).FirstOrDefault();
+            }
+            catch(EntryPointNotFoundException)
+            {
+                // Thrown when ran in an Azure Runbook
+                return null;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Added try/catch around InternalGetDeviceId for NetDesktop as this causes a crash when used from an Azure Runbook.

This can be simulated by running the following line in an Azure Runbook which equals the line being wrapped in try/catch here:
```powershell
[System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()
```
It will throw the exception:
`_Get-PnPAccessToken : Unable to find an entry point named 'GetPerAdapterInfo' in DLL 'iphlpapi.dll'_.`

Reported to us via https://github.com/pnp/PnP-PowerShell/issues/2726

We can't switch to using MSAL .Net Core or MSAL .Net Standard as within [PnP PowerShell](https://aka.ms/pnp-powershell) we are also using the interactive login method:

```c#
var token = await AzureAuthHelper.AuthenticateAsync(Tenant);
```
which requires a platform specific build of MSAL to be used, thus we need to stick with MSAL NetDesktop.

Used in PR https://github.com/pnp/PnP-PowerShell/pull/2735 