### PR TITLE
Adding test runs to release build

### DIFF
--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -46,7 +46,7 @@ steps:
     BuildPlatform: '$(BuildPlatform)'
     BuildConfiguration: '$(BuildConfiguration)'
     MsalClientSemVer: $(MsalClientSemVer)
-    Solution: 'Libs.sln'
+    Solution: 'LibsAndSamples.sln'
 
 # Run Unit Tests
 - template: template-run-unit-tests.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -63,13 +63,13 @@ steps:
 - template: template-run-unit-tests.yaml
   parameters:
     BuildConfiguration: '$(BuildConfiguration)'
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: eq(variables['RunTests'], 'true')
 
 # Run Integration Tests
 - template: template-run-integration-tests.yaml
   parameters:
     BuildConfiguration: '$(BuildConfiguration)'
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: eq(variables['RunTests'], 'true')
 
 # Publish nuget packages and symbols to VSTS package manager.
 - template: template-publish-packages-and-symbols.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -64,13 +64,11 @@ steps:
 - template: template-run-unit-tests.yaml
   parameters:
     BuildConfiguration: '$(BuildConfiguration)'
-    condition: eq(variables['RunTests'], 'true')
 
 # Run Integration Tests
 - template: template-run-integration-tests.yaml
   parameters:
     BuildConfiguration: '$(BuildConfiguration)'
-    condition: eq(variables['RunTests'], 'true')
 
 # Publish nuget packages and symbols to VSTS package manager.
 - template: template-publish-packages-and-symbols.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -48,6 +48,18 @@ steps:
     MsalClientSemVer: $(MsalClientSemVer)
     Solution: 'Libs.sln'
 
+# Run Unit Tests
+- template: template-run-unit-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+
+# Run Integration Tests
+- template: template-run-integration-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+
 # Run Post-build code analysis (e.g. Roslyn)
 - template: template-postbuild-code-analysis.yaml
 

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -28,6 +28,7 @@ steps:
   displayName: 'Use .Net Core sdk 2.x'
   inputs:
     version: 2.x
+  condition: eq(variables['RunTests'], 'true')
 
 - task: UseDotNet@2
   displayName: 'Use .Net Core sdk 5.x'

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -23,13 +23,6 @@ variables:
   
 steps:
 
-# For some reason the signing task ask for dotnet core 2
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.x'
-  inputs:
-    version: 2.x
-  condition: eq(variables['RunTests'], 'true')
-
 - task: UseDotNet@2
   displayName: 'Use .Net Core sdk 5.x'
   inputs:
@@ -52,23 +45,20 @@ steps:
 # Run Post-build code analysis (e.g. Roslyn)
 - template: template-postbuild-code-analysis.yaml
 
+# Run All Tests
+- template: template-run-all-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+
+# For some reason the signing task ask for dotnet core 2
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 2.x'
+  inputs:
+    version: 2.x
+  condition: eq(variables['RunTests'], 'true')
+
 # Pack and sign all of the nuget packages
 - template: template-pack-and-sign-all-nugets.yaml
-
-- task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 3.x'
-  inputs:
-    version: 3.x
-
-# Run Unit Tests
-- template: template-run-unit-tests.yaml
-  parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
-
-# Run Integration Tests
-- template: template-run-integration-tests.yaml
-  parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
 
 # Publish nuget packages and symbols to VSTS package manager.
 - template: template-publish-packages-and-symbols.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -48,6 +48,17 @@ steps:
     MsalClientSemVer: $(MsalClientSemVer)
     Solution: 'LibsAndSamples.sln'
 
+# Run Post-build code analysis (e.g. Roslyn)
+- template: template-postbuild-code-analysis.yaml
+
+# Pack and sign all of the nuget packages
+- template: template-pack-and-sign-all-nugets.yaml
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK 3.x'
+  inputs:
+    version: 3.x
+
 # Run Unit Tests
 - template: template-run-unit-tests.yaml
   parameters:
@@ -59,12 +70,6 @@ steps:
   parameters:
     BuildConfiguration: '$(BuildConfiguration)'
     condition: and(succeeded(), eq(variables['RunTests'], 'true'))
-
-# Run Post-build code analysis (e.g. Roslyn)
-- template: template-postbuild-code-analysis.yaml
-
-# Pack and sign all of the nuget packages
-- template: template-pack-and-sign-all-nugets.yaml
 
 # Publish nuget packages and symbols to VSTS package manager.
 - template: template-publish-packages-and-symbols.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -22,7 +22,11 @@ variables:
   BuildConfiguration: 'release'
   
 steps:
-
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK 3.x'
+  inputs:
+    version: 3.x
+    
 - task: UseDotNet@2
   displayName: 'Use .Net Core sdk 5.x'
   inputs:

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -59,7 +59,6 @@ steps:
   displayName: 'Use .Net Core sdk 2.x'
   inputs:
     version: 2.x
-  condition: eq(variables['RunTests'], 'true')
 
 # Pack and sign all of the nuget packages
 - template: template-pack-and-sign-all-nugets.yaml

--- a/build/template-ci-and-pr.yaml
+++ b/build/template-ci-and-pr.yaml
@@ -1,3 +1,5 @@
+# template-ci-and-pr.yaml
+# Builds and runs all tests for CI and PR pipelines
 
 parameters:
   BuildPlatform: 'any cpu'
@@ -24,12 +26,7 @@ steps:
     BuildConfiguration: '$(BuildConfiguration)'
     Solution: 'LibsAndSamples.sln'
 
-# Run Unit Tests
-- template: template-run-unit-tests.yaml
-  parameters:
-    BuildConfiguration: '$(BuildConfiguration)'
-
-# Run Integration Tests
-- template: template-run-integration-tests.yaml
+# Run All Tests
+- template: template-run-all-tests.yaml
   parameters:
     BuildConfiguration: '$(BuildConfiguration)'

--- a/build/template-run-all-tests.yaml
+++ b/build/template-run-all-tests.yaml
@@ -1,0 +1,19 @@
+# template-run-all-tests.yaml
+# Run all  tests across the LibsAndSamples.sln project
+
+parameters:
+  BuildConfiguration: 'debug'
+
+steps:
+
+- template: template-install-keyvault-secrets.yaml
+
+# Run Unit Tests
+- template: template-run-unit-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'
+
+# Run Integration Tests
+- template: template-run-integration-tests.yaml
+  parameters:
+    BuildConfiguration: '$(BuildConfiguration)'

--- a/build/template-run-integration-tests.yaml
+++ b/build/template-run-integration-tests.yaml
@@ -5,6 +5,7 @@ steps:
 
 - task: VSTest@2
   displayName: 'Run integration tests (.NET FX)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
     testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netfx\bin\**\net4*\Microsoft.Identity.Test.Integration.NetFx.dll'
@@ -16,6 +17,7 @@ steps:
 
 - task: VSTest@2
   displayName: 'Run integration tests (.NET Core)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
     testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netcore\bin\**\netcore*\Microsoft.Identity.Test.Integration.NetCore.dll'

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -10,6 +10,7 @@ steps:
 
 - task: VSTest@2
   displayName: 'Run unit tests (.NET FX)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
     testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\net4*\Microsoft.Identity.Test.Unit.dll'
@@ -19,6 +20,7 @@ steps:
 
 - task: VSTest@2
   displayName: 'Run unit tests (.NET CORE)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
     testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\netcore*\Microsoft.Identity.Test.Unit.dll'
@@ -29,16 +31,19 @@ steps:
 # install python and run cache tests
 - task: stevedower.python.PythonScript.PythonScript@1
   displayName: 'Update PIP'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     arguments: '-m pip install --upgrade pip'
 
 - task: stevedower.python.PythonScript.PythonScript@1
   displayName: 'Install MSAL.Python PIP'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     arguments: '-m pip install msal'
 
 - task: VSTest@2
   displayName: 'Run cache compat tests'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
     testAssemblyVer2: '**\CacheCompat\CommonCache.Test.Unit\bin\**\CommonCache.Test.Unit.dll'

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -6,8 +6,6 @@ parameters:
 
 steps:
 
-- template: template-install-keyvault-secrets.yaml
-
 - task: VSTest@2
   displayName: 'Run unit tests (.NET FX)'
   condition: and(succeeded(), eq(variables['RunTests'], 'true'))


### PR DESCRIPTION
Making changes to pipeline to allow tests to run on release build based on the value of RunTests.

RunTests can be set in the beginning of the test run.

true to run tests, false not to.

This will be true by default so tests will always run.

This will also trigger ui automation on the master branch

Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2278