### PR TITLE
WIP Clear ADAL cache during error

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Identity.Client.Cache
                 adalCache.Clear();
 
                 throw new MsalClientException(
-                    MsalError.InvalidAdalCacheMultipleRTs, 
+                    MsalError.InvalidAdalCacheMultipleRTs,
                     MsalErrorMessage.InvalidAdalCacheMultipleRTs);
             }
 

--- a/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
@@ -324,10 +324,9 @@ namespace Microsoft.Identity.Client.Cache
                     AdalCacheOperations.Deserialize(logger, legacyCachePersistence.LoadCache());
 
                 adalCache.Clear();
-
-                throw new MsalClientException(
-                    MsalError.InvalidAdalCacheMultipleRTs,
-                    MsalErrorMessage.InvalidAdalCacheMultipleRTs);
+                logger.Error(MsalErrorMessage.InvalidAdalCacheMultipleRTs);
+                legacyCachePersistence.WriteCache(AdalCacheOperations.Serialize(logger, adalCache));
+                return null;
             }
 
             return adalRts.FirstOrDefault();

--- a/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Identity.Client.Cache
             if (rtGroupsByEnv.Any(g => g.Count() > 1))
             {
                 //Due to the fact that there is a problem with the ADAL cache that causes this exception, The ADAL cache will be removed when 
-                //this exception is triggered so that the can sign in interactivly and repopulate the cache.
+                //this exception is triggered so that users can sign in interactivly and repopulate the cache.
                 IDictionary<AdalTokenCacheKey, AdalResultWrapper> adalCache =
                     AdalCacheOperations.Deserialize(logger, legacyCachePersistence.LoadCache());
 

--- a/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
@@ -318,6 +318,13 @@ namespace Microsoft.Identity.Client.Cache
             // if we have more than 1 RT per env, there is smth wrong with the ADAL cache
             if (rtGroupsByEnv.Any(g => g.Count() > 1))
             {
+                //Due to the fact that there is a problem with the ADAL cache that causes this exception, The ADAL cache will be removed when 
+                //this exception is triggered so that the can sign in interactivly and repopulate the cache.
+                IDictionary<AdalTokenCacheKey, AdalResultWrapper> adalCache =
+                    AdalCacheOperations.Deserialize(logger, legacyCachePersistence.LoadCache());
+
+                adalCache.Clear();
+
                 throw new MsalClientException(
                     MsalError.InvalidAdalCacheMultipleRTs, 
                     MsalErrorMessage.InvalidAdalCacheMultipleRTs);

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Identity.Client
             "See https://aka.ms/msal-net-custom-instance-metadata for more details.";
 
         public const string ScopesRequired = "At least one scope needs to be requested for this authentication flow.";
-        public const string InvalidAdalCacheMultipleRTs = "The ADAL cache is invalid as it contains multiple refresh token entries for one user. Mitigation: Delete the ADAL cache. If you do not maintain an ADAL cache, this may be a bug in MSAL.";
+        public const string InvalidAdalCacheMultipleRTs = "The ADAL cache is invalid as it contains multiple refresh token entries for one user. Deleting invalid ADAL cache.";
 
         public static string ExperimentalFeature(string methodName)
         {

--- a/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/CacheFallbackOperationsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/CacheTests/CacheFallbackOperationsTests.cs
@@ -206,6 +206,39 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         }
 
         [TestMethod]
+        public void GetAllAdalEntriesForMsal_MultipleRTsPerEnv()
+        {
+            // Arrange
+            PopulateLegacyWithRtAndId(
+                          _legacyCachePersistence,
+                          TestConstants.ClientId,
+                          TestConstants.ProductionPrefNetworkEnvironment,
+                          "uid",
+                          "tenantId",
+                          "user1");
+
+            PopulateLegacyWithRtAndId(
+                _legacyCachePersistence,
+                TestConstants.ClientId,
+                TestConstants.ProductionPrefNetworkEnvironment,
+                "uid",
+                "tenantId",
+                "user2");
+
+            // Act
+            var rt = CacheFallbackOperations.GetAdalEntryForMsal(
+                _logger,
+                _legacyCachePersistence,
+                new[] { TestConstants.ProductionPrefNetworkEnvironment },
+                TestConstants.ClientId,
+                null,
+                "uid");
+
+            // Assert
+            Assert.IsNull(rt, "Null should be returned.");
+        }
+
+        [TestMethod]
         public void RemoveAdalUser_RemovesUserWithSameId()
         {
             // Arrange


### PR DESCRIPTION
Potential fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1925

This error occurs when that ADAL cache is invalid due to multiple RTs for one account. This change will clear the ADAL cache to allow the user to continue 