### PR TITLE
Fix spelling and mark default to true for FallbackToGlobal

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Client
         /// <param name="fallbackToGlobal"><c>true</c> to fallback to global ESTS endpoint when calls to regional ESTS fail.
         /// This will only happen when MSAL is not able to detect a region or if there is no provided region in <param name="regionToUse"></param>
         /// <returns>The builder to chain the .With methods</returns>
-        [Obsolete("This method name has been changed to a more relevant name, please use WithPreferedAzureRegion instead which also includes added features.", true)]
+        [Obsolete("This method name has been changed to a more relevant name, please use WithPreferredAzureRegion instead which also includes added features.", true)]
         public AcquireTokenForClientParameterBuilder WithAzureRegion(bool useAzureRegion)
         {
             ValidateUseOfExpirementalFeature();
@@ -114,7 +114,7 @@ namespace Microsoft.Identity.Client
         /// <param name="fallbackToGlobal"><c>true</c> to fallback to global ESTS endpoint when calls to regional ESTS fail.
         /// This will only happen when MSAL is not able to detect a region or if there is no provided region in <param name="regionToUse"></param>
         /// <returns>The builder to chain the .With methods</returns>
-        public AcquireTokenForClientParameterBuilder WithPreferedAzureRegion(bool useAzureRegion = true, string regionUsedIfAutoDetectFails = "", bool fallbackToGlobal = false)
+        public AcquireTokenForClientParameterBuilder WithPreferredAzureRegion(bool useAzureRegion = true, string regionUsedIfAutoDetectFails = "", bool fallbackToGlobal = true)
         {
             ValidateUseOfExpirementalFeature();
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
 
                 await cca.AcquireTokenForClient(s_keyvaultScope)
-                .WithPreferedAzureRegion(true)
+                .WithPreferredAzureRegion(true)
                 .WithExtraQueryParameters(_dict)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
@@ -254,7 +254,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             string userProvidedRegion = "")
         {
             var result = await _confidentialClientApplication.AcquireTokenForClient(s_keyvaultScope)
-                            .WithPreferedAzureRegion(autoDetectRegion, userProvidedRegion)
+                            .WithPreferredAzureRegion(autoDetectRegion, userProvidedRegion)
                             .WithExtraQueryParameters(_dict)
                             .WithForceRefresh(withForceRefresh)
                             .ExecuteAsync()

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -107,8 +107,8 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
-        [Description("Test when the region could not be fetched")]
-        public async Task RegionNotFoundAsync()
+        [Description("Test when the region could not be fetched and fallback to global is set to false.")]
+        public async Task RegionNotFoundAndFallbackToGlobalIsFalseAsync()
         {
             _httpManager.AddRegionDiscoveryMockHandlerNotFound();
 
@@ -118,7 +118,7 @@ namespace Microsoft.Identity.Test.Unit
             {
                 AuthenticationResult result = await app
                 .AcquireTokenForClient(TestConstants.s_scope)
-                .WithPreferredAzureRegion(true)
+                .WithPreferredAzureRegion(true, fallbackToGlobal: false)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Test.Unit
 
             AuthenticationResult result = await app
                 .AcquireTokenForClient(TestConstants.s_scope)
-                .WithPreferedAzureRegion(true)
+                .WithPreferredAzureRegion(true)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 AuthenticationResult result = await app
                     .AcquireTokenForClient(TestConstants.s_scope)
-                    .WithPreferedAzureRegion(true)
+                    .WithPreferredAzureRegion(true)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 
@@ -118,7 +118,7 @@ namespace Microsoft.Identity.Test.Unit
             {
                 AuthenticationResult result = await app
                 .AcquireTokenForClient(TestConstants.s_scope)
-                .WithPreferedAzureRegion(true)
+                .WithPreferredAzureRegion(true)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 
@@ -146,7 +146,7 @@ namespace Microsoft.Identity.Test.Unit
             {
                 AuthenticationResult result = await app
                 .AcquireTokenForClient(TestConstants.s_scope)
-                .WithPreferedAzureRegion(true, string.Empty, true)
+                .WithPreferredAzureRegion(true, string.Empty, true)
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
 

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     tokenRequestHandler = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(authority: TestConstants.AuthorityRegional);
                     var authResult = await _app
                         .AcquireTokenForClient(TestConstants.s_scope)
-                        .WithPreferedAzureRegion(true)
+                        .WithPreferredAzureRegion(true)
                         .WithForceRefresh(forceRefresh)
                         .ExecuteAsync()
                         .ConfigureAwait(false);
@@ -220,7 +220,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     tokenRequestHandler = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(authority: TestConstants.AuthorityRegional);
                     authResult = await _app
                         .AcquireTokenForClient(TestConstants.s_scope)
-                        .WithPreferedAzureRegion(true, TestConstants.Region)
+                        .WithPreferredAzureRegion(true, TestConstants.Region)
                         .WithForceRefresh(forceRefresh)
                         .ExecuteAsync()
                         .ConfigureAwait(false);
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     tokenRequestHandler = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(authority: TestConstants.AuthorityRegional);
                     authResult = await _app
                         .AcquireTokenForClient(TestConstants.s_scope)
-                        .WithPreferedAzureRegion(true, "invalid")
+                        .WithPreferredAzureRegion(true, "invalid")
                         .WithForceRefresh(forceRefresh)
                         .ExecuteAsync()
                         .ConfigureAwait(false);
@@ -262,7 +262,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     var serviceEx = await AssertException.TaskThrowsAsync<MsalServiceException>(() =>
                         _app
                         .AcquireTokenForClient(TestConstants.s_scope)
-                        .WithPreferedAzureRegion(true)
+                        .WithPreferredAzureRegion(true)
                         .WithForceRefresh(true)
                         .WithCorrelationId(correlationId)
                         .ExecuteAsync())

--- a/tests/devapps/RegionalTestApp/Program.cs
+++ b/tests/devapps/RegionalTestApp/Program.cs
@@ -101,7 +101,7 @@ namespace TestApp
             Console.WriteLine("CCA created");
 
             AuthenticationResult result = await cca.AcquireTokenForClient(scopes)
-            .WithPreferedAzureRegion(withAzureRegion, regionUsedIfAutoDetectFails: "centralus")
+            .WithPreferredAzureRegion(withAzureRegion, regionUsedIfAutoDetectFails: "centralus")
             .WithExtraQueryParameters(dict)
             .ExecuteAsync()
             .ConfigureAwait(false);


### PR DESCRIPTION
Update the api as discussed in the meeting with default value for FallbackToGlobal as true.