### PR TITLE
Fix instance discovery caching.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -212,7 +212,9 @@ namespace Microsoft.Identity.Client.Http
                 requestMessage.Method = method;
                 requestMessage.Content = body;
 
-                logger.Verbose($"[HttpManager] Sending request. Method: {method}. URI path: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}{endpoint.AbsolutePath}")}. ");
+                logger.VerbosePii(
+                    $"[HttpManager] Sending request. Method: {method}. URI: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}{endpoint.AbsolutePath}")}. ",
+                    $"[HttpManager] Sending request. Method: {method}. Host: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}")}. ");
 
                 using (HttpResponseMessage responseMessage =
                     await client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false))

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -281,6 +281,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (result.AccessToken != null && 
                 AuthenticationRequestParameters.RequestContext.Logger.IsLoggingEnabled(LogLevel.Info))
             {
+                Uri canonicalAuthority = new Uri(AuthenticationRequestParameters.AuthorityInfo.CanonicalAuthority);
+                AuthenticationRequestParameters.RequestContext.Logger.InfoPii(
+                    $"Fetching access token from host {canonicalAuthority.Host}. Endpoint {canonicalAuthority}. ",
+                    $"Fetching access token from host {canonicalAuthority.Host}. ");
+
                 AuthenticationRequestParameters.RequestContext.Logger.Info(
                     string.Format(
                         CultureInfo.InvariantCulture,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -283,8 +283,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 Uri canonicalAuthority = new Uri(AuthenticationRequestParameters.AuthorityInfo.CanonicalAuthority);
                 AuthenticationRequestParameters.RequestContext.Logger.InfoPii(
-                    $"Fetching access token from host {canonicalAuthority.Host}. Endpoint {canonicalAuthority}. ",
-                    $"Fetching access token from host {canonicalAuthority.Host}. ");
+                    $"Fetched access token from host {canonicalAuthority.Host}. Endpoint {canonicalAuthority}. ",
+                    $"Fetched access token from host {canonicalAuthority.Host}. ");
 
                 AuthenticationRequestParameters.RequestContext.Logger.Info(
                     string.Format(

--- a/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
@@ -252,13 +252,18 @@ namespace Microsoft.Identity.Client.Region
                 requestContext.ApiEvent.FallbackToGlobal = false;
             }
 
+            if (canonicalAuthority.Host.StartsWith($"{s_region}."))
+            {
+                return canonicalAuthority;
+            }
+
             var builder = new UriBuilder(canonicalAuthority);
 
             if (KnownMetadataProvider.IsPublicEnvironment(canonicalAuthority.Host))
             {
                 builder.Host = $"{s_region}.login.microsoft.com";
             }
-            else if (!builder.Host.Equals($"{s_region}.login.microsoft.com"))
+            else
             {
                 builder.Host = $"{s_region}.{builder.Host}";
             }

--- a/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Identity.Client.Region
         {
             requestContext.ApiEvent.RegionDiscovered = region;
 
-            if (requestContext.ApiEvent.RegionSource == 0)
+            if (requestContext.ApiEvent.RegionSource == (int)RegionSource.None)
             {
                 requestContext.ApiEvent.RegionSource = (int)regionSource;
             }
@@ -199,7 +199,7 @@ namespace Microsoft.Identity.Client.Region
         {
             return new InstanceDiscoveryMetadataEntry()
             {
-                Aliases = new[] { regionalizedAuthority.Host, orginalAuthority.Host },
+                Aliases = new[] { regionalizedAuthority.Host },
                 PreferredCache = orginalAuthority.Host,
                 PreferredNetwork = regionalizedAuthority.Host
             };

--- a/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Identity.Client.Region
             }
             catch (Exception e)
             {
-                requestContext.Logger.Info("[Region discovery] Call to local imds failed. " + e);
+                requestContext.Logger.Info("[Region discovery] Call to local IMDS failed. " + e);
                 throw new MsalServiceException(MsalError.RegionDiscoveryFailed, MsalErrorMessage.RegionDiscoveryFailed, e);
             }
         }
@@ -194,7 +194,7 @@ namespace Microsoft.Identity.Client.Region
         {
             return new InstanceDiscoveryMetadataEntry()
             {
-                Aliases = new[] { regionalizedAuthority.Host },
+                Aliases = new[] { regionalizedAuthority.Host, orginalAuthority.Host },
                 PreferredCache = orginalAuthority.Host,
                 PreferredNetwork = regionalizedAuthority.Host
             };
@@ -243,7 +243,7 @@ namespace Microsoft.Identity.Client.Region
 
                     s_region = regionToUse;
                     requestContext.ApiEvent.FallbackToGlobal = false;
-                    requestContext.Logger.Info($"[Region discovery] Region auto detection failed. Region provided by the user will be used: ${regionToUse}.");
+                    requestContext.Logger.Info($"[Region discovery] Region auto detection failed. Region provided by the user will be used: {regionToUse}.");
                     LogTelemetryData(s_region, RegionSource.UserProvided, requestContext);
                 }
             }
@@ -258,7 +258,7 @@ namespace Microsoft.Identity.Client.Region
             {
                 builder.Host = $"{s_region}.login.microsoft.com";
             }
-            else
+            else if (!builder.Host.Equals($"{s_region}.login.microsoft.com"))
             {
                 builder.Host = $"{s_region}.{builder.Host}";
             }

--- a/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs
@@ -150,7 +150,12 @@ namespace Microsoft.Identity.Client.Region
         private void LogTelemetryData(string region, RegionSource regionSource, RequestContext requestContext)
         {
             requestContext.ApiEvent.RegionDiscovered = region;
-            requestContext.ApiEvent.RegionSource = (int)regionSource;
+
+            if (requestContext.ApiEvent.RegionSource == 0)
+            {
+                requestContext.ApiEvent.RegionSource = (int)regionSource;
+            }
+
             requestContext.ApiEvent.UserProvidedRegion = requestContext.ServiceBundle.Config.AuthorityInfo.RegionToUse;
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
@@ -179,9 +179,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await GetAuthenticationResultAsync().ConfigureAwait(false); // regional endpoint
             AssertTokenSource_IsIdP(result);
             AssertValidHost(true, factory);
-            result = await GetAuthenticationResultAsync(autoDetectRegion: false).ConfigureAwait(false); // global endpoint, new token
-            AssertValidHost(false, factory, 1);
-            AssertTokenSource_IsIdP(result);
+            result = await GetAuthenticationResultAsync(autoDetectRegion: false).ConfigureAwait(false); // global endpoint, use cached token
+            AssertTokenSource_IsCache(result);
             result = await GetAuthenticationResultAsync().ConfigureAwait(false); // regional endpoint, use cached token
             AssertTokenSource_IsCache(result);
         }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
             Environment.SetEnvironmentVariable(TestConstants.RegionName, "");
             _testRequestContext.ServiceBundle.Config.AuthorityInfo.RegionToUse = "";
             _harness?.Dispose();
+            _regionDiscoveryProvider.Clear();
             base.TestCleanup();
         }
 
@@ -145,7 +146,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
             Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
             
             // In the instance discovery flow, TryGetMetadataAsync is always called with a known authority first, then with regionalized.
-            var t = await _regionDiscoveryProvider.TryGetMetadataAsync(new Uri("https://login.microsoftonline.com/common/"), _testRequestContext).ConfigureAwait(false);
+            await _regionDiscoveryProvider.TryGetMetadataAsync(new Uri("https://login.microsoftonline.com/common/"), _testRequestContext).ConfigureAwait(false);
             InstanceDiscoveryMetadataEntry regionalMetadata = await _regionDiscoveryProvider.TryGetMetadataAsync(regionalizedAuthority, _testRequestContext).ConfigureAwait(false);
 
             ValidateInstanceMetadata(regionalMetadata);
@@ -376,13 +377,13 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
         {
             InstanceDiscoveryMetadataEntry expectedEntry = new InstanceDiscoveryMetadataEntry()
             {
-                Aliases = new[] { "centralus.login.microsoft.com", "login.microsoftonline.com" },
+                Aliases = new[] { "centralus.login.microsoft.com" },
                 PreferredCache = "login.microsoftonline.com",
                 PreferredNetwork = "centralus.login.microsoft.com"
             };
 
             Assert.IsNotNull(entry, "The instance metadata should not be empty.");
-            CollectionAssert.AreEqual(expectedEntry.Aliases, entry.Aliases);
+            Assert.AreEqual(expectedEntry.Aliases.Single(), entry.Aliases.Single());
             Assert.AreEqual(expectedEntry.PreferredCache, entry.PreferredCache);
             Assert.AreEqual(expectedEntry.PreferredNetwork, entry.PreferredNetwork);
         }

--- a/tests/devapps/RegionalTestApp/Program.cs
+++ b/tests/devapps/RegionalTestApp/Program.cs
@@ -45,7 +45,7 @@ namespace TestApp
 
             Console.WriteLine("=== Acquire token global ===");
             await AcquireTokenAsync(certificate, false).ConfigureAwait(false);
-
+            Console.ReadLine();
         }
 
         private static void Log(LogLevel level, string message, bool containsPii)


### PR DESCRIPTION
Fixes for two bugs with regional instance discovery.

After the app startup, during the instance discovery flow, there are at least two calls made to the `TryGetMetadataAsync` in `RegionDiscoveryProvider`. First call passes in a known authority (like login.microsoft.com). Second call passes in a regionalized authority (like region.login.microsoft.com).

1
In `BuildAuthorityWithRegionAsync` method there's [code at the end that transforms the passed-in URL by adding a region](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/018c34ef0efbd7902aa71a1370609998911c345d/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs#L263). During the first call, the known authority is correctly transformed into a regionalized authority. However, during the second call, a region is prepended to an already regionalized authority. Result - this adds an extra item into the instance discovery cache; this always ends up calling the `TryGetMetadataAsync` an extra time; and the token cache uses regionalized host instead of a known host in the token cache item key. Fix - check if URL is already regionalized before transforming.
![image](https://user-images.githubusercontent.com/34331512/107114126-651f8380-6818-11eb-8fe0-1dd0927b0a29.png)
![image](https://user-images.githubusercontent.com/34331512/107114140-8bddba00-6818-11eb-89e0-868534b76dc3.png)
![image](https://user-images.githubusercontent.com/34331512/107114142-8f714100-6818-11eb-9fe8-1597608067ec.png)

2
[When an `InstanceDiscoveryMetadataEntry` is created](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/018c34ef0efbd7902aa71a1370609998911c345d/src/client/Microsoft.Identity.Client/Region/RegionDiscoveryProvider.cs#L195), the original known authority host entry is not cached. Result - Every time there's a request for a token, a known authority is passed in, checked against the cache, not found, goes through regionalization code, then the regionalized authority is checked against the cache. Fix - add the known authority host as a key to the instance discovery cache with properties pointing to the regionalized host to skip the regionalization each time.
![image](https://user-images.githubusercontent.com/34331512/107114381-2db1d680-681a-11eb-9856-4a77500cfb9c.png)
![image](https://user-images.githubusercontent.com/34331512/107114382-2f7b9a00-681a-11eb-88d3-4cc0b7f0b5a6.png)

Todo: The telemetry unit tests need to be updated because previously both calls to `TryGetMetadataAsync` returned regions source as environment or IMDS; with this change, the second call is always returns cache source and overwrites the first telemetry.