### PR TITLE
Add WebView2

### DIFF
--- a/src/client/Microsoft.Identity.Client.Desktop/DesktopExtensions.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/DesktopExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Desktop
+{
+    /// <summary>
+    /// MSAL extensions for desktop apps
+    /// </summary>
+    public static class DesktopExtensions
+    {
+        /// <summary>
+        /// Adds enhanced support for desktop applications, e.g. CLI, WinForms, WPF apps.
+        /// 
+        /// Support added is around: 
+        /// 
+        /// - Windows Authentication Manager (WAM) broker, the recommended authentication mechanism on Windows 10 - https://aka.ms/msal-net-wam
+        /// - WebView2 embedded web view, based on Microsoft Edge - https://aka.ms/msal-net-webview2
+        /// </summary>
+        /// <remarks>These extensions live in a separate package to avoid adding dependencies to MSAL</remarks>
+        public static PublicClientApplicationBuilder WithDesktopFeatures(this PublicClientApplicationBuilder builder)
+        {
+            WamExtension.AddSupportForWam(builder);
+            AddSupportForWebView2(builder);
+
+            return builder;
+        }       
+
+        /// <summary>
+        /// Enables Windows broker flows on older platforms, such as .NET framework, where these are not available in the box with Microsoft.Identity.Client
+        /// For details about Windows broker, see https://aka.ms/msal-net-wam
+        /// </summary>
+        private static void AddSupportForWebView2(PublicClientApplicationBuilder builder)
+        {
+#if NET45_OR_GREATER
+            builder.Config.WebUiFactoryCreator =
+                () => new MsalDesktopWebUiFactory(fallbackToLegacyWebBrowser: true);
+#else
+      builder.Config.WebUiFactoryCreator =
+                () => new MsalDesktopWebUiFactory(fallbackToLegacyWebBrowser: false);
+#endif
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
@@ -25,8 +25,8 @@
     <PackageReleaseNotes>The changelog is available at https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/master/changelog.txt and the roadmap at https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki#roadmap </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>
-      This package contains binaries needed to use the Windows broker and other features with MSAL on older 
-      platforms such as .NET Framework and .NET Core 3.x      
+      This package contains binaries needed to use the Windows broker and other features with MSAL on older
+      platforms such as .NET Framework and .NET Core 3.x
     </Description>
     <PackageTags>Microsoft Authentication Library Desktop MSAL WAM broker Windows Authentication Manager</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -47,24 +47,26 @@
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetCore)'">
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
-    <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
-  </PropertyGroup>
-   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop)' or '$(TargetFramework)' == '$(TargetFrameworkNetCore)'">
-     <Compile Include="$(PathToMsalSources)\Platforms\Features\WamBroker\**\*.cs" LinkBase="WAM" />
-     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.17763.1000" />
-     <Reference Include="System.Windows.Forms" />
 
-   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop)' or '$(TargetFramework)' == '$(TargetFrameworkNetCore)'">
+    
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\WamBroker\**\*.cs" LinkBase="Features/WAM" />
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.17763.1000" />
+    <Reference Include="System.Windows.Forms" />
 
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\WebView2WebUi\**\*.cs" LinkBase="Features/WebView2WebUi" />
+    
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.705.50" />
 
-  <ItemGroup>
+  </ItemGroup>
+
+    <ItemGroup>
     <ProjectReference Include="..\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
   </ItemGroup>
 
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
- 
+
 
 </Project>

--- a/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
@@ -10,14 +9,18 @@ using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Web.WebView2.Core;
 
-namespace Microsoft.Identity.Client.Platforms.net5win
+namespace Microsoft.Identity.Client.Desktop
 {
-    internal class Net5WebUiFactory : IWebUIFactory
+    internal class MsalDesktopWebUiFactory : IWebUIFactory
     {
+        private readonly bool _fallbackToLegacyWebBrowser;
         private readonly Func<bool> _isWebView2AvailableFunc;
 
-        public Net5WebUiFactory(Func<bool> isWebView2AvailableForTest = null)
+        public MsalDesktopWebUiFactory(
+            bool fallbackToLegacyWebBrowser = false,
+            Func<bool> isWebView2AvailableForTest = null)
         {
+            _fallbackToLegacyWebBrowser = fallbackToLegacyWebBrowser;
             _isWebView2AvailableFunc = isWebView2AvailableForTest ?? IsWebView2Available;
         }
 
@@ -34,13 +37,20 @@ namespace Microsoft.Identity.Client.Platforms.net5win
                     coreUIParent.SystemWebViewOptions);
             }
 
-
             if (_isWebView2AvailableFunc())
             {
                 requestContext.Logger.Info("Using WebView2 embedded browser");
                 return new WebView2WebUi(coreUIParent, requestContext);
             }
 
+#if DESKTOP
+            if (_fallbackToLegacyWebBrowser)
+            {
+                requestContext.Logger.Info("Using legacy embedded browser");
+                return 
+                    new Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.InteractiveWebUI(coreUIParent, requestContext);
+            }
+#endif
             throw new MsalClientException(
                 MsalError.WebView2NotInstalled,
                 "The embedded browser needs WebView2 runtime to be installed. If you are an end user of the app, please download and install the WebView2 runtime from https://go.microsoft.com/fwlink/p/?LinkId=2124703 and restart the app." +

--- a/src/client/Microsoft.Identity.Client.Desktop/WamExtension.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/WamExtension.cs
@@ -1,6 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
+using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
+using Microsoft.Identity.Client.UI;
+using Microsoft.Web.WebView2.Core;
+
 namespace Microsoft.Identity.Client.Desktop
 {
     /// <summary>
@@ -21,9 +29,14 @@ namespace Microsoft.Identity.Client.Desktop
             }
 
             builder.Config.IsBrokerEnabled = true;
+            AddSupportForWam(builder);
+            return builder;
+        }
+
+        internal static void AddSupportForWam(PublicClientApplicationBuilder builder)
+        {
             builder.Config.BrokerCreatorFunc =
                 (uiParent, logger) => new Platforms.Features.WamBroker.WamBroker(uiParent, logger);
-            return builder;
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
@@ -87,22 +87,7 @@ namespace Microsoft.Identity.Client
         /// <returns>The builder to chain the .With methods</returns>
         public AcquireTokenInteractiveParameterBuilder WithUseEmbeddedWebView(bool useEmbeddedWebView)
         {
-#if NET_CORE || NETSTANDARD 
-            if (useEmbeddedWebView)
-            {
-                throw new MsalClientException(MsalError.WebviewUnavailable, "An embedded webview is not available on this platform. " +
-                    "Please use WithUseEmbeddedWebView(false) or leave the default. " +
-                    "See https://aka.ms/msal-net-os-browser for details about the system webview.");
-            }
-#elif WINDOWS_APP
-            if (!useEmbeddedWebView)
-            {
-                throw new MsalClientException(
-                   MsalError.WebviewUnavailable,
-                   "On UWP, MSAL does not offer a system webview out of the box. Please set .WithUseEmbeddedWebview to true or leave the default. " +
-                   "To use the UWP Web Authentication Manager (WAM) see https://aka.ms/msal-net-uwp-wam");
-            }
-#endif
+            // platform WebUI factories will validate this setting
 
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithEmbeddedWebView, useEmbeddedWebView);
             Parameters.UseEmbeddedWebView = useEmbeddedWebView ?

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Identity.Client
         public bool IsBrokerEnabled { get; internal set; }
 
         public Func<CoreUIParent, ICoreLogger, IBroker> BrokerCreatorFunc { get; set; }
+        public Func<IWebUIFactory> WebUiFactoryCreator { get; set; }
 
         public ITelemetryConfig TelemetryConfig { get; internal set; }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -262,10 +262,6 @@ namespace Microsoft.Identity.Client.Internal
 
             CoreUIParent coreUiParent = _interactiveParameters.UiParent;
 
-            coreUiParent.UseEmbeddedWebview = GetUseEmbeddedWebview(
-                _interactiveParameters.UseEmbeddedWebView,
-                _serviceBundle.PlatformProxy.UseEmbeddedWebViewDefault);
-
 #if WINDOWS_APP || DESKTOP
             // hidden web view can be used in both WinRT and desktop applications.
             coreUiParent.UseHiddenBrowser = _interactiveParameters.Prompt.Equals(Prompt.Never);
@@ -273,24 +269,11 @@ namespace Microsoft.Identity.Client.Internal
             coreUiParent.UseCorporateNetwork = _serviceBundle.Config.UseCorporateNetwork;
 #endif
 #endif            
-            return _serviceBundle.PlatformProxy.GetWebUiFactory()
-                .CreateAuthenticationDialog(coreUiParent, _requestParams.RequestContext);
+            return _serviceBundle.PlatformProxy.GetWebUiFactory(_requestParams.AppConfig)
+                .CreateAuthenticationDialog(
+                coreUiParent,
+                _interactiveParameters.UseEmbeddedWebView,
+                _requestParams.RequestContext);
         }
-
-        private static bool GetUseEmbeddedWebview(WebViewPreference userPreference, bool defaultValue)
-        {
-            switch (userPreference)
-            {
-                case WebViewPreference.NotSpecified:
-                    return defaultValue;
-                case WebViewPreference.Embedded:
-                    return true;
-                case WebViewPreference.System:
-                    return false;
-                default:
-                    throw new NotImplementedException("Unknown option");
-            }
-        }
-
     }
 }

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -154,7 +154,7 @@
     <Compile Include="$(PathToMsalSources)\Platforms\net5win\**\*.cs" LinkBase="Platforms\net5win" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\DefaultOSBrowser\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WamBroker\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsWebUi\**\*.cs" />
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsLegacyWebUi\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WebView2WebUi\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\win32\**\*.cs" />
 
@@ -174,7 +174,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetDesktop45)' Or '$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)' ">
     <Compile Include="$(PathToMsalSources)\Platforms\netdesktop\**\*.cs" LinkBase="Platforms\netdesktop" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\DefaultOSBrowser\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsWebUi\**\*.cs" />
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsLegacyWebUi\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\win32\**\*.cs" />
 
     <Reference Include="System" />

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -121,6 +121,7 @@
     <!-- Manually include the cs files -->
     <Compile Include="$(PathToMsalSources)\**\*.cs" Exclude="$(PathToMsalSources)\obj\**\*.*" />
     <Compile Remove="$(PathToMsalSources)\Platforms\**\*.*;$(PathToMsalSources)\Resources\*.cs" />
+    <Compile Include="Platforms\Features\win32\NativeDpiHelper.cs" />
 
     <EmbeddedResource Include="$(PathToMsalSources)\Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
@@ -155,11 +156,13 @@
     <Compile Include="$(PathToMsalSources)\Platforms\Features\DefaultOSBrowser\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WamBroker\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsWebUi\**\*.cs" />
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\WebView2WebUi\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\win32\**\*.cs" />
 
     <!-- This package reference is here to fix a bug in the WinRT interop. 
     It should not be required after the December release of .NET 5 SDK -->
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.705.50" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)' ">
@@ -259,6 +262,7 @@
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+
   <ItemGroup>
     <None Update="Platforms\Features\WamBroker\win32\Splash.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -121,7 +121,6 @@
     <!-- Manually include the cs files -->
     <Compile Include="$(PathToMsalSources)\**\*.cs" Exclude="$(PathToMsalSources)\obj\**\*.*" />
     <Compile Remove="$(PathToMsalSources)\Platforms\**\*.*;$(PathToMsalSources)\Resources\*.cs" />
-    <Compile Include="Platforms\Features\win32\NativeDpiHelper.cs" />
 
     <EmbeddedResource Include="$(PathToMsalSources)\Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -943,5 +943,12 @@ namespace Microsoft.Identity.Client
         /// pops up
         /// </summary>
         public const string WamPickerError = "wam_interactive_picker_error";
+
+        /// <summary>
+        /// <para>What happens?</para>The embedded browser cannot be started because a runtime component is missing.
+        /// <para>Mitigation</para>"The embedded browser needs WebView2 runtime to be installed. An end user of the app can download and install the WebView2 runtime from https://go.microsoft.com/fwlink/p/?LinkId=2124703 and restart the app.
+        ///  or the app developer can install the WebView2 runtime https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution
+        /// </summary>
+        public const string WebView2NotInstalled = "webview2_runtime_not_installed";
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidPlatformProxy.cs
@@ -29,14 +29,6 @@ namespace Microsoft.Identity.Client.Platforms.Android
     internal class AndroidPlatformProxy : AbstractPlatformProxy
     {
         internal const string AndroidDefaultRedirectUriTemplate = "msal{0}://auth";
-        private const string ChromePackage = "com.android.chrome";
-        // this is used to check if anything can open custom tabs.
-        // Must use the classic support. Leaving the reference androidx intent
-        //#if __ANDROID_29__
-        //        private const string CustomTabService = "androidx.browser.customtabs.action.CustomTabsService";
-        //#else
-        private const string CustomTabService = "android.support.customtabs.action.CustomTabsService";
-        //#endif
         public AndroidPlatformProxy(ICoreLogger logger) : base(logger)
         {
         }
@@ -162,51 +154,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
         }
         protected override IFeatureFlags CreateFeatureFlags() => new AndroidFeatureFlags();
 
-        public override bool IsSystemWebViewAvailable
-        {
-            get
-            {
-                bool isBrowserWithCustomTabSupportAvailable = IsBrowserWithCustomTabSupportAvailable();
-                return (isBrowserWithCustomTabSupportAvailable || IsChromeEnabled()) &&
-                       isBrowserWithCustomTabSupportAvailable;
-            }
-        }
-
-        private static bool IsBrowserWithCustomTabSupportAvailable()
-        {
-            Intent customTabServiceIntent = new Intent(CustomTabService);
-
-            IEnumerable<ResolveInfo> resolveInfoListWithCustomTabs =
-                Application.Context.PackageManager.QueryIntentServices(
-                    customTabServiceIntent, PackageInfoFlags.MatchAll);
-
-            // queryIntentServices could return null or an empty list if no matching service existed.
-            if (resolveInfoListWithCustomTabs == null || !resolveInfoListWithCustomTabs.Any())
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private static bool IsChromeEnabled()
-        {
-            try
-            {
-                ApplicationInfo applicationInfo = Application.Context.PackageManager.GetApplicationInfo(ChromePackage, 0);
-
-                // Chrome is difficult to uninstall on an Android device. Most users will disable it, but the package will still
-                // show up, therefore need to check application.Enabled is false
-                return applicationInfo.Enabled;
-            }
-            catch (PackageManager.NameNotFoundException)
-            {
-                // In case Chrome is actually uninstalled, GetApplicationInfo will throw
-                return false;
-            }
-        }
-
-        public override bool UseEmbeddedWebViewDefault => false;
+       
 
         public override IBroker CreateBroker(ApplicationConfiguration appConfig, CoreUIParent uiParent)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidWebUIFactory.cs
@@ -1,6 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Linq;
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview;
 using Microsoft.Identity.Client.Platforms.Android.SystemWebview;
@@ -12,20 +18,77 @@ namespace Microsoft.Identity.Client.Platforms.Android
     [global::Android.Runtime.Preserve(AllMembers = true)]
     internal class AndroidWebUIFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
+        private const string ChromePackage = "com.android.chrome";
+        // this is used to check if anything can open custom tabs.
+        // Must use the classic support. Leaving the reference androidx intent
+        //#if __ANDROID_29__
+        //        private const string CustomTabService = "androidx.browser.customtabs.action.CustomTabsService";
+        //#else
+        private const string CustomTabService = "android.support.customtabs.action.CustomTabsService";
+        //#endif
+
+        public IWebUI CreateAuthenticationDialog(
+            CoreUIParent coreUIParent,
+            WebViewPreference useEmbeddedWebView,
+            RequestContext requestContext)
         {
-            if (parent.UseEmbeddedWebview)
+            if (useEmbeddedWebView == WebViewPreference.Embedded)
             {
-                return new EmbeddedWebUI(parent)
+                return new EmbeddedWebUI(coreUIParent)
                 {
                     RequestContext = requestContext
                 };
             }
 
-            return new SystemWebUI(parent)
+            return new SystemWebUI(coreUIParent)
             {
                 RequestContext = requestContext
             };
         }
+
+        public bool IsSystemWebViewAvailable
+        {
+            get
+            {
+                bool isBrowserWithCustomTabSupportAvailable = IsBrowserWithCustomTabSupportAvailable();
+                return (isBrowserWithCustomTabSupportAvailable || IsChromeEnabled()) &&
+                       isBrowserWithCustomTabSupportAvailable;
+            }
+        }
+
+        private static bool IsBrowserWithCustomTabSupportAvailable()
+        {
+            Intent customTabServiceIntent = new Intent(CustomTabService);
+
+            IEnumerable<ResolveInfo> resolveInfoListWithCustomTabs =
+                Application.Context.PackageManager.QueryIntentServices(
+                    customTabServiceIntent, PackageInfoFlags.MatchAll);
+
+            // queryIntentServices could return null or an empty list if no matching service existed.
+            if (resolveInfoListWithCustomTabs == null || !resolveInfoListWithCustomTabs.Any())
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool IsChromeEnabled()
+        {
+            try
+            {
+                ApplicationInfo applicationInfo = Application.Context.PackageManager.GetApplicationInfo(ChromePackage, 0);
+
+                // Chrome is difficult to uninstall on an Android device. Most users will disable it, but the package will still
+                // show up, therefore need to check application.Enabled is false
+                return applicationInfo.Enabled;
+            }
+            catch (PackageManager.NameNotFoundException)
+            {
+                // In case Chrome is actually uninstalled, GetApplicationInfo will throw
+                return false;
+            }
+        }
+
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.WamBroker;
+using Microsoft.Identity.Client.UI;
+
+namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
+{
+    internal class WebView2WebUi : IWebUI
+    {
+        private CoreUIParent _parent;
+        private RequestContext _requestContext;
+
+        public WebView2WebUi(CoreUIParent parent, RequestContext requestContext)
+        {
+            _parent = parent;
+            _requestContext = requestContext;
+        }
+
+        public async Task<AuthorizationResult> AcquireAuthorizationAsync(
+            Uri authorizationUri, 
+            Uri redirectUri, 
+            RequestContext requestContext, 
+            CancellationToken cancellationToken)
+        {
+            AuthorizationResult result = null;
+            var sendAuthorizeRequest = new Action(() =>
+            {
+                result = InvokeEmbeddedWebview(authorizationUri, redirectUri);
+            });
+
+            if (Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA)
+            {
+                if (_parent.SynchronizationContext != null)
+                {
+                    var sendAuthorizeRequestWithTcs = new Action<object>((tcs) =>
+                    {
+                        try
+                        {
+                            result = InvokeEmbeddedWebview(authorizationUri, redirectUri);
+                            ((TaskCompletionSource<object>)tcs).TrySetResult(null);
+                        }
+                        catch (Exception e)
+                        {
+                            // Need to catch the exception here and put on the TCS which is the task we are waiting on so that
+                            // the exception comming out of Authenticate is correctly thrown.
+                            ((TaskCompletionSource<object>)tcs).TrySetException(e);
+                        }
+                    });
+
+                    var tcs2 = new TaskCompletionSource<object>();
+                    
+                    _parent.SynchronizationContext.Post(
+                        new SendOrPostCallback(sendAuthorizeRequestWithTcs), tcs2);
+                    await tcs2.Task.ConfigureAwait(false);
+                }
+                else
+                {
+                    using (var staTaskScheduler = new net45.StaTaskScheduler(1)) //TODO: move this to a common location
+                    {
+                        try
+                        {
+                            Task.Factory.StartNew(
+                                sendAuthorizeRequest,
+                                cancellationToken,
+                                TaskCreationOptions.None,
+                                staTaskScheduler).Wait();
+                        }
+                        catch (AggregateException ae)
+                        {
+                            requestContext.Logger.ErrorPii(ae.InnerException);
+                            // Any exception thrown as a result of running task will cause AggregateException to be thrown with
+                            // actual exception as inner.
+                            Exception innerException = ae.InnerExceptions[0];
+
+                            // In MTA case, AggregateException is two layer deep, so checking the InnerException for that.
+                            if (innerException is AggregateException)
+                            {
+                                innerException = ((AggregateException)innerException).InnerExceptions[0];
+                            }
+
+                            throw innerException;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                sendAuthorizeRequest();
+            }
+
+            return result;
+          
+        }
+
+        public Uri UpdateRedirectUri(Uri redirectUri)
+        {
+            RedirectUriHelper.Validate(redirectUri, usesSystemBrowser: false);
+            return redirectUri;
+        }
+
+        private AuthorizationResult InvokeEmbeddedWebview(Uri startUri, Uri endUri)
+        {
+            using (var form = new WinFormsPanelWithWebView2(
+                _parent.OwnerWindow, 
+                _requestContext.Logger, 
+                startUri, 
+                endUri))
+            {
+                return form.DisplayDialogAndInterceptUri();
+            }
+        }
+
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Features.WamBroker;
+using Microsoft.Identity.Client.Platforms.Features.Win32;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
@@ -63,7 +64,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
                 }
                 else
                 {
-                    using (var staTaskScheduler = new net45.StaTaskScheduler(1)) //TODO: move this to a common location
+                    using (var staTaskScheduler = new StaTaskScheduler(1)) 
                     {
                         try
                         {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/Win32Window.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/Win32Window.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Windows.Forms;
+
+namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
+{
+
+    internal class Win32Window : IWin32Window
+    {
+        public Win32Window(IntPtr handle)
+        {
+            Handle = handle;
+        }
+        public IntPtr Handle { get; }
+
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -27,52 +27,17 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
         private readonly ICoreLogger _logger;
         private readonly Uri _startUri;
         private readonly Uri _endUri;
-        //private Panel _webBrowserPanel; // todo: needed as member?
         private WebView2 _webView2;
 
         private AuthorizationResult _result;
 
         private IWin32Window _ownerWindow;
 
-
-        public AuthorizationResult DisplayDialogAndInterceptUri()
-        {
-            _webView2.CoreWebView2InitializationCompleted += WebView2Control_CoreWebView2InitializationCompleted;
-            _webView2.NavigationStarting += WebView2Control_NavigationStarting;
-            _webView2.AcceleratorKeyPressed += _webView2_AcceleratorKeyPressed;
-
-            // Starts the navigation
-            this._webView2.Source = _startUri;
-            DisplayDialog();
-
-            return _result;
-        }
-
-
-        private void DisplayDialog()
-        {
-            DialogResult uiResult = DialogResult.None;
-            InvokeHandlingOwnerWindow(() => uiResult = ShowDialog(_ownerWindow));
-
-            switch (uiResult)
-            {
-                case DialogResult.OK:
-                    break;
-                case DialogResult.Cancel:
-                    _result = AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel);
-                    break;
-                default:
-                    throw new MsalClientException(
-                        "webview2_unexpectedResult",
-                        "WebView2 returned an unexpected result: " + uiResult);
-            }
-        }
-
         public WinFormsPanelWithWebView2(
-            object ownerWindow,
-            ICoreLogger logger,
-            Uri startUri,
-            Uri endUri)
+         object ownerWindow,
+         ICoreLogger logger,
+         Uri startUri,
+         Uri endUri)
         {
             // TODO: title
             _logger = logger;
@@ -98,10 +63,41 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             }
 
             InitializeComponent();
-
-
         }
 
+        public AuthorizationResult DisplayDialogAndInterceptUri()
+        {
+            _webView2.CoreWebView2InitializationCompleted += WebView2Control_CoreWebView2InitializationCompleted;
+            _webView2.NavigationStarting += WebView2Control_NavigationStarting;
+            _webView2.AcceleratorKeyPressed += _webView2_AcceleratorKeyPressed;
+
+            // Starts the navigation
+            this._webView2.Source = _startUri;
+            DisplayDialog();
+
+            return _result;
+        }
+
+        private void DisplayDialog()
+        {
+            DialogResult uiResult = DialogResult.None;
+            InvokeHandlingOwnerWindow(() => uiResult = ShowDialog(_ownerWindow));
+
+            switch (uiResult)
+            {
+                case DialogResult.OK:
+                    break;
+                case DialogResult.Cancel:
+                    _result = AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel);
+                    break;
+                default:
+                    throw new MsalClientException(
+                        "webview2_unexpectedResult",
+                        "WebView2 returned an unexpected result: " + uiResult);
+            }
+        }
+
+     
         private void PlaceOnTop(object sender, EventArgs e)
         {
             // If we don't have an owner we need to make sure that the pop up browser

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             _webView2.AcceleratorKeyPressed += _webView2_AcceleratorKeyPressed;
 
             // Starts the navigation
-            this._webView2.Source = _startUri;
+            _webView2.Source = _startUri;
             DisplayDialog();
 
             return _result;
@@ -181,7 +181,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
                 ShowInTaskbar = null == _ownerWindow;
 
                 webBrowserPanel.ResumeLayout(false);
-                ResumeLayout(false);
+                ResumeLayout(false);                
             });
 
             this.Shown += PlaceOnTop;
@@ -253,7 +253,13 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             _webView2.CoreWebView2.Settings.AreHostObjectsAllowed = false;
             _webView2.CoreWebView2.Settings.IsScriptEnabled = true;
             _webView2.CoreWebView2.Settings.IsZoomControlEnabled = false;
-            _webView2.CoreWebView2.Settings.IsStatusBarEnabled = true;            
+            _webView2.CoreWebView2.Settings.IsStatusBarEnabled = true;
+            _webView2.CoreWebView2.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
+        }
+
+        private void CoreWebView2_DocumentTitleChanged(object sender, object e)
+        {
+            this.Text = _webView2.CoreWebView2.DocumentTitle ?? "";
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -1,0 +1,263 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.Win32;
+using Microsoft.Identity.Client.Platforms.net45;
+using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+
+namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
+{
+
+    internal class WinFormsPanelWithWebView2 : Form
+    {
+        private const int UIWidth = 566;
+        private readonly ICoreLogger _logger;
+        private readonly Uri _startUri;
+        private readonly Uri _endUri;
+        //private Panel _webBrowserPanel; // todo: needed as member?
+        private WebView2 _webView2;
+
+        private AuthorizationResult _result;
+
+        private IWin32Window _ownerWindow;
+
+
+        public AuthorizationResult DisplayDialogAndInterceptUri()
+        {
+            _webView2.CoreWebView2InitializationCompleted += WebView2Control_CoreWebView2InitializationCompleted;
+            _webView2.NavigationStarting += WebView2Control_NavigationStarting;
+            _webView2.AcceleratorKeyPressed += _webView2_AcceleratorKeyPressed;
+
+            // Starts the navigation
+            this._webView2.Source = _startUri;
+            DisplayDialog();
+
+            return _result;
+        }
+
+
+        private void DisplayDialog()
+        {
+            DialogResult uiResult = DialogResult.None;
+            InvokeHandlingOwnerWindow(() => uiResult = ShowDialog(_ownerWindow));
+
+            switch (uiResult)
+            {
+                case DialogResult.OK:
+                    break;
+                case DialogResult.Cancel:
+                    _result = AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel);
+                    break;
+                default:
+                    throw new MsalClientException(
+                        "webview2_unexpectedResult",
+                        "WebView2 returned an unexpected result: " + uiResult);
+            }
+        }
+
+        public WinFormsPanelWithWebView2(
+            object ownerWindow,
+            ICoreLogger logger,
+            Uri startUri,
+            Uri endUri)
+        {
+            // TODO: title
+            _logger = logger;
+            _startUri = startUri;
+            _endUri = endUri;
+
+            if (ownerWindow == null)
+            {
+                _ownerWindow = null;
+            }
+            else if (ownerWindow is IWin32Window)
+            {
+                _ownerWindow = (IWin32Window)ownerWindow;
+            }
+            else if (ownerWindow is IntPtr)
+            {
+                _ownerWindow = new Win32Window((IntPtr)ownerWindow);
+            }
+            else
+            {
+                throw new MsalException(MsalError.InvalidOwnerWindowType,
+                    "Invalid owner window type. Expected types are IWin32Window or IntPtr (for window handle).");
+            }
+
+            InitializeComponent();
+
+
+        }
+
+        private void PlaceOnTop(object sender, EventArgs e)
+        {
+            // If we don't have an owner we need to make sure that the pop up browser
+            // window is on top of other windows.  Activating the window will accomplish this.
+            if (null == Owner)
+            {
+                Activate();
+            }
+        }
+
+
+        /// <summary>
+        /// Some calls need to be made on the UI thread and this is the central place to check if we have an owner
+        /// window and if so, ensure we invoke on that proper thread.
+        /// </summary>
+        /// <param name="action"></param>
+        private void InvokeHandlingOwnerWindow(Action action)
+        {
+            // We only support WindowsForms (since our dialog is winforms based)
+            if (_ownerWindow != null && _ownerWindow is Control winFormsControl)
+            {
+                winFormsControl.Invoke(action);
+            }
+            else
+            {
+                action();
+            }
+        }
+
+        private void InitializeComponent()
+        {
+            InvokeHandlingOwnerWindow(() =>
+            {
+                Screen screen = (_ownerWindow != null)
+                    ? Screen.FromHandle(_ownerWindow.Handle)
+                    : Screen.PrimaryScreen;
+
+                // Window height is set to 70% of the screen height.
+                int uiHeight = (int)(Math.Max(screen.WorkingArea.Height, 160) * 70.0 / NativeDpiHelper.ZoomPercent);
+                var webBrowserPanel = new Panel();
+                webBrowserPanel.SuspendLayout();
+                SuspendLayout();
+
+                // webBrowser
+                _webView2 = new WebView2();
+                _webView2.Dock = DockStyle.Fill;
+                _webView2.Location = new Point(0, 25);
+                _webView2.MinimumSize = new Size(20, 20);
+                _webView2.Name = "WebView2";
+                _webView2.Size = new Size(UIWidth, 565);
+                _webView2.TabIndex = 1;
+
+                // webBrowserPanel
+                webBrowserPanel.Controls.Add(_webView2);
+                webBrowserPanel.Dock = DockStyle.Fill;
+                webBrowserPanel.BorderStyle = BorderStyle.None;
+                webBrowserPanel.Location = new Point(0, 0);
+                webBrowserPanel.Name = "webBrowserPanel";
+                webBrowserPanel.Size = new Size(UIWidth, uiHeight);
+                webBrowserPanel.TabIndex = 2;
+
+                // BrowserAuthenticationWindow
+                AutoScaleDimensions = new SizeF(6, 13);
+                AutoScaleMode = AutoScaleMode.Font;
+                ClientSize = new Size(UIWidth, uiHeight);
+                Controls.Add(webBrowserPanel);
+                FormBorderStyle = FormBorderStyle.FixedSingle;
+                Name = "BrowserAuthenticationWindow";
+
+                // Move the window to the center of the parent window only if owner window is set.
+                StartPosition = (_ownerWindow != null)
+                    ? FormStartPosition.CenterParent
+                    : FormStartPosition.CenterScreen;
+                Text = string.Empty;
+                ShowIcon = false;
+                MaximizeBox = false;
+                MinimizeBox = false;
+
+                // If we don't have an owner we need to make sure that the pop up browser
+                // window is in the task bar so that it can be selected with the mouse.
+                ShowInTaskbar = null == _ownerWindow;
+
+                webBrowserPanel.ResumeLayout(false);
+                ResumeLayout(false);
+            });
+
+            this.Shown += PlaceOnTop;
+        }
+
+        private void WebView2Control_NavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            if (CheckForEndUrl(new Uri(e.Uri)))
+            {
+                _logger.Verbose("[WebView2Control] Redirect uri reached. Stopping the interactive view");
+                e.Cancel = true;
+            }
+            else
+            {
+                _logger.Verbose("[WebView2Control] Navigating to " + e.Uri);
+            }
+        }
+
+        // Don't allow accelerator keys (ALT + back, ALT + forward etc.)
+        private void _webView2_AcceleratorKeyPressed(object sender, CoreWebView2AcceleratorKeyPressedEventArgs e)
+        {
+            _logger.Info("[WebView2Control] Accelerator key disabled");
+            e.Handled = true;
+        }
+
+
+        private bool CheckForEndUrl(Uri url)
+        {
+            bool readyToClose = false;
+
+            if (url.Authority.Equals(_endUri.Authority, StringComparison.OrdinalIgnoreCase) &&
+                url.AbsolutePath.Equals(_endUri.AbsolutePath))
+            {
+                _logger.Info("Redirect Uri was reached. Stopping webview navigation...");
+                _result = AuthorizationResult.FromUri(url.OriginalString);
+                readyToClose = true;
+            }
+
+            if (!readyToClose &&
+                !url.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) &&
+                !url.AbsoluteUri.Equals("about:blank", StringComparison.OrdinalIgnoreCase) &&
+                !url.Scheme.Equals("javascript", StringComparison.OrdinalIgnoreCase))
+            {
+
+                _logger.Error($"Redirection to non-HTTPS scheme ({url.Scheme}) found! Webview will fail...");
+
+                _result = AuthorizationResult.FromStatus(
+                    AuthorizationStatus.ErrorHttp,
+                    MsalError.NonHttpsRedirectNotSupported,
+                    MsalErrorMessage.NonHttpsRedirectNotSupported);
+
+                readyToClose = true;
+            }
+
+            if (readyToClose)
+            {
+                // This should close the dialog
+                DialogResult = DialogResult.OK;
+            }
+
+            return readyToClose;
+        }
+
+        private void WebView2Control_CoreWebView2InitializationCompleted(object sender, CoreWebView2InitializationCompletedEventArgs e)
+        {
+            _logger.Verbose("[WebView2Control] CoreWebView2InitializationCompleted ");
+            _webView2.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+            _webView2.CoreWebView2.Settings.AreDevToolsEnabled = false;
+            _webView2.CoreWebView2.Settings.AreHostObjectsAllowed = false;
+            _webView2.CoreWebView2.Settings.IsScriptEnabled = true;
+            _webView2.CoreWebView2.Settings.IsZoomControlEnabled = false;
+            _webView2.CoreWebView2.Settings.IsStatusBarEnabled = true;            
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -12,7 +12,6 @@ using System.Windows.Forms;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Features.Win32;
-using Microsoft.Identity.Client.Platforms.net45;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Web.WebView2.Core;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/Win32/NativeDpiHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/Win32/NativeDpiHelper.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Identity.Client.Platforms.Features.Win32;
+
+namespace Microsoft.Identity.Client.Platforms.Features.Win32
+{
+    internal static class NativeDpiHelper
+        
+    {
+        static NativeDpiHelper()
+        {
+            const double DefaultDpi = 96.0;
+
+            const int LOGPIXELSX = 88;
+            const int LOGPIXELSY = 90;
+
+            double deviceDpiX;
+            double deviceDpiY;
+
+            IntPtr dC = GetDC(IntPtr.Zero);
+            if (dC != IntPtr.Zero)
+            {
+                deviceDpiX = GetDeviceCaps(dC, LOGPIXELSX);
+                deviceDpiY = GetDeviceCaps(dC, LOGPIXELSY);
+                ReleaseDC(IntPtr.Zero, dC);
+            }
+            else
+            {
+                deviceDpiX = DefaultDpi;
+                deviceDpiY = DefaultDpi;
+            }
+
+            int zoomPercentX = (int)(100 * (deviceDpiX / DefaultDpi));
+            int zoomPercentY = (int)(100 * (deviceDpiY / DefaultDpi));
+
+            ZoomPercent = Math.Min(zoomPercentX, zoomPercentY);
+        }
+
+        /// <summary>
+        /// </summary>
+        public static int ZoomPercent { get; }
+
+
+        [DllImport("User32.dll", CallingConvention = CallingConvention.StdCall, ExactSpelling = true)]
+        internal static extern IntPtr GetDC(IntPtr hWnd);
+
+        [DllImport("User32.dll", CallingConvention = CallingConvention.StdCall, ExactSpelling = true)]
+        internal static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+        [DllImport("Gdi32.dll", CallingConvention = CallingConvention.StdCall, ExactSpelling = true)]
+        internal static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+
+        [DllImport("User32.dll", CallingConvention = CallingConvention.Winapi, ExactSpelling = true)]
+        internal static extern bool IsProcessDPIAware();
+    }
+}
+

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/Win32/StaTaskScheduler.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/Win32/StaTaskScheduler.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 // Moving the code to the library's main namespace
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.Win32
 {
     // This IDisposable class doe not need to implement Dispose method in standard way, because it is sealed.
     // If it ever needs to become inheritable, it should follow the standard pattern as desribed in http://msdn.microsoft.com/en-us/library/fs2xkftw(v=vs.110).aspx.

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/CustomWebBrowser.CustomWebBrowserEvent.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/CustomWebBrowser.CustomWebBrowserEvent.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal partial class CustomWebBrowser
     {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/CustomWebBrowser.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/CustomWebBrowser.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.Identity.Client.Platforms.Features.Win32;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal partial class CustomWebBrowser : WebBrowser
     {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/InteractiveWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/InteractiveWebUI.cs
@@ -4,7 +4,7 @@
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.UI;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal class InteractiveWebUI : WebUI
     {
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
         {
             AuthorizationResult result;
 
-            using (_dialog = new WindowsFormsWebAuthenticationDialog(OwnerWindow) {RequestContext = RequestContext})
+            using (_dialog = new WindowsFormsWebAuthenticationDialog(OwnerWindow) { RequestContext = RequestContext })
             {
                 result = _dialog.AuthenticateAAD(RequestUri, CallbackUri);
             }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/NavigateErrorStatus.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/NavigateErrorStatus.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal enum NavigateErrorStatusCode
     {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWebUI.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.UI;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal class SilentWebUI : WebUI, IDisposable
     {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWebUIDoneEventArgs.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWebUIDoneEventArgs.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal class SilentWebUIDoneEventArgs : EventArgs
     {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWindowsFormsAuthenticationDialog.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWindowsFormsAuthenticationDialog.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     /// <summary>
     /// </summary>

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebBrowserInterfaces.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebBrowserInterfaces.cs
@@ -5,7 +5,7 @@ using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal class NativeWrapper
     {
@@ -406,6 +406,6 @@ namespace Microsoft.Identity.Client.Platforms.net45
             void PrivacyImpactedStateChange([In] bool bImpacted);
         }
 
-        
+
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebBrowserNavigateErrorEventArgs.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebBrowserNavigateErrorEventArgs.cs
@@ -3,7 +3,7 @@
 
 using System.ComponentModel;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     /// <summary>
     /// </summary>
@@ -27,11 +27,11 @@ namespace Microsoft.Identity.Client.Platforms.net45
         // url as a string, as in case of error it could be invalid url
         /// <summary>
         /// </summary>
-        public string Url {get;}
+        public string Url { get; }
 
         /// <summary>
         /// </summary>
-        public object WebBrowserActiveXInstance {get;}
+        public object WebBrowserActiveXInstance { get; }
 
         /// <summary>
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebUI.cs
@@ -10,7 +10,7 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Features.Win32;
 using Microsoft.Identity.Client.UI;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     internal abstract class WebUI : IWebUI
     {
@@ -39,14 +39,14 @@ namespace Microsoft.Identity.Client.Platforms.net45
                 try
                 {
                     authorizationResult = Authenticate(authorizationUri, redirectUri);
-                   ((TaskCompletionSource<object>)tcs).TrySetResult(null);
+                    ((TaskCompletionSource<object>)tcs).TrySetResult(null);
                 }
                 catch (Exception e)
                 {
                     // Need to catch the exception here and put on the TCS which is the task we are waiting on so that
                     // the exception comming out of Authenticate is correctly thrown.
                     ((TaskCompletionSource<object>)tcs).TrySetException(e);
-               }
+                }
             });
 
             // If the thread is MTA, it cannot create or communicate with WebBrowser which is a COM control.

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/Win32Window.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/Win32Window.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Windows.Forms;
 
-namespace Microsoft.Identity.Client.Platforms.Features.Win32
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
 
     internal class Win32Window : IWin32Window
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.Win32
         {
             Handle = handle;
         }
-        public IntPtr Handle { get; }
 
+        public IntPtr Handle { get; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialog.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialog.cs
@@ -8,7 +8,7 @@ using System.Windows.Forms;
 using Microsoft.Identity.Client.Platforms.Features.Win32;
 using Microsoft.Identity.Client.UI;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     /// <summary>
     /// The browser dialog used for user authentication

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
@@ -13,7 +13,7 @@ using Microsoft.Identity.Client.Platforms.Features.Win32;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Client.Utils;
 
-namespace Microsoft.Identity.Client.Platforms.net45
+namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
     // This class (and related/derived classes) must be public so that COM can see them via ComVisible to attach to the browser.
     /// <summary>

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/CustomWebBrowser.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/CustomWebBrowser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using Microsoft.Identity.Client.Platforms.Features.Win32;
 
 namespace Microsoft.Identity.Client.Platforms.net45
 {
@@ -134,7 +135,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
                 info.dwDoubleClick = 0;
                 info.dwFlags = DOCHOSTUIFLAG_NO3DOUTERBORDER | DOCHOSTUIFLAG_DISABLE_SCRIPT_INACTIVE;
 
-                if (NativeWrapper.NativeMethods.IsProcessDPIAware())
+                if (NativeDpiHelper.IsProcessDPIAware())
                 {
                     info.dwFlags |= DOCHOSTUIFLAG_DPI_AWARE;
                 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WebBrowserInterfaces.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WebBrowserInterfaces.cs
@@ -406,19 +406,6 @@ namespace Microsoft.Identity.Client.Platforms.net45
             void PrivacyImpactedStateChange([In] bool bImpacted);
         }
 
-        internal static class NativeMethods
-        {
-            [DllImport("User32.dll", CallingConvention = CallingConvention.StdCall, ExactSpelling = true)]
-            internal static extern IntPtr GetDC(IntPtr hWnd);
-
-            [DllImport("User32.dll", CallingConvention = CallingConvention.StdCall, ExactSpelling = true)]
-            internal static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
-
-            [DllImport("Gdi32.dll", CallingConvention = CallingConvention.StdCall, ExactSpelling = true)]
-            internal static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
-
-            [DllImport("User32.dll", CallingConvention = CallingConvention.Winapi, ExactSpelling = true)]
-            internal static extern bool IsProcessDPIAware();
-        }
+        
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WebUI.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.Win32;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.net45

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/Win32Window.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/Win32Window.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Windows.Forms;
+
+namespace Microsoft.Identity.Client.Platforms.Features.Win32
+{
+
+    internal class Win32Window : IWin32Window
+    {
+        public Win32Window(IntPtr handle)
+        {
+            Handle = handle;
+        }
+        public IntPtr Handle { get; }
+
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WindowsFormsWebAuthenticationDialog.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WindowsFormsWebAuthenticationDialog.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using Microsoft.Identity.Client.Platforms.Features.Win32;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.net45
@@ -85,8 +86,8 @@ namespace Microsoft.Identity.Client.Platforms.net45
 
         private void SetBrowserZoom()
         {
-            int windowsZoomPercent = DpiHelper.ZoomPercent;
-            if (NativeWrapper.NativeMethods.IsProcessDPIAware() && 100 != windowsZoomPercent && !_zoomed)
+            int windowsZoomPercent = NativeDpiHelper.ZoomPercent;
+            if (NativeDpiHelper.IsProcessDPIAware() && 100 != windowsZoomPercent && !_zoomed)
             {
                 // There is a bug in some versions of the IE browser control that causes it to
                 // ignore scaling unless it is changed.

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsWebUi/WindowsFormsWebAuthenticationDialogBase.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.Win32;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Client.Utils;
 
@@ -63,7 +64,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
             }
             else if (ownerWindow is IntPtr)
             {
-                this.ownerWindow = new WindowsFormsWin32Window { Handle = (IntPtr)ownerWindow };
+                this.ownerWindow = new Win32Window((IntPtr)ownerWindow);
             }
             else
             {
@@ -304,7 +305,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
                     : Screen.PrimaryScreen;
 
                 // Window height is set to 70% of the screen height.
-                int uiHeight = (int)(Math.Max(screen.WorkingArea.Height, 160) * 70.0 / DpiHelper.ZoomPercent);
+                int uiHeight = (int)(Math.Max(screen.WorkingArea.Height, 160) * 70.0 / NativeDpiHelper.ZoomPercent);
                 _webBrowserPanel = new Panel();
                 _webBrowserPanel.SuspendLayout();
                 SuspendLayout();
@@ -380,50 +381,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
             string messageUnknown = string.Format(CultureInfo.InvariantCulture, formatUnknown, statusCode);
             return new MsalClientException(MsalError.AuthenticationUiFailedError, messageUnknown);
         }
-
-        private sealed class WindowsFormsWin32Window : IWin32Window
-        {
-            public IntPtr Handle { get; set; }
-        }
-
-        /// <summary>
-        /// </summary>
-        protected static class DpiHelper
-        {
-            static DpiHelper()
-            {
-                const double DefaultDpi = 96.0;
-
-                const int LOGPIXELSX = 88;
-                const int LOGPIXELSY = 90;
-
-                double deviceDpiX;
-                double deviceDpiY;
-
-                IntPtr dC = NativeWrapper.NativeMethods.GetDC(IntPtr.Zero);
-                if (dC != IntPtr.Zero)
-                {
-                    deviceDpiX = NativeWrapper.NativeMethods.GetDeviceCaps(dC, LOGPIXELSX);
-                    deviceDpiY = NativeWrapper.NativeMethods.GetDeviceCaps(dC, LOGPIXELSY);
-                    NativeWrapper.NativeMethods.ReleaseDC(IntPtr.Zero, dC);
-                }
-                else
-                {
-                    deviceDpiX = DefaultDpi;
-                    deviceDpiY = DefaultDpi;
-                }
-
-                int zoomPercentX = (int)(100 * (deviceDpiX / DefaultDpi));
-                int zoomPercentY = (int)(100 * (deviceDpiY / DefaultDpi));
-
-                ZoomPercent = Math.Min(zoomPercentX, zoomPercentY);
-            }
-
-            /// <summary>
-            /// </summary>
-            public static int ZoomPercent { get; }
-        }
-
+     
         /// <summary>
         /// </summary>
         internal static class NativeMethods

--- a/src/client/Microsoft.Identity.Client/Platforms/Mac/MacUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Mac/MacUIFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Identity.Client.Internal;
+﻿using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
 
@@ -6,21 +7,24 @@ namespace Microsoft.Identity.Client.Platforms.Mac
 {
     internal class MacUIFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
+        public bool IsSystemWebViewAvailable => true;
+
+        public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {
-            if (!parent.UseEmbeddedWebview)
+            if (webViewPreference == WebViewPreference.System)
             {
                 return new DefaultOsBrowserWebUi(
                     requestContext.ServiceBundle.PlatformProxy,
                     requestContext.Logger,
-                    parent.SystemWebViewOptions);
+                    coreUIParent.SystemWebViewOptions);
             }
 
             return new MacEmbeddedWebUI()
             {
-                CoreUIParent = parent,
+                CoreUIParent = coreUIParent,
                 RequestContext = requestContext
             };
         }
+
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/IosWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/IosWebUIFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview;
 using Microsoft.Identity.Client.Platforms.iOS.SystemWebview;
@@ -11,22 +12,27 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 {
     internal class IosWebUIFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
+        public bool IsSystemWebViewAvailable => true;
+
+        public IWebUI CreateAuthenticationDialog(
+            CoreUIParent coreUIParent, 
+            WebViewPreference useEmbeddedWebView, 
+            RequestContext requestContext)
         {
-            if (parent.UseEmbeddedWebview)
+            if (useEmbeddedWebView == WebViewPreference.Embedded)
             {
                 return new EmbeddedWebUI()
                 {
                     RequestContext = requestContext,
-                    CoreUIParent = parent
+                    CoreUIParent = coreUIParent
                 };
             }
-
-            //there is no need to pass UIParent.
+            
             return new SystemWebUI()
             {
                 RequestContext = requestContext
             };
         }
+
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSPlatformProxy.cs
@@ -29,10 +29,6 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         {
         }
 
-        public override bool IsSystemWebViewAvailable => true;
-
-        public override bool UseEmbeddedWebViewDefault => false;
-        
         public override Task<string> GetUserPrincipalNameAsync()
         {
             return Task.FromResult(string.Empty);

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
 using Microsoft.Identity.Client.Platforms.net45;
@@ -14,27 +15,37 @@ namespace Microsoft.Identity.Client.Platforms.net5win
 {
     internal class Net5WebUiFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
-        {
-            // no support for hidden ui browser 
+        private readonly Func<bool> _isWebView2AvailableFunc;
 
-            if (!parent.UseEmbeddedWebview)
+        public Net5WebUiFactory(Func<bool> isWebView2AvailableForTest = null)
+        {
+            _isWebView2AvailableFunc = isWebView2AvailableForTest ?? IsWebView2Available;
+        }
+
+        public bool IsSystemWebViewAvailable => true;
+
+        public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference useEmbeddedWebView, RequestContext requestContext)
+        {
+            if (useEmbeddedWebView == WebViewPreference.System)
             {
                 requestContext.Logger.Info("Using system browser");
                 return new DefaultOsBrowserWebUi(
                     requestContext.ServiceBundle.PlatformProxy,
                     requestContext.Logger,
-                    parent.SystemWebViewOptions);
+                    coreUIParent.SystemWebViewOptions);
             }
 
-            if (IsWebView2Available())
+
+            if (_isWebView2AvailableFunc())
             {
                 requestContext.Logger.Info("Using WebView2 embedded browser");
-                return new WebView2WebUi(parent, requestContext);
+                return new WebView2WebUi(coreUIParent, requestContext);
             }
 
-            requestContext.Logger.Info("Using legacy WebBrowser embedded browser");
-            return new InteractiveWebUI(parent, requestContext);
+            throw new MsalClientException(
+                MsalError.WebView2NotInstalled,
+                "The embedded browser needs WebView2 runtime to be installed. If you are an end user of the app, please download and install the WebView2 runtime from https://go.microsoft.com/fwlink/p/?LinkId=2124703 and restart the app." +
+                " If you are an app developer, please ensure that your app installs the WebView2 runtime https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution");
         }
 
         private bool IsWebView2Available()

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
 using Microsoft.Identity.Client.Platforms.net45;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
@@ -24,8 +25,14 @@ namespace Microsoft.Identity.Client.Platforms.net5win
                     parent.SystemWebViewOptions);
             }
 
-            return new 
+            // TODO: factory logic
+            var legacy =  new 
                 InteractiveWebUI(parent, requestContext);
+            var wv2 = new WebView2WebUi(parent, requestContext);
+
+            IWebUI used = wv2;
+
+            return used;
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
 using Microsoft.Identity.Client.Platforms.net45;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
+using Microsoft.Web.WebView2.Core;
 
 namespace Microsoft.Identity.Client.Platforms.net5win
 {
@@ -19,20 +20,27 @@ namespace Microsoft.Identity.Client.Platforms.net5win
 
             if (!parent.UseEmbeddedWebview)
             {
+                requestContext.Logger.Info("Using system browser");
                 return new DefaultOsBrowserWebUi(
                     requestContext.ServiceBundle.PlatformProxy,
                     requestContext.Logger,
                     parent.SystemWebViewOptions);
             }
 
-            // TODO: factory logic
-            var legacy =  new 
-                InteractiveWebUI(parent, requestContext);
-            var wv2 = new WebView2WebUi(parent, requestContext);
+            if (IsWebView2Available())
+            {
+                requestContext.Logger.Info("Using WebView2 embedded browser");
+                return new WebView2WebUi(parent, requestContext);
+            }
 
-            IWebUI used = wv2;
+            requestContext.Logger.Info("Using legacy WebBrowser embedded browser");
+            return new InteractiveWebUI(parent, requestContext);
+        }
 
-            return used;
+        private bool IsWebView2Available()
+        {
+            string wv2Version = CoreWebView2Environment.GetAvailableBrowserVersionString();
+            return !string.IsNullOrEmpty(wv2Version);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WinPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WinPlatformProxy.cs
@@ -52,8 +52,6 @@ namespace Microsoft.Identity.Client.Platforms.net5win
 
         protected override IWebUIFactory CreateWebUiFactory() => new Net5WebUiFactory();
 
-        public override bool UseEmbeddedWebViewDefault => true;
-
         public override string GetDefaultRedirectUri(string clientId, bool useRecommendedRedirectUri = false)
         {
             if (useRecommendedRedirectUri)

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -221,7 +221,6 @@ namespace Microsoft.Identity.Client.Platforms.netcore
         {
             return PoPProviderFactory.GetOrCreateProvider();
         }
-        public override bool UseEmbeddedWebViewDefault => false;
 
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
@@ -12,8 +12,19 @@ namespace Microsoft.Identity.Client.Platforms.Shared.NetStdCore
     {
         public bool IsSystemWebViewAvailable => true;
 
-        public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
+        public IWebUI CreateAuthenticationDialog(
+            CoreUIParent coreUIParent, 
+            WebViewPreference webViewPreference, 
+            RequestContext requestContext)
         {
+            if (webViewPreference == WebViewPreference.Embedded)
+            {
+                throw new MsalClientException(MsalError.WebviewUnavailable, 
+                   "An embedded webview is not available in the box on .NET Core 3.x " +
+                   "Please reference the package Microsoft.Indentity.Client.Desktop and call WithDesktopFeatures(). See https://aka.ms/msal-net-webview2 " +
+                   "Or use the system webview - see https://aka.ms/msal-net-os-browser");
+            }
+
             return new DefaultOsBrowserWebUi(
                 requestContext.ServiceBundle.PlatformProxy,
                 requestContext.Logger,

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
@@ -9,12 +10,14 @@ namespace Microsoft.Identity.Client.Platforms.Shared.NetStdCore
 {
     internal class NetCoreWebUIFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
+        public bool IsSystemWebViewAvailable => true;
+
+        public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {
             return new DefaultOsBrowserWebUi(
                 requestContext.ServiceBundle.PlatformProxy,
                 requestContext.Logger,
-                parent.SystemWebViewOptions);
+                coreUIParent.SystemWebViewOptions);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
@@ -10,22 +11,28 @@ namespace Microsoft.Identity.Client.Platforms.net45
 {
     internal class NetDesktopWebUIFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
+        public bool IsSystemWebViewAvailable => true;
+
+        public IWebUI CreateAuthenticationDialog(
+            CoreUIParent coreUIParent, 
+            WebViewPreference useEmbeddedWebView, 
+            RequestContext requestContext)
         {
-            if (parent.UseHiddenBrowser)
+            if (coreUIParent.UseHiddenBrowser)
             {
-                return new SilentWebUI(parent, requestContext);
+                return new SilentWebUI(coreUIParent, requestContext);
             }
 
-            if (!parent.UseEmbeddedWebview)
+            if (useEmbeddedWebView == WebViewPreference.System)
             {
                 return new DefaultOsBrowserWebUi(
                     requestContext.ServiceBundle.PlatformProxy,
                     requestContext.Logger,
-                    parent.SystemWebViewOptions);
+                    coreUIParent.SystemWebViewOptions);
             }
 
-            return new InteractiveWebUI(parent, requestContext);
+            // Use the old legacy WebUi by default on .NET classic
+            return new InteractiveWebUI(coreUIParent, requestContext);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.UI;

--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
@@ -135,8 +135,5 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
         {            
             return Task.FromResult(0);
         }
-
-        public override bool UseEmbeddedWebViewDefault => false;
-
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard13/WebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard13/WebUIFactory.cs
@@ -15,9 +15,11 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {
-            throw new PlatformNotSupportedException("Possible Cause: If you are using an XForms app, or generally a netstandard assembly, " +
+            throw new PlatformNotSupportedException(
+                "Possible Cause: If you are using an XForms app, or generally a netstandard assembly, " +
                 "make sure you add a reference to Microsoft.Identity.Client.dll from each platform assembly " +
-                "(e.g. UWP, Android, iOS), not just from the common netstandard assembly");
+                "(e.g. UWP, Android, iOS), not just from the common netstandard assembly. " +
+                "A browser is not avaiable in the box on .NETStandard 1.3");
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard13/WebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard13/WebUIFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.UI;
@@ -10,7 +11,9 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
 {
     internal class WebUIFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
+        public bool IsSystemWebViewAvailable => false;
+
+        public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {
             throw new PlatformNotSupportedException("Possible Cause: If you are using an XForms app, or generally a netstandard assembly, " +
                 "make sure you add a reference to Microsoft.Identity.Client.dll from each platform assembly " +

--- a/src/client/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/uap/UapPlatformProxy.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Identity.Client.Platforms.uap
 
         public override ITokenCacheBlobStorage CreateTokenCacheBlobStorage() => new UapTokenCacheBlobStorage(CryptographyManager, Logger);
 
-        protected override IWebUIFactory CreateWebUiFactory() => new WebUIFactory();
+        protected override IWebUIFactory CreateWebUiFactory() => new UapWebUIFactory();
         protected override ICryptographyManager InternalGetCryptographyManager() => new UapCryptographyManager();
         protected override IPlatformLogger InternalGetPlatformLogger() => new EventSourcePlatformLogger();
 
@@ -201,8 +201,7 @@ namespace Microsoft.Identity.Client.Platforms.uap
             return MatsConverter.AsInt(OsPlatform.Win32);
         }
         protected override IFeatureFlags CreateFeatureFlags() => new UapFeatureFlags();
-
-        public override bool IsSystemWebViewAvailable => false;
+       
 
         public override IDeviceAuthManager CreateDeviceAuthManager()
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Identity.Client.Platforms.uap
             {
                 throw new MsalClientException(
                     MsalError.WebviewUnavailable,
-                    "On UWP, MSAL does not offer a system webUI out of the box. Please set .WithUseEmbeddedWebview to false. " +
-                    "To use the UWP Web Authentication Manager (WAM) see https://aka.ms/msal-net-uwp-wam");
+                    "On UWP, MSAL cannot use the system browser. " +
+                    "The preffered auth mechanism is the Web Authentication Manager (WAM) see https://aka.ms/msal-net-uwp-wam");
             }
 
             return new WebUI(coreUIParent, requestContext);

--- a/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
@@ -1,16 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.uap
 {
-    internal class WebUIFactory : IWebUIFactory
+    internal class UapWebUIFactory : IWebUIFactory
     {
-        public IWebUI CreateAuthenticationDialog(CoreUIParent parent, RequestContext requestContext)
+        public bool IsSystemWebViewAvailable => false;
+
+        public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {
-            if (!parent.UseEmbeddedWebview)
+            if (webViewPreference == WebViewPreference.System)
             {
                 throw new MsalClientException(
                     MsalError.WebviewUnavailable,
@@ -18,7 +21,7 @@ namespace Microsoft.Identity.Client.Platforms.uap
                     "To use the UWP Web Authentication Manager (WAM) see https://aka.ms/msal-net-uwp-wam");
             }
 
-            return new WebUI(parent, requestContext);
+            return new WebUI(coreUIParent, requestContext);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
@@ -17,10 +17,6 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
     /// </summary>
     internal interface IPlatformProxy
     {
-        bool IsSystemWebViewAvailable { get; }
-
-        bool UseEmbeddedWebViewDefault { get; }
-
         /// <summary>
         /// Gets the device model. On some TFMs this is not returned for security reasonons.
         /// </summary>
@@ -72,7 +68,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
 
         IPlatformLogger PlatformLogger { get; }
 
-        IWebUIFactory GetWebUiFactory();
+        IWebUIFactory GetWebUiFactory(ApplicationConfiguration appConfig);
 
         IPoPCryptoProvider GetDefaultPoPCryptoProvider();
 
@@ -81,7 +77,6 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
         string GetDeviceNetworkState();
         int GetMatsOsPlatformCode();
         string GetMatsOsPlatform();
-        void /* for test */ SetWebUiFactory(IWebUIFactory webUiFactory);
 
         IFeatureFlags GetFeatureFlags();
 

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
@@ -37,39 +37,18 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             _productName = new Lazy<string>(InternalGetProductName);
             _cryptographyManager = new Lazy<ICryptographyManager>(InternalGetCryptographyManager);
             _platformLogger = new Lazy<IPlatformLogger>(InternalGetPlatformLogger);
-        }
+        }      
 
-        public virtual bool IsSystemWebViewAvailable
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public virtual bool UseEmbeddedWebViewDefault
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        protected IWebUIFactory OverloadWebUiFactory { get; set; }
         protected IFeatureFlags OverloadFeatureFlags { get; set; }
 
         protected ICoreLogger Logger { get; }
 
         /// <inheritdoc />
-        public IWebUIFactory GetWebUiFactory()
+        public IWebUIFactory GetWebUiFactory(ApplicationConfiguration appConfig)
         {
-            return OverloadWebUiFactory ?? CreateWebUiFactory();
-        }
-
-        /// <inheritdoc />
-        public void SetWebUiFactory(IWebUIFactory webUiFactory)
-        {
-            OverloadWebUiFactory = webUiFactory;
+            return appConfig.WebUiFactoryCreator != null ?
+              appConfig.WebUiFactoryCreator() :
+              CreateWebUiFactory();            
         }
 
         /// <inheritdoc />
@@ -77,7 +56,6 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         {
             return _deviceModel.Value;
         }
-
 
         /// <inheritdoc />
         public string GetOperatingSystem()

--- a/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -58,7 +58,10 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public bool IsSystemWebViewAvailable
         {
-            get => ServiceBundle.PlatformProxy.IsSystemWebViewAvailable;
+            get
+            {
+                return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsSystemWebViewAvailable;
+            }
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
+++ b/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
@@ -13,6 +13,7 @@ using AppKit;
 #endif
 
 using System.Threading;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 
 namespace Microsoft.Identity.Client.UI
 {
@@ -20,9 +21,9 @@ namespace Microsoft.Identity.Client.UI
     {
         public CoreUIParent()
         {
+
         }
 
-        internal bool UseEmbeddedWebview { get; set; }
         internal SynchronizationContext SynchronizationContext { get; set; }
 
         internal SystemWebViewOptions SystemWebViewOptions { get; set; }

--- a/src/client/Microsoft.Identity.Client/UI/IWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/UI/IWebUIFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 
@@ -10,6 +11,10 @@ namespace Microsoft.Identity.Client.UI
     {
         IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent,
+            WebViewPreference webViewPreference,
             RequestContext requestContext);
+
+        bool IsSystemWebViewAvailable { get; }
+        
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AcquireTokenInteractiveBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AcquireTokenInteractiveBuilderTests.cs
@@ -199,19 +199,6 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
 
 #endif
 
-#if NET_CORE 
-        [TestMethod]
-        public async Task TestAcquireTokenInteractive_EmbeddedNetCore_Async()
-        {
-            var ex = await AssertException.TaskThrowsAsync<MsalClientException>(() =>
-                 AcquireTokenInteractiveParameterBuilder.Create(_harness.Executor, TestConstants.s_scope)
-                                                         .WithUseEmbeddedWebView(true)
-                                                         .ExecuteAsync()
-                                                        ).ConfigureAwait(false);
-            Assert.AreEqual(MsalError.WebviewUnavailable, ex.ErrorCode);
-        }
-#endif
-
         [TestMethod]
         public async Task TestAcquireTokenInteractive_Options_Async()
         {

--- a/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Identity.Test.Unit
                           .WithDebugLoggingCallback()
                           .BuildConcrete();
 
-                // mock webUi authorization
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"), null, TestConstants.ProductionPrefNetworkEnvironment);
+                app.ServiceBundle.ConfigureMockWebUI(
+                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"),
+                    null, 
+                    TestConstants.ProductionPrefNetworkEnvironment);
 
                 // mock token request
                 httpManager.AddMockHandler(new MockHttpMessageHandler

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
-                MsalMockHelpers.ConfigureMockWebUI(pca);
+                pca.ServiceBundle.ConfigureMockWebUI();
+
                 await RunAfterAccessFailureAsync(pca, () =>
                     pca.AcquireTokenInteractive(new[] { "User.Read" }).ExecuteAsync())
                         .ConfigureAwait(false);
@@ -196,8 +197,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     await Task.Delay(10).ConfigureAwait(false);
                 });
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    pca.ServiceBundle.PlatformProxy,
+
+                pca.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(pca.AppConfig.RedirectUri + "?code=some-code"));
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
@@ -238,9 +239,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 Assert.IsFalse(accounts.Any());
 
                 Trace.WriteLine("Step 2 - call AcquireTokenInteractive - it will save new tokens in the cache");
-                MsalMockHelpers.ConfigureMockWebUI(
-                        app.ServiceBundle.PlatformProxy,
-                         AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI(
+                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
                 _harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();
                 var cacheAccessRecorder2 = app.UserTokenCache.RecordAccess();
@@ -280,7 +280,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             var userTokenCacheInternal = Substitute.For<ITokenCacheInternal>();
             var semaphore = new SemaphoreSlim(1, 1);
             userTokenCacheInternal.Semaphore.Returns(semaphore);
-            
+
             var cca = ConfidentialClientApplicationBuilder
                 .Create(TestConstants.ClientId)
                 .WithAuthority(new Uri(TestConstants.AuthorityTestTenant))
@@ -290,7 +290,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 .BuildConcrete();
 
             userTokenCacheInternal.IsTokenCacheSerialized().Returns(false);
-            
+
             // Act
             await cca.GetAccountsAsync().ConfigureAwait(false);
 
@@ -312,7 +312,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             await cca.UserTokenCacheInternal.Received().OnAfterAccessAsync(Arg.Any<TokenCacheNotificationArgs>()).ConfigureAwait(true);
 
 
-        }    
+        }
 
         [TestMethod]
         public async Task AcquireTokenForClient_DoesNotFireNotifications_WhenTokenCacheIsNotSerialized_Async()

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
@@ -181,8 +181,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                                           .WithTelemetry(new TraceTelemetryConfig())
                                           .BuildConcrete();
 
-            MsalMockHelpers.ConfigureMockWebUI(
-                app.ServiceBundle.PlatformProxy,
+            app.ServiceBundle.ConfigureMockWebUI(
                 AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
             harness.HttpManager.AddMockHandler(new MockHttpMessageHandler

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheTests.cs
@@ -41,17 +41,18 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                                                             new TestLegacyCachePersistance())
                                                         .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+
+                app.ServiceBundle.ConfigureMockWebUI(
+                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+
                 HttpResponseMessage response = MockHelpers.CreateSuccessTokenResponseMessageWithUid(
-                    TestConstants.Uid, 
-                    TestConstants.Utid, 
+                    TestConstants.Uid,
+                    TestConstants.Utid,
                     "testuser@contoso.com");
 
                 httpManager.AddResponseMockHandlerForPost(response);
 
-               AuthenticationResult result = app.AcquireTokenInteractive(TestConstants.s_scope).ExecuteAsync(CancellationToken.None).Result;
+                AuthenticationResult result = app.AcquireTokenInteractive(TestConstants.s_scope).ExecuteAsync(CancellationToken.None).Result;
                 Assert.IsNotNull(result);
 
                 // make sure Msal stored RT in Adal cache
@@ -128,8 +129,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 httpManager.AddInstanceDiscoveryMockHandler();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                app.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(ClientApplicationBase.DefaultAuthority);
@@ -153,8 +153,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                                                              new Uri(ClientApplicationBase.DefaultAuthority),
                                                              true).BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app1.ServiceBundle.PlatformProxy,
+                app1.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 app1.UserTokenCache.SetBeforeAccess((TokenCacheNotificationArgs args) =>

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -241,8 +241,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 //Ensure that the PublicClientApplication init does not remove the port from the authority
                 Assert.AreEqual(customPortAuthority, app.Authority);
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                
+                app.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(customPortAuthority);

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/PublicApiInstanceMetadataTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/PublicApiInstanceMetadataTests.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                     .WithTelemetry(new TraceTelemetryConfig())
                     .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                
+                app.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 // the rest of the communication with AAD happens on the preferred_network alias, not on login.windows.net
@@ -106,8 +106,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                     .WithHttpManager(harness.HttpManager)
                     .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                
+                app.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 // the rest of the communication with AAD happens on the preferred_network alias, not on login.windows.net

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsTest.cs
@@ -146,9 +146,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
                                                                             .WithTelemetry(new TraceTelemetryConfig())
                                                                             .BuildConcrete();
 
-                var mockUi = MsalMockHelpers.ConfigureMockWebUI(
-                     app.ServiceBundle.PlatformProxy,
-                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                var mockUi = 
+                     app.ServiceBundle.ConfigureMockWebUI(
+                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 mockUi.QueryParamsToValidate = new Dictionary<string, string> { { OAuth2Parameter.Claims, TestConstants.Claims } };
 
@@ -180,9 +180,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
                               .WithClientCapabilities(TestConstants.ClientCapabilities)
                               .BuildConcrete();
 
-                var mockUi = MsalMockHelpers.ConfigureMockWebUI(
-                     app.ServiceBundle.PlatformProxy,
-                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                var mockUi = 
+                     app.ServiceBundle.ConfigureMockWebUI(
+                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 mockUi.QueryParamsToValidate = new Dictionary<string, string> { {
                         OAuth2Parameter.Claims,
@@ -215,9 +215,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
                                 .WithTelemetry(new TraceTelemetryConfig())
                                 .BuildConcrete();
 
-                var mockUi = MsalMockHelpers.ConfigureMockWebUI(
-                     app.ServiceBundle.PlatformProxy,
-                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                var mockUi = 
+                     app.ServiceBundle.ConfigureMockWebUI(
+                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 mockUi.QueryParamsToValidate = new Dictionary<string, string> {
                     { OAuth2Parameter.Claims,

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/PlatformProxyFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/PlatformProxyFactoryTests.cs
@@ -156,19 +156,18 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
             Assert.IsTrue(proxy.BrokerSupportsWamAccounts);
             Assert.IsTrue(proxy.CanBrokerSupportSilentAuth());
 
-            Assert.IsTrue(proxy.IsSystemWebViewAvailable);
+            
             Assert.AreSame(
                 Constants.DefaultRedirectUri,
                 proxy.GetDefaultRedirectUri("cid", false));
 
 #if DESKTOP || NET5_WIN
-            Assert.IsTrue(proxy.UseEmbeddedWebViewDefault);
+            
             Assert.AreSame(
                 Constants.NativeClientRedirectUri,
                 proxy.GetDefaultRedirectUri("cid", true));
 
-#else
-            Assert.IsFalse(proxy.UseEmbeddedWebViewDefault);
+#else            
              Assert.AreSame(
                 Constants.LocalHostRedirectUri,
                 proxy.GetDefaultRedirectUri("cid", true));

--- a/tests/Microsoft.Identity.Test.Unit/OAuthClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/OAuthClientTests.cs
@@ -141,8 +141,8 @@ namespace Microsoft.Identity.Test.Unit
                                                                             .WithTelemetry(new TraceTelemetryConfig())
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                
+                app.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 //Initiates PKeyAuth challenge which will trigger an additional request sent to AAD to satisfy the PKeyAuth challenge
@@ -186,8 +186,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var pca = builder.BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    pca.ServiceBundle.PlatformProxy,
+                pca.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(pca.AppConfig.RedirectUri + "?code=some-code"));
 
                 //Initiates PKeyAuth challenge which will trigger an additional request sent to AAD to satisfy the PKeyAuth challenge

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationSchemeTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationSchemeTests.cs
@@ -47,9 +47,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithHttpManager(httpManager)
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
@@ -82,7 +81,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 // silent call with no key id (i.e. BearerScheme) - the existing AT will not be returned
                 silentResult = await RunSilentCallAsync(
-                    httpManager, 
+                    httpManager,
                     app,
                     scheme: null,
                     expectRtRefresh: true).ConfigureAwait(false);
@@ -108,17 +107,15 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithHttpManager(httpManager)
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
                 // Act
-               var ex = await AssertException.TaskThrowsAsync<MsalClientException>(() => app
-                    .AcquireTokenInteractive(TestConstants.s_scope)
-                    .WithAuthenticationScheme(authScheme)
-                    .ExecuteAsync()).ConfigureAwait(false);
+                var ex = await AssertException.TaskThrowsAsync<MsalClientException>(() => app
+                     .AcquireTokenInteractive(TestConstants.s_scope)
+                     .WithAuthenticationScheme(authScheme)
+                     .ExecuteAsync()).ConfigureAwait(false);
 
                 Assert.AreEqual(MsalError.TokenTypeMismatch, ex.ErrorCode);
             }
@@ -145,7 +142,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         private static async Task<AuthenticationResult> RunSilentCallAsync(
             MockHttpManager httpManager,
             PublicClientApplication app,
-            IAuthenticationScheme scheme, 
+            IAuthenticationScheme scheme,
             bool expectRtRefresh)
         {
             if (expectRtRefresh)
@@ -164,7 +161,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             return await builder
                 .ExecuteAsync().ConfigureAwait(false);
 
-           
+
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     MockResult = AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code")
                 };
 
-                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+                app.ServiceBundle.ConfigureMockWebUI(ui);
 
                 try
                 {
@@ -152,7 +152,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?code=some-code&state=mismatched")
                 };
 
-                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+                app.ServiceBundle.ConfigureMockWebUI(ui);
 
                 try
                 {
@@ -184,9 +184,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithTelemetry(new TraceTelemetryConfig())
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
@@ -226,9 +224,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithHttpManager(harness.HttpManager)
                                                                             .WithTelemetry(new TraceTelemetryConfig())
                                                                             .BuildConcrete();
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
                 var userCacheAccess = app.UserTokenCache.RecordAccess();
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
@@ -252,9 +248,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
 
                 // repeat interactive call and pass in the same user
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
                     TestConstants.AuthorityCommonTenant,
@@ -316,9 +310,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithTelemetry(new TraceTelemetryConfig())
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
@@ -335,9 +327,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual(TestConstants.Utid, result.TenantId);
 
                 // repeat interactive call and pass in the same user
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 harness.HttpManager.AddMockHandler(
                     new MockHttpMessageHandler
@@ -382,9 +372,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithTelemetry(receiver.HandleTelemetryEvents)
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
@@ -408,8 +396,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 };
 
                 // repeat interactive call and pass in the same user
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                
+                app.ServiceBundle.ConfigureMockWebUI(
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"),
                     dict);
 
@@ -467,9 +455,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithTelemetry(new TraceTelemetryConfig())
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
@@ -486,9 +472,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 // TODO: Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
 
                 // repeat interactive call and pass in the same user
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 httpManager.AddMockHandler(
                     new MockHttpMessageHandler
@@ -533,9 +517,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .WithTelemetry(new TraceTelemetryConfig())
                     .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 // add mock response bigger than 1MB for Http Client
                 httpManager.AddFailingRequest(new InvalidOperationException());
@@ -561,15 +543,15 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .BuildConcrete();
 
                 // repeat interactive call and pass in the same user
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    new MockWebUI()
-                    {
-                        ExceptionToThrow = new MsalClientException(
-                            MsalError.AuthenticationUiFailedError,
-                            "Failed to invoke webview",
-                            new InvalidOperationException("some-inner-Exception"))
-                    });
+              
+                    app.ServiceBundle.ConfigureMockWebUI(
+                        new MockWebUI()
+                        {
+                            ExceptionToThrow = new MsalClientException(
+                                MsalError.AuthenticationUiFailedError,
+                                "Failed to invoke webview",
+                                new InvalidOperationException("some-inner-Exception"))
+                        });
 
                 try
                 {
@@ -692,7 +674,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     MockResult = AuthorizationResult.FromStatus(AuthorizationStatus.UserCancel)
                 };
 
-                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+                app.ServiceBundle.ConfigureMockWebUI(ui);
+                ;
 
                 try
                 {
@@ -740,7 +723,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?error=access_denied")
                 };
 
-                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+                app.ServiceBundle.ConfigureMockWebUI(ui);
+                ;
 
                 try
                 {
@@ -919,9 +903,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithHttpManager(httpManager)
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 
@@ -980,9 +962,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .WithTelemetry(new TraceTelemetryConfig())
                     .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                                app.ServiceBundle.PlatformProxy,
-                                AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 MockHttpManagerExtensions.AddAdfs2019MockHandler(httpManager);
 
@@ -1023,9 +1003,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .WithTelemetry(new TraceTelemetryConfig())
                     .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                                app.ServiceBundle.PlatformProxy,
-                                AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 MockHttpManagerExtensions.AddAdfs2019MockHandler(httpManager);
 
@@ -1109,9 +1087,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .WithTelemetry(new TraceTelemetryConfig())
                     .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTestsWithB2C.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTestsWithB2C.cs
@@ -35,9 +35,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .WithTelemetry(new TraceTelemetryConfig())
                                                                             .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                                        AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.B2CLoginAuthority);
 
@@ -64,7 +62,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .BuildConcrete();
 
                 MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                    app.ServiceBundle,
                                         AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.B2CAuthority);
@@ -92,7 +90,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .BuildConcrete();
 
                 MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                    app.ServiceBundle,
                                         AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.B2CLoginAuthority);
@@ -120,7 +118,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .BuildConcrete();
 
                 MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                    app.ServiceBundle,
                                         AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 httpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.B2CCustomDomain);
@@ -184,7 +182,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     "?error=access_denied&error_description=AADB2C90091%3a+The+user+has+cancelled+entering+self-asserted+information.")
                 };
 
-                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+                MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle, ui);
 
                 try
                 {
@@ -238,7 +236,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                             .BuildConcrete();
 
                 MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
+                    app.ServiceBundle,
                                         AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 // Arrange 1 - interactive call with 0 scopes
@@ -289,7 +287,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 MockResult = AuthorizationResult.FromUri(authority + "?code=some-code")
             };
 
-            MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle.PlatformProxy, ui);
+            MsalMockHelpers.ConfigureMockWebUI(app.ServiceBundle, ui);
             harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(authority);
 
             var result = app

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TelemetryTests.cs
@@ -135,9 +135,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                .WithRedirectUri("http://localhost")
                                .BuildConcrete();
 
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                app.ServiceBundle.ConfigureMockWebUI();
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
 

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/FociTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/FociTests.cs
@@ -343,8 +343,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 _harness.HttpManager.AddInstanceDiscoveryMockHandler();
             }
 
-            MsalMockHelpers.ConfigureMockWebUI(
-                app.ServiceBundle.PlatformProxy,
+            app.ServiceBundle.ConfigureMockWebUI(
                 AuthorizationResult.FromUri(TestConstants.B2CLoginAuthority + "?code=some-code"));
 
             _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?code=some-code"),
                     QueryParamsToValidate = TestConstants.ExtraQueryParameters
                 };
-                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle.PlatformProxy, ui);
+                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle, ui);
 
                 MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
 
@@ -143,7 +143,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?code=some-code")
                 };
 
-                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle.PlatformProxy, ui);
+                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle, ui);
 
                 MockInstanceDiscoveryAndOpenIdRequest(harness.HttpManager);
 
@@ -238,7 +238,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 {
                     MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?error=" + OAuth2Error.LoginRequired),
                 };
-                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle.PlatformProxy, webUi);
+                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle, webUi);
 
                 AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
@@ -275,7 +275,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     MockResult = AuthorizationResult.FromUri(
                         TestConstants.AuthorityHomeTenant + "?error=invalid_request&error_description=some error description")
                 };
-                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle.PlatformProxy, webUi);
+                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle, webUi);
 
                 request = new InteractiveRequest(
                     parameters,
@@ -303,7 +303,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     // error code and error description is empty string (not null)
                     MockResult = AuthorizationResult.FromUri(TestConstants.AuthorityHomeTenant + "?error=some_error&error_description= "),
                 };
-                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle.PlatformProxy, webUi);
+                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle, webUi);
 
                 AuthenticationRequestParameters parameters = harness.CreateAuthenticationRequestParameters(
                     TestConstants.AuthorityHomeTenant,
@@ -346,7 +346,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 var request = new InteractiveRequest(
                     parameters,
                     interactiveParameters);
-                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle.PlatformProxy, new MockWebUI());
+                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle, new MockWebUI());
 
                 try
                 {

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestWithCustomWebUiTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 };
 
                 var ui = new CustomWebUiHandler(customWebUi);
-                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle.PlatformProxy, ui);
+                MsalMockHelpers.ConfigureMockWebUI(harness.ServiceBundle, ui);
 
                 var request = new InteractiveRequest(
                     parameters,

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
                     _requestContext);
 
             // Assert
-            Assert.IsTrue(webUi is InteractiveWebUI);
+            Assert.IsTrue(webUi is Client.Platforms.Features.WinFormsLegacyWebUi.InteractiveWebUI);
         }
 #endif
 

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Assert
             Assert.IsTrue(webUi is WebView2WebUi);
         }
-
+#if DESKTOP
         [TestMethod]
         public void DefaultEmbedded_Legacy()
         {
@@ -66,8 +66,9 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
                     _requestContext);
 
             // Assert
-            Assert.IsTrue(webUi is WebView2WebUi);
+            Assert.IsTrue(webUi is InteractiveWebUI);
         }
+#endif
 
         [TestMethod]
         public void DefaultEmbedded_WebView2NotAvailable()

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if DESKTOP || NET_CORE
+using System;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Desktop;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
+using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
+using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.WebUITests
+{
+    [TestClass]
+    public class MsalDesktopWebUiTests
+    {
+        private readonly CoreUIParent _parent = new CoreUIParent();
+        private readonly RequestContext _requestContext =
+            new RequestContext(TestCommon.CreateDefaultServiceBundle(), Guid.NewGuid());
+
+        [TestMethod]
+        public void IsSystemWebUiAvailable()
+        {
+            var webUIFactory = new MsalDesktopWebUiFactory();
+
+            Assert.IsTrue(webUIFactory.IsSystemWebViewAvailable);
+        }
+
+        [TestMethod]
+        public void DefaultEmbedded_WebView2Available()
+        {
+            // Arrange
+            var webUIFactory = new MsalDesktopWebUiFactory(
+                fallbackToLegacyWebBrowser: false, 
+                isWebView2AvailableForTest: () => true);
+
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(
+                    _parent,
+                    WebViewPreference.NotSpecified,
+                    _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is WebView2WebUi);
+        }
+
+        [TestMethod]
+        public void DefaultEmbedded_Legacy()
+        {
+            // Arrange
+            var webUIFactory = new MsalDesktopWebUiFactory(
+                fallbackToLegacyWebBrowser: true,
+                isWebView2AvailableForTest: () => false);
+
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(
+                    _parent,
+                    WebViewPreference.NotSpecified,
+                    _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is WebView2WebUi);
+        }
+
+        [TestMethod]
+        public void DefaultEmbedded_WebView2NotAvailable()
+        {
+            // Arrange
+            var webUIFactory = new MsalDesktopWebUiFactory(
+               fallbackToLegacyWebBrowser: false,
+               isWebView2AvailableForTest: () => false);
+
+
+            // Act
+            var ex = AssertException.Throws<MsalClientException>(() =>
+                webUIFactory.CreateAuthenticationDialog(
+                    _parent,
+                    WebViewPreference.NotSpecified,
+                    _requestContext));
+
+            // Assert
+            Assert.AreEqual(MsalError.WebView2NotInstalled, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void Embedded()
+        {
+            // Arrange
+            var webUIFactory = new MsalDesktopWebUiFactory(
+               fallbackToLegacyWebBrowser: false,
+               isWebView2AvailableForTest: () => true);
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is WebView2WebUi);
+        }
+
+        [TestMethod]
+        public void NetCoreFactory_System()
+        {
+            // Arrange
+            var webUIFactory = new MsalDesktopWebUiFactory(
+              fallbackToLegacyWebBrowser: false,
+              isWebView2AvailableForTest: () => true);
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(
+                _parent, 
+                WebViewPreference.System, 
+                _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is DefaultOsBrowserWebUi);
+        }
+    }
+}
+
+#endif

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/Net5WebUIFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/Net5WebUIFactoryTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#if NET5_WIN 
+
+using System;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
+using Microsoft.Identity.Client.Platforms.net5win;
+using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
+using Microsoft.Identity.Client.Platforms.Shared.NetStdCore;
+using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.WebUITests
+{
+    [TestClass]
+    public class Net5WebUIFactoryTests
+    {
+        private readonly CoreUIParent _parent = new CoreUIParent();
+        private readonly RequestContext _requestContext =
+            new RequestContext(TestCommon.CreateDefaultServiceBundle(), Guid.NewGuid());
+
+        [TestMethod]
+        public void IsSystemWebUiAvailable()
+        {
+            var webUIFactory = new Net5WebUiFactory();
+
+            Assert.IsTrue(webUIFactory.IsSystemWebViewAvailable);
+        }
+
+        [TestMethod]
+        public void DefaultEmbedded_WebView2Available()
+        {
+            // Arrange
+            var webUIFactory = new Net5WebUiFactory(() => true);
+
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(
+                    _parent,
+                    WebViewPreference.NotSpecified,
+                    _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is WebView2WebUi);
+
+        }
+
+        [TestMethod]
+        public void DefaultEmbedded_WebView2NotAvailable()
+        {
+            // Arrange
+            var webUIFactory = new Net5WebUiFactory(() => false);
+
+
+            // Act
+            var ex = AssertException.Throws<MsalClientException>(() =>
+                webUIFactory.CreateAuthenticationDialog(
+                    _parent,
+                    WebViewPreference.NotSpecified,
+                    _requestContext));
+
+            // Assert
+            Assert.AreEqual(MsalError.WebView2NotInstalled, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void Embedded()
+        {
+            // Arrange
+            var webUIFactory = new Net5WebUiFactory(() => true);
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is WebView2WebUi);
+        }
+
+        [TestMethod]
+        public void NetCoreFactory_System()
+        {
+            // Arrange
+            var webUIFactory = new Net5WebUiFactory();
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.System, _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is DefaultOsBrowserWebUi);
+        }
+    }
+}
+#endif

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/NetCoreWebUIFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/NetCoreWebUIFactoryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #if NET_CORE 
 using System;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
@@ -9,6 +10,7 @@ using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.Platforms.Shared.NetStdCore;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.WebUITests
@@ -41,10 +43,14 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Arrange
 
             // Act
-            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContext);
+           var ex = AssertException.Throws<MsalClientException>(
+               ()=> _webUIFactory.CreateAuthenticationDialog(
+                    _parent, 
+                    WebViewPreference.Embedded, 
+                    _requestContext));
 
             // Assert
-            Assert.IsTrue(webUi is DefaultOsBrowserWebUi);
+            Assert.AreEqual(MsalError.WebviewUnavailable, ex.ErrorCode);
         }
 
         [TestMethod]
@@ -53,7 +59,10 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Arrange
 
             // Act
-            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.System, _requestContext);
+            var webUi = _webUIFactory.CreateAuthenticationDialog(
+                _parent, 
+                WebViewPreference.System, 
+                _requestContext);
 
             // Assert
             Assert.IsTrue(webUi is DefaultOsBrowserWebUi);

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/NetCoreWebUIFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/NetCoreWebUIFactoryTests.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if NET_CORE || NET5_WIN
+#if NET_CORE 
 using System;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
@@ -20,15 +21,43 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
         private readonly RequestContext _requestContext = new RequestContext(TestCommon.CreateDefaultServiceBundle(), Guid.NewGuid());
 
         [TestMethod]
-        public void Net45Factory_DefaultEmbedded()
+        public void NetCoreFactory_DefaultEmbedded()
         {
             // Arrange
 
             // Act
-            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, _requestContext);
+            var webUi = _webUIFactory.CreateAuthenticationDialog(
+                _parent, 
+                WebViewPreference.NotSpecified, 
+                _requestContext);
 
             // Assert
             Assert.IsTrue(webUi is DefaultOsBrowserWebUi);
+        }
+
+        [TestMethod]
+        public void NetCoreFactory_Embedded()
+        {
+            // Arrange
+
+            // Act
+            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is DefaultOsBrowserWebUi);
+        }
+
+        [TestMethod]
+        public void NetCoreFactory_System()
+        {
+            // Arrange
+
+            // Act
+            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.System, _requestContext);
+
+            // Assert
+            Assert.IsTrue(webUi is DefaultOsBrowserWebUi);
+            Assert.IsTrue(_webUIFactory.IsSystemWebViewAvailable);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/NetDesktopWebUIFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/NetDesktopWebUIFactoryTests.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT License.
 #if DESKTOP
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi;
 using Microsoft.Identity.Client.Platforms.net45;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
@@ -27,8 +23,6 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
         [TestMethod]
         public void Net45Factory_DefaultEmbedded()
         {
-            
-
             // Act
             var webUi = _webUIFactory.CreateAuthenticationDialog(
                 _parent, 

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/NetDesktopWebUIFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/NetDesktopWebUIFactoryTests.cs
@@ -27,11 +27,13 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
         [TestMethod]
         public void Net45Factory_DefaultEmbedded()
         {
-            // Arrange
-            _parent.UseEmbeddedWebview = true;
+            
 
             // Act
-            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, _requestContext);
+            var webUi = _webUIFactory.CreateAuthenticationDialog(
+                _parent, 
+                Client.ApiConfig.Parameters.WebViewPreference.Embedded,
+                _requestContext);
 
             // Assert
             Assert.IsTrue(webUi is InteractiveWebUI);
@@ -44,7 +46,10 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             _parent.UseHiddenBrowser = true;
 
             // Act
-            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, _requestContext);
+            var webUi = _webUIFactory.CreateAuthenticationDialog(
+                _parent, 
+                Client.ApiConfig.Parameters.WebViewPreference.NotSpecified,
+                _requestContext);
 
             // Assert
             Assert.IsTrue(webUi is SilentWebUI);
@@ -53,14 +58,15 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
         [TestMethod]
         public void Net45Factory_SystemWebUi()
         {
-            // Arrange
-            _parent.UseEmbeddedWebview = false;
 
             // Act
-            var webUi = _webUIFactory.CreateAuthenticationDialog(_parent, _requestContext);
-
+            var webUi = _webUIFactory.CreateAuthenticationDialog(
+                           _parent,
+                           Client.ApiConfig.Parameters.WebViewPreference.System,
+                           _requestContext);
             // Assert
             Assert.IsTrue(webUi is DefaultOsBrowserWebUi);
+            Assert.IsTrue(_webUIFactory.IsSystemWebViewAvailable);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationSchemeTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationSchemeTests.cs
@@ -118,11 +118,7 @@ namespace Microsoft.Identity.Test.Unit.PoP
                                 .WithHttpManager(harness.HttpManager)
                                 .WithExperimentalFeatures()
                                 .WithClientSecret("some-secret")
-                                .BuildConcrete();
-
-                MsalMockHelpers.ConfigureMockWebUI(
-                    app.ServiceBundle.PlatformProxy,
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+                                .BuildConcrete();             
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
                     TestConstants.AuthorityCommonTenant,

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -74,11 +74,11 @@ namespace NetCoreWinFormsWAM
                 .Create(clientId)
                 .WithAuthority(this.authorityCbx.Text)
                 .WithExperimentalFeatures(true)
-#if NETCOREAPP3_1
-                .WithWindowsBroker(this.useBrokerChk.Checked)
-#else
-                .WithBroker(this.useBrokerChk.Checked)
+#if !NET5_0
+                .WithDesktopFeatures()
 #endif
+                .WithBroker(this.useBrokerChk.Checked)
+
                 // there is no need to construct the PCA with this redirect URI, 
                 // but WAM uses it. We could enforce it.
                 .WithRedirectUri($"ms-appx-web://microsoft.aad.brokerplugin/{clientId}")                
@@ -252,7 +252,7 @@ namespace NetCoreWinFormsWAM
             AuthenticationResult result = null;
             var scopes = GetScopes();
 
-            var builder = pca.AcquireTokenInteractive(scopes)
+            var builder = pca.AcquireTokenInteractive(scopes)                
                 .WithParentActivityOrWindow(this.Handle);
 
 
@@ -280,7 +280,7 @@ namespace NetCoreWinFormsWAM
 
 
             await Task.Delay(500).ConfigureAwait(false);
-            result = await builder.ExecuteAsync().ConfigureAwait(false);
+            result = await builder.ExecuteAsync().ConfigureAwait(false); 
 
 
             return result;

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -72,10 +72,11 @@ namespace NetDesktopWinForms
                 .Create(clientId)
                 .WithAuthority(this.authorityCbx.Text)
                 .WithExperimentalFeatures(true)
-                .WithWindowsBroker(this.useBrokerChk.Checked)
+                .WithDesktopFeatures()
+                .WithBroker(this.useBrokerChk.Checked)
                 // there is no need to construct the PCA with this redirect URI, 
                 // but WAM uses it. We could enforce it.
-                .WithRedirectUri($"ms-appx-web://microsoft.aad.brokerplugin/{clientId}")
+                //.WithRedirectUri($"ms-appx-web://microsoft.aad.brokerplugin/{clientId}")
                 .WithMsaPassthrough(msaPt)
                 .WithLogging((x, y, z) => Debug.WriteLine($"{x} {y}"), LogLevel.Verbose, true)
                 .Build();


### PR DESCRIPTION
- [x] WebView2 logic on .NET 5
- [x] WebUi Factory logic 
- [x] Add support to NET Classic and Net Core 3.1 via Desktop package

# Functionality

## MSAL standalone

|  	|  Embedded WebView	| Default WebView 	|  	
|-	|-	|-	|
|  NET Fx (no change)	        | Legacy 	|  Embedded 		|  
|  NET Core (no change)	| N/A 	| System  	|  	
|  NET5-WIn	|  WebView2  only |  Embedded 	|  	

## MSAL + MSAL.Desktop

Enabled by adding `pcaBuilder.WithDesktopFeatures()`, which also enabled WAM on these languages.

|  	|  Embedded WebView	| Default WebView 	|  	
|-	|-	|-	|
|  NET Fx         | WebView2, fallback to Legacy |  Embedded 		|  
|  NET Core 	| WebView2 only	| Embedded |  	

@henrik-me @jmprieur - could you please validate this behaviour in the tables above let me know if it's ok ?

### Testing: 

- Platforms: net5, netfx, net core
- App type: console, wpf, win forms
- Other logic: launch from MTA thread, from STA thread, with / without capturing SyncronizationContext (console will not have it)

Review help: please test commit by commit. You can skip refacotring commints.