### PR TITLE
Update comments about missing exception in http client

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -34,7 +34,12 @@ namespace Microsoft.Identity.Client
         /// or setting the Agent.
         /// </summary>
         /// <param name="httpClientFactory">HTTP client factory</param>
-        /// <remarks>MSAL does not guarantee that it will not modify the HttpClient, for example by adding new headers.</remarks>
+        /// <remarks>MSAL does not guarantee that it will not modify the HttpClient, for example by adding new headers.
+        /// Prior to the changes needed in order to make MSAL's httpClients thread safe (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2046/files),
+        /// the httpClient had the possibility of throwing an exception stating "Properties can only be modified before sending the first request".
+        /// MSAL's httpClient will no longer throw this exception after 4.19.0 (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.19.0)
+        /// see (https://aka.ms/msal-httpclient-info) for more information.
+        /// </remarks>
         /// <returns>The builder to chain the .With methods</returns>
         public T WithHttpClientFactory(IMsalHttpClientFactory httpClientFactory)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Http/NetDesktopHttpClientFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Http/NetDesktopHttpClientFactory.cs
@@ -10,9 +10,7 @@ namespace Microsoft.Identity.Client.Platforms.net45.Http
 {
     internal class NetDesktopHttpClientFactory : IMsalHttpClientFactory
     {
-        //Prior to the changes needed in order to make MSAL's httpClients thread safe (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2046/files),
-        //the httpClient had the possibility to throw an exception stating "Properties can only be modified before sending the first request".
-        //MSAL's httpClient will no longer throw this exception after 4.19.0 (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.19.0)
+        //Please see (https://aka.ms/msal-httpclient-info) for important information regarding the HttpClient.
         private static readonly Lazy<HttpClient> _httpClient = new Lazy<HttpClient>(() => InitializeClient());
 
         public HttpClient GetHttpClient()

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Http/NetDesktopHttpClientFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Http/NetDesktopHttpClientFactory.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Identity.Client.Platforms.net45.Http
 {
     internal class NetDesktopHttpClientFactory : IMsalHttpClientFactory
     {
+        //Prior to the changes needed in order to make MSAL's httpClients thread safe (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2046/files),
+        //the httpClient had the possibility to throw an exception stating "Properties can only be modified before sending the first request".
+        //MSAL's httpClient will no longer throw this exception after 4.19.0 (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.19.0)
         private static readonly Lazy<HttpClient> _httpClient = new Lazy<HttpClient>(() => InitializeClient());
 
         public HttpClient GetHttpClient()

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/SimpleHttpClientFactory.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/SimpleHttpClientFactory.cs
@@ -18,9 +18,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
     /// </remarks>
     internal class SimpleHttpClientFactory : IMsalHttpClientFactory
     {
-        //Prior to the changes needed in order to make MSAL's httpClients thread safe (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2046/files),
-        //the httpClient had the possibility to throw an exception stating "Properties can only be modified before sending the first request".
-        //MSAL's httpClient will no longer throw this exception after 4.19.0 (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.19.0)
+        //Please see (https://aka.ms/msal-httpclient-info) for important information regarding the HttpClient.
         private static readonly Lazy<HttpClient> s_httpClient = new Lazy<HttpClient>(() => InitializeClient());
 
         private static HttpClient InitializeClient()

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/SimpleHttpClientFactory.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/SimpleHttpClientFactory.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
     /// </remarks>
     internal class SimpleHttpClientFactory : IMsalHttpClientFactory
     {
+        //Prior to the changes needed in order to make MSAL's httpClients thread safe (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2046/files),
+        //the httpClient had the possibility to throw an exception stating "Properties can only be modified before sending the first request".
+        //MSAL's httpClient will no longer throw this exception after 4.19.0 (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.19.0)
         private static readonly Lazy<HttpClient> s_httpClient = new Lazy<HttpClient>(() => InitializeClient());
 
         private static HttpClient InitializeClient()


### PR DESCRIPTION
Addressing this: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2046#discussion_r526348786