### PR TITLE
Add a default null value to the parameter authenticationResultMetadata

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Client
             string idToken,
             IEnumerable<string> scopes,
             Guid correlationId,
-            AuthenticationResultMetadata authenticationResultMetadata,
+            AuthenticationResultMetadata authenticationResultMetadata = null,
             string tokenType = "Bearer")
         {
             AccessToken = accessToken;


### PR DESCRIPTION
Fix for the breaking change in 4.17.0