### PR TITLE
fix spelling

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -201,7 +201,7 @@ Bug Fixes:
 
 **When migrating a Xamarin application from ADAL.NET to MSAL.NET and preserving the keychain, a CryptographicException can be thrown from the BrokerKeyHelper.** MSAL.NET now does the broker key keychain look up by Service and Account only. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1628).
 
-**WithProofOfPossession produces a token of type POP when it is expected to be PoP**. MSAL.NET will now produce a token of type PoP when WithProofOfPosession() is used. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1711).
+**WithProofOfPossession produces a token of type POP when it is expected to be PoP**. MSAL.NET will now produce a token of type PoP when WithProofOfPossession() is used. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1711).
 
 
 4.10.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -47,7 +47,7 @@ Bug Fixes:
 ============
 New Features: 
 **MSAL now expose the configured certificate on Confidential Client Application**. This helps manage multiple instances of Confidential Client Application.
-**Experimental WAM intergration on Windows for .NET classic, .NET core and UWP**. See https://aka.ms/msal-net-wam.
+**Experimental WAM integration on Windows for .NET classic, .NET core and UWP**. See https://aka.ms/msal-net-wam.
 
 Bug Fixes: 
 **Fix AcquireTokenByIntegratedWindowsAuthentication on .NET core**. Reverted the HTTP client used on .NET core as it was not possible to use default authentication which is needed for WS-trust. See issue [#1988](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1988).
@@ -195,13 +195,13 @@ New Features:
 
 **MSAL.NET will now remove accounts from the cache that have expired refresh tokens**. MSAL.NET will remove both the refresh token and the associated account if the `suberror` is "bad_token" to avaoid unnecessary calls to AzureAD. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/1720).
 
-**MSAL.NET uses telemetry schema V2** MSAL.NET has been updated to use Http telemetry schema V2. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1681).
+**MSAL.NET uses telemetry schema V2** MSAL.NET has been updated to use HTTP telemetry schema V2. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1681).
 
 Bug Fixes:
 
 **When migrating a Xamarin application from ADAL.NET to MSAL.NET and preserving the keychain, a CryptographicException can be thrown from the BrokerKeyHelper.** MSAL.NET now does the broker key keychain look up by Service and Account only. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1628).
 
-**WithProofOfPosession produces a token of type POP when it is expected to be PoP**. MSAL.NET will now produce a token of type PoP when WithProofOfPosession() is used. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1711).
+**WithProofOfPossession produces a token of type POP when it is expected to be PoP**. MSAL.NET will now produce a token of type PoP when WithProofOfPosession() is used. [Issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1711).
 
 
 4.10.0

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
@@ -57,13 +57,13 @@ namespace Microsoft.Identity.Client
         /// <item>This is an experimental API. The method signature may change in the future without involving a major version upgrade.</item>
         /// </list>
         /// </remarks>
-        public T WithProofOfPosession(PopAuthenticationConfiguration popAuthenticationConfiguration)
+        public T WithProofOfPossession(PopAuthenticationConfiguration popAuthenticationConfiguration)
         {
             if (!ServiceBundle.Config.ExperimentalFeaturesEnabled)
             {
                 throw new MsalClientException(
                     MsalError.ExperimentalFeature,
-                    MsalErrorMessage.ExperimentalFeature(nameof(WithProofOfPosession)));
+                    MsalErrorMessage.ExperimentalFeature(nameof(WithProofOfPossession)));
             }
 
             CommonParameters.PopAuthenticationConfiguration = popAuthenticationConfiguration ?? throw new ArgumentNullException(nameof(popAuthenticationConfiguration));

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
-        public AcquireTokenSilentParameterBuilder WithProofOfPosession(PopAuthenticationConfiguration popAuthenticationConfiguration)
+        public AcquireTokenSilentParameterBuilder WithProofOfPossession(PopAuthenticationConfiguration popAuthenticationConfiguration)
         {
             ConfidentialClientApplication.GuardMobileFrameworks();
 
@@ -141,7 +141,7 @@ namespace Microsoft.Identity.Client
             {
                 throw new MsalClientException(
                     MsalError.ExperimentalFeature,
-                    MsalErrorMessage.ExperimentalFeature(nameof(WithProofOfPosession)));
+                    MsalErrorMessage.ExperimentalFeature(nameof(WithProofOfPossession)));
             }
 
             CommonParameters.PopAuthenticationConfiguration = popAuthenticationConfiguration ?? throw new ArgumentNullException(nameof(popAuthenticationConfiguration));

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await pca
                 .AcquireTokenForClient(s_keyvaultScope)
                 .WithExtraQueryParameters(GetTestSliceParams())
-                .WithProofOfPosession(popConfig)
+                .WithProofOfPossession(popConfig)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 
@@ -153,7 +153,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var result = await pca
                 .AcquireTokenForClient(s_keyvaultScope)
                 .WithExtraQueryParameters(GetTestSliceParams())
-                .WithProofOfPosession(popConfig1)
+                .WithProofOfPossession(popConfig1)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 
@@ -174,7 +174,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var accounts = await pca.GetAccountsAsync().ConfigureAwait(false);
             result = await pca
                 .AcquireTokenSilent(s_keyvaultScope, accounts.Single())
-                .WithProofOfPosession(popConfig1)
+                .WithProofOfPossession(popConfig1)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 
@@ -186,7 +186,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // Call some other Uri - the same pop assertion can be reused, i.e. no need to call Evo
             result = await pca
               .AcquireTokenSilent(s_keyvaultScope, accounts.Single())
-              .WithProofOfPosession(popConfig2)
+              .WithProofOfPossession(popConfig2)
               .ExecuteAsync()
               .ConfigureAwait(false);
 
@@ -212,7 +212,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Build();
 
             var result = await confidentialApp.AcquireTokenForClient(s_keyvaultScope)
-                .WithProofOfPosession(popConfig)
+                .WithProofOfPossession(popConfig)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 
@@ -240,7 +240,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             popConfig.HttpMethod = HttpMethod.Get;
 
             var result = await confidentialApp.AcquireTokenForClient(s_keyvaultScope)
-                .WithProofOfPosession(popConfig)
+                .WithProofOfPossession(popConfig)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 
@@ -269,7 +269,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             popConfig.HttpMethod = HttpMethod.Get;
 
             var result = await confidentialApp.AcquireTokenForClient(s_keyvaultScope)
-                .WithProofOfPosession(popConfig)
+                .WithProofOfPossession(popConfig)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 
@@ -297,7 +297,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             popConfig.HttpMethod = HttpMethod.Post;
 
             var result = await confidentialApp.AcquireTokenForClient(s_keyvaultScope)
-                .WithProofOfPosession(popConfig)
+                .WithProofOfPossession(popConfig)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         {
             var cca = ConfidentialClientApplicationBuilder.Create(Guid.NewGuid().ToString()).WithClientSecret("some-secret").Build();
             MsalClientException ex = await AssertException.TaskThrowsAsync<MsalClientException>(
-                () => cca.AcquireTokenForClient(new[] { "scope" }).WithProofOfPosession(null).ExecuteAsync())
+                () => cca.AcquireTokenForClient(new[] { "scope" }).WithProofOfPossession(null).ExecuteAsync())
                 .ConfigureAwait(false);
 
             Assert.AreEqual(MsalError.ExperimentalFeature, ex.ErrorCode);

--- a/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationSchemeTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationSchemeTests.cs
@@ -14,7 +14,6 @@ using NSubstitute;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Client;
 using System.Threading;
-using Microsoft.Identity.Client.PlatformsCommon;
 using Microsoft.Identity.Client.Utils;
 using System.Threading.Tasks;
 using Microsoft.Identity.Test.Common.Mocks;
@@ -138,7 +137,7 @@ namespace Microsoft.Identity.Test.Unit.PoP
                 var provider = PoPProviderFactory.GetOrCreateProvider(testClock);
 
                 await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithProofOfPosession(popConfig)
+                    .WithProofOfPossession(popConfig)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 
@@ -155,7 +154,7 @@ namespace Microsoft.Identity.Test.Unit.PoP
 
                 provider = PoPProviderFactory.GetOrCreateProvider(testClock);
                 await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithProofOfPosession(popConfig)
+                    .WithProofOfPossession(popConfig)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 
@@ -172,7 +171,7 @@ namespace Microsoft.Identity.Test.Unit.PoP
 
                 provider = PoPProviderFactory.GetOrCreateProvider(testClock);
                 await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithProofOfPosession(popConfig)
+                    .WithProofOfPossession(popConfig)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 

--- a/tests/devapps/NetFxConsoleTestApp/Program.cs
+++ b/tests/devapps/NetFxConsoleTestApp/Program.cs
@@ -273,7 +273,7 @@ namespace NetFx
                                 var popConfig = new PopAuthenticationConfiguration(new Uri(PoPUri)) {HttpMethod = s_popMethod };
                                 silentBuilder = silentBuilder
                                     .WithExtraQueryParameters(GetTestSliceParams())
-                                    .WithProofOfPosession(popConfig);
+                                    .WithProofOfPossession(popConfig);
                             }
 
 
@@ -309,7 +309,7 @@ namespace NetFx
 
                                         silentBuilder = silentBuilder
                                             .WithExtraQueryParameters(GetTestSliceParams())
-                                            .WithProofOfPosession(popConfig);
+                                            .WithProofOfPossession(popConfig);
                                     }
                                     return silentBuilder.ExecuteAsync();
                                 })
@@ -485,7 +485,7 @@ namespace NetFx
         {
             var httpClient = new HttpClient();
             HttpResponseMessage response;
-            var request = new System.Net.Http.HttpRequestMessage(HttpMethod.Get, GraphAPIEndpoint);
+            var request = new HttpRequestMessage(HttpMethod.Get, GraphAPIEndpoint);
             request.Headers.Add("Authorization", authHeader);
             response = await httpClient.SendAsync(request).ConfigureAwait(false);
 
@@ -518,7 +518,7 @@ namespace NetFx
         }
 
         /// <summary>
-        /// This calls a special endpoint that validates any POP token against a configurable http request.
+        /// This calls a special endpoint that validates any POP token against a configurable HTTP request.
         /// The HTTP request is configured through headers.
         /// </summary>
         private static async Task CallPoPVerificationAPIAsync(string authHeader)


### PR DESCRIPTION
@jmprieur @bgavrilMS  i don't think possession is spelled right. i was updating the PoP sample and noticed it. [See below](https://tools.ietf.org/html/draft-ietf-oauth-pop-architecture-08#:~:text=OAuth%202.0%20Proof-of-Possession%20%28PoP%29%20Security%20Architecture%20draft-ietf-oauth-pop-architecture-08.txt%20Abstract,resources%20%28without%20demonstrating%20possession%20of%20a%20cryptographic%20key%29.):
![image](https://user-images.githubusercontent.com/19942418/100047379-2c4e4180-2dc7-11eb-9d4e-0dc88302c057.png)
