### PR TITLE
Add telemetry for cache refresh

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/CacheRefresh.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheRefresh.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.;
+
+namespace Microsoft.Identity.Client.Region
+{
+    // Enum to be used only for telemetry, to log reason for cache refresh and fetching AT from ests.
+    internal enum CacheRefresh
+    {
+        None = -1, // When no cache is used
+        NoCachedAT = 0, // When there is no AT is found in the cache
+        Expired = 1, // When the token refresh happens due to expired token in cache
+        RefreshIn = 2, // When the token refresh happens due to refresh in
+        ForceRefresh = 3 // When the token refresh happens due to force refresh
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -38,14 +38,7 @@ namespace Microsoft.Identity.Client.Cache
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {
             await RefreshCacheForReadOperationsAsync(CacheEvent.TokenTypes.AT).ConfigureAwait(false);
-            MsalAccessTokenCacheItem msalAccessToken = await TokenCacheInternal.FindAccessTokenAsync(_requestParams).ConfigureAwait(false);
-
-            if (msalAccessToken == null && _requestParams.RequestContext.ApiEvent.CacheRefresh == null)
-            {
-                _requestParams.RequestContext.ApiEvent.CacheRefresh = "0";
-            }
-
-            return msalAccessToken;
+            return await TokenCacheInternal.FindAccessTokenAsync(_requestParams).ConfigureAwait(false);
         }
 
         public async Task<Tuple<MsalAccessTokenCacheItem, MsalIdTokenCacheItem>> SaveTokenResponseAsync(MsalTokenResponse tokenResponse)

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -38,7 +38,14 @@ namespace Microsoft.Identity.Client.Cache
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {
             await RefreshCacheForReadOperationsAsync(CacheEvent.TokenTypes.AT).ConfigureAwait(false);
-            return await TokenCacheInternal.FindAccessTokenAsync(_requestParams).ConfigureAwait(false);
+            MsalAccessTokenCacheItem msalAccessToken = await TokenCacheInternal.FindAccessTokenAsync(_requestParams).ConfigureAwait(false);
+
+            if (msalAccessToken == null && _requestParams.RequestContext.ApiEvent.CacheRefresh == null)
+            {
+                _requestParams.RequestContext.ApiEvent.CacheRefresh = "0";
+            }
+
+            return msalAccessToken;
         }
 
         public async Task<Tuple<MsalAccessTokenCacheItem, MsalIdTokenCacheItem>> SaveTokenResponseAsync(MsalTokenResponse tokenResponse)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -56,10 +56,20 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         AuthenticationRequestParameters.RequestContext.CorrelationId,
                         TokenSource.Cache);
                 }
+
+                if (cachedAccessTokenItem != null && cachedAccessTokenItem.NeedsRefresh())
+                {
+                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = "2";
+                }
             }
             else
             {
                 logger.Info("Skipped looking for an Access Token in the cache because ForceRefresh or Claims were set. ");
+
+                if (_clientParameters.ForceRefresh)
+                {
+                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = "3";
+                }
             }
 
             // No AT in the cache or AT needs to be refreshed

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             MsalAccessTokenCacheItem cachedAccessTokenItem = null;
             var logger = AuthenticationRequestParameters.RequestContext.Logger;
-            int cacheRefresh = (int) CacheRefresh.None;
+            CacheRefresh cacheRefresh = CacheRefresh.None;
 
             if (!_clientParameters.ForceRefresh && 
                 string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
@@ -61,11 +61,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 }
                 else if (cachedAccessTokenItem == null)
                 {
-                    cacheRefresh = (int) CacheRefresh.NoCachedAT;
+                    cacheRefresh = CacheRefresh.NoCachedAT;
                 }
                 else
                 {
-                    cacheRefresh = (int) CacheRefresh.RefreshIn;
+                    cacheRefresh = CacheRefresh.RefreshIn;
                 }
             }
             else
@@ -74,11 +74,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
                 if (_clientParameters.ForceRefresh)
                 {
-                    cacheRefresh = (int) CacheRefresh.ForceRefresh;
+                    cacheRefresh = CacheRefresh.ForceRefresh;
                 }
             }
 
-            AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = cacheRefresh;
+            if (AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh == null)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = (int)cacheRefresh;
+            }
 
             // No AT in the cache or AT needs to be refreshed
             try

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -71,7 +71,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 cacheRefresh = CacheRefresh.ForceRefresh;
             }
 
-            AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = (int) cacheRefresh;
+            if (AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh == null)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = (int)cacheRefresh;
+            }
 
             var msalTokenResponse = await SendTokenRequestAsync(GetBodyParameters(), cancellationToken).ConfigureAwait(false);
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -9,6 +9,7 @@ using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using System.Linq;
+using Microsoft.Identity.Client.Region;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {
@@ -35,6 +36,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
 
             await ResolveAuthorityEndpointsAsync().ConfigureAwait(false);
+            CacheRefresh cacheRefresh = CacheRefresh.None;
 
             if (!_onBehalfOfParameters.ForceRefresh)
             {
@@ -59,11 +61,17 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         AuthenticationRequestParameters.RequestContext.CorrelationId,
                         TokenSource.Cache);
                 }
+                else
+                {
+                    cacheRefresh = CacheRefresh.NoCachedAT;
+                }
             }
             else
             {
-                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = "3";
+                cacheRefresh = CacheRefresh.ForceRefresh;
             }
+
+            AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = (int) cacheRefresh;
 
             var msalTokenResponse = await SendTokenRequestAsync(GetBodyParameters(), cancellationToken).ConfigureAwait(false);
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -60,6 +60,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         TokenSource.Cache);
                 }
             }
+            else
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = "3";
+            }
 
             var msalTokenResponse = await SendTokenRequestAsync(GetBodyParameters(), cancellationToken).ConfigureAwait(false);
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -54,10 +54,20 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                     AuthenticationRequestParameters.RequestContext.ApiEvent.IsAccessTokenCacheHit = true;
                     return await CreateAuthenticationResultAsync(cachedAccessTokenItem).ConfigureAwait(false);
                 }
+
+                if (cachedAccessTokenItem != null && cachedAccessTokenItem.NeedsRefresh())
+                {
+                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = "2"; 
+                }
             }
             else
             {
                 logger.Info("Skipped looking for an Access Token because ForceRefresh or Claims were set. ");
+
+                if (_silentParameters.ForceRefresh)
+                {
+                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = "3";
+                }
             }
 
             // No AT or AT.RefreshOn > Now --> refresh the RT

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -71,7 +71,10 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                 logger.Info("Skipped looking for an Access Token because ForceRefresh or Claims were set. ");
             }
 
-            AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = (int) cacheRefresh;
+            if (AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh == null)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheRefresh = (int)cacheRefresh;
+            }
 
             // No AT or AT.RefreshOn > Now --> refresh the RT
             try

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Http/HttpTelemetryManager.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Http/HttpTelemetryManager.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.Http
         }
 
         /// <summary>
-        /// Expected format: 2|api_id,force_refresh|platform_config
+        /// Expected format: 3|api_id,force_refresh,cache_refresh|platform_config
         /// platform_config: region,region_source,is_token_cache_serialized,user_provided_region,validate_use_region,fallback_to_global,is_legacy_cache_enabled
         /// </summary>
         public string GetCurrentRequestHeader(ApiEvent eventInProgress)
@@ -124,6 +124,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.Http
             eventInProgress.TryGetValue(MsalTelemetryBlobEventNames.IsValidUserProvidedRegion, out string isValidUserProvidedRegion);
             eventInProgress.TryGetValue(MsalTelemetryBlobEventNames.IsLegacyCacheEnabledKey, out string isLegacyCacheEnabled);
             eventInProgress.TryGetValue(MsalTelemetryBlobEventNames.FallbackToGlobal, out string fallbackToGlobal);
+            eventInProgress.TryGetValue(MsalTelemetryBlobEventNames.CacheRefreshKey, out string cacheRefresh);
 
             // Since regional fields will only be logged in case it is opted.
             var platformConfig = new StringBuilder();
@@ -137,7 +138,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.Http
             platformConfig.Append(ConvertFromStringToBitwise(isLegacyCacheEnabled));
 
             return $"{TelemetryConstants.HttpTelemetrySchemaVersion2}" +
-                $"|{apiId},{ConvertFromStringToBitwise(forceRefresh)}" +
+                $"|{apiId},{ConvertFromStringToBitwise(forceRefresh)},{cacheRefresh}" +
                 $"|{platformConfig}";
         }
 

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Http/HttpTelemetryManager.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Http/HttpTelemetryManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.Http
 
         /// <summary>
         /// CSV expected format:
-        ///      2|silent_successful_count|failed_requests|errors|platform_fields
+        ///      3|silent_successful_count|failed_requests|errors|platform_fields
         ///      failed_request is: api_id_1,correlation_id_1,api_id_2,correlation_id_2|error_1,error_2
         ///      platform_fields: region_1,region_source_1,region_2,region_source_2
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Constants/MsalTelemetryBlobEventNames.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Constants/MsalTelemetryBlobEventNames.cs
@@ -31,5 +31,6 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Constants
         public const string IsValidUserProvidedRegion = "msal.is_valid_user_provided_region";
         public const string FallbackToGlobal = "msal.fallback_to_global";
         public const string IsLegacyCacheEnabledKey = "msal.is_legacy_cache_enabled";
+        public const string CacheRefreshKey = "msal.cache_refresh";
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Events/ApiEvent.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Events/ApiEvent.cs
@@ -7,6 +7,7 @@ using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Constants;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.Region;
+using Microsoft.Identity.Client.Cache;
 
 namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
 {
@@ -232,10 +233,23 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
 #pragma warning restore CA1305 // Specify IFormatProvider
         }
 
-        public string CacheRefresh
+        public int? CacheRefresh
         {
-            get => this.ContainsKey(CacheRefreshKey) ? this[CacheRefreshKey] : null;
-            set => this[CacheRefreshKey] = value;
+            get
+            {
+                if (this.ContainsKey(CacheRefreshKey))
+                {
+                    int val = (int)Enum.Parse(typeof(CacheRefresh), this[CacheRefreshKey]);
+                    if (val != -1)
+                    {
+                        return val;
+                    }
+                }
+
+                return null;
+            }
+
+            set => this[CacheRefreshKey] = (value)?.ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Events/ApiEvent.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Events/ApiEvent.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
         public const string IsValidUserProvidedRegionKey = EventNamePrefix + "is_valid_user_provided_region";
         public const string FallbackToGlobalKey = EventNamePrefix + "fallback_to_global";
         public const string IsLegacyCacheEnabledKey = EventNamePrefix + "is_legacy_cache_enabled";
+        public const string CacheRefreshKey = EventNamePrefix + "cache_refresh";
 
         public enum ApiIds
         {
@@ -229,6 +230,12 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
             set { this[IsLegacyCacheEnabledKey] = value.ToString().ToLowerInvariant(); }
             get { return this[IsLegacyCacheEnabledKey] == true.ToString().ToLowerInvariant(); }
 #pragma warning restore CA1305 // Specify IFormatProvider
+        }
+
+        public string CacheRefresh
+        {
+            get => this.ContainsKey(CacheRefreshKey) ? this[CacheRefreshKey] : null;
+            set => this[CacheRefreshKey] = value;
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
 
     internal static class TelemetryConstants
     {
-        public const string HttpTelemetrySchemaVersion2 = "2";
+        public const string HttpTelemetrySchemaVersion2 = "3";
         public const string HttpTelemetryPipe = "|";
         public const string XClientCurrentTelemetry = "x-client-current-telemetry";
         public const string XClientLastTelemetry = "x-client-last-telemetry";

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -462,6 +462,8 @@ namespace Microsoft.Identity.Client
                         "Access token has expired or about to expire. " +
                         GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
                 }
+
+                requestParams.RequestContext.ApiEvent.CacheRefresh = "1";
             }
 
             return null;

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
@@ -9,6 +9,7 @@ using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Requests;
+using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Test.Unit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -75,13 +76,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             authenticationRequestParameters.RequestContext.ApiEvent = new ApiEvent(
                 authenticationRequestParameters.RequestContext.Logger,
                 ServiceBundle.PlatformProxy.CryptographyManager,
-                "")
-            {
-                ApiId = authenticationRequestParameters.ApiId,
-                ApiTelemId = authenticationRequestParameters.ApiTelemId,
-                AccountId = "",
-                WasSuccessful = false
-            };
+                Guid.NewGuid().AsMatsCorrelationId());
 
             return authenticationRequestParameters;
         }

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpAndServiceBundle.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 ApiId = apiId
             };
 
-            return new AuthenticationRequestParameters(
+            AuthenticationRequestParameters authenticationRequestParameters = new AuthenticationRequestParameters(
                 ServiceBundle,
                 tokenCache,
                 commonParameters,
@@ -71,6 +71,19 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 Account = account,
                 Authority = Authority.CreateAuthority(authority, validateAuthority)
             };
+
+            authenticationRequestParameters.RequestContext.ApiEvent = new ApiEvent(
+                authenticationRequestParameters.RequestContext.Logger,
+                ServiceBundle.PlatformProxy.CryptographyManager,
+                "")
+            {
+                ApiId = authenticationRequestParameters.ApiId,
+                ApiTelemId = authenticationRequestParameters.ApiTelemId,
+                AccountId = "",
+                WasSuccessful = false
+            };
+
+            return authenticationRequestParameters;
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await GetAuthenticationResultAsync().ConfigureAwait(false); // regional endpoint
             AssertTokenSource_IsIdP(result);
             AssertValidHost(true, factory);
-            AssertTelemetry(factory, "2|1004,0|centralus,1,0,,,0,1");
+            AssertTelemetry(factory, "3|1004,0,0|centralus,1,0,,,0,1");
 
         }
 
@@ -125,12 +125,12 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await GetAuthenticationResultAsync(userProvidedRegion: TestConstants.Region).ConfigureAwait(false); // regional endpoint
             AssertTokenSource_IsIdP(result);
             AssertValidHost(true, factory);
-            AssertTelemetry(factory, "2|1004,0|centralus,1,0,centralus,1,0,1");
+            AssertTelemetry(factory, "3|1004,0,0|centralus,1,0,centralus,1,0,1");
 
             result = await GetAuthenticationResultAsync(userProvidedRegion: TestConstants.Region, withForceRefresh: true).ConfigureAwait(false); // regional endpoint
             AssertTokenSource_IsIdP(result);
             AssertValidHost(true, factory, 1);
-            AssertTelemetry(factory, "2|1004,1|centralus,3,0,centralus,,0,1", 1);
+            AssertTelemetry(factory, "3|1004,1,3|centralus,3,0,centralus,,0,1", 1);
 
         }
 
@@ -152,12 +152,12 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await GetAuthenticationResultAsync(userProvidedRegion: "invalid").ConfigureAwait(false); // regional endpoint
             AssertTokenSource_IsIdP(result);
             AssertValidHost(true, factory);
-            AssertTelemetry(factory, "2|1004,0|centralus,1,0,invalid,0,0,1");
+            AssertTelemetry(factory, "3|1004,0,0|centralus,1,0,invalid,0,0,1");
 
             result = await GetAuthenticationResultAsync(userProvidedRegion: TestConstants.Region, withForceRefresh: true).ConfigureAwait(false); // regional endpoint
             AssertTokenSource_IsIdP(result);
             AssertValidHost(true, factory, 1);
-            AssertTelemetry(factory, "2|1004,1|centralus,3,0,centralus,,0,1", 1);
+            AssertTelemetry(factory, "3|1004,1,3|centralus,3,0,centralus,,0,1", 1);
            
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         // HTTP Telemetry Constants
         private static Guid CorrelationId = new Guid("ad8c894a-557f-48c0-b045-c129590c344e");
-        private const string XClientCurrentTelemetryROPC = "2|1003,0|,,0,,,,1";
-        private const string XClientCurrentTelemetryROPCFailure = "2|1003,0|,,0,,,,1";
-        private const string XClientLastTelemetryROPC = "2|0|||";
+        private const string XClientCurrentTelemetryROPC = "3|1003,0,|,,0,,,,1";
+        private const string XClientCurrentTelemetryROPCFailure = "3|1003,0,|,,0,,,,1";
+        private const string XClientLastTelemetryROPC = "3|0|||";
         private const string XClientLastTelemetryROPCFailure =
-            "2|0|1003,ad8c894a-557f-48c0-b045-c129590c344e|invalid_grant|,";
+            "3|0|1003,ad8c894a-557f-48c0-b045-c129590c344e|invalid_grant|,";
         private const string ApiIdAndCorrelationIdSection =
             "1003,ad8c894a-557f-48c0-b045-c129590c344e";
         private const string InvalidGrantError = "invalid_grant";

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/HttpTelemetryRecorder.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/HttpTelemetryRecorder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Identity.Test.Integration.net45.Infrastructure
             string[] splitCsv = telemetryCsv.Split('|');
             string[] splitApiIdAndForceRefresh = splitCsv[1].Split(',');
             ApiId.Add(splitApiIdAndForceRefresh[0]);
-            string forceRefresh = splitApiIdAndForceRefresh[splitApiIdAndForceRefresh.Length - 1];
+            string forceRefresh = splitApiIdAndForceRefresh[splitApiIdAndForceRefresh.Length - 2];
             ForceRefresh = forceRefresh;
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
+using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common;
@@ -1111,6 +1112,10 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 serviceBundle, 
                 scopes: new HashSet<string>());
             requestParams.Account = TestConstants.s_user;
+            requestParams.RequestContext.ApiEvent = new ApiEvent(
+                serviceBundle.DefaultLogger,
+                serviceBundle.PlatformProxy.CryptographyManager,
+                Guid.NewGuid().AsMatsCorrelationId());
 
             string scopeInCache = TestConstants.s_scope.FirstOrDefault();
 

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
@@ -48,19 +48,19 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
         /// <summary>
         /// 1.  Acquire Token For Client with Region successfully
-        ///        Current_request = 2 | ATC_ID, 0 | centralus, 1, 0,
-        ///        Last_request = 2 | 0 | | |
+        ///        Current_request = 3 | ATC_ID, 0, | centralus, 1, 0,
+        ///        Last_request = 3 | 0 | | |
         /// 
         /// 2. Acquire Token for client with Region -> HTTP error 503 (Service Unavailable)
         ///
-        ///        Current_request = 2 | ATC_ID, 1 | centralus, 3, 0,
-        ///        Last_request = 2 | 0 | | |
+        ///        Current_request = 3 | ATC_ID, 1, | centralus, 3, 0,
+        ///        Last_request = 3 | 0 | | |
         ///
         /// 3. Acquire Token For Client with Region -> successful
         ///
         /// Sent to the server - 
-        ///        Current_request = 2 | ATC_ID, 1 | centralus, 3, 0,
-        ///        Last_request = 2 | 0 |  ATC_ID, corr_step_2  | ServiceUnavailable | centralus, 3
+        ///        Current_request = 3 | ATC_ID, 1, | centralus, 3, 0,
+        ///        Last_request = 3 | 0 |  ATC_ID, corr_step_2  | ServiceUnavailable | centralus, 3
         /// </summary>
         [TestMethod]
         public async Task TelemetryAcceptanceTestAsync()
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
             Trace.WriteLine("Step 1. Acquire Token For Client with region successful");
             var result = await RunAcquireTokenForClientAsync(AcquireTokenForClientOutcome.Success).ConfigureAwait(false);
             AssertCurrentTelemetry(result.HttpRequest, ApiIds.AcquireTokenForClient, forceRefresh: false, "1");
-            AssertPreviousTelemetry(result.HttpRequest, expectedSilentCount: 0); // Previous_request = 2|0|||
+            AssertPreviousTelemetry(result.HttpRequest, expectedSilentCount: 0); // Previous_request = 3|0|||
 
             Trace.WriteLine("Step 2. Acquire Token For Client -> HTTP 5xx error (i.e. AAD is down)");
             result = await RunAcquireTokenForClientAsync(AcquireTokenForClientOutcome.AADUnavailableError).ConfigureAwait(false);
@@ -102,8 +102,8 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
         /// <summary>
         /// Acquire token for client with serialized token cache successfully
-        ///    Current_request = 2 | ATC_ID, 0 | centralus, 1, 1
-        ///    Last_request = 2 | 0 | | |
+        ///    Current_request = 3 | ATC_ID, 0, | centralus, 1, 1
+        ///    Last_request = 3 | 0 | | |
         /// </summary>
         [TestMethod]
         public async Task TelemetrySerializedTokenCacheTestAsync()
@@ -125,8 +125,8 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
         /// <summary>
         /// Acquire token for client with regionToUse when auto region discovery fails
-        ///    Current_request = 2 | ATC_ID, 0 | centralus, 1, 1, centralus,
-        ///    Last_request = 2 | 0 | | |
+        ///    Current_request = 3 | ATC_ID, 0, | centralus, 1, 1, centralus,
+        ///    Last_request = 3 | 0 | | |
         /// </summary>
         [TestMethod]
         public async Task TelemetryUserProvidedRegionAutoDiscoveryFailsTestsAsync()
@@ -145,8 +145,8 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
         /// <summary>
         /// Acquire token for client with regionToUse when auto region discovery passes with region same as regionToUse
-        ///    Current_request = 2 | ATC_ID, 0 | centralus, 1, 1, centralus, 1
-        ///    Last_request = 2 | 0 | | |
+        ///    Current_request = 3 | ATC_ID, 0, | centralus, 1, 1, centralus, 1
+        ///    Last_request = 3 | 0 | | |
         /// </summary>
         [TestMethod]
         public async Task TelemetryUserProvidedRegionAutoDiscoverRegionSameTestsAsync()
@@ -167,8 +167,8 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
         /// <summary>
         /// Acquire token for client with regionToUse when auto region discovery passes with region different from regionToUse
-        ///    Current_request = 2 | ATC_ID, 0 | centralus, 1, 1, invalid, 0
-        ///    Last_request = 2 | 0 | | |
+        ///    Current_request = 3 | ATC_ID, 0, | centralus, 1, 1, invalid, 0
+        ///    Last_request = 3 | 0 | | |
         /// </summary>
         [TestMethod]
         public async Task TelemetryUserProvidedRegionAutoDiscoverRegionDifferentTestsAsync()
@@ -189,8 +189,8 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
         /// <summary>
         /// Acquire token for client with regionToUse when auto region discovery fails
-        ///    Current_request = 2 | ATC_ID, 0 | centralus, 1, 1, centralus,
-        ///    Last_request = 2 | 0 | | |
+        ///    Current_request = 3 | ATC_ID, 0, | centralus, 1, 1, centralus,
+        ///    Last_request = 3 | 0 | | |
         /// </summary>
         [TestMethod]
         public async Task TelemetryUserProvidedRegionAutoDiscoveryFailsFallbackToGlobalTestsAsync()
@@ -336,7 +336,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                 ((int)apiId).ToString(CultureInfo.InvariantCulture),
                 actualTelemetryParts[1].Split(',')[0]); // current_api_id
 
-            Assert.IsTrue(actualTelemetryParts[1].EndsWith(forceRefresh ? "1" : "0")); // force_refresh flag
+            Assert.AreEqual(forceRefresh ? "1" : "0", actualTelemetryParts[1].Split(',')[1]); // force_refresh flag
 
             string[] platformConfig = actualTelemetryParts[2].Split(',');
             Assert.AreEqual(isCacheSerialized ? "1" : "0", platformConfig[2]);


### PR DESCRIPTION
#2356 

As per spec:


0 if token request goes to ESTS because no cached AT exists, 
1 if token request goes to ESTS becasue cached AT expired, 
2 if token request goes to ESTS because refresh_in was used and the existing token needs to be refreshed, 
3 if token request goes to ESTS because force_refresh was set to true, blank if the cache is not hit to make the request

@neha-bhargava  - if you're using a broker, please confirm that the value will be ""

