### PR TITLE
More verbose logging around FindAT and SaveMsalResponse

### DIFF
--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -150,10 +150,10 @@ namespace Microsoft.Identity.Client
             var accountsFromCache = await GetAccountsFromCacheAsync(apiId, homeAccountIdFilter).ConfigureAwait(false);
             var accountsFromBroker = await GetAccountsFromBrokerAsync(homeAccountIdFilter).ConfigureAwait(false);
 
-            ServiceBundle.DefaultLogger.Info($"Found {accountsFromCache.Count()} cache accounts and {accountsFromCache.Count()} broker accounts");
+            ServiceBundle.DefaultLogger.Info($"Found {accountsFromCache.Count()} cache accounts and {accountsFromBroker.Count()} broker accounts");
             IEnumerable<IAccount> cacheAndBrokerAccounts = MergeAccounts(accountsFromCache, accountsFromBroker);
 
-            ServiceBundle.DefaultLogger.Verbose($"Returning {cacheAndBrokerAccounts.Count()} accounts");
+            ServiceBundle.DefaultLogger.Info($"Returning {cacheAndBrokerAccounts.Count()} accounts");
             return cacheAndBrokerAccounts;
         }
 
@@ -213,6 +213,12 @@ namespace Microsoft.Identity.Client
                 if (!cacheAccounts.Any(x => x.HomeAccountId.Equals(account.HomeAccountId)))
                 {
                     allAccounts.Add(account);
+                }
+                else
+                {
+                    ServiceBundle.DefaultLogger.InfoPii(
+                        "Account merge eliminated broker account with id: " + account.HomeAccountId,
+                        "Account merge eliminated an account");
                 }
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Logger/MsalLogger.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Logger/MsalLogger.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Identity.Client.Internal.Logger
             bool isDefaultPlatformLoggingEnabled,
             LogCallback loggingCallback)
         {
-            _correlationId = correlationId;
+            _correlationId = correlationId.Equals(Guid.Empty)
+                    ? string.Empty
+                    : " - " + _correlationId;
             PiiLoggingEnabled = enablePiiLogging;
             _loggingCallback = loggingCallback;
             _minLogLevel = logLevel;
@@ -71,7 +73,7 @@ namespace Microsoft.Identity.Client.Internal.Logger
 
         public static ICoreLogger NullLogger => s_nullLogger.Value;
 
-        private readonly Guid _correlationId;
+        private readonly string _correlationId;
 
         public bool PiiLoggingEnabled { get; }
 
@@ -155,10 +157,6 @@ namespace Microsoft.Identity.Client.Internal.Logger
         {
             if (IsLoggingEnabled(logLevel))
             {
-                string correlationId = _correlationId.Equals(Guid.Empty)
-                    ? string.Empty
-                    : " - " + _correlationId;
-
                 var msalIdParameters = MsalIdHelper.GetMsalIdParameters(this);
                 string os = "N/A";
                 if (msalIdParameters.TryGetValue(MsalIdParameter.OS, out string osValue))
@@ -175,7 +173,7 @@ namespace Microsoft.Identity.Client.Internal.Logger
                     isLoggingPii ? "(True)" : "(False)",
                     MsalIdHelper.GetMsalVersion(),
                     msalIdParameters[MsalIdParameter.Product],
-                    os, DateTime.UtcNow, correlationId, ClientInformation, messageToLog);
+                    os, DateTime.UtcNow, _correlationId, ClientInformation, messageToLog);
 
                 if (_isDefaultPlatformLoggingEnabled)
                 {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -284,13 +284,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private void LogReturnedToken(AuthenticationResult result)
         {
-            if (result.AccessToken != null)
+            if (result.AccessToken != null && 
+                AuthenticationRequestParameters.RequestContext.Logger.IsLoggingEnabled(LogLevel.Info))
             {
                 AuthenticationRequestParameters.RequestContext.Logger.Info(
                     string.Format(
                         CultureInfo.InvariantCulture,
-                        "=== Token Acquisition finished successfully. An access token was returned with Expiration Time: {0} ===",
-                        result.ExpiresOn));
+                        "=== Token Acquisition finished successfully. An access token was returned with Expiration Time: {0} and Scopes {1}",
+                        result.ExpiresOn, 
+                        string.Join(" ", result.Scopes)));
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -9,6 +9,8 @@ using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Json;
 using Microsoft.Identity.Json.Linq;
 using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Core;
+using System.Text;
 
 namespace Microsoft.Identity.Client.OAuth2
 {
@@ -180,6 +182,44 @@ namespace Microsoft.Identity.Client.OAuth2
             };
 
             return msalTokenResponse;
+        }
+
+        public void Log(ICoreLogger logger, LogLevel logLevel)
+        {
+            if (logger.IsLoggingEnabled(logLevel))
+            {
+                StringBuilder withPii = new StringBuilder();
+                StringBuilder withoutPii = new StringBuilder();
+
+                withPii.AppendLine("==MsalTokenResponse==");
+                withoutPii.AppendLine("==MsalTokenResponse==");
+
+                withPii.AppendLine($"Error: {Error} ErrorDescription: {ErrorDescription}");
+                withoutPii.AppendLine($"Error: {Error} ErrorDescription: {ErrorDescription}");
+                withPii.AppendLine($"Scopes: {Scope} ");
+                withoutPii.AppendLine($"Scopes: {Scope} ");
+                withPii.AppendLine($"ExpiresIn: {ExpiresIn} RefreshIn {RefreshIn}");
+                withoutPii.AppendLine($"ExpiresIn: {ExpiresIn} RefreshIn {RefreshIn}");
+
+                withoutPii.AppendLine(
+                    $"AccessToken {!String.IsNullOrEmpty(AccessToken)} " +
+                    $"AccessToken Type {TokenType} " +
+                    $"RefreshToken {!String.IsNullOrEmpty(RefreshToken)} " +
+                    $"IdToken {!String.IsNullOrEmpty(IdToken)} " +
+                    $"ClientInfo {!String.IsNullOrEmpty(ClientInfo)} ");
+
+                withPii.AppendLine(
+                    $"AccessToken {!String.IsNullOrEmpty(AccessToken)} " +
+                    $"AccessToken Type {TokenType} " +
+                    $"RefreshToken {!String.IsNullOrEmpty(RefreshToken)} " +
+                    $"IdToken {!String.IsNullOrEmpty(IdToken)} " +
+                    $"ClientInfo {ClientInfo} ");
+
+                withPii.AppendLine($"FamilyId: {FamilyId} WamAccountId {!string.IsNullOrEmpty(WamAccountId)}");
+                withoutPii.AppendLine($"FamilyId: {FamilyId} WamAccountId {!string.IsNullOrEmpty(WamAccountId)}");
+
+                logger.Log(logLevel, withPii.ToString(), withoutPii.ToString());
+            }
         }
     }    
 }


### PR DESCRIPTION
No perf impact on FindAccessToken logic...

Before
|                         Method | TokenCacheSize |     Mean |   Error |  StdDev |
|------------------------------- |--------------- |---------:|--------:|--------:|
| AcquireTokenForClientTestAsync |         100000 | 104.9 ms | 2.06 ms | 2.37 ms |

After
|                         Method | TokenCacheSize |     Mean |   Error |  StdDev |
|------------------------------- |--------------- |---------:|--------:|--------:|
| AcquireTokenForClientTestAsync |         100000 | 104.4 ms | 2.05 ms | 2.52 ms |

