### PR TITLE
fix spelling in xml, logs, comments & spelling

### DIFF
--- a/src/client/Microsoft.Identity.Client/AccountId.cs
+++ b/src/client/Microsoft.Identity.Client/AccountId.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Identity.Client
         public string Identifier { get; }
 
         /// <summary>
-        /// For Azure AD, a string representation for a Guid which is the Object ID of the user owning the account in the tenant
+        /// For Azure AD, a string representation for a GUID which is the Object ID of the user owning the account in the tenant
         /// </summary>
         public string ObjectId { get; }
 
         /// <summary>
-        /// For Azure AD, a string representation for a Guid, which is the ID of the tenant where the account resides.
+        /// For Azure AD, a string representation for a GUID, which is the ID of the tenant where the account resides.
         /// </summary>
         public string TenantId { get; }
 
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Constructor of an AccountId meant for Adfs scenarios since Adfs instances lack tenant ids.
+        /// Constructor of an AccountId meant for ADFS scenarios since ADFS instances lack tenant ids.
         /// </summary>
         /// <param name="adfsIdentifier">Unique identifier for the account if authority is ADFS</param>
         public AccountId(string adfsIdentifier)
@@ -67,7 +67,7 @@ namespace Microsoft.Identity.Client
 
             if (elements.Length == 1)
             {
-                return new AccountId(str); //Account id is from Adfs; no . in the string
+                return new AccountId(str); //Account id is from ADFS; no . in the string
             }
 
             return new AccountId(str, elements[0], elements[1]);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Identity.Client
         /// <paramref name="tenant"/> can also contain the string representation of a GUID (tenantId),
         /// or even <c>common</c>, <c>organizations</c> or <c>consumers</c> but in this case
         /// it's recommended to use another override (<see cref="WithAuthority(AzureCloudInstance, Guid, bool)"/>
-        /// and <see cref="WithAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"./>
+        /// and <see cref="WithAuthority(AzureCloudInstance, AadAuthorityAudience, bool)"/>
         /// </remarks>
         /// <returns>The builder to chain the .With methods.</returns>
         public T WithAuthority(

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client
     /// </summary>
     /// <typeparam name="T"></typeparam>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]  // hide confidentail client on mobile
+    [System.ComponentModel.EditorBrowsable(EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
     public abstract class AbstractConfidentialClientAcquireTokenParameterBuilder<T>
         : AbstractAcquireTokenParameterBuilder<T>
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Client
         ///  PoP tokens are similar to Bearer tokens, but are bound to the HTTP request and to a cryptographic key, which MSAL can manage on Windows.
         ///  See https://aka.ms/msal-net-pop
         /// </summary>
-        /// <param name="popAuthenticationConfiguration">Configuration properties used to construct a proof of possesion request.</param>
+        /// <param name="popAuthenticationConfiguration">Configuration properties used to construct a proof of possession request.</param>
         /// <remarks>
         /// <list type="bullet">
         /// <item> An Authentication header is automatically added to the request</item>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Client
     /// Builder for AcquireTokenByAuthorizationCode
     /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
     public sealed class AcquireTokenByAuthorizationCodeParameterBuilder :
         AbstractConfidentialClientAcquireTokenParameterBuilder<AcquireTokenByAuthorizationCodeParameterBuilder>
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
+        /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
@@ -60,13 +60,13 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
+        /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         public AcquireTokenByRefreshTokenParameterBuilder WithSendX5C(bool withSendX5C)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Client
     /// See https://aka.ms/msal-net-client-credentials
     /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
     public sealed class AcquireTokenForClientParameterBuilder :
         AbstractConfidentialClientAcquireTokenParameterBuilder<AcquireTokenForClientParameterBuilder>
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
+        /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Client
     /// See https://aka.ms/msal-net-on-behalf-of
     /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
     public sealed class AcquireTokenOnBehalfOfParameterBuilder :
         AbstractConfidentialClientAcquireTokenParameterBuilder<AcquireTokenOnBehalfOfParameterBuilder>
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
+        /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client
         /// sure that conditional access policies are applied immediately, rather than after the expiration of the access token.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
-        /// <remarks>Avoid un-necessarily setting <paramref name="forceRefresh"/> to <c>true</c> true in order to
+        /// <remarks>Avoid unnecessarily setting <paramref name="forceRefresh"/> to <c>true</c> true in order to
         /// avoid negatively affecting the performance of your application</remarks>
         public AcquireTokenSilentParameterBuilder WithForceRefresh(bool forceRefresh)
         {
@@ -101,13 +101,13 @@ namespace Microsoft.Identity.Client
         /// this method will send the public certificate to Azure AD along with the token request,
         /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
         /// This saves the application admin from the need to explicitly manage the certificate rollover
-        /// (either via portal or powershell/CLI operation). For details see https://aka.ms/msal-net-sni
+        /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         public AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
         {
@@ -121,7 +121,7 @@ namespace Microsoft.Identity.Client
         ///  PoP tokens are similar to Bearer tokens, but are bound to the HTTP request and to a cryptographic key, which MSAL can manage on Windows.
         ///  See https://aka.ms/msal-net-pop
         /// </summary>
-        /// <param name="popAuthenticationConfiguration">Configuration properties used to construct a proof of possesion request.</param>
+        /// <param name="popAuthenticationConfiguration">Configuration properties used to construct a proof of possession request.</param>
         /// <remarks>
         /// <list type="bullet">
         /// <item> An Authentication header is automatically added to the request</item>
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Client
         /// </list>
         /// </remarks>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         public AcquireTokenSilentParameterBuilder WithProofOfPosession(PopAuthenticationConfiguration popAuthenticationConfiguration)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client
     ///     that are only used for AcquireToken?
     /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
     public sealed class GetAuthorizationRequestUrlParameterBuilder :
         AbstractConfidentialClientAcquireTokenParameterBuilder<GetAuthorizationRequestUrlParameterBuilder>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/SystemWebViewOptions.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/SystemWebViewOptions.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Identity.Client
 #if NET_CORE || DESKTOP || NETSTANDARD
 
         /// <summary>
-        /// Use Microsoft Edge to navigate to the given uri. On non-windows platforms it uses 
-        /// whatever browser is the default
+        /// Use Microsoft Edge to navigate to the given URI. On non-windows platforms it uses 
+        /// whatever browser is the default.
         /// </summary>
         public static async Task OpenWithEdgeBrowserAsync(Uri uri)
         {
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Client
 
 
         /// <summary>
-        /// Use Microsoft Edge Chromium to navigate to the given uri. Requires the browser to be installed.
+        /// Use Microsoft Edge Chromium to navigate to the given URI. Requires the browser to be installed.
         /// On Linux, uses the default system browser instead, as Edge is not available.
         /// </summary>
         public static async Task OpenWithChromeEdgeBrowserAsync(Uri uri)

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Identity.Client
         /// </param>
         /// <param name="enableDefaultPlatformLogging">Flag to enable/disable logging to platform defaults.
         /// In Desktop/UWP, Event Tracing is used. In iOS, NSLog is used.
-        /// In android, logcat is used. The default value is <c>false</c>
+        /// In android, Logcat is used. The default value is <c>false</c>
         /// </param>
         /// <returns>The builder to chain the .With methods</returns>
         /// <exception cref="InvalidOperationException"/> is thrown if the loggingCallback
@@ -375,7 +375,7 @@ namespace Microsoft.Identity.Client
         /// Sets Extra Query Parameters for the query string in the HTTP authentication request
         /// </summary>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority.
-        /// The string needs to be properly URL-encdoded and ready to send as a string of segments of the form <c>key=value</c> separated by an ampersand character.
+        /// The string needs to be properly URL-encoded and ready to send as a string of segments of the form <c>key=value</c> separated by an ampersand character.
         /// </param>
         /// <returns></returns>
         public T WithExtraQueryParameters(string extraQueryParameters)
@@ -440,7 +440,7 @@ namespace Microsoft.Identity.Client
 
             CreateAuthorityInfoFromEnums();
 
-            //Adfs does not require client id to be in the form of a Guid
+            //ADFS does not require client id to be in the form of a GUID.
             //if (Config.AuthorityInfo?.AuthorityType != AuthorityType.Adfs && !Guid.TryParse(Config.ClientId, out _))
             //{
             //    throw new MsalClientException(MsalError.ClientIdMustBeAGuid, MsalErrorMessage.ClientIdMustBeAGuid);
@@ -560,10 +560,10 @@ namespace Microsoft.Identity.Client
         /// Adds a known Azure AD authority to the application to sign-in users from a single
         /// organization (single tenant application) specified by its tenant ID. See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <param name="cloudInstanceUri">Azure Cloud instance</param>
-        /// <param name="tenantId">Guid of the tenant from which to sign-in users</param>
+        /// <param name="cloudInstanceUri">Azure Cloud instance.</param>
+        /// <param name="tenantId">GUID of the tenant from which to sign-in users.</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
-        /// <returns>The builder to chain the .With methods</returns>
+        /// <returns>The builder to chain the .With methods.</returns>
         public T WithAuthority(
             string cloudInstanceUri,
             Guid tenantId,
@@ -641,11 +641,11 @@ namespace Microsoft.Identity.Client
         /// name or tenant ID. See https://aka.ms/msal-net-application-configuration.
         /// </summary>
         /// <param name="azureCloudInstance">Instance of Azure Cloud (for instance Azure
-        /// worldwide cloud, Azure German Cloud, US government ...)</param>
+        /// worldwide cloud, Azure German Cloud, US government ...).</param>
         /// <param name="tenant">Domain name associated with the Azure AD tenant from which
-        /// to sign-in users. This can also be a guid</param>
+        /// to sign-in users. This can also be a GUID.</param>
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
-        /// <returns>The builder to chain the .With methods</returns>
+        /// <returns>The builder to chain the .With methods.</returns>
         public T WithAuthority(
             AzureCloudInstance azureCloudInstance,
             string tenant,

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Tenant from which the application will allow users to sign it. This can be:
-        /// a domain associated with a tenant, a guid (tenant id), or a meta-tenant (e.g. consumers).
+        /// a domain associated with a tenant, a GUID (tenant id), or a meta-tenant (e.g. consumers).
         /// This property is mutually exclusive with <see cref="AadAuthorityAudience"/>. If both
         /// are provided, an exception will be thrown.
         /// </summary>
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Specific instance in the case of Azure Active Directory.
-        /// It allows users to use the enum instead of the explicit url.
+        /// It allows users to use the enum instead of the explicit URL.
         /// This property is mutually exclusive with <see cref="Instance"/>. If both
         /// are provided, an exception will be thrown.
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
     public class ConfidentialClientApplicationBuilder : AbstractApplicationBuilder<ConfidentialClientApplicationBuilder>
     {
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.Client
         /// <returns>A <see cref="ConfidentialClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a confidential client application instance</returns>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         public static ConfidentialClientApplicationBuilder CreateWithApplicationOptions(
             ConfidentialClientApplicationOptions options)
@@ -57,7 +57,7 @@ namespace Microsoft.Identity.Client
         /// <returns>A <see cref="ConfidentialClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a confidential client application instance</returns>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         public static ConfidentialClientApplicationBuilder Create(string clientId)
         {

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Identity.Client
 {
     /// <summary>
     /// Configuration options for a confidential client application
-    /// (Web app / Web API / daemon app). See https://aka.ms/msal-net/application-configuration
+    /// (web app / web API / daemon app). See https://aka.ms/msal-net/application-configuration
     /// </summary>
     public class ConfidentialClientApplicationOptions : ApplicationOptions
     {

--- a/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
@@ -8,19 +8,19 @@ using System.Security.Cryptography.X509Certificates;
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// Configuration properties used to build a public or confidential client application
+    /// Configuration properties used to build a public or confidential client application.
     /// </summary>
     public interface IAppConfig
     {
         /// <summary>
         /// Client ID (also known as App ID) of the application as registered in the
-        /// application registration portal (https://aka.ms/msal-net-register-app)
+        /// application registration portal (https://aka.ms/msal-net-register-app).
         /// </summary>
         string ClientId { get; }
 
         /// <summary>
         /// Flag telling if logging of Personally Identifiable Information (PII) is enabled/disabled for
-        /// the application. See https://aka.ms/msal-net-logging
+        /// the application. See https://aka.ms/msal-net-logging.
         /// </summary>
         /// <seealso cref="IsDefaultPlatformLoggingEnabled"/>
         bool EnablePiiLogging { get; }
@@ -33,14 +33,14 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Level of logging requested for the app.
-        /// See https://aka.ms/msal-net-logging
+        /// See https://aka.ms/msal-net-logging.
         /// </summary>
         LogLevel LogLevel { get; }
 
         /// <summary>
         /// Flag telling if logging to platform defaults is enabled/disabled for the app.
         /// In Desktop/UWP, Event Tracing is used. In iOS, NSLog is used.
-        /// In Android, logcat is used. See https://aka.ms/msal-net-logging
+        /// In Android, logcat is used. See https://aka.ms/msal-net-logging.
         /// </summary>
         bool IsDefaultPlatformLoggingEnabled { get; }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Allows usage of features that are experimental and would otherwise throw a specific exception. 
         /// Use of experimental features in production is not recommended and are subject to be removed between builds. 
-        /// For details see https://aka.ms/msal-net-experimental-features
+        /// For details see https://aka.ms/msal-net-experimental-features.
         /// </summary>
         bool ExperimentalFeaturesEnabled { get; }
 
@@ -107,14 +107,14 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         string ClientSecret { get; }
 
         /// <summary>
         /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         X509Certificate2 ClientCredentialCertificate { get; }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Identity.Client
 
 #if WINDOWS_APP
         /// <summary>
-        /// Flag to enable authentication with the user currently logged-in in Windows.
+        /// Flag to enable authentication with the user currently logged-in on Windows.
         /// When set to true, the application will try to connect to the corporate network using windows integrated authentication.
         /// </summary>
         bool UseCorporateNetwork { get; }

--- a/src/client/Microsoft.Identity.Client/AppConfig/IMsalHttpClientFactory.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IMsalHttpClientFactory.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Identity.Client
 {
     /// <summary>
     /// Factory responsible for creating HttpClient
-    /// .Net recommends to use a single instance of HttpClient
+    /// .Net recommends to use a single instance of HttpClient.
     /// </summary>
     /// <remarks>
     /// Implementations must be thread safe. Consider creating and configuring an HttpClient in the constructor
@@ -16,11 +16,11 @@ namespace Microsoft.Identity.Client
     public interface IMsalHttpClientFactory
     {
         /// <summary>
-        /// Method returning an Http client that will be used to
+        /// Method returning an HTTP client that will be used to
         /// communicate with Azure AD. This enables advanced scenarios.
-        /// See https://aka.ms/msal-net-application-configuration
+        /// See https://aka.ms/msal-net-application-configuration.
         /// </summary>
-        /// <returns>An Http client</returns>
+        /// <returns>An HTTP client.</returns>
         HttpClient GetHttpClient();
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Client.AppConfig
 {
 
     /// <summary>
-    /// Configuration properties used to construct a proof of possesion request.
+    /// Configuration properties used to construct a proof of possession request.
     /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client.AppConfig
     public class PopAuthenticationConfiguration
     {
         /// <summary>
-        /// Constructs the configuration properties used to construct a proof of possesion request
+        /// Constructs the configuration properties used to construct a proof of possession request
         /// </summary>
         /// <param name="requestUri"></param>
         public PopAuthenticationConfiguration(Uri requestUri)
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Client.AppConfig
         }
 
         /// <summary>
-        /// An HTTP uri to the protected resource which requires a PoP token. The PoP token will be cryptographically bound to the request.
+        /// An HTTP URI to the protected resource which requires a PoP token. The PoP token will be cryptographically bound to the request.
         /// </summary>
         public Uri RequestUri { get; }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client.AppConfig
         /// An extensibility point that allows developers to define their own key management. 
         /// Leave <c>null</c> and MSAL will use a default implementation, which generates an RSA key pair in memory and refreshes it every 8 hours.
         /// Important note: if you want to change the key (e.g. rotate the key), you should create a new instance of this object,
-        /// as MSAL.NET will keep a thumbprint of keys in memory
+        /// as MSAL.NET will keep a thumbprint of keys in memory.
         /// </summary>
         public IPoPCryptoProvider PopCryptoProvider { get; set; }
     }

--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Identity.Client
         /// <term><c>http://localhost</c></term>
         /// </item>
         /// </list>
-        /// NOTE:There will be an update to the default rediect uri in the future to accomodate for system browsers on the 
+        /// NOTE:There will be an update to the default redirect URI in the future to accommodate for system browsers on the 
         /// .NET desktop and .NET Core platforms.
         /// </summary>
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
@@ -100,7 +100,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// You can specify a Keychain Access Group to use for persisting the token cache across multiple applications.
-        /// This enables you to share the token cache between several applications having the same keychain access group.
+        /// This enables you to share the token cache between several applications having the same Keychain access group.
         /// Sharing the token cache allows single sign-on between all of the applications that use the same Keychain access Group.
         /// See https://aka.ms/msal-net-ios-keychain-security-group for more information.
         /// </summary>
@@ -128,7 +128,7 @@ namespace Microsoft.Identity.Client
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a public client application instance</returns>
 #if !SUPPORTS_BROKER
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
         public PublicClientApplicationBuilder WithBroker(bool enableBroker = true)
         {
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Client
 
 #if WINDOWS_APP
         /// <summary>
-        /// Flag to enable authentication with the user currently logged-in in Windows.
+        /// Flag to enable authentication with the user currently logged-in on Windows.
         /// </summary>
         /// <param name="useCorporateNetwork">When set to true, the application will try to connect to the corporate network using windows integrated authentication.</param>
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/IPoPCryptoProvider.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/IPoPCryptoProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
     /// <summary>
     /// An abstraction over an the asymmetric key operations needed by POP, that encapsulates a pair of 
     /// public and private keys and some typical crypto operations.
-    /// All symetric operations are SHA256
+    /// All symmetric operations are SHA256.
     /// </summary>
     /// <remarks>
     /// Important: The 2 methods on this interface will be called at different times but MUST return details of 
@@ -24,12 +24,12 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
     public interface IPoPCryptoProvider
     {
         /// <summary>
-        /// The cannonical representation of the JWK.  See https://tools.ietf.org/html/rfc7638#section-3
+        /// The canonical representation of the JWK.  See https://tools.ietf.org/html/rfc7638#section-3
         /// </summary>
         string CannonicalPublicKeyJwk { get; }
 
         /// <summary>
-        /// Algorithm used to sign proof of possesion request. 
+        /// Algorithm used to sign proof of possession request. 
         /// See https://docs.microsoft.com/en-us/azure/key-vault/keys/about-keys#signverify for ECD
         /// See https://docs.microsoft.com/en-us/azure/key-vault/keys/about-keys#signverify-1 for RSA
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/InMemoryCryptoProvider.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/InMemoryCryptoProvider.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
         }
 
         /// <summary>
-        /// Creates the cannonical representation of the JWK.  See https://tools.ietf.org/html/rfc7638#section-3
-        /// The number of parameters as well as the lexicographic order is important, as this string will be hashed to get a thumbprint
+        /// Creates the canonical representation of the JWK.  See https://tools.ietf.org/html/rfc7638#section-3.
+        /// The number of parameters as well as the lexicographic order is important, as this string will be hashed to get a thumbprint.
         /// </summary>
         private static string ComputeCannonicalJwk(RSAParameters rsaPublicKey)
         {

--- a/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace Microsoft.Identity.Client
 {

--- a/src/client/Microsoft.Identity.Client/Cache/AdalCacheOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/AdalCacheOperations.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Client.Cache
             {
                 BinaryWriter writer = new BinaryWriter(stream);
                 writer.Write(SchemaVersion);
-                logger.Info(string.Format(CultureInfo.CurrentCulture, "Serializing token cache with {0} items.",
+                logger.Info(string.Format(CultureInfo.CurrentCulture, "Serializing token cache with {0} items. ",
                     tokenCacheDictionary.Count));
 
                 writer.Write(tokenCacheDictionary.Count);
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.Cache
                 int blobSchemaVersion = reader.ReadInt32();
                 if (blobSchemaVersion != SchemaVersion)
                 {
-                    logger.Warning("The version of the persistent state of the cache does not match the current schema, so skipping deserialization.");
+                    logger.Warning("The version of the persistent state of the cache does not match the current schema, so skipping deserialization. ");
                     return dictionary;
                 }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client.Cache
                     dictionary[key] = resultEx;
                 }
 
-                logger.Info(string.Format(CultureInfo.CurrentCulture, "Deserialized {0} items to token cache.", count));
+                logger.Info(string.Format(CultureInfo.CurrentCulture, "Deserialized {0} items to token cache. ", count));
             }
 
             return dictionary;

--- a/src/client/Microsoft.Identity.Client/Cache/AdalUserInfo.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/AdalUserInfo.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Client.Cache
         public DateTimeOffset? PasswordExpiresOn { get; internal set; }
 
         /// <summary>
-        /// Gets the url where the user can change the expiring password. The value can be null.
+        /// Gets the URL where the user can change the expiring password. The value can be null.
         /// </summary>
         [JsonProperty]
         public Uri PasswordChangeUrl { get; internal set; }

--- a/src/client/Microsoft.Identity.Client/Cache/AdalUsersForMsal.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/AdalUsersForMsal.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Identity.Client.Cache
                             (envAliases?.ContainsOrdinalIgnoreCase(Authority.GetEnviroment(u.Authority)) ?? true))
                             .ToLookup(u => u.ClientInfo, u => u.UserInfo)
                             .ToDictionary(group => group.Key, group => group.First());
-
         }
 
         public IEnumerable<AdalUserInfo> GetUsersWithoutClientInfo(IEnumerable<string> envAliases)

--- a/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheFallbackOperations.cs
@@ -31,13 +31,13 @@ namespace Microsoft.Identity.Client.Cache
             {
                 if (rtItem == null)
                 {
-                    logger.Info("No refresh token available. Skipping writing to ADAL legacy cache.");
+                    logger.Info("No refresh token available. Skipping writing to ADAL legacy cache. ");
                     return;
                 }
 
                 if (!string.IsNullOrEmpty(rtItem.FamilyId))
                 {
-                    logger.Info("Not writing FRT in ADAL legacy cache");
+                    logger.Info("Not writing FRT in ADAL legacy cache. ");
                     return;
                 }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Identity.Client.Cache
         /// Algorithm to delete:
         ///
         /// DisplayableId cannot be null
-        /// Removal is scoped by enviroment and clientId;
+        /// Removal is scoped by environment and clientId;
         ///
         /// If accountId != null then delete everything with the same clientInfo
         /// otherwise, delete everything with the same displayableId
@@ -222,7 +222,6 @@ namespace Microsoft.Identity.Client.Cache
                         keysToRemove.Add(kvp.Key);
                     }
                 }
-
             }
 
             foreach (AdalTokenCacheKey key in keysToRemove)
@@ -268,10 +267,10 @@ namespace Microsoft.Identity.Client.Cache
                     filtered = true;
                 }
 
-                // We should filter at leasts by one criteria to ensure we retrun adequate RT
+                // We should filter at leasts by one criteria to ensure we return adequate RT
                 if (!filtered)
                 {
-                    logger.Warning("Could not filter ADAL entries by either UPN or unique ID, skipping.");
+                    logger.Warning("Could not filter ADAL entries by either UPN or unique ID, skipping. ");
                     return null;
                 }
 
@@ -302,6 +301,5 @@ namespace Microsoft.Identity.Client.Cache
 
             return null;
         }
-
     }
 }

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -14,10 +14,10 @@ using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 namespace Microsoft.Identity.Client.Cache
 {
     /// <summary>
-    /// MSAL should only interact with the cache though this object. It is reponsible for firing cache notifications.
+    /// MSAL should only interact with the cache though this object. It is responsible for firing cache notifications.
     /// Flows should only perform (at most) 2 cache accesses: one to read data and one to write tokens. Reading data multiple times 
-    /// (e.g. read all ATs, read all RTs) should not refresh the cache from disk because of perf impact.
-    /// Write operations are still the responsability of TokenCache.
+    /// (e.g. read all ATs, read all RTs) should not refresh the cache from disk because of performance impact.
+    /// Write operations are still the responsibility of TokenCache.
     /// </summary>
     internal class CacheSessionManager : ICacheSessionManager
     {

--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalAppMetadataCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalAppMetadataCacheItem.cs
@@ -10,7 +10,7 @@ using Microsoft.Identity.Json.Linq;
 namespace Microsoft.Identity.Client.Cache.Items
 {
     /// <summary>
-    /// Apps shouldn't rely on its presence, unless the app itself wrote it. It means that SDK should translate absense of app metadata to the default values of its required fields.
+    /// Apps shouldn't rely on its presence, unless the app itself wrote it. It means that SDK should translate absence of app metadata to the default values of its required fields.
     /// Other apps that don't support app metadata should never remove existing app metadata.
     /// App metadata is a non-removable entity.It means there's no need for a public API to remove app metadata, and it shouldn't be removed when removeAccount is called.
     /// App metadata is a non-secret entity. It means that it cannot store any secret information, like tokens, nor PII, like username etc.
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Client.Cache.Items
 
         /// <summary>
         /// The family id of which this application is part of. This is an internal feature and there is currently a single app,
-        /// with id 1. If familyId is empty, it means an app is not part of a family. A missing entry means unkown status.
+        /// with id 1. If familyId is empty, it means an app is not part of a family. A missing entry means unknown status.
         /// </summary>
         public string FamilyId { get; }
 

--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalItemWithAdditionalFields.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalItemWithAdditionalFields.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Json.Linq;
 
 namespace Microsoft.Identity.Client.Cache.Items

--- a/src/client/Microsoft.Identity.Client/Cache/Keys/IiOSKey.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Keys/IiOSKey.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Identity.Client.Cache.Keys
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Client.Cache.Keys
 {
     internal interface IiOSKey
     {

--- a/src/client/Microsoft.Identity.Client/Cache/TokenCacheDictionarySerializer.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/TokenCacheDictionarySerializer.cs
@@ -11,7 +11,7 @@ using Microsoft.Identity.Json.Linq;
 namespace Microsoft.Identity.Client.Cache
 {
     /// <remarks>
-    /// The dictionary serializer does not handle Unknown Nodes
+    /// The dictionary serializer does not handle unknown nodes.
     /// </remarks>
     internal class TokenCacheDictionarySerializer : ITokenCacheSerializable
     {

--- a/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Client
         /// Acquires a security token from the authority configured in the app using the authorization code
         /// previously received from the STS.
         /// It uses the OAuth 2.0 authorization code flow (See https://aka.ms/msal-net-authorization-code).
-        /// It's usually used in web apps (for instance ASP.NET / ASP.NET Core Web apps) which sign-in users,
+        /// It's usually used in web apps (for instance ASP.NET / ASP.NET Core web apps) which sign-in users,
         /// and can request an authorization code.
         /// This method does not lookup the token cache, but stores the result in it, so it can be looked up
         /// using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilent(IEnumerable{string}, IAccount)"/>.

--- a/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -19,10 +19,10 @@ using System.Security.Cryptography.X509Certificates;
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// Class to be used for confidential client applications (Web Apps, Web APIs, and daemon applications).
+    /// Class to be used for confidential client applications (web apps, web APIs, and daemon applications).
     /// </summary>
     /// <remarks>
-    /// Confidential client applications are typically applications which run on servers (Web Apps, Web API, or even service/daemon applications).
+    /// Confidential client applications are typically applications which run on servers (web apps, web API, or even service/daemon applications).
     /// They are considered difficult to access, and therefore capable of keeping an application secret (hold configuration
     /// time secrets as these values would be difficult for end users to extract).
     /// A web app is the most common confidential client. The clientId is exposed through the web browser, but the secret is passed only in the back channel
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Client
         /// Acquires a security token from the authority configured in the app using the authorization code
         /// previously received from the STS.
         /// It uses the OAuth 2.0 authorization code flow (See https://aka.ms/msal-net-authorization-code).
-        /// It's usually used in Web Apps (for instance ASP.NET / ASP.NET Core Web apps) which sign-in users,
+        /// It's usually used in web apps (for instance ASP.NET / ASP.NET Core Web apps) which sign-in users,
         /// and can request an authorization code.
         /// This method does not lookup the token cache, but stores the result in it, so it can be looked up
         /// using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilent(IEnumerable{string}, IAccount)"/>.
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Acquires an access token for this application (usually a Web API) from the authority configured in the application,
-        /// in order to access another downstream protected Web API on behalf of a user using the OAuth 2.0 On-Behalf-Of flow.
+        /// in order to access another downstream protected web API on behalf of a user using the OAuth 2.0 On-Behalf-Of flow.
         /// See https://aka.ms/msal-net-on-behalf-of.
         /// This confidential client application was itself called with a token which will be provided in the
         /// <paramref name="userAssertion">userAssertion</paramref> parameter.

--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenInteractiveParameterBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenInteractiveParameterBuilderExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Client.Extensibility
     public static class AcquireTokenInteractiveParameterBuilderExtensions
     {
         /// <summary>
-        ///     Extension method enabling MSAL.NET extenders for public client applications to set a custom web ui
+        ///     Extension method enabling MSAL.NET extenders for public client applications to set a custom web UI
         ///     that will let the user sign-in with Azure AD, present consent if needed, and get back the authorization
         ///     code
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/Extensibility/ICustomWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/ICustomWebUI.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Identity.Client.Extensibility
 {
     /// <summary>
-    /// Interface that an MSAL.NET extender can implement to provide their own Web UI in public client applications
+    /// Interface that an MSAL.NET extender can implement to provide their own web UI in public client applications
     /// to sign-in user and have them consented part of the Authorization code flow.
     /// MSAL.NET provides an embedded web view for Windows and Mac, but there are other scenarios not yet supported.
     /// This extensibility point enables them to provide such UI in a secure way
@@ -16,12 +16,12 @@ namespace Microsoft.Identity.Client.Extensibility
     public interface ICustomWebUi
     {
         /// <summary>
-        /// Method called by MSAL.NET to delegate the authentication code Web with the Secure Token Service (STS)
+        /// Method called by MSAL.NET to delegate the authentication code web with the Secure Token Service (STS)
         /// </summary>
         /// <param name="authorizationUri"> URI computed by MSAL.NET that will let the UI extension
         /// navigate to the STS authorization endpoint in order to sign-in the user and have them consent
         /// </param>
-        /// <param name="redirectUri">The redirect Uri that was configured. The auth code will be appended to this redirect uri and the browser
+        /// <param name="redirectUri">The redirect URI that was configured. The auth code will be appended to this redirect URI and the browser
         /// will redirect to it.
         /// </param>
         /// <param name="cancellationToken">The cancellation token to which you should respond to.

--- a/src/client/Microsoft.Identity.Client/Extensibility/SSHExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/SSHExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Client.SSHCertificates
         }
 
         /// <summary>
-        /// Instructs AAD to return an SSH certificate instead of a Bearer token. Attempts to retrive
+        /// Instructs AAD to return an SSH certificate instead of a Bearer token. Attempts to retrieve
         /// the certificate from the token cache, and if one is not found, attempts to acquire one silently, 
         /// using the refresh token. See https://aka.ms/msal-net-ssh for details.
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Identity.Client.Http
 
 #if WINDOWS_APP
             // WORKAROUND
-            // On UWP there is a bug in the Http stack that causes an exception to be thrown when moving around a stream.
+            // On UWP there is a bug in the HTTP stack that causes an exception to be thrown when moving around a stream.
             // https://stackoverflow.com/questions/31774058/postasync-throwing-irandomaccessstream-error-when-targeting-windows-10-uwp
             // LoadIntoBufferAsync is necessary to buffer content for multiple reads - see https://stackoverflow.com/questions/26942514/multiple-calls-to-httpcontent-readasasync
             // Documentation is sparse, but it looks like loading the buffer into memory avoids the bug, without

--- a/src/client/Microsoft.Identity.Client/Http/RedirectUriHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Http/RedirectUriHelper.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Identity.Client.Http
     internal class RedirectUriHelper
     {
         /// <summary>
-        /// Check common redirect uri problems.
-        /// Optionally check that the redirect uri is not the OAuth2 standard redirect uri https://login.microsoftonline.com/common/oauth2/nativeclientb
+        /// Check common redirect URI problems.
+        /// Optionally check that the redirect URI is not the OAuth2 standard redirect URI https://login.microsoftonline.com/common/oauth2/nativeclientb
         /// when using a system browser, because the browser cannot redirect back to the app.
         /// </summary>
         public static void Validate(Uri redirectUri, bool usesSystemBrowser = false)
@@ -50,24 +50,24 @@ namespace Microsoft.Identity.Client.Http
             // It's important to use the original string here because the bundleId is case sensitive
             string actualRedirectUriString = redirectUri.OriginalString;
 
-            // MSAL style redirect uri - case sensitive
+            // MSAL style redirect URI - case sensitive
             if (string.Equals(expectedRedirectUri, actualRedirectUriString.TrimEnd('/'), StringComparison.Ordinal))
             {
-                logger.Verbose("Valid MSAL style redirect Uri detected.");
+                logger.Verbose("Valid MSAL style redirect Uri detected. ");
                 return;
             }
 
-            // ADAL style redirect uri - my_scheme://{bundleID} 
+            // ADAL style redirect URI - my_scheme://{bundleID} 
             if (redirectUri.Authority.Equals(bundleId, StringComparison.OrdinalIgnoreCase))
             {
-                logger.Verbose("Valid ADAL style redirect Uri detected.");
+                logger.Verbose("Valid ADAL style redirect Uri detected. ");
                 return;
             }
 
             throw new MsalClientException(
                 MsalError.CannotInvokeBroker,
                 $"The broker redirect URI is incorrect, it should be {expectedRedirectUri} or app_scheme ://{bundleId} - " +
-                $"please visit https://aka.ms/msal-net-xamarin for details about redirect URIs.");
+                $"please visit https://aka.ms/msal-net-xamarin for details about redirect URIs. ");
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.Client
 
         /// <Summary>
         /// Gets the URL of the authority, or the security token service (STS) from which MSAL.NET will acquire security tokens.
-        /// The return value of this propety is either the value provided by the developer in the constructor of the application, or otherwise
+        /// The return value of this property is either the value provided by the developer in the constructor of the application, or otherwise
         /// the value of the <see cref="ClientApplicationBase.Authority"/> static member (that is <c>https://login.microsoftonline.com/common/</c>)
         /// </Summary>
         // TODO: move to IAppConfig like ClientId?

--- a/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
@@ -9,10 +9,10 @@ using Microsoft.Identity.Client.ApiConfig;
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// Component to be used with confidential client applications like Web Apps/API.
+    /// Component to be used with confidential client applications like web apps/API.
     /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidentail client on mobile
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
     public partial interface IConfidentialClientApplication : IClientApplicationBase
     {
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client
         /// [V3 API] Acquires a security token from the authority configured in the app using the authorization code
         /// previously received from the STS.
         /// It uses the OAuth 2.0 authorization code flow (See https://aka.ms/msal-net-authorization-code).
-        /// It's usually used in Web Apps (for instance ASP.NET / ASP.NET Core Web apps) which sign-in users,
+        /// It's usually used in web apps (for instance ASP.NET / ASP.NET Core web apps) which sign-in users,
         /// and can request an authorization code.
         /// This method does not lookup the token cache, but stores the result in it, so it can be looked up
         /// using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilent(IEnumerable{string}, IAccount)"/>.

--- a/src/client/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Client
 {
     /// <summary>
     /// Interface to be used with desktop or mobile applications (Desktop / UWP / Xamarin.iOS / Xamarin.Android).
-    /// public client applications are not trusted to safely keep application secrets, and therefore they only access Web APIs in the name of the user only.
+    /// public client applications are not trusted to safely keep application secrets, and therefore they only access web APIs in the name of the user only.
     /// For details see https://aka.ms/msal-net-client-applications.
     /// </summary>
     public partial interface IPublicClientApplication : IClientApplicationBase

--- a/src/client/Microsoft.Identity.Client/ITokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/ITokenCache.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Identity.Client
     /// </summary>
     public partial interface ITokenCache
     {
-
         /// <summary>
         /// Sets a delegate to be notified before any library method accesses the cache. This gives an option to the
         /// delegate to deserialize a cache entry for the application and accounts specified in the <see cref="TokenCacheNotificationArgs"/>.

--- a/src/client/Microsoft.Identity.Client/ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/ITokenCacheInternal.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// FOCI - check in the app metadata to see if the app is part of the family
         /// </summary>
-        /// <returns>null if unkown, true or false if app metadata has details</returns>
+        /// <returns>null if unknown, true or false if app metadata has details</returns>
         Task<bool?> IsFociMemberAsync(AuthenticationRequestParameters requestParams, string familyId);     
 
         void SetIosKeychainSecurityGroup(string securityGroup);

--- a/src/client/Microsoft.Identity.Client/ITokenCacheSerializer.cs
+++ b/src/client/Microsoft.Identity.Client/ITokenCacheSerializer.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// This interface will be available in TokenCacheNotifiactionArgs callback to enable serialization/deserialization of the cache.
+    /// This interface will be available in TokenCacheNotificationArgs callback to enable serialization/deserialization of the cache.
     /// </summary>
     /// <remarks>
     /// The methods in this class are not thread safe. It is expected that they will be called from the token cache callbacks, 

--- a/src/client/Microsoft.Identity.Client/ITokenCacheSerializer.cs
+++ b/src/client/Microsoft.Identity.Client/ITokenCacheSerializer.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// This interface will be available in TokenCacheNOtifiactionArgs callback to enable serialization/deserialization of the cache.
+    /// This interface will be available in TokenCacheNotifiactionArgs callback to enable serialization/deserialization of the cache.
     /// </summary>
     /// <remarks>
     /// The methods in this class are not thread safe. It is expected that they will be called from the token cache callbacks, 
@@ -95,6 +95,5 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         [Obsolete("Support for the MSAL v2 token cache format will be dropped in the next major version", false)]
         void DeserializeMsalV2(byte[] msalV2State);
-
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Authority.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Authority.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Instance
 
             switch (configAuthorityInfo.AuthorityType)
             {
-                // ADFS and B2C are tenantless, no need to consider tenant
+                // ADFS and B2C are tenant-less, no need to consider tenant
                 case AuthorityType.Adfs:
                     return requestAuthorityInfo == null ?
                         new AdfsAuthority(configAuthorityInfo) :
@@ -201,7 +201,7 @@ namespace Microsoft.Identity.Client.Instance
         internal abstract string TenantId { get; }
 
         /// <summary>
-        /// Gets a tenanted authority if the current authority is tenantless.
+        /// Gets a tenanted authority if the current authority is tenant-less.
         /// Returns the original authority on B2C and ADFS
         /// </summary>
         internal abstract string GetTenantedAuthority(string tenantId);

--- a/src/client/Microsoft.Identity.Client/Instance/B2CAuthority.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/B2CAuthority.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Identity.Client.Instance
 {
     internal class B2CAuthority : AadAuthority
     {
-        public const string Prefix = "tfp"; // The http path of B2C authority looks like "/tfp/<your_tenant_name>/..."
+        public const string Prefix = "tfp"; // The HTTP path of B2C authority looks like "/tfp/<your_tenant_name>/..."
         public const string B2CCanonicalAuthorityTemplate = "https://{0}/{1}/{2}/{3}/";
 
         internal B2CAuthority(AuthorityInfo authorityInfo)
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Client.Instance
 
         internal override string GetTenantedAuthority(string tenantId)
         {
-            // For B2C, tenant is not changeble
+            // For B2C, tenant is not changeable
             return AuthorityInfo.CanonicalAuthority;
         }
     }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Internal;

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/IKnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/IKnownMetadataProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System.Collections.Generic;
 using Microsoft.Identity.Client.Core;
 

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
     /// If user provided metadata via <see cref="AbstractApplicationBuilder{T}.WithInstanceDiscoveryMetadata(string)"/> use it exclusively. Otherwise:
     /// 
     /// 1. Static cache (this is populated from the network)
-    /// 2. Well-known cache if all environments present in the token cache are known (this is hardcoded into msal)
+    /// 2. Well-known cache if all environments present in the token cache are known (this is hard-coded into MSAL)
     /// 3. Cache stored in token cache (Not currently implemented)
     /// 5. AAD discovery endpoint 
     /// 6. If going to the network fails with an error different than "invalid_instance" (i.e.authority validation failed), use the well-known instance metadata entry for the given authority
@@ -110,7 +110,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 case AuthorityType.Adfs:
                 case AuthorityType.B2C:
 
-                    requestContext.Logger.Info("[Instance Discovery] Skipping Instance discovery for non-AAD authority");
+                    requestContext.Logger.Info("[Instance Discovery] Skipping Instance discovery for non-AAD authority. ");
                     return await GetMetadataEntryAsync(authority, requestContext).ConfigureAwait(false);
 
                 default:
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 // ADFS and B2C do not support instance discovery 
                 case AuthorityType.Adfs:
                 case AuthorityType.B2C:
-                    requestContext.Logger.Info("[Instance Discovery] Skipping Instance discovery for non-AAD authority");
+                    requestContext.Logger.Info("[Instance Discovery] Skipping Instance discovery for non-AAD authority. ");
                     return CreateEntryForSingleAuthority(authorityUri);
 
                 default:
@@ -174,7 +174,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             {
                 if (!requestContext.ServiceBundle.Config.AuthorityInfo.ValidateAuthority)
                 {
-                    requestContext.Logger.Info("[Instance Discovery] Skipping Instance discovery as validate authority is set to false.");
+                    requestContext.Logger.Info("[Instance Discovery] Skipping Instance discovery as validate authority is set to false. ");
                     return CreateEntryForSingleAuthority(authorityUri);
                 }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 }
 
                 string message =
-                    "[Instance Discovery] Instance Discovery failed. Potential cause: no network connection or discovery endpoint is busy. See exception below. MSAL will continue without network instance metadata.";
+                    "[Instance Discovery] Instance Discovery failed. Potential cause: no network connection or discovery endpoint is busy. See exception below. MSAL will continue without network instance metadata. ";
 
                 requestContext.Logger.WarningPii(message + " Authority: " + authorityUri, message);
                 requestContext.Logger.WarningPii(ex);

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -101,17 +101,16 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             if (canUseProvider)
             {
                 s_knownEntries.TryGetValue(environment, out InstanceDiscoveryMetadataEntry entry);
-                logger.Verbose($"[Instance Discovery] Tried to use known metadata provider for {environment}. Success? {entry != null}");
+                logger.Verbose($"[Instance Discovery] Tried to use known metadata provider for {environment}. Success? {entry != null}. ");
 
                 return entry;
             }
 
             logger.VerbosePii(
                 $"[Instance Discovery] Could not use known metadata provider because at least one environment in the cache is not known. Environments in cache: {string.Join(" ", existingEnvironmentsInCache)} ",
-                $"[Instance Discovery] Could not use known metadata provider because at least one environment in the cache is not known");
+                $"[Instance Discovery] Could not use known metadata provider because at least one environment in the cache is not known. ");
             return null;
         }
-
 
         public static bool IsKnownEnvironment(string environment)
         {

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkCacheMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkCacheMetadataProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         public InstanceDiscoveryMetadataEntry GetMetadata(string environment, ICoreLogger logger)
         {
             s_cache.TryGetValue(environment, out InstanceDiscoveryMetadataEntry entry);
-            logger.Verbose($"[Instance Discovery] Tried to use network cache provider for {environment}. Success? {entry != null}");
+            logger.Verbose($"[Instance Discovery] Tried to use network cache provider for {environment}. Success? {entry != null}. ");
 
             return entry;
         }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             var cachedEntry = _networkCacheMetadataProvider.GetMetadata(environment, logger);
             if (cachedEntry != null)
             {
-                logger.Verbose($"[Instance Discovery] The network provider found an entry for {environment}");
+                logger.Verbose($"[Instance Discovery] The network provider found an entry for {environment}. ");
                 return cachedEntry;
             }
 
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             CacheInstanceDiscoveryMetadata(discoveryResponse);
 
             cachedEntry = _networkCacheMetadataProvider.GetMetadata(environment, logger);
-            logger.Verbose($"[Instance Discovery] After hitting the discovery endpoint, the network provider found an entry for {environment} ? {cachedEntry != null}");
+            logger.Verbose($"[Instance Discovery] After hitting the discovery endpoint, the network provider found an entry for {environment} ? {cachedEntry != null}. ");
 
             return cachedEntry;
         }
@@ -111,8 +111,8 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 authority.Port);
 
             requestContext.Logger.InfoPii(
-                $"Fetching instance discovery from the network from host {discoveryHost}. Endpoint {instanceDiscoveryEndpoint}",
-                $"Fetching instance discovery from the network from host {discoveryHost}");
+                $"Fetching instance discovery from the network from host {discoveryHost}. Endpoint {instanceDiscoveryEndpoint}. ",
+                $"Fetching instance discovery from the network from host {discoveryHost}. ");
 
             return new Uri(instanceDiscoveryEndpoint);
         }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/UserMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/UserMetadataProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         {
             _entries.TryGetValue(environment ?? "", out InstanceDiscoveryMetadataEntry entry);
 
-            logger.Verbose($"[Instance Discovery] Tried to use user metadata provider for {environment}. Success? {entry != null}");
+            logger.Verbose($"[Instance Discovery] Tried to use user metadata provider for {environment}. Success? {entry != null}. ");
 
             if (entry == null)
             {

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             {
                 if (string.IsNullOrEmpty(_optionalBrokerInstallUrl))
                 {
-                    _logger.Info("Broker is required but not installed. An app uri has not been provided.");
+                    _logger.Info("Broker is required but not installed. An app URI has not been provided. ");
                     return null;
                 }
 
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             if (!string.IsNullOrEmpty(msalTokenResponse.AccessToken))
             {
                 _logger.Info(
-                    "Success. Broker response contains an access token");
+                    "Success. Broker response contains an access token. ");
                 return;
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
 
         /// <summary>
         /// If device auth is required but the broker is not enabled, AAD will
-        /// signal this by returning an url pointing to the broker app that needs to be installed.
+        /// signal this by returning an URL pointing to the broker app that needs to be installed.
         /// </summary>
         void HandleInstallUrl(string appLink);
 

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Client.Internal
         }
 
         #region TestBuilders
-        //The following builders methods are inteded for testing
+        //The following builders methods are intended for testing
         public static ClientCredentialWrapper CreateWithCertificate(X509Certificate2 certificate, IDictionary<string, string> claimsToSign = null)
         {
             return new ClientCredentialWrapper(certificate, claimsToSign);
@@ -100,7 +100,7 @@ namespace Microsoft.Identity.Client.Internal
         private void CheckCertificateKeySize(X509Certificate2 cert)
         {
             //Currently, the min key size is enforced on desktop (net 45) as 2048 as it is the current industry standard.
-            //This is not enforced on netCore unfortunalty and adding this enforcement may break customers on netCore.
+            //This is not enforced on netCore unfortunately and adding this enforcement may break customers on netCore.
             //NetCore can only enforce a min key size of 512 since it is enforced by the portal already.
 #if DESKTOP
             if (cert.PublicKey.Key.KeySize < MinKeySizeInBits)

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Identity.Client.Internal
             }
 
             /// <summary>
-            /// x5t = base64 url encoded cert thumbprint 
+            /// x5t = base64 URL encoded cert thumbprint 
             /// </summary>
             /// <remarks>
             /// Mandatory for ADFS 2019

--- a/src/client/Microsoft.Identity.Client/Internal/RequestContext.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/RequestContext.cs
@@ -34,6 +34,5 @@ namespace Microsoft.Identity.Client.Internal
                 ServiceBundle.HttpTelemetryManager,
                 eventToStart);
         }
-
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             var logger = this.RequestContext.Logger;
 
-            // Create Pii enabled string builder
+            // Create PII enabled string builder
             var builder = new StringBuilder(
                 Environment.NewLine + "=== Request Data ===" + Environment.NewLine + "Authority Provided? - " +
                 (Authority != null) + Environment.NewLine);
@@ -190,7 +190,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             string messageWithPii = builder.ToString();
 
-            // Create no Pii enabled string builder
+            // Create no PII enabled string builder
             builder = new StringBuilder(
                 Environment.NewLine + "=== Request Data ===" +
                 Environment.NewLine + "Authority Provided? - " + (Authority != null) +

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialHelper.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
     {
         /// <summary>
         ///     Determines whether or not the cached client assertion can be used again for the next authentication request by
-        ///     checking it's
-        ///     values against incoming request parameters.
+        ///     checking its values against incoming request parameters.
         /// </summary>
         /// <returns>Returns true if the previously cached client assertion is valid</returns>
         public static bool ValidateClientAssertion(ClientCredentialWrapper clientCredential, string audience, bool sendX5C)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
             else
             {
-                logger.Info("Skipped looking for an Access Token in the cache because ForceRefresh or Claims were set");
+                logger.Info("Skipped looking for an Access Token in the cache because ForceRefresh or Claims were set. ");
             }
 
             // No AT in the cache or AT needs to be refreshed
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
                 if (cachedAccessTokenItem != null && isAadUnavailable)
                 {
-                    logger.Info("Returning existing access token. It is not expired, but should be refreshed.");
+                    logger.Info("Returning existing access token. It is not expired, but should be refreshed. ");
                     return new AuthenticationResult(
                         cachedAccessTokenItem,
                         null,
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         TokenSource.Cache);
                 }
 
-                logger.Warning("Either the exception does not indicate a problem with AAD or the token cache does not have an AT that is usable.");
+                logger.Warning("Either the exception does not indicate a problem with AAD or the token cache does not have an AT that is usable. ");
                 throw;
             }
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
@@ -14,7 +14,6 @@ using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {
-
     /// <summary>
     /// This class decides the workflow of an interactive request. The business rules are: 
     /// 
@@ -23,7 +22,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
     /// 1.2. If this fails, e.g. if broker is not installed, the use a web view (goto 2)
     /// 
     /// 2. Use a webview and get an auth code and look at the auth code
-    /// 2.1. If the auth code has a special format, showing that a broker is needed then. Invoke the broker flow (step 1) with a broker installation url
+    /// 2.1. If the auth code has a special format, showing that a broker is needed then. Invoke the broker flow (step 1) with a broker installation URL
     /// 2.2. Otherwise exchange the auth code for tokens (normal authorize_code grant)
     /// </summary>
     internal class InteractiveRequest : RequestBase
@@ -103,21 +102,21 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             if (_requestParams.IsBrokerConfigured)
             {
-                _logger.Info("Broker is configured. Starting broker flow without knowing the broker installation app link.");
+                _logger.Info("Broker is configured. Starting broker flow without knowing the broker installation app link. ");
 
                 MsalTokenResponse tokenResponse = await FetchTokensFromBrokerAsync(
-                    null, // we don't have an installation uri yet
+                    null, // we don't have an installation URI yet
                     cancellationToken)
                     .ConfigureAwait(false);
 
                 // if we don't get back a result, then continue with the WebUi 
                 if (tokenResponse != null)
                 {
-                    _logger.Info("Broker attempt completed successfully");
+                    _logger.Info("Broker attempt completed successfully. ");
                     return tokenResponse;
                 }
 
-                _logger.Info("Broker attempt did not complete, most likely because the broker is not installed. Attempting to use a browser / web ui");
+                _logger.Info("Broker attempt did not complete, most likely because the broker is not installed. Attempting to use a browser / web UI. ");
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
@@ -130,7 +129,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             var result = await authorizationFetcher.FetchAuthCodeAndPkceVerifierAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            _logger.Info("An authorization code was retrieved from the /authorize endpoint.");
+            _logger.Info("An authorization code was retrieved from the /authorize endpoint. ");
             string authCode = result.Item1;
             string pkceCodeVerifier = result.Item2;
 
@@ -139,7 +138,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return await RunBrokerWithInstallUriAsync(brokerInstallUri, cancellationToken).ConfigureAwait(false);
             }
 
-            _logger.Info("Exchanging the auth code for tokens");
+            _logger.Info("Exchanging the auth code for tokens. ");
             var authCodeExchangeComponent =
                 _authCodeExchangeComponentOverride ??
                 new AuthCodeExchangeComponent(
@@ -154,9 +153,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private async Task<MsalTokenResponse> RunBrokerWithInstallUriAsync(string brokerInstallUri, CancellationToken cancellationToken)
         {
-            _logger.Info(
-                                "Based on the auth code, the broker flow is required. " +
-                                "Starting broker flow knowing the broker installation app link.");
+            _logger.Info("Based on the auth code, the broker flow is required. " + 
+                "Starting broker flow knowing the broker installation app link. ");
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             }
             else
             {
-                logger.Info("Skipped looking for an Access Token because ForceRefresh or Claims were set");
+                logger.Info("Skipped looking for an Access Token because ForceRefresh or Claims were set. ");
             }
 
             // No AT or AT.RefreshOn > Now --> refresh the RT
@@ -70,21 +70,21 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                 if (MsalError.BadToken.Equals(e.SubError, StringComparison.OrdinalIgnoreCase))
                 {
                     await CacheManager.TokenCacheInternal.RemoveAccountAsync(AuthenticationRequestParameters.Account, AuthenticationRequestParameters.RequestContext).ConfigureAwait(false);
-                    logger.Warning("Failed to refresh access token because the refresh token is invalid, removing account from cache.");
+                    logger.Warning("Failed to refresh access token because the refresh token is invalid, removing account from cache. ");
                     throw;
                 }
 
                 bool isAadUnavailable = e.IsAadUnavailable();
 
-                logger.Warning($"Refreshing the RT failed. Is AAD down? {isAadUnavailable}. Is there an AT in the cache that is usable? {cachedAccessTokenItem != null}");
+                logger.Warning($"Refreshing the RT failed. Is AAD down? {isAadUnavailable}. Is there an AT in the cache that is usable? {cachedAccessTokenItem != null} ");
 
                 if (cachedAccessTokenItem != null && isAadUnavailable)
                 {
-                    logger.Info("Returning existing access token. It is not expired, but should be refreshed.");
+                    logger.Info("Returning existing access token. It is not expired, but should be refreshed. ");
                     return await CreateAuthenticationResultAsync(cachedAccessTokenItem).ConfigureAwait(false);
                 }
 
-                logger.Warning("Failed to refresh the RT and cannot use existing AT (expired or missing).");
+                logger.Warning("Failed to refresh the RT and cannot use existing AT (expired or missing). ");
                 throw;
             }
         }
@@ -152,12 +152,12 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             if (isFamilyMember.HasValue && !isFamilyMember.Value)
             {
                 AuthenticationRequestParameters.RequestContext.Logger.Verbose(
-                    "[FOCI] App is not part of the family, skipping FOCI.");
+                    "[FOCI] App is not part of the family, skipping FOCI. ");
 
                 return null;
             }
 
-            logger.Verbose("[FOCI] App is part of the family or unknown, looking for FRT");
+            logger.Verbose("[FOCI] App is part of the family or unknown, looking for FRT. ");
             var familyRefreshToken = await CacheManager.FindFamilyRefreshTokenAsync(TheOnlyFamilyId).ConfigureAwait(false);
             logger.Verbose("[FOCI] FRT found? " + (familyRefreshToken != null));
 
@@ -168,7 +168,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                     MsalTokenResponse frtTokenResponse = await RefreshAccessTokenAsync(familyRefreshToken, cancellationToken)
                         .ConfigureAwait(false);
 
-                    logger.Verbose("[FOCI] FRT refresh succeeded");
+                    logger.Verbose("[FOCI] FRT refresh succeeded. ");
                     return frtTokenResponse;
                 }
                 catch (MsalServiceException ex)
@@ -182,14 +182,14 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                     if (MsalError.InvalidGrantError.Equals(ex?.ErrorCode, StringComparison.OrdinalIgnoreCase) &&
                         MsalError.ClientMismatch.Equals(ex?.SubError, StringComparison.OrdinalIgnoreCase))
                     {
-                        logger.Error("[FOCI] FRT refresh failed - client mismatch");
+                        logger.Error("[FOCI] FRT refresh failed - client mismatch. ");
                         return null;
                     }
 
                     // Rethrow failures to refresh the FRT, other than client_mismatch, because
                     // apps need to handle them in the same way they handle exceptions from refreshing the RT.
                     // For example, some apps have special handling for MFA errors.
-                    logger.Error("[FOCI] FRT refresh failed - other error");
+                    logger.Error("[FOCI] FRT refresh failed - other error. ");
                     throw;
 #endif
                 }
@@ -211,7 +211,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             {
                 msalTokenResponse.RefreshToken = msalRefreshTokenItem.Secret;
                 AuthenticationRequestParameters.RequestContext.Logger.Info(
-                    "Refresh token was missing from the token refresh response, so the refresh token in the request is returned instead");
+                    "Refresh token was missing from the token refresh response, so the refresh token in the request is returned instead. ");
             }
 
             return msalTokenResponse;
@@ -222,7 +222,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             var msalRefreshTokenItem = await CacheManager.FindRefreshTokenAsync().ConfigureAwait(false);
             if (msalRefreshTokenItem == null)
             {
-                AuthenticationRequestParameters.RequestContext.Logger.Verbose("No Refresh Token was found in the cache");
+                AuthenticationRequestParameters.RequestContext.Logger.Verbose("No Refresh Token was found in the cache. ");
 
                 throw new MsalUiRequiredException(
                     MsalError.NoTokensFoundError,
@@ -243,8 +243,6 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             };
 
             return dict;
-        }
-
-       
+        }       
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             {
                 if (AuthenticationRequestParameters.Account == null )
                 {
-                    _logger.Verbose("No account passed to AcquireTokenSilent");
+                    _logger.Verbose("No account passed to AcquireTokenSilent. ");
                     throw new MsalUiRequiredException(
                        MsalError.UserNullError,
                        MsalErrorMessage.MsalUiRequiredMessage,
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
 
                 if (!isBrokerConfigured) // IsCurrentBrokerAccount = true
                 {
-                    _logger.Verbose("No account passed to AcquireTokenSilent");
+                    _logger.Verbose("No account passed to AcquireTokenSilent. ");
                     throw new MsalUiRequiredException(
                        MsalError.CurrentBrokerAccount,
                        "Only some brokers (WAM) can log in the current account. ",
@@ -82,11 +82,11 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             }
             catch (MsalException ex)
             {
-                _logger.Verbose("Token cache could not satisfy silent request");
+                _logger.Verbose("Token cache could not satisfy silent request. ");
 
                 if (isBrokerConfigured && ShouldTryWithBrokerError(ex.ErrorCode))
                 {
-                    _logger.Info("Attempting to use broker instead");
+                    _logger.Info("Attempting to use broker instead. ");
                     return await _brokerStrategyLazy.Value.ExecuteAsync(cancellationToken).ConfigureAwait(false);
                 }
 

--- a/src/client/Microsoft.Identity.Client/MsalException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalException.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Identity.Client
 
             string innerExceptionContents = InnerException == null 
                 ? string.Empty 
-                : string.Format(CultureInfo.InvariantCulture, "\nInner Excception: {0}", InnerException.ToString());
+                : string.Format(CultureInfo.InvariantCulture, "\nInner Exception: {0}", InnerException.ToString());
 
             return string.Format(
                 CultureInfo.InvariantCulture, 

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -135,8 +135,8 @@ namespace Microsoft.Identity.Client
 
         #region Public Properties
         /// <summary>
-        /// Gets the status code returned from http layer. This status code is either the <c>HttpStatusCode</c> in the inner
-        /// <see cref="System.Net.Http.HttpRequestException"/> response or the the NavigateError Event Status Code in a browser based flow (See
+        /// Gets the status code returned from HTTP layer. This status code is either the <c>HttpStatusCode</c> in the inner
+        /// <see cref="System.Net.Http.HttpRequestException"/> response or the NavigateError Event Status Code in a browser based flow (See
         /// http://msdn.microsoft.com/en-us/library/bb268233(v=vs.85).aspx).
         /// You can use this code for purposes such as implementing retry logic or error investigation.
         /// </summary>
@@ -153,7 +153,7 @@ namespace Microsoft.Identity.Client
         /// If your application is a <see cref="IPublicClientApplication"/>, you should just call <see cref="IPublicClientApplication.AcquireTokenInteractive(System.Collections.Generic.IEnumerable{string})"/>
         /// and add the <see cref="AbstractAcquireTokenParameterBuilder{T}.WithClaims(string)"/> modifier.
         /// </description></item>
-        /// <item>><description>If your application is a <see cref="IConfidentialClientApplication"/>, (therefore doing the On-Behalf-Of flow), you should throw an Http unauthorize
+        /// <item>><description>If your application is a <see cref="IConfidentialClientApplication"/>, (therefore doing the On-Behalf-Of flow), you should throw an HTTP unauthorize
         /// exception with a message containing the claims</description></item>
         /// </list>
         /// For more details see https://aka.ms/msal-net-claim-challenge
@@ -168,7 +168,7 @@ namespace Microsoft.Identity.Client
 
 
         /// <summary>
-        /// Contains the http headers from the server response that indicated an error.
+        /// Contains the HTTP headers from the server response that indicated an error.
         /// </summary>
         /// <remarks>
         /// When the server returns a 429 Too Many Requests error, a Retry-After should be set. It is important to read and respect the
@@ -184,8 +184,7 @@ namespace Microsoft.Identity.Client
         #endregion
 
         /// <remarks>
-        /// The suberror should not be exposed for public consumption yet, as STS needs to do some work
-        /// first.
+        /// The suberror should not be exposed for public consumption yet, as STS needs to do some work first.
         /// </remarks>
         internal string SubError { get; set; }
 

--- a/src/client/Microsoft.Identity.Client/OAuth2/DeviceAuthJWTResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/DeviceAuthJWTResponse.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Identity.Client.OAuth2
     {
         public DeviceAuthHeader(string base64EncodedCertificate)
         {
-            this.Alg = "RS256";
-            this.Type = "JWT";
-            this.X5c = new List<string>();
-            this.X5c.Add(base64EncodedCertificate);
+            Alg = "RS256";
+            Type = "JWT";
+            X5c = new List<string>();
+            X5c.Add(base64EncodedCertificate);
         }
 
         [JsonProperty("x5c")]
@@ -39,9 +39,9 @@ namespace Microsoft.Identity.Client.OAuth2
         
         public DeviceAuthPayload(string audience, string nonce)
         {
-            this.Nonce = nonce;
-            this.Audience = audience;
-            this.Iat = _defaultDeviceAuthJWTTimeSpan.Value;
+            Nonce = nonce;
+            Audience = audience;
+            Iat = _defaultDeviceAuthJWTTimeSpan.Value;
         }
 
         [JsonProperty("iat")]
@@ -57,21 +57,21 @@ namespace Microsoft.Identity.Client.OAuth2
 
     internal class DeviceAuthJWTResponse
     {
-        private readonly DeviceAuthHeader header;
-        private readonly DeviceAuthPayload payload;
+        private readonly DeviceAuthHeader _header;
+        private readonly DeviceAuthPayload _payload;
 
         public DeviceAuthJWTResponse(string audience, string nonce,
             string base64EncodedCertificate)
         {
-            this.header = new DeviceAuthHeader(base64EncodedCertificate);
-            this.payload = new DeviceAuthPayload(audience, nonce);
+            _header = new DeviceAuthHeader(base64EncodedCertificate);
+            _payload = new DeviceAuthPayload(audience, nonce);
         }
 
         public string GetResponseToSign()
         {
-            return String.Format(CultureInfo.InvariantCulture, "{0}.{1}",
-                Base64UrlHelpers.Encode(JsonHelper.SerializeToJson(header).ToByteArray()),
-                Base64UrlHelpers.Encode(JsonHelper.SerializeToJson(payload).ToByteArray()));
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}",
+                Base64UrlHelpers.Encode(JsonHelper.SerializeToJson(_header).ToByteArray()),
+                Base64UrlHelpers.Encode(JsonHelper.SerializeToJson(_payload).ToByteArray()));
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Identity.Client.OAuth2
         public const string Prompt = "prompt"; // prompt is not standard oauth2 parameter
         public const string ClientInfo = "client_info"; // restrict_to_hint is not standard oauth2 parameter
 
-        public const string Claims = "claims"; // claims is not a standard oauth2 paramter
+        public const string Claims = "claims"; // claims is not a standard oauth2 parameter
 
         public const string TokenType = "token_type"; // not a standard OAuth2 param
         public const string RequestConfirmation = "req_cnf"; // not a standard OAuth2 param

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/HttpStatusProvider.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/HttpStatusProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Identity.Client.Internal.Requests;
@@ -9,7 +10,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
     internal class HttpStatusProvider : IThrottlingProvider
     {
         /// <summary>
-        /// Default timespan that blocks an application, if HTTP 429 and HTTP 5xx was recieved and Retry-After HTTP header was NOT returned by AAD.
+        /// Default timespan that blocks an application, if HTTP 429 and HTTP 5xx was received and Retry-After HTTP header was NOT returned by AAD.
         /// </summary>
         internal static readonly TimeSpan s_throttleDuration = TimeSpan.FromSeconds(60); // internal for test
 
@@ -35,8 +36,8 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
                 // if a retry-after header is present, another provider will take care of this
                 !RetryAfterProvider.TryGetRetryAfterValue(ex.Headers, out _)) 
             {
-                logger.Info($"[Throttling] Http status code {ex.StatusCode} encountered - " +
-                    $"throttling for {s_throttleDuration.TotalSeconds} seconds");
+                logger.Info($"[Throttling] HTTP status code {ex.StatusCode} encountered - " +
+                    $"throttling for {s_throttleDuration.TotalSeconds} seconds. ");
 
                 var thumbprint = ThrottleCommon.GetRequestStrictThumbprint(bodyParams,
                     requestParams.AuthorityInfo.CanonicalAuthority,

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/RetryAfterProvider.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/RetryAfterProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Net.Http.Headers;

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/SingletonThrottlingManager.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/SingletonThrottlingManager.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Identity.Client.Internal.Requests;
 
 namespace Microsoft.Identity.Client.OAuth2.Throttling
 {
-
     /// <summary>
     /// Throttling is the action through which MSAL blocks applications from making repeated 
     /// bad requests to the server. This works by MSAL detecting certain conditions when the server
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
     /// 
     /// Throttling occurs in the following conditions:
     /// <list type="bullet">
-    /// <item>Afetr receving an RetryAfter header</item>
+    /// <item>After receiving an RetryAfter header</item>
     /// <item>After receiving 429, 5xx HTTP status.</item>    
     /// </list>
     /// This class manages the throttling providers and is itself a provider

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Identity.Client.Core;

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCache.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCache.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCacheEntry.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCacheEntry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.Identity.Client.OAuth2.Throttling
@@ -34,6 +35,5 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
                     CreationTime > DateTimeOffset.Now;      // creation in the future (i.e. user changed the machine time)
             }
         }
-
     }
 }

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/UiRequiredProvider.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/UiRequiredProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
                 var logger = requestParams.RequestContext.Logger;
 
                 logger.Info($"[Throttling] MsalUiRequiredException encountered - " +
-                    $"throttling for {s_uiRequiredExpiration.TotalSeconds} seconds");
+                    $"throttling for {s_uiRequiredExpiration.TotalSeconds} seconds. ");
 
                 var thumbprint = GetRequestStrictThumbprint(bodyParams,
                     requestParams.AuthorityInfo.CanonicalAuthority,

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBroker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         private static SemaphoreSlim s_readyForResponse = new SemaphoreSlim(0);
 
         private static MsalTokenResponse s_androidBrokerTokenResponse = null;
-        //Since the correlation ID is not returned from the broker response, it must be stored at the beginning of the authentication call and reinjected into the response at the end.
+        //Since the correlation ID is not returned from the broker response, it must be stored at the beginning of the authentication call and re-injected into the response at the end.
         private static string s_correlationId;
         private readonly AndroidBrokerHelper _brokerHelper;
         private readonly ICoreLogger _logger;

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/BrokerConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/BrokerConstants.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         public const string ChallangeRequestCertAuthDelimeter = ";";
 
         /**
-         * Apk packagename that will install AD-Authenticator. It is used to
+         * APK package name that will install AD-Authenticator. It is used to
          * query if this app installed or not from package manager.
          */
         public const string PackageName = "com.microsoft.windowsintune.companyportal";

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
         {
             base.OnCreate(bundle);
 
-            // If activity is killed by the os, savedInstance will be the saved bundle.
+            // If activity is killed by the OS, savedInstance will be the saved bundle.
             if (bundle != null)
             {
                 _restarted = true;

--- a/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Client
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Class to be used to acquire tokens in desktop or mobile applications (Desktop / UWP / Xamarin.iOS / Xamarin.Android).
-    /// public client applications are not trusted to safely keep application secrets, and therefore they only access Web APIs in the name of the user only.
+    /// public client applications are not trusted to safely keep application secrets, and therefore they only access web APIs in the name of the user only.
     /// For details see https://aka.ms/msal-net-client-applications
     /// </summary>
     /// <remarks>
@@ -97,7 +97,7 @@ namespace Microsoft.Identity.Client
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
         /// <summary>
-        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on
+        /// Acquires a security token on a device without a web browser, by letting the user authenticate on
         /// another device. This is done in two steps:
         /// <list type="bullet">
         /// <item><description>The method first acquires a device code from the authority and returns it to the caller via

--- a/src/client/Microsoft.Identity.Client/TelemetryCallback.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCallback.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// This callback is for the raw telemetry events (app, http, cache) that we want to aggregate using MATS.
+    /// This callback is for the raw telemetry events (app, HTTP, cache) that we want to aggregate using MATS.
     /// </summary>
     /// <param name="events"></param>
     internal delegate void TelemetryCallback(List<Dictionary<string, string>> events);

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Client
             IdToken idToken = IdToken.Parse(response.IdToken);
             if (idToken == null)
             {
-                requestParams.RequestContext.Logger.Info("ID Token not present in response.");
+                requestParams.RequestContext.Logger.Info("ID Token not present in response. ");
             }
 
             var tenantId = Authority
@@ -250,7 +250,7 @@ namespace Microsoft.Identity.Client
         private static string GetPreferredUsernameFromIdToken(bool isAdfsAuthority, IdToken idToken)
         {
             // The preferred_username value cannot be null or empty in order to comply with the ADAL/MSAL Unified cache schema.
-            // It will be set to "preferred_username not in idtoken"
+            // It will be set to "preferred_username not in id token"
             if (idToken == null)
             {
                 return NullPreferredUsernameDisplayLabel;
@@ -260,7 +260,7 @@ namespace Microsoft.Identity.Client
             {
                 if (isAdfsAuthority)
                 {
-                    //The direct to adfs scenario does not return preferred_username in the id token so it needs to be set to the upn
+                    //The direct to ADFS scenario does not return preferred_username in the id token so it needs to be set to the UPN
                     return !string.IsNullOrEmpty(idToken.Upn)
                         ? idToken.Upn
                         : NullPreferredUsernameDisplayLabel;
@@ -457,7 +457,7 @@ namespace Microsoft.Identity.Client
             }
             else
             {
-                requestParams.RequestContext.Logger.Error("Multiple tokens found for matching authority, client_id, user and scopes.");
+                requestParams.RequestContext.Logger.Error("Multiple tokens found for matching authority, client_id, user and scopes. ");
 
                 throw new MsalClientException(
                     MsalError.MultipleTokensMatchedError,
@@ -553,9 +553,7 @@ namespace Microsoft.Identity.Client
             if (candidateRt != null)
                 return candidateRt;
 
-            requestParams.RequestContext.Logger.Info("Checking ADAL cache for matching RT");
-
-          
+            requestParams.RequestContext.Logger.Info("Checking ADAL cache for matching RT. ");          
 
             // ADAL legacy cache does not store FRTs
             if (requestParams.Account != null && string.IsNullOrEmpty(familyId))
@@ -577,7 +575,7 @@ namespace Microsoft.Identity.Client
             var logger = requestParams.RequestContext.Logger;
             if (requestParams?.AuthorityInfo?.CanonicalAuthority == null)
             {
-                logger.Warning("No authority details, can't check app metadata. Returning unknown");
+                logger.Warning("No authority details, can't check app metadata. Returning unknown. ");
                 return null;
             }
 
@@ -599,7 +597,7 @@ namespace Microsoft.Identity.Client
             // version of MSAL which did not record app metadata.
             if (appMetadata == null)
             {
-                logger.Warning("No app metadata found. Returning unknown");
+                logger.Warning("No app metadata found. Returning unknown. ");
                 return null;
             }
 
@@ -627,7 +625,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<MsalAccountCacheItem> accountCacheItems = _accessor.GetAllAccounts();
 
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
-                logger.Verbose($"GetAccounts found {rtCacheItems.Count()} RTs and {accountCacheItems.Count()} accounts in MSAL cache.");
+                logger.Verbose($"GetAccounts found {rtCacheItems.Count()} RTs and {accountCacheItems.Count()} accounts in MSAL cache. ");
 
             AdalUsersForMsal adalUsersResult = CacheFallbackOperations.GetAllAdalUsersForMsal(
                 Logger,
@@ -650,7 +648,7 @@ namespace Microsoft.Identity.Client
             accountCacheItems = accountCacheItems.Where(acc => instanceMetadata.Aliases.ContainsOrdinalIgnoreCase(acc.Environment));
 
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
-                logger.Verbose($"GetAccounts found {rtCacheItems.Count()} RTs and {accountCacheItems.Count()} accounts in MSAL cache after environment filtering.");
+                logger.Verbose($"GetAccounts found {rtCacheItems.Count()} RTs and {accountCacheItems.Count()} accounts in MSAL cache after environment filtering. ");
 
             IDictionary<string, Account> clientInfoToAccountMap = new Dictionary<string, Account>();
             foreach (MsalRefreshTokenCacheItem rtItem in rtCacheItems)

--- a/src/client/Microsoft.Identity.Client/TokenCache.Notifications.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.Notifications.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="afterAccess">Delegate set in order to handle the cache serialization in the case where the <see cref="TokenCache.HasStateChanged"/>
         /// member of the cache is <c>true</c></param>
-        /// <remarks>In the case where the delegate is used to serialize the cache entierely (not just a row), it might
+        /// <remarks>In the case where the delegate is used to serialize the cache entirely (not just a row), it might
         /// want to call <see cref="Serialize()"/></remarks>
 #if !SUPPORTS_CUSTOM_CACHE
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/client/Microsoft.Identity.Client/TokenCache.Serialization.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.Serialization.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Identity.Client
 {
     public sealed partial class TokenCache : ITokenCacheInternal
     {
-        // Unkown token cache data support for forwards compatibility.
+        // Unknown token cache data support for forwards compatibility.
         private IDictionary<string, JToken> _unknownNodes;
 
         byte[] ITokenCacheSerializer.SerializeAdalV3()

--- a/src/client/Microsoft.Identity.Client/TokenSource.cs
+++ b/src/client/Microsoft.Identity.Client/TokenSource.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/client/Microsoft.Identity.Client/UiRequiredExceptionClassification.cs
+++ b/src/client/Microsoft.Identity.Client/UiRequiredExceptionClassification.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client
         PromptNeverFailed,
 
         /// <summary>
-        /// An AcquireTokenSilent call failed. This is ussually part of the pattern 
+        /// An AcquireTokenSilent call failed. This is usually part of the pattern 
         /// of calling AcquireTokenSilent for getting a token from the cache, followed by an a different
         /// AcquireToken call for getting a token from AAD. See the error message for details. 
         /// See https://aka.ms/msal-net-UiRequiredException for details.

--- a/src/client/Microsoft.Identity.Client/UserAssertion.cs
+++ b/src/client/Microsoft.Identity.Client/UserAssertion.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Identity.Client
 #pragma warning disable CS1587 // XML comment is not placed on a valid language element
     /// <summary>
     /// Type containing an assertion representing a user's credentials. This type is used in the
-    /// On-Behalf-Of flow in confidential client applications, enabling a Web API to request a token
-    /// for another downsteam API in the name of the user whose credentials are held by this <c>UserAssertion</c>
+    /// On-Behalf-Of flow in confidential client applications, enabling a web API to request a token
+    /// for another downstream API in the name of the user whose credentials are held by this <c>UserAssertion</c>
     /// See https://aka.ms/msal-net-on-behalf-of
     /// </summary>
 #if DESKTOP || NET_CORE || NETSTANDARD1_3


### PR DESCRIPTION
should be easy to review in "unified" format. was looking for aka.ms links and fixing some things.
![image](https://user-images.githubusercontent.com/19942418/99617167-8ddf6c00-29d3-11eb-9b5f-9fd86de9faf3.png)
