### PR TITLE
Disable all MATS telemetry if not configured

### DIFF
--- a/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryManager.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryManager.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
-using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Constants;
 
 namespace Microsoft.Identity.Client.TelemetryCore
@@ -46,15 +45,33 @@ namespace Microsoft.Identity.Client.TelemetryCore
             _onlySendFailureTelemetry = onlySendFailureTelemetry;
         }
 
+        private bool IsMatsConfigured
+        {
+            get
+            {
+                return Callback != null ||
+                    _applicationConfiguration.TelemetryConfig != null;
+            }
+        }
+
         public TelemetryCallback Callback { get; }
 
         public void StartEvent(EventBase eventToStart)
         {
+            if (!IsMatsConfigured)
+            {
+                return;
+            }
             _eventsInProgress[new EventKey(eventToStart)] = eventToStart;
         }
 
         public void StopEvent(EventBase eventToStop)
         {
+            if (!IsMatsConfigured)
+            {
+                return;
+            }
+
             var eventKey = new EventKey(eventToStop);
 
             // Locate the same name event in the EventsInProgress map
@@ -102,6 +119,11 @@ namespace Microsoft.Identity.Client.TelemetryCore
 
         public void Flush(string correlationId)
         {
+            if (!IsMatsConfigured)
+            {
+                return;
+            }
+
             if (!_completedEvents.ContainsKey(correlationId))
             {
                 // No completed Events returned for RequestId

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/TelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/TelemetryTests.cs
@@ -18,9 +18,6 @@ using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Test.Common.Mocks;
 using Microsoft.Identity.Client.UI;
-using NSubstitute;
-using Microsoft.Identity.Client.PlatformsCommon.Factories;
-using Microsoft.Identity.Client.Platforms.net45;
 using Microsoft.Identity.Client.Internal.Logger;
 
 namespace Microsoft.Identity.Test.Unit.PublicApiTests
@@ -155,7 +152,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             }
         }
 
-        internal class MockProxy : NetDesktopPlatformProxy
+        internal class MockProxy : Client.Platforms.net45.NetDesktopPlatformProxy
         {
 
             public MockProxy() : base(new NullLogger())

--- a/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/TelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit.net45/PublicApiTests/TelemetryTests.cs
@@ -13,10 +13,19 @@ using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Test.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Identity.Client.Internal;
+using System.Linq;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.Common.Mocks;
+using Microsoft.Identity.Client.UI;
+using NSubstitute;
+using Microsoft.Identity.Client.PlatformsCommon.Factories;
+using Microsoft.Identity.Client.Platforms.net45;
+using Microsoft.Identity.Client.Internal.Logger;
 
 namespace Microsoft.Identity.Test.Unit.PublicApiTests
 {
-    public class MyReceiver : ITelemetryReceiver
+    public class MyReceiver :   ITelemetryReceiver
     {
         public List<Dictionary<string, string>> EventsReceived { get; private set; }
 
@@ -41,7 +50,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
     }
 
     [TestClass]
-    public class TelemetryTests
+    public class TelemetryTests : TestBase
     {
         private const string ClientId = "a1b3c3d4";
 
@@ -92,6 +101,71 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             }
             Assert.IsTrue(_myReceiver.EventsReceived.Count > 0);
         }
+
+        [TestMethod]
+        public void NoTelemetryLogicIfNoCallbackOrConfig()
+        {
+
+            _telemetryManager = new TelemetryManager(
+                _serviceBundle.Config,
+                _platformProxy,
+                null,
+                true);
+
+            var correlationId = Guid.NewGuid().AsMatsCorrelationId();
+
+            var e1 = new ApiEvent(_logger, _crypto, correlationId) { Authority = new Uri("https://login.microsoftonline.com"), AuthorityType = "Aad" };
+            _telemetryManager.StartEvent(e1);
+            _telemetryManager.StopEvent(e1);
+
+            Assert.IsTrue(!_telemetryManager._completedEvents.Any());
+
+        }
+
+        [TestMethod]
+        public async Task DoNotCallPlatformProxyAsync()
+        {
+            // Arrange
+            using (var harness = new MockHttpAndServiceBundle())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                               .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                               .WithHttpManager(harness.HttpManager)
+                               .WithPlatformProxy(new NoDeviceIdProxy(new NullLogger()))
+                               .WithRedirectUri("http://localhost")
+                               .BuildConcrete();
+
+                MsalMockHelpers.ConfigureMockWebUI(
+                    app.ServiceBundle.PlatformProxy,
+                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
+
+                // Act
+                await app
+                    .AcquireTokenInteractive(TestConstants.s_scope)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert - NoDeviceIdProxy would fail if InternalGetDeviceId is called
+            }
+        }
+
+        internal class NoDeviceIdProxy : NetDesktopPlatformProxy
+        {
+            public NoDeviceIdProxy(ICoreLogger logger) : base(logger)
+            {
+            }
+
+            protected override string InternalGetDeviceId()
+            {
+                Assert.Fail("Should not call GetDeviceId");
+                return null;
+            }
+        }
+
 
         [TestMethod]
         [TestCategory("TelemetryInternalAPI")]


### PR DESCRIPTION
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1912