### PR TITLE
Added tenantID to suggested app token cache key

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/SuggestedWebCacheKeyFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/SuggestedWebCacheKeyFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Identity.Client.Internal.Requests;
 
 namespace Microsoft.Identity.Client.Cache
@@ -54,6 +55,13 @@ namespace Microsoft.Identity.Client.Cache
 
             if (requestParameters.ApiId == TelemetryCore.Internal.Events.ApiEvent.ApiIds.AcquireTokenForClient)
             {
+                if (!string.IsNullOrEmpty(requestParameters.Authority.TenantId) &&
+                    Guid.TryParse(requestParameters.Authority.TenantId, out var tenantId))
+                {
+                    key = $"{requestParameters.AppConfig.ClientId}_{tenantId:D}_AppTokenCache";
+                    return true;
+                }
+
                 key = requestParameters.AppConfig.ClientId + "_AppTokenCache";
                 return true;
             }

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item>the homeAccountId for AcquireTokenSilent, GetAccount(homeAccountId), RemoveAccount and when writing tokens on confidential client calls</item>
         /// <item>clientID + "_AppTokenCache" for AcquireTokenForClient</item>
+        /// <item>clientID_tenantID + "_AppTokenCache" for AcquireTokenForClient when tenant specific authority</item>
         /// <item>the hash of the original token for AcquireTokenOnBehalfOf</item>
         /// </list>
         /// </summary>

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/SuggestedWebCacheKeyTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/SuggestedWebCacheKeyTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Cache;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Internal.Requests;
+using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
+using Microsoft.Identity.Test.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.CacheTests
+{
+    [TestClass]
+    public class SuggestedWebCacheKeyTests
+    {
+        private IServiceBundle _serviceBundle;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this._serviceBundle = TestCommon.CreateDefaultServiceBundle();
+        }
+
+        [TestMethod]
+        public void TestCacheKeyForCommonAuthority()
+        {
+            // Arrange
+            var appTokenCache = new TokenCache(this._serviceBundle, isApplicationTokenCache: true);
+            var requestContext = new RequestContext(this._serviceBundle , Guid.NewGuid());
+            var acquireTokenCommonParameters = new AcquireTokenCommonParameters
+            {
+                ApiId = ApiEvent.ApiIds.AcquireTokenForClient,
+            };
+            var parameters = new AuthenticationRequestParameters(
+                this._serviceBundle,
+                appTokenCache,
+                acquireTokenCommonParameters, requestContext);
+
+
+            // Act
+            var actualKey = SuggestedWebCacheKeyFactory.GetKeyFromRequest(parameters);
+
+            // Assert
+            Assert.IsNotNull(actualKey);
+            var expectedKey = $"{this._serviceBundle.Config.ClientId}_AppTokenCache";
+            Assert.AreEqual(expectedKey, actualKey);
+        }
+
+        [TestMethod]
+        public void TestCacheKeyForTenantAuthority()
+        {
+            // Arrange
+            const string tenantId = TestConstants.AadTenantId;
+            var appTokenCache = new TokenCache(this._serviceBundle, isApplicationTokenCache: true);
+            var requestContext = new RequestContext(this._serviceBundle , Guid.NewGuid());
+            var tenantAuthority = AuthorityInfo.FromAadAuthority(AzureCloudInstance.AzurePublic, tenant: tenantId, validateAuthority: false);
+            var acquireTokenCommonParameters = new AcquireTokenCommonParameters
+            {
+                ApiId = ApiEvent.ApiIds.AcquireTokenForClient,
+                AuthorityOverride = tenantAuthority
+            };
+
+            var parameters = new AuthenticationRequestParameters(
+                this._serviceBundle,
+                appTokenCache,
+                acquireTokenCommonParameters, requestContext);
+
+
+            // Act
+            var actualKey = SuggestedWebCacheKeyFactory.GetKeyFromRequest(parameters);
+
+            // Assert
+            Assert.IsNotNull(actualKey);
+            var expectedKey = $"{this._serviceBundle.Config.ClientId}_{tenantId}_AppTokenCache";
+            Assert.AreEqual(expectedKey, actualKey);
+        }
+    }
+}


### PR DESCRIPTION
@bgavrilMS here's a proposed fix to adding the tenantID to the suggested cache key on app tokens (see #2381).