### PR TITLE
Enabling AcquireTokenADFSV4InteractiveFederatedTest

### DIFF
--- a/tests/Microsoft.Identity.Test.Android.UIAutomation/androidTests.cs
+++ b/tests/Microsoft.Identity.Test.Android.UIAutomation/androidTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Test.UIAutomation
                 AcquireTokenSilentTest,
 
                 AcquireTokenADFSV3InteractiveFederatedTest,
-                //AcquireTokenADFSV4InteractiveFederatedTest,
+                AcquireTokenADFSV4InteractiveFederatedTest,
                 AcquireTokenADFSV2019InteractiveFederatedTest,
 
                 B2CLocalAccountAcquireTokenTest,


### PR DESCRIPTION
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1920