### PR TITLE
Disable ADAL cache

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -191,6 +191,17 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// Enables or disables ADAL cache.
+        /// </summary>
+        /// <param name="disableAdalCache">Flag that indicates whether the ADAL cache operations will be invoked.</param>
+        /// <returns></returns>
+        public T WithDisabledAdalCache(bool disableAdalCache = true)
+        {
+            Config.IsAdalCacheEnabled = disableAdalCache;
+            return (T)this;
+        }
+
+        /// <summary>
         /// Sets the logging callback. For details see https://aka.ms/msal-net-logging
         /// </summary>
         /// <param name="loggingCallback"></param>

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -191,13 +191,18 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Enables or disables ADAL cache.
+        /// Enables ADAL cache serialialization and deserialization.
         /// </summary>
-        /// <param name="disableAdalCache">Flag that indicates whether the ADAL cache operations will be invoked.</param>
-        /// <returns></returns>
-        public T WithDisabledAdalCache(bool disableAdalCache = true)
+        /// <param name="enableAdalCacheCompatibility">Enable ADAL cache compatibility.</param>
+        /// <returns>The builder to chain the .With methods.</returns>
+        /// <remarks>
+        /// ADAL is a previous generation of this authentication library. This flag is only needed for 
+        /// specific migration scenarios from ADAL.NET to MSAL.NET when both library versions are running side-by-side.
+        /// Enabling this flag has a performance impact on token cache access.
+        /// </remarks>
+        public T WithAdalCacheCompatibility(bool enableAdalCacheCompatibility = true)
         {
-            Config.IsAdalCacheEnabled = disableAdalCache;
+            Config.AdalCacheCompatibilityEnabled = enableAdalCacheCompatibility;
             return (T)this;
         }
 
@@ -367,6 +372,7 @@ namespace Microsoft.Identity.Client
             WithClientName(applicationOptions.ClientName);
             WithClientVersion(applicationOptions.ClientVersion);
             WithClientCapabilities(applicationOptions.ClientCapabilities);
+            WithAdalCacheCompatibility(applicationOptions.AdalCacheCompatibilityEnabled);
 
             WithLogging(
                 null,

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -191,20 +191,20 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Enables ADAL cache serialization and deserialization.
+        /// Enables legacy ADAL cache serialization and deserialization.
         /// </summary>
-        /// <param name="enableAdalCacheCompatibility">Enable ADAL cache compatibility.</param>
+        /// <param name="enableLegacyCacheCompatibility">Enable legacy ADAL cache compatibility.</param>
         /// <returns>The builder to chain the .With methods.</returns>
         /// <remarks>
         /// ADAL is a previous legacy generation of MSAL.NET authentication library. 
-        /// If you don't use <c>.WithAdalCacheCompatiblity(false)</c>, then by default, the ADAL cache is used
+        /// If you don't use <c>.WithLegacyCacheCompatibility(false)</c>, then by default, the ADAL cache is used
         /// (along with MSAL cache). <c>true</c> flag is only needed for specific migration scenarios 
         /// from ADAL.NET to MSAL.NET when both library versions are running side-by-side.
-        /// To improve performance add <c>.WithAdalCacheCompatiblity(false)</c> unless you care about migration scenarios.
+        /// To improve performance add <c>.WithLegacyCacheCompatibility(false)</c> unless you care about migration scenarios.
         /// </remarks>
-        public T WithAdalCacheCompatibility(bool enableAdalCacheCompatibility = true)
+        public T WithLegacyCacheCompatibility(bool enableLegacyCacheCompatibility = true)
         {
-            Config.AdalCacheCompatibilityEnabled = enableAdalCacheCompatibility;
+            Config.LegacyCacheCompatibilityEnabled = enableLegacyCacheCompatibility;
             return (T)this;
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.Identity.Client
             WithClientName(applicationOptions.ClientName);
             WithClientVersion(applicationOptions.ClientVersion);
             WithClientCapabilities(applicationOptions.ClientCapabilities);
-            WithAdalCacheCompatibility(applicationOptions.AdalCacheCompatibilityEnabled);
+            WithLegacyCacheCompatibility(applicationOptions.LegacyCacheCompatibilityEnabled);
 
             WithLogging(
                 null,

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -191,14 +191,16 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Enables ADAL cache serialialization and deserialization.
+        /// Enables ADAL cache serialization and deserialization.
         /// </summary>
         /// <param name="enableAdalCacheCompatibility">Enable ADAL cache compatibility.</param>
         /// <returns>The builder to chain the .With methods.</returns>
         /// <remarks>
-        /// ADAL is a previous generation of this authentication library. This flag is only needed for 
-        /// specific migration scenarios from ADAL.NET to MSAL.NET when both library versions are running side-by-side.
-        /// Enabling this flag has a performance impact on token cache access.
+        /// ADAL is a previous legacy generation of MSAL.NET authentication library. 
+        /// If you don't use <c>.WithAdalCacheCompatiblity(false)</c>, then by default, the ADAL cache is used
+        /// (along with MSAL cache). <c>true</c> flag is only needed for specific migration scenarios 
+        /// from ADAL.NET to MSAL.NET when both library versions are running side-by-side.
+        /// To improve performance add <c>.WithAdalCacheCompatiblity(false)</c> unless you care about migration scenarios.
         /// </remarks>
         public T WithAdalCacheCompatibility(bool enableAdalCacheCompatibility = true)
         {

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client
         public bool MergeWithDefaultClaims { get; internal set; }
         internal int ConfidentialClientCredentialCount;
 
-        public bool IsAdalCacheEnabled { get; internal set; }
+        public bool IsAdalCacheEnabled { get; internal set; } = true;
 
         #region Authority
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Identity.Client
         public bool MergeWithDefaultClaims { get; internal set; }
         internal int ConfidentialClientCredentialCount;
 
+        public bool IsAdalCacheEnabled { get; internal set; }
+
         #region Authority
 
         public InstanceDiscoveryResponse CustomInstanceDiscoveryMetadata { get; set; }

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client
         public bool MergeWithDefaultClaims { get; internal set; }
         internal int ConfidentialClientCredentialCount;
 
-        public bool IsAdalCacheEnabled { get; internal set; } = true;
+        public bool AdalCacheCompatibilityEnabled { get; internal set; } = true;
 
         #region Authority
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client
         public bool MergeWithDefaultClaims { get; internal set; }
         internal int ConfidentialClientCredentialCount;
 
-        public bool AdalCacheCompatibilityEnabled { get; internal set; } = true;
+        public bool LegacyCacheCompatibilityEnabled { get; internal set; } = true;
 
         #region Authority
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
@@ -121,5 +121,10 @@ namespace Microsoft.Identity.Client
         /// For more details see https://aka.ms/msal-net-claims-request
         /// </remarks>
         public IEnumerable<string> ClientCapabilities { get; set; }
+
+        /// <summary>
+        /// Enables ADAL cache serialialization and deserialization.
+        /// </summary>
+        public bool AdalCacheCompatibilityEnabled { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
@@ -123,8 +123,8 @@ namespace Microsoft.Identity.Client
         public IEnumerable<string> ClientCapabilities { get; set; }
 
         /// <summary>
-        /// Enables ADAL cache serialialization and deserialization.
+        /// Enables legacy ADAL cache serialization and deserialization.
         /// </summary>
-        public bool AdalCacheCompatibilityEnabled { get; set; }
+        public bool LegacyCacheCompatibilityEnabled { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
@@ -104,9 +104,9 @@ namespace Microsoft.Identity.Client
         IEnumerable<string> ClientCapabilities { get; }
 
         /// <summary>
-        /// Indicates whether the ADAL cache operations will be invoked.
+        /// Enables ADAL cache serialialization and deserialization.
         /// </summary>
-        bool IsAdalCacheEnabled { get; }
+        bool AdalCacheCompatibilityEnabled { get; }
 
         /// <summary>
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
@@ -103,6 +103,10 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         IEnumerable<string> ClientCapabilities { get; }
 
+        /// <summary>
+        /// Indicates whether the ADAL cache operations will be invoked.
+        /// </summary>
+        bool IsAdalCacheEnabled { get; }
 
         /// <summary>
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
@@ -104,9 +104,9 @@ namespace Microsoft.Identity.Client
         IEnumerable<string> ClientCapabilities { get; }
 
         /// <summary>
-        /// Enables ADAL cache serialialization and deserialization.
+        /// Enables legacy ADAL cache serialization and deserialization.
         /// </summary>
-        bool AdalCacheCompatibilityEnabled { get; }
+        bool LegacyCacheCompatibilityEnabled { get; }
 
         /// <summary>
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Identity.Client
                     UpdateAppMetadata(requestParams.ClientId, instanceDiscoveryMetadata.PreferredCache, response.FamilyId);
 
                     // Do not save RT in ADAL cache for client credentials flow or B2C                        
-                    if (ServiceBundle.Config.IsAdalCacheEnabled &&
+                    if (ServiceBundle.Config.AdalCacheCompatibilityEnabled &&
                         !requestParams.IsClientCredentialRequest &&
                         requestParams.AuthorityInfo.AuthorityType != AuthorityType.B2C)
                     {
@@ -561,7 +561,7 @@ namespace Microsoft.Identity.Client
             requestParams.RequestContext.Logger.Info("Checking ADAL cache for matching RT. ");
 
             // ADAL legacy cache does not store FRTs
-            if (ServiceBundle.Config.IsAdalCacheEnabled &&
+            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled &&
                 requestParams.Account != null &&
                 string.IsNullOrEmpty(familyId))
             {
@@ -641,7 +641,7 @@ namespace Microsoft.Identity.Client
 
             AdalUsersForMsal adalUsersResult = null;
 
-            if (ServiceBundle.Config.IsAdalCacheEnabled)
+            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
             {
                 adalUsersResult = CacheFallbackOperations.GetAllAdalUsersForMsal(
                     Logger,
@@ -678,7 +678,7 @@ namespace Microsoft.Identity.Client
                 }
             }
 
-            if (ServiceBundle.Config.IsAdalCacheEnabled)
+            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
             {
                 UpdateMapWithAdalAccountsWithClientInfo(
                     environment,
@@ -802,7 +802,7 @@ namespace Microsoft.Identity.Client
                     }
 
                     tokenCacheInternal.RemoveMsalAccountWithNoLocks(account, requestContext);
-                    if (ServiceBundle.Config.IsAdalCacheEnabled)
+                    if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
                     {
                         RemoveAdalUser(account);
                     }

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -639,9 +639,11 @@ namespace Microsoft.Identity.Client
                 StringComparer.OrdinalIgnoreCase);
             allEnvironmentsInCache.UnionWith(rtCacheItems.Select(rt => rt.Environment));
 
+            AdalUsersForMsal adalUsersResult = null;
+
             if (ServiceBundle.Config.IsAdalCacheEnabled)
             {
-                AdalUsersForMsal adalUsersResult = CacheFallbackOperations.GetAllAdalUsersForMsal(
+                adalUsersResult = CacheFallbackOperations.GetAllAdalUsersForMsal(
                     Logger,
                     LegacyCachePersistence,
                     ClientId);
@@ -676,11 +678,14 @@ namespace Microsoft.Identity.Client
                 }
             }
 
-            UpdateMapWithAdalAccountsWithClientInfo(
-                environment,
-                instanceMetadata.Aliases,
-                adalUsersResult,
-                clientInfoToAccountMap);
+            if (ServiceBundle.Config.IsAdalCacheEnabled)
+            {
+                UpdateMapWithAdalAccountsWithClientInfo(
+                    environment,
+                    instanceMetadata.Aliases,
+                    adalUsersResult,
+                    clientInfoToAccountMap);
+            }
 
             // Add WAM accounts stored in MSAL's cache - for which we do not have an RT
             if (requestParameters.IsBrokerConfigured && ServiceBundle.PlatformProxy.BrokerSupportsWamAccounts)

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Identity.Client
                     UpdateAppMetadata(requestParams.ClientId, instanceDiscoveryMetadata.PreferredCache, response.FamilyId);
 
                     // Do not save RT in ADAL cache for client credentials flow or B2C                        
-                    if (ServiceBundle.Config.AdalCacheCompatibilityEnabled &&
+                    if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled &&
                         !requestParams.IsClientCredentialRequest &&
                         requestParams.AuthorityInfo.AuthorityType != AuthorityType.B2C)
                     {
@@ -561,7 +561,7 @@ namespace Microsoft.Identity.Client
             requestParams.RequestContext.Logger.Info("Checking ADAL cache for matching RT. ");
 
             // ADAL legacy cache does not store FRTs
-            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled &&
+            if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled &&
                 requestParams.Account != null &&
                 string.IsNullOrEmpty(familyId))
             {
@@ -641,7 +641,7 @@ namespace Microsoft.Identity.Client
 
             AdalUsersForMsal adalUsersResult = null;
 
-            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
+            if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled)
             {
                 adalUsersResult = CacheFallbackOperations.GetAllAdalUsersForMsal(
                     Logger,
@@ -678,7 +678,7 @@ namespace Microsoft.Identity.Client
                 }
             }
 
-            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
+            if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled)
             {
                 UpdateMapWithAdalAccountsWithClientInfo(
                     environment,
@@ -802,7 +802,7 @@ namespace Microsoft.Identity.Client
                     }
 
                     tokenCacheInternal.RemoveMsalAccountWithNoLocks(account, requestContext);
-                    if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
+                    if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled)
                     {
                         RemoveAdalUser(account);
                     }

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -206,23 +206,26 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        private static List<IAccount> UpdateWithAdalAccountsWithoutClientInfo(
+        private List<IAccount> UpdateWithAdalAccountsWithoutClientInfo(
             string envFromRequest,
             IEnumerable<string> envAliases,
             AdalUsersForMsal adalUsers,
             IDictionary<string, Account> clientInfoToAccountMap)
         {
             var accounts = new List<IAccount>();
-
             accounts.AddRange(clientInfoToAccountMap.Values);
-            var uniqueUserNames = clientInfoToAccountMap.Values.Select(o => o.Username).Distinct().ToList();
 
-            foreach (AdalUserInfo user in adalUsers.GetUsersWithoutClientInfo(envAliases))
+            if (ServiceBundle.Config.IsAdalCacheEnabled)
             {
-                if (!string.IsNullOrEmpty(user.DisplayableId) && !uniqueUserNames.Contains(user.DisplayableId))
+                var uniqueUserNames = clientInfoToAccountMap.Values.Select(o => o.Username).Distinct().ToList();
+
+                foreach (AdalUserInfo user in adalUsers.GetUsersWithoutClientInfo(envAliases))
                 {
-                    accounts.Add(new Account(null, user.DisplayableId, envFromRequest));
-                    uniqueUserNames.Add(user.DisplayableId);
+                    if (!string.IsNullOrEmpty(user.DisplayableId) && !uniqueUserNames.Contains(user.DisplayableId))
+                    {
+                        accounts.Add(new Account(null, user.DisplayableId, envFromRequest));
+                        uniqueUserNames.Add(user.DisplayableId);
+                    }
                 }
             }
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Identity.Client
             var accounts = new List<IAccount>();
             accounts.AddRange(clientInfoToAccountMap.Values);
 
-            if (ServiceBundle.Config.IsAdalCacheEnabled)
+            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
             {
                 var uniqueUserNames = clientInfoToAccountMap.Values.Select(o => o.Username).Distinct().ToList();
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Identity.Client
             var accounts = new List<IAccount>();
             accounts.AddRange(clientInfoToAccountMap.Values);
 
-            if (ServiceBundle.Config.AdalCacheCompatibilityEnabled)
+            if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled)
             {
                 var uniqueUserNames = clientInfoToAccountMap.Values.Select(o => o.Username).Distinct().ToList();
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client
         private ICoreLogger Logger => ServiceBundle.DefaultLogger;
 
         internal IServiceBundle ServiceBundle { get; }
-        internal ILegacyCachePersistence LegacyCachePersistence { get; }
+        internal ILegacyCachePersistence LegacyCachePersistence { get; set; }
         internal string ClientId => ServiceBundle.Config.ClientId;
 
         ITokenCacheAccessor ITokenCacheInternal.Accessor => _accessor;

--- a/tests/Microsoft.Identity.Client.Performance/AdalCacheOperationsTests.cs
+++ b/tests/Microsoft.Identity.Client.Performance/AdalCacheOperationsTests.cs
@@ -53,9 +53,11 @@ namespace Microsoft.Identity.Test.Performance
             _requestParams.TenantUpdatedCanonicalAuthority = Authority.CreateAuthorityWithTenant(
                 _requestParams.AuthorityInfo,
                 TestConstants.Utid);
+            _requestParams.Account = new Account(TestConstants.s_userIdentifier, $"1{TestConstants.DisplayableId}", TestConstants.ProductionPrefNetworkEnvironment);
 
             AddHostToInstanceCache(serviceBundle, TestConstants.ProductionPrefNetworkEnvironment);
 
+            LegacyTokenCacheHelper.PopulateLegacyCache(serviceBundle.DefaultLogger, _cache.LegacyPersistence, TokenCacheSize);
             TokenCacheHelper.AddRefreshTokensToCache(_cache.Accessor, TokenCacheSize);
         }
 
@@ -83,19 +85,19 @@ namespace Microsoft.Identity.Test.Performance
         [BenchmarkCategory("GetRefreshToken"), Benchmark(Baseline = true)]
         public async Task<string> FindRefreshToken_EnabledAdalCache_TestAsync()
         {
-            return await FindRefreshToken_TestAsync().ConfigureAwait(true);
+            return await FindRefreshTokenAsync().ConfigureAwait(true);
         }
 
         [BenchmarkCategory("GetRefreshToken"), Benchmark]
         public async Task<string> FindRefreshToken_DisabledAdalCache_TestAsync()
         {
-            return await FindRefreshToken_TestAsync().ConfigureAwait(true);
+            return await FindRefreshTokenAsync().ConfigureAwait(true);
         }
 
-        private async Task<string> FindRefreshToken_TestAsync()
+        private async Task<string> FindRefreshTokenAsync()
         {
             var result = await _cache.FindRefreshTokenAsync(_requestParams).ConfigureAwait(true);
-            return result.ClientId;
+            return result?.ClientId;
         }
         #endregion
 

--- a/tests/Microsoft.Identity.Client.Performance/AdalCacheOperationsTests.cs
+++ b/tests/Microsoft.Identity.Client.Performance/AdalCacheOperationsTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.Instance.Discovery;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Internal.Requests;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Unit;
+
+namespace Microsoft.Identity.Test.Performance
+{
+    public class AdalCacheOperationsTests
+    {
+        private ITokenCacheInternal _cache;
+        private MsalTokenResponse _response;
+        private AuthenticationRequestParameters _requestParams;
+
+        [Params(1, 100, 1000)]
+        public int TokenCacheSize { get; set; }
+
+        [GlobalSetup(Target = nameof(SaveTokenResponse_EnabledAdalCache_TestAsync))]
+        public void GlobalSetup_EnabledAdalCache()
+        {
+            GlobalSetup(true);
+        }
+
+        [GlobalSetup(Target = nameof(SaveTokenResponse_DisabledAdalCache_TestAsync))]
+        public void GlobalSetup_DisabledAdalCache()
+        {
+            GlobalSetup(false);
+        }
+
+        private void GlobalSetup(bool enableAdalCache)
+        {
+            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isAdalCacheEnabled: enableAdalCache);
+
+            _cache = new TokenCache(serviceBundle, false);
+            _response = TestConstants.CreateMsalTokenResponse();
+
+            _requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
+            _requestParams.TenantUpdatedCanonicalAuthority = Authority.CreateAuthorityWithTenant(
+                _requestParams.AuthorityInfo,
+                TestConstants.Utid);
+
+            AddHostToInstanceCache(serviceBundle, TestConstants.ProductionPrefNetworkEnvironment);
+
+            TokenCacheHelper.AddRefreshTokensToCache(_cache.Accessor, TokenCacheSize);
+        }
+
+        [Benchmark(Baseline = true)]
+        public async Task<string> SaveTokenResponse_EnabledAdalCache_TestAsync()
+        {
+            return await SaveTokenResponse_TestAsync().ConfigureAwait(true);
+        }
+
+        [Benchmark]
+        public async Task<string> SaveTokenResponse_DisabledAdalCache_TestAsync()
+        {
+            return await SaveTokenResponse_TestAsync().ConfigureAwait(true);
+        }
+
+        private async Task<string> SaveTokenResponse_TestAsync()
+        {
+            var result = await _cache.SaveTokenResponseAsync(_requestParams, _response).ConfigureAwait(true);
+            return result.Item1.ClientId;
+        }
+
+        private void AddHostToInstanceCache(IServiceBundle serviceBundle, string host)
+        {
+            (serviceBundle.InstanceDiscoveryManager as InstanceDiscoveryManager)
+                .AddTestValueToStaticProvider(
+                    host,
+                    new InstanceDiscoveryMetadataEntry
+                    {
+                        PreferredNetwork = host,
+                        PreferredCache = host,
+                        Aliases = new string[]
+                        {
+                            host
+                        }
+                    });
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Client.Performance/AdalCacheOperationsTests.cs
+++ b/tests/Microsoft.Identity.Client.Performance/AdalCacheOperationsTests.cs
@@ -1,23 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Test.Common;
-using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Test.Unit;
 
 namespace Microsoft.Identity.Test.Performance
 {
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     public class AdalCacheOperationsTests
     {
         private ITokenCacheInternal _cache;
@@ -27,13 +26,17 @@ namespace Microsoft.Identity.Test.Performance
         [Params(1, 100, 1000)]
         public int TokenCacheSize { get; set; }
 
-        [GlobalSetup(Target = nameof(SaveTokenResponse_EnabledAdalCache_TestAsync))]
+        [GlobalSetup(Targets = new[] { 
+            nameof(SaveTokenResponse_EnabledAdalCache_TestAsync), 
+            nameof(FindRefreshToken_EnabledAdalCache_TestAsync) })]
         public void GlobalSetup_EnabledAdalCache()
         {
             GlobalSetup(true);
         }
 
-        [GlobalSetup(Target = nameof(SaveTokenResponse_DisabledAdalCache_TestAsync))]
+        [GlobalSetup(Targets = new[] { 
+            nameof(SaveTokenResponse_DisabledAdalCache_TestAsync), 
+            nameof(FindRefreshToken_DisabledAdalCache_TestAsync) })]
         public void GlobalSetup_DisabledAdalCache()
         {
             GlobalSetup(false);
@@ -56,13 +59,14 @@ namespace Microsoft.Identity.Test.Performance
             TokenCacheHelper.AddRefreshTokensToCache(_cache.Accessor, TokenCacheSize);
         }
 
-        [Benchmark(Baseline = true)]
+        #region SaveToken
+        [BenchmarkCategory("SaveTokenResponse"), Benchmark(Baseline = true)]
         public async Task<string> SaveTokenResponse_EnabledAdalCache_TestAsync()
         {
             return await SaveTokenResponse_TestAsync().ConfigureAwait(true);
         }
 
-        [Benchmark]
+        [BenchmarkCategory("SaveTokenResponse"), Benchmark]
         public async Task<string> SaveTokenResponse_DisabledAdalCache_TestAsync()
         {
             return await SaveTokenResponse_TestAsync().ConfigureAwait(true);
@@ -73,6 +77,27 @@ namespace Microsoft.Identity.Test.Performance
             var result = await _cache.SaveTokenResponseAsync(_requestParams, _response).ConfigureAwait(true);
             return result.Item1.ClientId;
         }
+        #endregion
+
+        #region GetRefreshToken
+        [BenchmarkCategory("GetRefreshToken"), Benchmark(Baseline = true)]
+        public async Task<string> FindRefreshToken_EnabledAdalCache_TestAsync()
+        {
+            return await FindRefreshToken_TestAsync().ConfigureAwait(true);
+        }
+
+        [BenchmarkCategory("GetRefreshToken"), Benchmark]
+        public async Task<string> FindRefreshToken_DisabledAdalCache_TestAsync()
+        {
+            return await FindRefreshToken_TestAsync().ConfigureAwait(true);
+        }
+
+        private async Task<string> FindRefreshToken_TestAsync()
+        {
+            var result = await _cache.FindRefreshTokenAsync(_requestParams).ConfigureAwait(true);
+            return result.ClientId;
+        }
+        #endregion
 
         private void AddHostToInstanceCache(IServiceBundle serviceBundle, string host)
         {

--- a/tests/Microsoft.Identity.Client.Performance/LegacyCacheOperationsTests.cs
+++ b/tests/Microsoft.Identity.Client.Performance/LegacyCacheOperationsTests.cs
@@ -19,7 +19,7 @@ using Microsoft.Identity.Test.Unit;
 namespace Microsoft.Identity.Test.Performance
 {
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByMethod)]
-    public class AdalCacheOperationsTests
+    public class LegacyCacheOperationsTests
     {
         private ITokenCacheInternal _cache;
         private MsalTokenResponse _response;
@@ -31,12 +31,12 @@ namespace Microsoft.Identity.Test.Performance
         public int TokenCacheSize { get; set; }
 
         [ParamsAllValues]
-        public bool EnableAdalCache { get; set; }
+        public bool EnableLegacyCache { get; set; }
 
         [GlobalSetup]
         public void GlobalSetup()
         {
-            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isAdalCacheEnabled: EnableAdalCache);
+            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isLegacyCacheEnabled: EnableLegacyCache);
 
             _requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
             _cache = new TokenCache(serviceBundle, false);

--- a/tests/Microsoft.Identity.Client.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Client.Performance/Program.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Test.Performance
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<AcquireTokenForClientLargeCacheTests>(
+            BenchmarkRunner.Run<AdalCacheOperationsTests>(
                 DefaultConfig.Instance
                     .WithOptions(ConfigOptions.DontOverwriteResults)
                     .AddJob(

--- a/tests/Microsoft.Identity.Client.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Client.Performance/Program.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Test.Performance
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<AdalCacheOperationsTests>(
+            BenchmarkRunner.Run<LegacyCacheOperationsTests>(
                 DefaultConfig.Instance
                     .WithOptions(ConfigOptions.DontOverwriteResults)
                     .AddJob(

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/LegacyTokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/LegacyTokenCacheHelper.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client.Cache;
+using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Test.Unit;
+
+namespace Microsoft.Identity.Test.Common.Core.Mocks
+{
+    internal class LegacyTokenCacheHelper
+    {
+        internal static void PopulateLegacyCache(ICoreLogger logger, ILegacyCachePersistence legacyCachePersistence, int tokenQuantity = 1)
+        {
+            for (int i = 1; i <= tokenQuantity; i++)
+            {
+                PopulateLegacyWithRtAndId(
+                    logger,
+                    legacyCachePersistence,
+                    TestConstants.ClientId,
+                    TestConstants.ProductionPrefNetworkEnvironment,
+                    TestConstants.Uid,
+                    TestConstants.Utid,
+                    $"{i}{TestConstants.DisplayableId}");
+            }
+        }
+
+        internal static void PopulateLegacyCache(ICoreLogger logger, ILegacyCachePersistence legacyCachePersistence)
+        {
+            PopulateLegacyWithRtAndId(
+                logger,
+                legacyCachePersistence,
+                TestConstants.ClientId,
+                TestConstants.ProductionPrefNetworkEnvironment,
+                "uid1",
+                "tenantId1",
+                "user1");
+
+            PopulateLegacyWithRtAndId(
+                logger,
+                legacyCachePersistence,
+                TestConstants.ClientId,
+                TestConstants.ProductionPrefNetworkEnvironment,
+                "uid2",
+                "tenantId2",
+                "user2");
+
+            PopulateLegacyWithRtAndId(
+                logger,
+                legacyCachePersistence,
+                TestConstants.ClientId,
+                TestConstants.ProductionPrefNetworkEnvironment,
+                null,
+                null,
+                "no_client_info_user3");
+
+            PopulateLegacyWithRtAndId(
+                logger,
+                legacyCachePersistence,
+                TestConstants.ClientId,
+                TestConstants.ProductionPrefNetworkEnvironment,
+                null,
+                null,
+                "no_client_info_user4");
+
+            PopulateLegacyWithRtAndId(
+                logger,
+                legacyCachePersistence,
+                TestConstants.ClientId,
+                TestConstants.SovereignNetworkEnvironment, // different env
+                "uid4",
+                "tenantId4",
+                "sovereign_user5");
+
+            PopulateLegacyWithRtAndId(
+                logger,
+                legacyCachePersistence,
+                "other_client_id", // different client id
+                TestConstants.SovereignNetworkEnvironment,
+                "uid5",
+                "tenantId5",
+                "user6");
+        }
+
+        internal static void PopulateLegacyWithRtAndId(
+            ICoreLogger logger,
+            ILegacyCachePersistence legacyCachePersistence,
+            string clientId,
+            string env,
+            string uid,
+            string uniqueTenantId,
+            string username)
+        {
+            PopulateLegacyWithRtAndId(logger, legacyCachePersistence, clientId, env, uid, uniqueTenantId, username, "scope1");
+        }
+
+        internal static void PopulateLegacyWithRtAndId(
+            ICoreLogger logger,
+            ILegacyCachePersistence legacyCachePersistence,
+            string clientId,
+            string env,
+            string uid,
+            string uniqueTenantId,
+            string username,
+            string scope)
+        {
+            string clientInfoString;
+            string homeAccountId;
+            if (string.IsNullOrEmpty(uid) || string.IsNullOrEmpty(uniqueTenantId))
+            {
+                clientInfoString = null;
+                homeAccountId = null;
+            }
+            else
+            {
+                clientInfoString = MockHelpers.CreateClientInfo(uid, uniqueTenantId);
+                homeAccountId = ClientInfo.CreateFromJson(clientInfoString).ToAccountIdentifier();
+            }
+
+            var rtItem = new MsalRefreshTokenCacheItem(env, clientId, "someRT", clientInfoString, null, homeAccountId);
+
+            var idTokenCacheItem = new MsalIdTokenCacheItem(
+                env,
+                clientId,
+                MockHelpers.CreateIdToken(uid, username),
+                clientInfoString,
+                homeAccountId,
+                tenantId: uniqueTenantId);
+
+            CacheFallbackOperations.WriteAdalRefreshToken(
+                logger,
+                legacyCachePersistence,
+                rtItem,
+                idTokenCacheItem,
+                "https://" + env + "/common",
+                uid,
+                scope);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/LegacyTokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/LegacyTokenCacheHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                     logger,
                     legacyCachePersistence,
                     TestConstants.ClientId,
-                    TestConstants.ProductionPrefNetworkEnvironment,
+                    TestConstants.ProductionPrefCacheEnvironment,
                     TestConstants.Uid,
                     TestConstants.Utid,
                     $"{i}{TestConstants.DisplayableId}");

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public static long ValidExpiresIn = 28800;
         public static long ValidExtendedExpiresIn = 57600;
 
-        internal void PopulateCacheForClientCredential(ITokenCacheAccessor accessor, int tokensQuantity = 1)
+        internal void PopulateCacheForClientCredential(ITokenCacheAccessor accessor, int tokenQuantity = 1)
         {
-            for (int i = 1; i <= tokensQuantity; i++)
+            for (int i = 1; i <= tokenQuantity; i++)
             {
                 var atItem = CreateAccessTokenItem(string.Format(System.Globalization.CultureInfo.InvariantCulture, TestConstants.ScopeStrFormat, i));
                 accessor.SaveAccessToken(atItem);

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -190,6 +190,14 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             accessor.SaveRefreshToken(rtItem);
         }
 
+        public static void AddRefreshTokensToCache(ITokenCacheAccessor cacheAccessor, int tokensQuantity = 1)
+        {
+            for (int i = 1; i <= tokensQuantity; i++)
+            {
+                AddRefreshTokenToCache(cacheAccessor, Guid.NewGuid().ToString(), TestConstants.Utid);
+            }
+        }
+
         public static void AddAccountToCache(
             ITokenCacheAccessor accessor, 
             string uid, 

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Test.Common
                 EnablePiiLogging = enablePiiLogging,
                 IsExtendedTokenLifetimeEnabled = isExtendedTokenLifetimeEnabled,
                 AuthorityInfo = AuthorityInfo.FromAuthorityUri(authority, validateAuthority),
-                IsAdalCacheEnabled = isAdalCacheEnabled
+                AdalCacheCompatibilityEnabled = isAdalCacheEnabled
             };            
             return new ServiceBundle(appConfig, clearCaches);
         }

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Identity.Test.Common
             bool enablePiiLogging = false,
             string clientId = TestConstants.ClientId,
             bool clearCaches = true,
-            bool validateAuthority = true)
+            bool validateAuthority = true,
+            bool isAdalCacheEnabled = true)
         {
             
             var appConfig = new ApplicationConfiguration()
@@ -69,7 +70,8 @@ namespace Microsoft.Identity.Test.Common
                 LogLevel = LogLevel.Verbose,
                 EnablePiiLogging = enablePiiLogging,
                 IsExtendedTokenLifetimeEnabled = isExtendedTokenLifetimeEnabled,
-                AuthorityInfo = AuthorityInfo.FromAuthorityUri(authority, validateAuthority)
+                AuthorityInfo = AuthorityInfo.FromAuthorityUri(authority, validateAuthority),
+                IsAdalCacheEnabled = isAdalCacheEnabled
             };            
             return new ServiceBundle(appConfig, clearCaches);
         }

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Identity.Test.Common
             string clientId = TestConstants.ClientId,
             bool clearCaches = true,
             bool validateAuthority = true,
-            bool isAdalCacheEnabled = true)
+            bool isLegacyCacheEnabled = true)
         {
             
             var appConfig = new ApplicationConfiguration()
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Test.Common
                 EnablePiiLogging = enablePiiLogging,
                 IsExtendedTokenLifetimeEnabled = isExtendedTokenLifetimeEnabled,
                 AuthorityInfo = AuthorityInfo.FromAuthorityUri(authority, validateAuthority),
-                AdalCacheCompatibilityEnabled = isAdalCacheEnabled
+                LegacyCacheCompatibilityEnabled = isLegacyCacheEnabled
             };            
             return new ServiceBundle(appConfig, clearCaches);
         }

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
@@ -340,15 +340,15 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         }
 
         [TestMethod]
-        public void TestConstructor_WithAdalCacheCompatibility()
+        public void TestConstructor_WithLegacyCacheCompatibility()
         {
             var cca = ConfidentialClientApplicationBuilder
                       .Create(TestConstants.ClientId)
                       .WithClientSecret(TestConstants.ClientSecret)
-                      .WithAdalCacheCompatibility(true)
+                      .WithLegacyCacheCompatibility(true)
                       .Build();
 
-            Assert.AreEqual(true, cca.AppConfig.AdalCacheCompatibilityEnabled);
+            Assert.AreEqual(true, cca.AppConfig.LegacyCacheCompatibilityEnabled);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
@@ -338,5 +338,17 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             Assert.AreEqual(ex.ErrorCode, MsalError.InvalidUserInstanceMetadata);
         }
+
+        [TestMethod]
+        public void TestConstructor_WithAdalCacheCompatibility()
+        {
+            var cca = ConfidentialClientApplicationBuilder
+                      .Create(TestConstants.ClientId)
+                      .WithClientSecret(TestConstants.ClientSecret)
+                      .WithAdalCacheCompatibility(true)
+                      .Build();
+
+            Assert.AreEqual(true, cca.AppConfig.AdalCacheCompatibilityEnabled);
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheFallbackOperationsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheFallbackOperationsTests.cs
@@ -39,8 +39,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void GetAllAdalUsersForMsal_ScopedBy_ClientIdAndEnv()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
-
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
 
             // Act - query users by env and clientId
             var adalUsers =
@@ -97,7 +96,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void GetAllAdalEntriesForMsal_FilterBy_Upn()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
 
             // Act - query Adal Entries For Msal with valid Upn as a filter
             var rt =
@@ -109,7 +108,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                         TestConstants.SovereignNetworkEnvironment },
                     TestConstants.ClientId,
                     new Account(null, "User1", null));
-                     
 
             Assert.AreEqual("uid1.tenantId1", rt.HomeAccountId);
 
@@ -131,7 +129,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void GetAllAdalEntriesForMsal_FilterBy_UniqueId()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
 
             // Act - query Adal Entries For Msal with valid UniqueId as a filter
             var rt =
@@ -164,7 +162,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void GetAllAdalEntriesForMsal_NoFilter()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
 
             // Act - query Adal Entries For Msal with valid Upn and UniqueId as a filter
             var rt =
@@ -184,7 +182,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void GetAllAdalEntriesForMsal_FilterBy_UniqueIdAndUpn()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
 
             // Act - query Adal Entries For Msal with valid Upn and UniqueId as a filter
             var rt =
@@ -200,7 +198,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual("uid1.tenantId1", rt.HomeAccountId);
 
             // Act - query Adal Entries For Msal with invalid Upn and valid UniqueId as a filter
-            rt  =
+            rt =
                 CacheFallbackOperations.GetRefreshToken(
                     _logger,
                     _legacyCachePersistence,
@@ -230,15 +228,17 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void GetAllAdalEntriesForMsal_MultipleRTsPerEnv()
         {
             // Arrange
-            PopulateLegacyWithRtAndId(
-                          _legacyCachePersistence,
-                          TestConstants.ClientId,
-                          TestConstants.ProductionPrefNetworkEnvironment,
-                          "uid",
-                          "tenantId1",
-                          "user1");
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId(
+                _logger,
+                _legacyCachePersistence,
+                TestConstants.ClientId,
+                TestConstants.ProductionPrefNetworkEnvironment,
+                "uid",
+                "tenantId1",
+                "user1");
 
-            PopulateLegacyWithRtAndId(
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId(
+                _logger,
                 _legacyCachePersistence,
                 TestConstants.ClientId,
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -262,9 +262,10 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void RemoveAdalUser_RemovesUserWithSameId()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
 
-            PopulateLegacyWithRtAndId( // different clientId -> should not be deleted
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId( // different clientId -> should not be deleted
+                _logger,
                 _legacyCachePersistence,
                 "other_client_id",
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -272,7 +273,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 "tenantId1",
                 "user1_other_client_id");
 
-            PopulateLegacyWithRtAndId( // different env -> should be deleted
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId( // different env -> should be deleted
+                _logger,
                 _legacyCachePersistence,
                 TestConstants.ClientId,
                 "other_env",
@@ -297,7 +299,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             AssertByUsername(
                 adalUsers,
-                new[] { TestConstants.ProductionPrefNetworkEnvironment},
+                new[] { TestConstants.ProductionPrefNetworkEnvironment },
                 new[]
                 {
                     "user2",
@@ -313,9 +315,10 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void RemoveAdalUser_RemovesUserNoClientInfo()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
 
-            PopulateLegacyWithRtAndId(
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId(
+                _logger,
                 _legacyCachePersistence,
                 "other_client_id",
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -323,7 +326,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 null,
                 "no_client_info_user3"); // no client info, different client id -> won't be deleted
 
-            PopulateLegacyWithRtAndId(
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId(
+                _logger,
                 _legacyCachePersistence,
                 TestConstants.ClientId,
                 "other_env",
@@ -394,7 +398,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void RemoveAdalUser_RemovesUserNoClientInfo_And_NoDisplayName()
         {
             // Arrange
-            PopulateLegacyCache(_legacyCachePersistence);
+            LegacyTokenCacheHelper.PopulateLegacyCache(_logger, _legacyCachePersistence);
             IDictionary<AdalTokenCacheKey, AdalResultWrapper> adalCacheBeforeDelete =
                 AdalCacheOperations.Deserialize(_logger, _legacyCachePersistence.LoadCache());
             Assert.AreEqual(6, adalCacheBeforeDelete.Count);
@@ -420,7 +424,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // adal cache can have different cache entities for the
             // same user/account with client info and wihout
             // CacheFallbackOperations.RemoveAdalUser should remove both
-            PopulateLegacyWithRtAndId(
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId(
+                _logger,
                 _legacyCachePersistence,
                 TestConstants.ClientId,
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -431,7 +436,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             AssertCacheEntryCount(1);
 
-            PopulateLegacyWithRtAndId(
+            LegacyTokenCacheHelper.PopulateLegacyWithRtAndId(
+                _logger,
                 _legacyCachePersistence,
                 TestConstants.ClientId,
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -463,17 +469,17 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             var rtItem = new MsalRefreshTokenCacheItem(
                 TestConstants.ProductionPrefNetworkEnvironment,
                 TestConstants.ClientId,
-                "someRT", 
-                clientInfo, 
-                null, 
+                "someRT",
+                clientInfo,
+                null,
                 homeAccountId);
 
             var idTokenCacheItem = new MsalIdTokenCacheItem(
                 TestConstants.ProductionPrefCacheEnvironment, // different env
                 TestConstants.ClientId,
                 MockHelpers.CreateIdToken("u1", "username"),
-                clientInfo, 
-                tenantId: "ut1", 
+                clientInfo,
+                tenantId: "ut1",
                 homeAccountId: homeAccountId);
 
             // Act
@@ -505,16 +511,16 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 TestConstants.ProductionPrefNetworkEnvironment,
                 TestConstants.ClientId,
                 "someRT",
-                clientInfo, 
-                "familyId", 
+                clientInfo,
+                "familyId",
                 homeAccountId);
 
             var idTokenCacheItem = new MsalIdTokenCacheItem(
                 TestConstants.ProductionPrefNetworkEnvironment, // different env
                 TestConstants.ClientId,
                 MockHelpers.CreateIdToken("u1", "username"),
-                clientInfo, 
-                tenantId: "ut1", 
+                clientInfo,
+                tenantId: "ut1",
                 homeAccountId: homeAccountId);
 
             // Act
@@ -530,57 +536,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             AssertCacheEntryCount(0);
         }
 
-        private void PopulateLegacyCache(ILegacyCachePersistence legacyCachePersistence)
-        {
-            PopulateLegacyWithRtAndId(
-                legacyCachePersistence,
-                TestConstants.ClientId,
-                TestConstants.ProductionPrefNetworkEnvironment,
-                "uid1",
-                "tenantId1",
-                "user1");
-
-            PopulateLegacyWithRtAndId(
-                legacyCachePersistence,
-                TestConstants.ClientId,
-                TestConstants.ProductionPrefNetworkEnvironment,
-                "uid2",
-                "tenantId2",
-                "user2");
-
-            PopulateLegacyWithRtAndId(
-                legacyCachePersistence,
-                TestConstants.ClientId,
-                TestConstants.ProductionPrefNetworkEnvironment,
-                null,
-                null,
-                "no_client_info_user3");
-
-            PopulateLegacyWithRtAndId(
-                legacyCachePersistence,
-                TestConstants.ClientId,
-                TestConstants.ProductionPrefNetworkEnvironment,
-                null,
-                null,
-                "no_client_info_user4");
-
-            PopulateLegacyWithRtAndId(
-                legacyCachePersistence,
-                TestConstants.ClientId,
-                TestConstants.SovereignNetworkEnvironment, // different env
-                "uid4",
-                "tenantId4",
-                "sovereign_user5");
-
-            PopulateLegacyWithRtAndId(
-                legacyCachePersistence,
-                "other_client_id", // different client id
-                TestConstants.SovereignNetworkEnvironment,
-                "uid5",
-                "tenantId5",
-                "user6");
-        }
-
         private static void AssertUsersByDisplayName(
             IEnumerable<string> expectedUsernames,
             IEnumerable<AdalUserInfo> adalUserInfos,
@@ -589,59 +544,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             string[] actualUsernames = adalUserInfos.Select(x => x.DisplayableId).ToArray();
 
             CollectionAssert.AreEquivalent(expectedUsernames.ToArray(), actualUsernames, errorMessage);
-        }
-
-        private void PopulateLegacyWithRtAndId(
-            ILegacyCachePersistence legacyCachePersistence,
-            string clientId,
-            string env,
-            string uid,
-            string uniqueTenantId,
-            string username)
-        {
-            PopulateLegacyWithRtAndId(legacyCachePersistence, clientId, env, uid, uniqueTenantId, username, "scope1");
-        }
-
-        private void PopulateLegacyWithRtAndId(
-            ILegacyCachePersistence legacyCachePersistence,
-            string clientId,
-            string env,
-            string uid,
-            string uniqueTenantId,
-            string username,
-            string scope)
-        {
-            string clientInfoString;
-            string homeAccountId;
-            if (string.IsNullOrEmpty(uid) || string.IsNullOrEmpty(uniqueTenantId))
-            {
-                clientInfoString = null;
-                homeAccountId = null;
-            }
-            else
-            {
-                clientInfoString = MockHelpers.CreateClientInfo(uid, uniqueTenantId);
-                homeAccountId = ClientInfo.CreateFromJson(clientInfoString).ToAccountIdentifier();
-            }
-
-            var rtItem = new MsalRefreshTokenCacheItem(env, clientId, "someRT", clientInfoString, null, homeAccountId);
-
-            var idTokenCacheItem = new MsalIdTokenCacheItem(
-                env,
-                clientId,
-                MockHelpers.CreateIdToken(uid, username),
-                clientInfoString,
-                homeAccountId,
-                tenantId: uniqueTenantId);
-
-            CacheFallbackOperations.WriteAdalRefreshToken(
-                _logger,
-                legacyCachePersistence,
-                rtItem,
-                idTokenCacheItem,
-                "https://" + env + "/common",
-                uid,
-                scope);
         }
 
         private static void AssertByUsername(

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
-        public async Task WithAdalCacheCompatibilityTest_Async(bool enableAdalCacheCompatibility)
+        public async Task WithLegacyCacheCompatibilityTest_Async(bool enableLegacyCacheCompatibility)
         {
             // Arrange
             var legacyCachePersistence = Substitute.For<ILegacyCachePersistence>();
-            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isAdalCacheEnabled: enableAdalCacheCompatibility);
+            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isLegacyCacheEnabled: enableLegacyCacheCompatibility);
             var requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
             var response = TestConstants.CreateMsalTokenResponse();
 
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             await cache.RemoveAccountAsync(requestParams.Account, requestContext).ConfigureAwait(true);
 
             // Assert
-            if (enableAdalCacheCompatibility)
+            if (enableLegacyCacheCompatibility)
             {
                 legacyCachePersistence.ReceivedWithAnyArgs().LoadCache();
                 legacyCachePersistence.ReceivedWithAnyArgs().WriteCache(Arg.Any<byte[]>());

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -44,6 +44,45 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             base.TestInitialize();
         }
 
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task WithAdalCacheCompatibilityTest_Async(bool enableAdalCacheCompatibility)
+        {
+            // Arrange
+            var legacyCachePersistence = Substitute.For<ILegacyCachePersistence>();
+            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isAdalCacheEnabled: enableAdalCacheCompatibility);
+            var requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
+            var response = TestConstants.CreateMsalTokenResponse();
+
+            ITokenCacheInternal cache = new TokenCache(serviceBundle, false);
+            ((TokenCache)cache).LegacyCachePersistence = legacyCachePersistence;      
+            
+            var requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
+            requestParams.TenantUpdatedCanonicalAuthority = Authority.CreateAuthorityWithTenant(
+                requestParams.AuthorityInfo,
+                TestConstants.Utid);
+            requestParams.Account = new Account(TestConstants.s_userIdentifier, $"1{TestConstants.DisplayableId}", TestConstants.ProductionPrefNetworkEnvironment);
+
+            // Act
+            await cache.FindRefreshTokenAsync(requestParams).ConfigureAwait(true);
+            await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(true);
+            await cache.GetAccountsAsync(requestParams).ConfigureAwait(true);
+            await cache.RemoveAccountAsync(requestParams.Account, requestContext).ConfigureAwait(true);
+
+            // Assert
+            if (enableAdalCacheCompatibility)
+            {
+                legacyCachePersistence.ReceivedWithAnyArgs().LoadCache();
+                legacyCachePersistence.ReceivedWithAnyArgs().WriteCache(Arg.Any<byte[]>());
+            }
+            else
+            {
+                legacyCachePersistence.DidNotReceiveWithAnyArgs().LoadCache();
+                legacyCachePersistence.DidNotReceiveWithAnyArgs().WriteCache(Arg.Any<byte[]>());
+            }
+        }
+
         [TestMethod]
         public void GetExactScopesMatchedAccessTokenTest()
         {


### PR DESCRIPTION
Issue #1770 

- [x] Measure improvement (start with baseline and explore improvements for a small and large cache sizes)
- [x] Flag to disable ADAL cache fallback (.WithDisableAdalCache - suggestions welcome)

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-9850H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.101
  [Host]                      : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
  Job-GetAllAccessTokensTests : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT

Job=Job-GetAllAccessTokensTests  

```
|      Method | Cache Size | ADAL Cache Enabled |          Mean |         Error |        StdDev |        Median |
|------------ |--------------- |---------------- |--------------:|--------------:|--------------:|--------------:|
|   SaveToken |              1 |           False |    **114.627 μs** |     5.0409 μs |    14.3002 μs |    110.700 μs |
|   SaveToken |              1 |            True |    **254.866 μs** |    15.1876 μs |    43.0847 μs |    249.400 μs |
|   SaveToken |            100 |           False |    **125.229 μs** |     7.9097 μs |    22.8214 μs |    117.900 μs |
|   SaveToken |            100 |            True |  **3,839.003 μs** |   426.3727 μs | 1,250.4775 μs |  3,531.600 μs |
|   SaveToken |           1000 |           False |    **311.947 μs** |    46.2354 μs |   130.4077 μs |    290.300 μs |
|   SaveToken |           1000 |            True | **19,656.353 μs** | 1,146.5410 μs | 3,233.8394 μs | 18,760.100 μs |
|             |                |                 |               |               |               |               |
|   FindToken |              1 |           False |      **6.064 μs** |     0.0728 μs |     0.0681 μs |      6.036 μs |
|   FindToken |              1 |            True |     **25.042 μs** |     0.2029 μs |     0.1799 μs |     25.029 μs |
|   FindToken |            100 |           False |    **292.248 μs** |     5.0886 μs |     4.7599 μs |    291.118 μs |
|   FindToken |            100 |            True |  **1,247.194 μs** |    13.2774 μs |    12.4197 μs |  1,244.227 μs |
|   FindToken |           1000 |           False |  **2,918.332 μs** |    29.1596 μs |    25.8492 μs |  2,916.822 μs |
|   FindToken |           1000 |            True | **13,160.303 μs** |    68.0861 μs |    56.8550 μs | 13,175.005 μs |
|             |                |                 |               |               |               |               |
| GetAllUsers |              1 |           False |      **4.115 μs** |     0.0369 μs |     0.0308 μs |      4.122 μs |
| GetAllUsers |              1 |            True |     **26.792 μs** |     0.3861 μs |     0.3611 μs |     26.760 μs |
| GetAllUsers |            100 |           False |     **21.667 μs** |     0.3096 μs |     0.2896 μs |     21.775 μs |
| GetAllUsers |            100 |            True |  **1,034.691 μs** |     5.3541 μs |     5.0082 μs |  1,033.355 μs |
| GetAllUsers |           1000 |           False |    **176.886 μs** |     1.6854 μs |     1.5765 μs |    176.577 μs |
| GetAllUsers |           1000 |            True | **12,433.904 μs** |   247.6150 μs |   433.6777 μs | 12,483.295 μs |
|             |                |                 |               |               |               |               |
|  RemoveUser |              1 |           False |      **1.033 μs** |     0.0075 μs |     0.0062 μs |      1.035 μs |
|  RemoveUser |              1 |            True |      **2.185 μs** |     0.0384 μs |     0.0341 μs |      2.192 μs |
|  RemoveUser |            100 |           False |      **5.625 μs** |     0.0164 μs |     0.0137 μs |      5.621 μs |
|  RemoveUser |            100 |            True |      **6.830 μs** |     0.0394 μs |     0.0307 μs |      6.838 μs |
|  RemoveUser |           1000 |           False |     **48.304 μs** |     0.9617 μs |     0.9876 μs |     48.550 μs |
|  RemoveUser |           1000 |            True |     **48.664 μs** |     0.9403 μs |     0.9235 μs |     48.667 μs |