### PR TITLE
Remove misleading / badly named header from Kerberos

### DIFF
--- a/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -61,13 +61,12 @@ namespace Microsoft.Identity.Client.WsTrust
         {
             var headers = new Dictionary<string, string>
             {
-                { "ContentType", "application/soap+xml" },
                 { "SOAPAction", (wsTrustEndpoint.Version == WsTrustVersion.WsTrust2005) ? XmlNamespace.Issue2005.ToString() : XmlNamespace.Issue.ToString() }
             };
 
             var body = new StringContent(
                 wsTrustRequest,
-                Encoding.UTF8, headers["ContentType"]);
+                Encoding.UTF8, "application/soap+xml");
 
             HttpResponse resp = await _httpManager.SendPostForceResponseAsync(wsTrustEndpoint.Uri, headers, body, requestContext.Logger).ConfigureAwait(false);
 


### PR DESCRIPTION
This is related to #2193 but it is not a fix.