### PR TITLE
Add suggested cache key for confidential client scenarios

### DIFF
--- a/src/client/Microsoft.Identity.Client/AccountId.cs
+++ b/src/client/Microsoft.Identity.Client/AccountId.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client
                 return false;
             }
 
-            return string.Compare(Identifier, otherMsalAccountId.Identifier, StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Equals(Identifier, otherMsalAccountId.Identifier, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Identity.Client.Cache
                                _requestParams.Account,
                                hasStateChanged: false, 
                                TokenCacheInternal.IsApplicationCache,
-                               _requestParams.SuggestedCacheKey ?? _requestParams.Account?.HomeAccountId?.Identifier);
+                               _requestParams.SuggestedWebAppCacheKey);
 
                             try
                             {

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Identity.Client.Cache
                 {
                     if (!_cacheRefreshedForRead) // double check locking
                     {
-                        
                         using (_requestParams.RequestContext.CreateTelemetryHelper(cacheEvent))
                         {
                             TokenCacheNotificationArgs args = new TokenCacheNotificationArgs(
@@ -109,7 +108,8 @@ namespace Microsoft.Identity.Client.Cache
                                _requestParams.ClientId,
                                _requestParams.Account,
                                hasStateChanged: false, 
-                               TokenCacheInternal.IsApplicationCache);
+                               TokenCacheInternal.IsApplicationCache,
+                               _requestParams.SuggestedCacheKey ?? _requestParams.Account?.HomeAccountId?.Identifier);
 
                             try
                             {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         public bool HasScopes => Scope != null && Scope.Any();
 
         public string ClientId { get; }
+
         public Uri RedirectUri { get; set; }
 
         /// <summary>
@@ -86,7 +87,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public string ClaimsAndClientCapabilities { get; private set; }
 
-        public string SuggestedCacheKey { get; set; }
+        /// <summary>
+        /// Used by Identity.Web (and others) to store token caches given the 1 cache per user pattern.
+        /// </summary>
+        public string SuggestedWebAppCacheKey { get; set; }
 
         /// <summary>
         /// Indicates if the user configured claims via .WithClaims. Not affected by Client Capabilities
@@ -102,7 +106,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public AuthorityInfo AuthorityOverride => _commonParameters.AuthorityOverride;
 
-        internal bool IsBrokerConfigured { get; set; }
+        internal bool IsBrokerConfigured { get; set; /* set only for test */ }
 
         public IAuthenticationScheme AuthenticationScheme => _commonParameters.AuthenticationScheme;
 
@@ -160,6 +164,13 @@ namespace Microsoft.Identity.Client.Internal.Requests
             builder.AppendLine("Redirect Uri - " + RedirectUri?.OriginalString);
             builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
             builder.AppendLine("ClaimsAndClientCapabilities - " + ClaimsAndClientCapabilities);
+            builder.AppendLine("Authority - " + AuthorityInfo?.CanonicalAuthority);
+            builder.AppendLine("ApiId - " + ApiId);
+            builder.AppendLine("SuggestedCacheKey - " + SuggestedWebAppCacheKey);
+            builder.AppendLine("IsConfidentialClient - " + IsConfidentialClient);
+            builder.AppendLine("SendX5C - " + SendX5C);
+            builder.AppendLine("LoginHint - " + LoginHint);
+            builder.AppendLine("IsBrokerConfigured - " + IsBrokerConfigured);
 
             string messageWithPii = builder.ToString();
 
@@ -170,6 +181,13 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 Environment.NewLine);
             builder.AppendLine("Scopes - " + Scope?.AsSingleString());
             builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
+            builder.AppendLine("ApiId - " + ApiId);
+            builder.AppendLine("SuggestedCacheKey - " + SuggestedWebAppCacheKey);
+            builder.AppendLine("IsConfidentialClient - " + IsConfidentialClient);
+            builder.AppendLine("SendX5C - " + SendX5C);
+            builder.AppendLine("LoginHint ? " + !string.IsNullOrEmpty(LoginHint));
+            builder.AppendLine("IsBrokerConfigured - " + IsBrokerConfigured);
+
             logger.InfoPii(messageWithPii, builder.ToString());
         }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -86,6 +86,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public string ClaimsAndClientCapabilities { get; private set; }
 
+        public string SuggestedCacheKey { get; set; }
+
         /// <summary>
         /// Indicates if the user configured claims via .WithClaims. Not affected by Client Capabilities
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (!_clientParameters.ForceRefresh && 
                 string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
+                AuthenticationRequestParameters.SuggestedCacheKey = AuthenticationRequestParameters.ClientId + "_AppTokenCache";
                 cachedAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
 
                 if (cachedAccessTokenItem != null && !cachedAccessTokenItem.NeedsRefresh())

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (!_clientParameters.ForceRefresh && 
                 string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
-                AuthenticationRequestParameters.SuggestedCacheKey = AuthenticationRequestParameters.ClientId + "_AppTokenCache";
+                AuthenticationRequestParameters.SuggestedWebAppCacheKey = AuthenticationRequestParameters.ClientId + "_AppTokenCache";
                 cachedAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
 
                 if (cachedAccessTokenItem != null && !cachedAccessTokenItem.NeedsRefresh())

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             // or new assertion has been passed. We should not use Refresh Token
             // for the user because the new incoming token may have updated claims
             // like mfa etc.
-            AuthenticationRequestParameters.SuggestedCacheKey = AuthenticationRequestParameters.UserAssertion.AssertionHash;
+            AuthenticationRequestParameters.SuggestedWebAppCacheKey = AuthenticationRequestParameters.UserAssertion.AssertionHash;
             MsalAccessTokenCacheItem msalAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
             if (msalAccessTokenItem != null)
             {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             // or new assertion has been passed. We should not use Refresh Token
             // for the user because the new incoming token may have updated claims
             // like mfa etc.
-
+            AuthenticationRequestParameters.SuggestedCacheKey = AuthenticationRequestParameters.UserAssertion.AssertionHash;
             MsalAccessTokenCacheItem msalAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
             if (msalAccessTokenItem != null)
             {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentClientAuthStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentClientAuthStrategy.cs
@@ -39,11 +39,12 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
         {
             IAccount account = await GetAccountFromParamsOrLoginHintAsync(_silentParameters).ConfigureAwait(false);
             AuthenticationRequestParameters.Account = account;
+            AuthenticationRequestParameters.SuggestedWebAppCacheKey = account.HomeAccountId?.Identifier;
 
             AuthenticationRequestParameters.Authority = Authority.CreateAuthorityForRequest(
                 ServiceBundle.Config.AuthorityInfo,
                 AuthenticationRequestParameters.AuthorityOverride,
-                account?.HomeAccountId?.TenantId);
+                account.HomeAccountId?.TenantId);
         }
 
         public async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
         {
             try
             {
+                AuthenticationRequestParameters.SuggestedCacheKey = _silentParameters.Account?.HomeAccountId?.Identifier;
                 _logger.Info("Attempting to acquire token using using local cache...");
                 return await _clientStrategy.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
         {
             try
             {
-                AuthenticationRequestParameters.SuggestedCacheKey = _silentParameters.Account?.HomeAccountId?.Identifier;
                 _logger.Info("Attempting to acquire token using using local cache...");
                 return await _clientStrategy.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Identity.Client
                     account,
                     hasStateChanged: true,
                     (this as ITokenCacheInternal).IsApplicationCache,
-                    requestParams.SuggestedCacheKey ?? homeAccountId);
+                    requestParams.SuggestedWebAppCacheKey);
 
 #pragma warning disable CS0618 // Type or member is obsolete
                 HasStateChanged = true;

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -111,13 +111,13 @@ namespace Microsoft.Identity.Client
             await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
-
                 var args = new TokenCacheNotificationArgs(
                     this,
                     ClientId,
                     account,
                     hasStateChanged: true,
-                    (this as ITokenCacheInternal).IsApplicationCache);
+                    (this as ITokenCacheInternal).IsApplicationCache,
+                    requestParams.SuggestedCacheKey ?? homeAccountId);
 
 #pragma warning disable CS0618 // Type or member is obsolete
                 HasStateChanged = true;
@@ -163,7 +163,7 @@ namespace Microsoft.Identity.Client
                     if (!requestParams.IsClientCredentialRequest &&
                         requestParams.AuthorityInfo.AuthorityType != AuthorityType.B2C)
                     {
-                        var authorityWithPrefferedCache = Authority.CreateAuthorityWithEnvironment(
+                        var authorityWithPreferredCache = Authority.CreateAuthorityWithEnvironment(
                                 requestParams.TenantUpdatedCanonicalAuthority.AuthorityInfo,
                                 instanceDiscoveryMetadata.PreferredCache);
 
@@ -172,7 +172,7 @@ namespace Microsoft.Identity.Client
                             LegacyCachePersistence,
                             msalRefreshTokenCacheItem,
                             msalIdTokenCacheItem,
-                            authorityWithPrefferedCache.AuthorityInfo.CanonicalAuthority,
+                            authorityWithPreferredCache.AuthorityInfo.CanonicalAuthority,
                             msalIdTokenCacheItem.IdToken.ObjectId,
                             response.Scope);
                     }
@@ -661,7 +661,13 @@ namespace Microsoft.Identity.Client
 
                 try
                 {
-                    var args = new TokenCacheNotificationArgs(this, ClientId, account, true, (this as ITokenCacheInternal).IsApplicationCache);
+                    var args = new TokenCacheNotificationArgs(
+                        this, 
+                        ClientId, 
+                        account, 
+                        true, 
+                        (this as ITokenCacheInternal).IsApplicationCache,
+                        account.HomeAccountId.Identifier);
 
                     try
                     {
@@ -748,7 +754,13 @@ namespace Microsoft.Identity.Client
             await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
-                TokenCacheNotificationArgs args = new TokenCacheNotificationArgs(this, ClientId, null, true, (this as ITokenCacheInternal).IsApplicationCache);
+                TokenCacheNotificationArgs args = new TokenCacheNotificationArgs(
+                    this, 
+                    ClientId, 
+                    null, 
+                    true, 
+                    (this as ITokenCacheInternal).IsApplicationCache,
+                    null);
 
                 try
                 {

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -59,7 +59,18 @@ namespace Microsoft.Identity.Client
         public bool IsApplicationCache { get; }
 
         /// <summary>
-        ///
+        /// A suggested token cache key, which can be used with general purpose storage mechanisms that allow 
+        /// storing key-value pairs and key based retrieval. Useful in applications that store 1 token cache per user, 
+        /// the recommended pattern for web apps.
+        /// 
+        /// The value is: 
+        /// 
+        /// <list type="bullet">
+        /// <item>the homeAccountId for AcquireTokenSilent and GetAccount(homeAccountId)</item>
+        /// <item>clientID + "_AppTokenCache" for AcquireTokenForClient</item>
+        /// <item>the hash of the original token for AcquireTokenOnBehalfOf</item>
+        /// <item>null for all other calls, such as PubliClientApplication calls, which should persist the token cache in a single location</item>
+        /// </list>
         /// </summary>
         public string SuggestedCacheKey { get; }
     }

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -16,13 +16,15 @@ namespace Microsoft.Identity.Client
             string clientId,
             IAccount account,
             bool hasStateChanged,
-            bool isAppCache)
+            bool isAppCache,
+            string suggestedCacheKey = null)
         {
             TokenCache = tokenCacheSerializer;
             ClientId = clientId;
             Account = account;
             HasStateChanged = hasStateChanged;
             IsApplicationCache = isAppCache;
+            SuggestedCacheKey = suggestedCacheKey;
         }
 
         /// <summary>
@@ -55,5 +57,10 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-app-cache-serialization for details.
         /// </remarks>
         public bool IsApplicationCache { get; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public string SuggestedCacheKey { get; }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private const string AdfsCertName = "IDLABS-APP-Confidential-Client-Cert-OnPrem";
         private const string AppCacheKey = "16dab2ba-145d-4b1b-8569-bf4b9aed4dc8_AppTokenCache";
         private KeyVaultSecretsProvider _keyVault;
-        private static string _publicCloudCcaSecret;
-        private static string _arlingtonCCASecret;
+        private static string s_publicCloudCcaSecret;
+        private static string s_arlingtonCCASecret;
 
         [ClassInitialize]
         public static void ClassInitialize(TestContext context)
@@ -70,8 +70,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             if (_keyVault == null)
             {
                 _keyVault = new KeyVaultSecretsProvider();
-                _publicCloudCcaSecret = _keyVault.GetSecret(TestConstants.MsalCCAKeyVaultUri).Value;
-                _arlingtonCCASecret = _keyVault.GetSecret(TestConstants.MsalArlingtonCCAKeyVaultUri).Value;
+                s_publicCloudCcaSecret = _keyVault.GetSecret(TestConstants.MsalCCAKeyVaultUri).Value;
+                s_arlingtonCCASecret = _keyVault.GetSecret(TestConstants.MsalArlingtonCCAKeyVaultUri).Value;
             }
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         {
             var cca = ConfidentialClientApplicationBuilder
                .Create(PublicCloudConfidentialClientID)
-               .WithClientSecret(_publicCloudCcaSecret)
+               .WithClientSecret(s_publicCloudCcaSecret)
                .WithRedirectUri(RedirectUri)
                .WithTestLogging()
                .Build();
@@ -143,7 +143,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             MsalAssert.AssertAuthResult(authResult);
             appCacheRecorder.AssertAccessCounts(2, 1);
             Assert.IsTrue(appCacheRecorder.LastNotificationArgs.IsApplicationCache);
-            Assert.AreEqual(AppCacheKey, appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
+            Assert.AreEqual(PublicCloudConfidentialClientID + "_AppTokenCache", appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
         }
 
         [TestMethod]
@@ -180,7 +180,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             MsalAssert.AssertAuthResult(authResult);
             appCacheRecorder.AssertAccessCounts(2, 1);
             Assert.IsTrue(appCacheRecorder.LastNotificationArgs.IsApplicationCache);
-            Assert.AreEqual(AppCacheKey, appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
+            Assert.AreEqual(PublicCloudConfidentialClientID + "_AppTokenCache", appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
         }
 
         [TestMethod]
@@ -188,7 +188,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         {
             await RunTestWithClientSecretAsync(PublicCloudConfidentialClientID,
                                                            PublicCloudTestAuthority,
-                                                           _publicCloudCcaSecret).ConfigureAwait(false);
+                                                           s_publicCloudCcaSecret).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -197,7 +197,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         {
             await RunTestWithClientSecretAsync(ArlingtonConfidentialClientIDOBO,
                                                            ArlingtonAuthority,
-                                                           _arlingtonCCASecret).ConfigureAwait(false);
+                                                           s_arlingtonCCASecret).ConfigureAwait(false);
         }
 
         public async Task RunTestWithClientSecretAsync(string clientID, string authority, string secret)
@@ -219,7 +219,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             MsalAssert.AssertAuthResult(authResult);
             appCacheRecorder.AssertAccessCounts(1, 1);
             Assert.IsTrue(appCacheRecorder.LastNotificationArgs.IsApplicationCache);
-            Assert.AreEqual(AppCacheKey, appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
+            Assert.AreEqual(clientID + "_AppTokenCache", appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
 
             // Call again to ensure token cache is hit
             authResult = await confidentialApp.AcquireTokenForClient(s_keyvaultScope)
@@ -229,7 +229,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             MsalAssert.AssertAuthResult(authResult);
             appCacheRecorder.AssertAccessCounts(2, 1);
             Assert.IsTrue(appCacheRecorder.LastNotificationArgs.IsApplicationCache);
-            Assert.AreEqual(AppCacheKey, appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
+            Assert.AreEqual(clientID + "_AppTokenCache", appCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/ConfidentialClientIntegrationTests.cs
@@ -587,6 +587,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             MsalAssert.AssertAuthResult(authResult, user);
             Assert.AreEqual(atHash, userCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
+
+            await confidentialApp.GetAccountsAsync().ConfigureAwait(false);
+            Assert.IsNull(userCacheRecorder.LastNotificationArgs.SuggestedCacheKey);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AcquireTokenSilentTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AcquireTokenSilentTests.cs
@@ -408,6 +408,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 Assert.AreEqual(MsalError.MultipleAccountsForLoginHint, exception.ErrorCode);
                 Assert.AreEqual(UiRequiredExceptionClassification.AcquireTokenSilentFailed, exception.Classification);
+                Assert.IsNull(cacheAccess.LastNotificationArgs.SuggestedCacheKey);
                 cacheAccess.AssertAccessCounts(1, 0);
             }
         }
@@ -479,6 +480,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 Assert.AreEqual(1, app.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count());
                 Assert.AreEqual(1, app.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Count());
+                Assert.AreEqual("my-uid.my-utid", cacheAccess.LastNotificationArgs.SuggestedCacheKey);
                 cacheAccess.AssertAccessCounts(1, 1);
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AcquireTokenSilentTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/AcquireTokenSilentTests.cs
@@ -796,7 +796,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 // Assert
                 cacheAccess.AssertAccessCounts(4, 0);
-                Assert.AreEqual(homeAccId, cacheAccess.LastNotificationArgs.SuggestedCacheKey);
+                Assert.IsNull(cacheAccess.LastNotificationArgs.SuggestedCacheKey, 
+                    "MSAL does not know the home account id of the account associated with this username. It needs to load the cache first.");
 
             }
         }


### PR DESCRIPTION
This is for #1902 for confidential client scenarios, and has more info on the issue.

[ ] OBO should use the AT hash as the cache key, because the claims in the AT can change, so we use the AT directly to determine the cache key so the right AT is used.

[ ] Client credentials uses `{client_id} + "_AppTokenCache"`, as it's using the app token cache, so it needs the token based on the client id. MS Identity Web suffixes it w/`"_AppTokenCache"`, so we'd like to keep this pattern to not break current customers.

[ ] all other confidential client flows (including silent) use the home account id, as the key, because there is a user account. 

In order to make the changes in MS Identity Web, we'd need to have this addition included in a nuget package. We have a deadline of July 6 on our end. cc: @jmprieur @henrik-me 