### PR TITLE
Update JSON.NET code to work with Unity.

### DIFF
--- a/build/platform_and_feature_flags.props
+++ b/build/platform_and_feature_flags.props
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkMac)'">
     <DefineConstants>$(DefineConstants);MAC;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)' Or '$(TargetFramework)' == '$(TargetFrameworkNetStandardUnityAOT)'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/build/platform_and_feature_flags.props
+++ b/build/platform_and_feature_flags.props
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkMac)'">
     <DefineConstants>$(DefineConstants);MAC;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)' Or '$(TargetFramework)' == '$(TargetFrameworkNetStandardUnityAOT)'">
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworkNetDesktop461>net461</TargetFrameworkNetDesktop461>
-    <TargetFrameworkNetStandard>netstandard1.3</TargetFrameworkNetStandard>
     <TargetFrameworkNetStandardUnityAOT>netstandard1.3</TargetFrameworkNetStandardUnityAOT>
     <TargetFrameworkNetCore>netcoreapp2.1</TargetFrameworkNetCore>
 

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworkNetDesktop461>net461</TargetFrameworkNetDesktop461>
     <TargetFrameworkNetStandard>netstandard1.3</TargetFrameworkNetStandard>
+    <TargetFrameworkNetStandardUnityAOT>netstandard1.3</TargetFrameworkNetStandardUnityAOT>
     <TargetFrameworkNetCore>netcoreapp2.1</TargetFrameworkNetCore>
 
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
@@ -12,7 +13,7 @@
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
     <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
 
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetStandardUnityAOT);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Linux')) Or '$(NetCoreOnly)' !='' ">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);</TargetFrameworks>
   </PropertyGroup>
@@ -111,6 +112,10 @@
     <!-- These are for MSAL json/* build infra -->
     <DefineConstants>$(DefineConstants);PORTABLE;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_SERIALIZATION;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DYNAMIC;HAVE_EXPRESSIONS;HAVE_FSHARP_TYPES;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_BINDER;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_OBSOLETE_FORMATTER_ASSEMBLY_STYLE;HAVE_XML_DOCUMENT;HAVE_CONCURRENT_DICTIONARY;HAVE_ICONVERTIBLE;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandardUnityAOT)'">
+    <!-- These are for MSAL json/* build infra for Unity -->
+    <DefineConstants>$(DefineConstants);PORTABLE;UNITY_LTS;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_SERIALIZATION;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DYNAMIC;HAVE_EXPRESSIONS;HAVE_FSHARP_TYPES;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_BINDER;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_OBSOLETE_FORMATTER_ASSEMBLY_STYLE;HAVE_XML_DOCUMENT;HAVE_CONCURRENT_DICTIONARY;HAVE_ICONVERTIBLE;$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(APPCENTER_BUILD)' != ''">
     <DefineConstants>$(DefineConstants);IS_APPCENTER_BUILD</DefineConstants>
   </PropertyGroup>
@@ -125,7 +130,7 @@
     <EmbeddedResource Include="$(PathToMsalSources)\Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)' Or '$(TargetFramework)' == '$(TargetFrameworkNetStandardUnityAOT)'">
     <Compile Include="$(PathToMsalSources)\Platforms\netstandard13\**\*.cs" LinkBase="Platforms\netstandard13" />
 
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworkNetDesktop461>net461</TargetFrameworkNetDesktop461>
-    <TargetFrameworkNetStandardUnityAOT>netstandard1.3</TargetFrameworkNetStandardUnityAOT>
+    <TargetFrameworkNetStandard>netstandard1.3</TargetFrameworkNetStandard>
     <TargetFrameworkNetCore>netcoreapp2.1</TargetFrameworkNetCore>
 
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
@@ -12,7 +12,7 @@
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
     <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
 
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetStandardUnityAOT);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Linux')) Or '$(NetCoreOnly)' !='' ">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);</TargetFrameworks>
   </PropertyGroup>
@@ -109,11 +109,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
     <!-- These are for MSAL json/* build infra -->
-    <DefineConstants>$(DefineConstants);PORTABLE;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_SERIALIZATION;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DYNAMIC;HAVE_EXPRESSIONS;HAVE_FSHARP_TYPES;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_BINDER;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_OBSOLETE_FORMATTER_ASSEMBLY_STYLE;HAVE_XML_DOCUMENT;HAVE_CONCURRENT_DICTIONARY;HAVE_ICONVERTIBLE;$(AdditionalConstants)</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandardUnityAOT)'">
-    <!-- These are for MSAL json/* build infra for Unity -->
-    <DefineConstants>$(DefineConstants);PORTABLE;UNITY_LTS;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_SERIALIZATION;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DYNAMIC;HAVE_EXPRESSIONS;HAVE_FSHARP_TYPES;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_BINDER;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_OBSOLETE_FORMATTER_ASSEMBLY_STYLE;HAVE_XML_DOCUMENT;HAVE_CONCURRENT_DICTIONARY;HAVE_ICONVERTIBLE;$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);UNITY;PORTABLE;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_SERIALIZATION;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DYNAMIC;HAVE_EXPRESSIONS;HAVE_FSHARP_TYPES;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_BINDER;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_OBSOLETE_FORMATTER_ASSEMBLY_STYLE;HAVE_XML_DOCUMENT;HAVE_CONCURRENT_DICTIONARY;HAVE_ICONVERTIBLE;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(APPCENTER_BUILD)' != ''">
     <DefineConstants>$(DefineConstants);IS_APPCENTER_BUILD</DefineConstants>
@@ -129,7 +125,7 @@
     <EmbeddedResource Include="$(PathToMsalSources)\Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)' Or '$(TargetFramework)' == '$(TargetFrameworkNetStandardUnityAOT)'">
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
     <Compile Include="$(PathToMsalSources)\Platforms\netstandard13\**\*.cs" LinkBase="Platforms\netstandard13" />
 
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/src/client/Microsoft.Identity.Client/json/Serialization/DefaultContractResolver.cs
+++ b/src/client/Microsoft.Identity.Client/json/Serialization/DefaultContractResolver.cs
@@ -1379,7 +1379,7 @@ namespace Microsoft.Identity.Json.Serialization
             // warning - this method use to cause errors with Intellitrace. Retest in VS Ultimate after changes
             IValueProvider valueProvider;
 
-#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC)
+#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC || UNITY_LTS)
             if (DynamicCodeGeneration)
             {
                 valueProvider = new DynamicValueProvider(member);
@@ -1388,7 +1388,7 @@ namespace Microsoft.Identity.Json.Serialization
             {
                 valueProvider = new ReflectionValueProvider(member);
             }
-#elif !PORTABLE40
+#elif !(PORTABLE40 || UNITY_LTS)
             valueProvider = new ExpressionValueProvider(member);
 #else
             valueProvider = new ReflectionValueProvider(member);

--- a/src/client/Microsoft.Identity.Client/json/Serialization/DefaultContractResolver.cs
+++ b/src/client/Microsoft.Identity.Client/json/Serialization/DefaultContractResolver.cs
@@ -1379,7 +1379,7 @@ namespace Microsoft.Identity.Json.Serialization
             // warning - this method use to cause errors with Intellitrace. Retest in VS Ultimate after changes
             IValueProvider valueProvider;
 
-#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC || UNITY_LTS)
+#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC || UNITY)
             if (DynamicCodeGeneration)
             {
                 valueProvider = new DynamicValueProvider(member);
@@ -1388,7 +1388,7 @@ namespace Microsoft.Identity.Json.Serialization
             {
                 valueProvider = new ReflectionValueProvider(member);
             }
-#elif !(PORTABLE40 || UNITY_LTS)
+#elif !(PORTABLE40 || UNITY)
             valueProvider = new ExpressionValueProvider(member);
 #else
             valueProvider = new ReflectionValueProvider(member);

--- a/src/client/Microsoft.Identity.Client/json/Serialization/ExpressionValueProvider.cs
+++ b/src/client/Microsoft.Identity.Client/json/Serialization/ExpressionValueProvider.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET20 || NET35)
+#if !(NET20 || NET35 || UNITY_LTS)
 
 using System;
 using System.Collections.Generic;

--- a/src/client/Microsoft.Identity.Client/json/Serialization/ExpressionValueProvider.cs
+++ b/src/client/Microsoft.Identity.Client/json/Serialization/ExpressionValueProvider.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET20 || NET35 || UNITY_LTS)
+#if !(NET20 || NET35 || UNITY)
 
 using System;
 using System.Collections.Generic;

--- a/src/client/Microsoft.Identity.Client/json/Serialization/JsonTypeReflector.cs
+++ b/src/client/Microsoft.Identity.Client/json/Serialization/JsonTypeReflector.cs
@@ -515,15 +515,18 @@ namespace Microsoft.Identity.Json.Serialization
         {
             get
             {
-#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC)
+#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC || UNITY_LTS)
                 if (DynamicCodeGeneration)
                 {
                     return DynamicReflectionDelegateFactory.Instance;
                 }
 
                 return LateBoundReflectionDelegateFactory.Instance;
+
+#elif UNITY_LTS
+                 return LateBoundReflectionDelegateFactory.Instance;
 #else
-                return ExpressionReflectionDelegateFactory.Instance;
+                 return ExpressionReflectionDelegateFactory.Instance;
 #endif
             }
         }

--- a/src/client/Microsoft.Identity.Client/json/Serialization/JsonTypeReflector.cs
+++ b/src/client/Microsoft.Identity.Client/json/Serialization/JsonTypeReflector.cs
@@ -515,7 +515,7 @@ namespace Microsoft.Identity.Json.Serialization
         {
             get
             {
-#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC || UNITY_LTS)
+#if !(PORTABLE40 || PORTABLE || DOTNET || ANDROID || iOS || MAC || UNITY)
                 if (DynamicCodeGeneration)
                 {
                     return DynamicReflectionDelegateFactory.Instance;
@@ -523,7 +523,7 @@ namespace Microsoft.Identity.Json.Serialization
 
                 return LateBoundReflectionDelegateFactory.Instance;
 
-#elif UNITY_LTS
+#elif UNITY
                  return LateBoundReflectionDelegateFactory.Instance;
 #else
                  return ExpressionReflectionDelegateFactory.Instance;

--- a/src/client/Microsoft.Identity.Client/json/Utilities/ExpressionReflectionDelegateFactory.cs
+++ b/src/client/Microsoft.Identity.Client/json/Utilities/ExpressionReflectionDelegateFactory.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET20 || NET35)
+#if !(NET20 || NET35 || UNITY_LTS)
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/client/Microsoft.Identity.Client/json/Utilities/ExpressionReflectionDelegateFactory.cs
+++ b/src/client/Microsoft.Identity.Client/json/Utilities/ExpressionReflectionDelegateFactory.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET20 || NET35 || UNITY_LTS)
+#if !(NET20 || NET35 || UNITY)
 
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Microsoft.Identity.Test.Performance/JsonTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/JsonTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Microsoft.Identity.Client.Instance.Discovery;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Test.Unit;
+
+namespace Microsoft.Identity.Test.Performance
+{
+    public class JsonTests
+    {
+        private readonly string _msalTokenResponseJson;
+        private readonly MsalTokenResponse _msalTokenResponse;
+
+        private readonly string _instanceDiscoveryResponseJson;
+        private readonly InstanceDiscoveryResponse _instanceDiscoveryResponse;
+
+        private readonly string _oAuth2ResponseBaseJson;
+        private readonly OAuth2ResponseBase _oAuth2ResponseBase;
+
+        public JsonTests()
+        {
+            _oAuth2ResponseBase = InitOAuth2ResponseBase(new OAuth2ResponseBase());
+            _oAuth2ResponseBaseJson = JsonHelper.SerializeToJson<OAuth2ResponseBase>(_oAuth2ResponseBase);
+
+            _msalTokenResponse = InitMsalTokenResponse(new MsalTokenResponse());
+            _msalTokenResponseJson = JsonHelper.SerializeToJson<MsalTokenResponse>(_msalTokenResponse);
+
+            _instanceDiscoveryResponse = InitInstanceDiscoveryResponse(new InstanceDiscoveryResponse());
+            _instanceDiscoveryResponseJson = JsonHelper.SerializeToJson<InstanceDiscoveryResponse>(_instanceDiscoveryResponse);
+        }
+
+        private InstanceDiscoveryResponse InitInstanceDiscoveryResponse(InstanceDiscoveryResponse instanceDiscoveryResponse)
+        {
+            int entries = 30;
+            instanceDiscoveryResponse.TenantDiscoveryEndpoint = TestConstants.DiscoveryEndPoint;
+            instanceDiscoveryResponse.Metadata = new InstanceDiscoveryMetadataEntry[entries];
+
+            InitOAuth2ResponseBase(instanceDiscoveryResponse);
+
+            for (int i = 0; i < entries; i++)
+            {
+                instanceDiscoveryResponse.Metadata[i] = new InstanceDiscoveryMetadataEntry
+                {
+                    Aliases = new[] { "login.windows.net", "login.microsoftonline.com" },
+                    PreferredCache = "login.windows.net",
+                    PreferredNetwork = "login.microsoftonline.com"
+                };
+            }
+
+            return instanceDiscoveryResponse;
+        }
+
+        private OAuth2ResponseBase InitOAuth2ResponseBase(OAuth2ResponseBase oAuth2ResponseBase)
+        {
+            oAuth2ResponseBase.Error = "OAuth error";
+            oAuth2ResponseBase.SubError = "OAuth suberror";
+            oAuth2ResponseBase.ErrorDescription = "OAuth error description";
+            oAuth2ResponseBase.ErrorCodes = new[] { "error1", "error2", "error3" };
+            oAuth2ResponseBase.CorrelationId = "1234-123-1234";
+            oAuth2ResponseBase.Claims = "claim1 claim2";
+
+            return oAuth2ResponseBase;
+        }
+
+        private MsalTokenResponse InitMsalTokenResponse(MsalTokenResponse msalTokenResponse)
+        {
+            msalTokenResponse.TokenType = "token type";
+            msalTokenResponse.AccessToken = "access token";
+            msalTokenResponse.RefreshToken = "refresh token";
+            msalTokenResponse.Scope = "scope scope";
+            msalTokenResponse.ClientInfo = "client info";
+            msalTokenResponse.IdToken = "id token";
+            msalTokenResponse.ExpiresIn = 123;
+            msalTokenResponse.ExtendedExpiresIn = 12345;
+            msalTokenResponse.RefreshIn = 12333;
+            msalTokenResponse.FamilyId = "family id";
+
+            InitOAuth2ResponseBase(msalTokenResponse);
+
+            return msalTokenResponse;
+        }
+
+        [Benchmark]
+        public string Serialize_MsalTokenResponse_Test()
+        {
+            return JsonHelper.SerializeToJson<MsalTokenResponse>(_msalTokenResponse);
+        }
+
+        [Benchmark]
+        public string Deserialize_MsalTokenResponse_Test()
+        {
+            return JsonHelper.DeserializeFromJson<MsalTokenResponse>(_msalTokenResponseJson).CorrelationId;
+        }
+
+        [Benchmark]
+        public string Serialize_InstanceDiscoveryResponse_Test()
+        {
+            return JsonHelper.SerializeToJson<InstanceDiscoveryResponse>(_instanceDiscoveryResponse);
+        }
+
+        [Benchmark]
+        public string Deserialize_InstanceDiscoveryResponse_Test()
+        {
+            return JsonHelper.DeserializeFromJson<InstanceDiscoveryResponse>(_instanceDiscoveryResponseJson).CorrelationId;
+        }
+
+        [Benchmark]
+        public string Serialize_OAuth2ResponseBase_Test()
+        {
+            return JsonHelper.SerializeToJson<OAuth2ResponseBase>(_oAuth2ResponseBase);
+        }
+
+        [Benchmark]
+        public string Deserialize_OAuth2ResponseBase_Test()
+        {
+            return JsonHelper.DeserializeFromJson<OAuth2ResponseBase>(_oAuth2ResponseBaseJson).CorrelationId;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Test.Performance/Program.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Identity.Test.Performance
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<CryptoManagerTests>(
+            BenchmarkRunner.Run<JsonTests>(
                 DefaultConfig.Instance
                     .WithOptions(ConfigOptions.DontOverwriteResults)
                     .AddJob(


### PR DESCRIPTION
One of the possible solutions to #2428.

Adds a Unity preprocessor flag. Updates the JSON.NET code to use late bound serializers for Unity.

- [x] Make code changes
- [x] Run perf tests before & after change.

**Perf test results**
NetCore3.1 before changes:
|                                     Method |      Mean |     Error |    StdDev |
|------------------------------------------- |----------:|----------:|----------:|
|           Serialize_MsalTokenResponse_Test |  7.819 μs | 0.0984 μs | 0.0920 μs |
|         Deserialize_MsalTokenResponse_Test | 12.899 μs | 0.1522 μs | 0.1423 μs |
|   Serialize_InstanceDiscoveryResponse_Test | 41.662 μs | 0.0342 μs | 0.0267 μs |
| Deserialize_InstanceDiscoveryResponse_Test | 72.998 μs | 0.8727 μs | 0.7288 μs |
|          Serialize_OAuth2ResponseBase_Test |  2.213 μs | 0.0152 μs | 0.0134 μs |
|        Deserialize_OAuth2ResponseBase_Test |  3.852 μs | 0.0332 μs | 0.0295 μs |

NetCore3.1 after changes:
|                                     Method |      Mean |     Error |    StdDev |
|------------------------------------------- |----------:|----------:|----------:|
|           Serialize_MsalTokenResponse_Test |  8.112 μs | 0.1621 μs | 0.1991 μs |
|         Deserialize_MsalTokenResponse_Test | 13.649 μs | 0.2716 μs | 0.2789 μs |
|   Serialize_InstanceDiscoveryResponse_Test | 42.060 μs | 0.5941 μs | 0.5267 μs |
| Deserialize_InstanceDiscoveryResponse_Test | 74.561 μs | 1.1682 μs | 0.9755 μs |
|          Serialize_OAuth2ResponseBase_Test |  2.240 μs | 0.0425 μs | 0.0398 μs |
|        Deserialize_OAuth2ResponseBase_Test |  4.008 μs | 0.0425 μs | 0.0398 μs |

Net472 before changes:
|                                     Method |      Mean |     Error |    StdDev |
|------------------------------------------- |----------:|----------:|----------:|
|           Serialize_MsalTokenResponse_Test |  4.139 μs | 0.0195 μs | 0.0163 μs |
|         Deserialize_MsalTokenResponse_Test |  8.706 μs | 0.0936 μs | 0.0830 μs |
|   Serialize_InstanceDiscoveryResponse_Test | 28.913 μs | 0.3980 μs | 0.3528 μs |
| Deserialize_InstanceDiscoveryResponse_Test | 46.775 μs | 0.6654 μs | 0.6224 μs |
|          Serialize_OAuth2ResponseBase_Test |  1.566 μs | 0.0201 μs | 0.0167 μs |
|        Deserialize_OAuth2ResponseBase_Test |  2.635 μs | 0.0167 μs | 0.0148 μs |

Net472 after changes:
|                                     Method |      Mean |     Error |    StdDev |
|------------------------------------------- |----------:|----------:|----------:|
|           Serialize_MsalTokenResponse_Test |  7.405 μs | 0.0803 μs | 0.0712 μs |
|         Deserialize_MsalTokenResponse_Test | 13.201 μs | 0.0551 μs | 0.0488 μs |
|   Serialize_InstanceDiscoveryResponse_Test | 41.115 μs | 0.5279 μs | 0.4408 μs |
| Deserialize_InstanceDiscoveryResponse_Test | 78.641 μs | 0.4463 μs | 0.4175 μs |
|          Serialize_OAuth2ResponseBase_Test |  2.341 μs | 0.0135 μs | 0.0120 μs |
|        Deserialize_OAuth2ResponseBase_Test |  4.302 μs | 0.0077 μs | 0.0068 μs |