### PR TITLE
Remove debugger in CacheCompat.Test.MsalV3 project

### DIFF
--- a/tests/CacheCompat/CommonCache.Test.MsalV3/Program.cs
+++ b/tests/CacheCompat/CommonCache.Test.MsalV3/Program.cs
@@ -24,9 +24,6 @@ namespace CommonCache.Test.MsalV2
             /// <inheritdoc />
             protected override async Task<IEnumerable<CacheExecutorAccountResult>> InternalExecuteAsync(TestInputData testInputData)
             {
-                Debugger.Launch();
-                Debugger.Break();
-
                 string resource = TestInputData.MsGraph;
                 string[] scopes = new[]
                 {


### PR DESCRIPTION
I assume the Debugger calls were for manual testing. @bgavrilMS proposing to remove them because every time I run unit tests locally, the Attach Debugger window pop ups...