### PR TITLE
Bogavril/wv2 options

### DIFF
--- a/build/platform_and_feature_flags.props
+++ b/build/platform_and_feature_flags.props
@@ -1,18 +1,18 @@
 <Project>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetCore)' ">
-    <DefineConstants>$(DefineConstants);NET_CORE;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;SUPPORTS_BROKER</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET_CORE;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;SUPPORTS_BROKER;SUPPORTS_WEBVIEW2</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNet5Win)' ">
-    <DefineConstants>$(DefineConstants);NET5_WIN;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;SUPPORTS_BROKER</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET5_WIN;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;SUPPORTS_BROKER;SUPPORTS_WEBVIEW2</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkUap)' ">
     <DefineConstants>$(DefineConstants);WINDOWS_APP;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <DefineConstants>$(DefineConstants);ANDROID;SUPPORTS_BROKER;</DefineConstants>
+    <DefineConstants>$(DefineConstants);ANDROID;SUPPORTS_BROKER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetDesktop45)' Or '$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)' ">
-    <DefineConstants>$(DefineConstants);DESKTOP;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;</DefineConstants>
+    <DefineConstants>$(DefineConstants);DESKTOP;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;SUPPORTS_WEBVIEW2</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)'">
     <DefineConstants>$(DefineConstants);SUPPORTS_BROKER</DefineConstants>
@@ -24,6 +24,6 @@
     <DefineConstants>$(DefineConstants);MAC;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE;SUPPORTS_OS_SYSTEM_BROWSER;SUPPORTS_WEBVIEW2</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Client.Desktop
                     coreUIParent.SystemWebViewOptions);
             }
 
-            if (_isWebView2AvailableFunc(coreUIParent?.WebView2Options?.BrowserExecutableFolder))
+            if (_isWebView2AvailableFunc(coreUIParent?.EmbeddedWebviewOptions?.WebView2BrowserExecutableFolder))
             {
                 requestContext.Logger.Info("Using WebView2 embedded browser");
                 return new WebView2WebUi(coreUIParent, requestContext);

--- a/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
@@ -63,9 +63,16 @@ namespace Microsoft.Identity.Client.Desktop
 
         private bool IsWebView2Available(string browserExecutableFolder)
         {
-            // if browserExecutableFolder is null, WebView2 SDK will choose global runtime, otherwise, a local runtime.
-            string wv2Version = CoreWebView2Environment.GetAvailableBrowserVersionString(browserExecutableFolder);
-            return !string.IsNullOrEmpty(wv2Version);
+            try
+            {
+
+                string wv2Version = CoreWebView2Environment.GetAvailableBrowserVersionString(browserExecutableFolder);
+                return !string.IsNullOrEmpty(wv2Version);
+            }
+            catch (WebView2RuntimeNotFoundException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client.Desktop/WamExtension.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/WamExtension.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Client.Desktop
                     MsalErrorMessage.ExperimentalFeature(nameof(WithWindowsBroker)));
             }
 
-            builder.Config.IsBrokerEnabled = true;
+            builder.Config.IsBrokerEnabled = enableBroker;
             AddSupportForWam(builder);
             return builder;
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
@@ -115,6 +115,25 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+        // Remark: Default browser WebUI is not available on mobile (Android, iOS, UWP), but allow it at runtime
+        // to avoid MissingMethodException
+        /// <summary>
+        /// Specifies options for using the system OS browser handle interactive authentication.
+        /// </summary>
+        /// <param name="options">Data object with options</param>
+        /// <returns>The builder to chain the .With methods</returns>
+#if !SUPPORTS_WEBVIEW2
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] // hide everywhere but NetStandard
+#endif
+        public AcquireTokenInteractiveParameterBuilder WithWebView2Options(WebView2Options options)
+        {
+            WebView2Options.ValidatePlatformAvailability();
+
+            CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSystemBrowserOptions);
+            Parameters.UiParent.WebView2Options = options;
+            return this;
+        }
+
         /// <summary>
         /// Sets the <paramref name="loginHint"/>, in order to avoid select account
         /// dialogs in the case the user is signed-in with several identities. This method is mutually exclusive

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Client
         #if !SUPPORTS_WEBVIEW2 // currently only WebView2 allows customization
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         #endif
-        public AcquireTokenInteractiveParameterBuilder WithEmbeddedWebviewOptions(
+        public AcquireTokenInteractiveParameterBuilder WithEmbeddedWebViewOptions(
             EmbeddedWebViewOptions options)
         {
             EmbeddedWebViewOptions.ValidatePlatformAvailability();

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
@@ -115,22 +115,21 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
-        // Remark: Default browser WebUI is not available on mobile (Android, iOS, UWP), but allow it at runtime
-        // to avoid MissingMethodException
         /// <summary>
-        /// Specifies options for using the system OS browser handle interactive authentication.
+        /// Specifies options for using the embedded wevbiew for interactive authentication.
         /// </summary>
         /// <param name="options">Data object with options</param>
         /// <returns>The builder to chain the .With methods</returns>
-#if !SUPPORTS_WEBVIEW2
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] // hide everywhere but NetStandard
-#endif
-        public AcquireTokenInteractiveParameterBuilder WithWebView2Options(WebView2Options options)
+        #if !SUPPORTS_WEBVIEW2 // currently only WebView2 allows customization
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        #endif
+        public AcquireTokenInteractiveParameterBuilder WithEmbeddedWebviewOptions(
+            EmbeddedWebViewOptions options)
         {
-            WebView2Options.ValidatePlatformAvailability();
+            EmbeddedWebViewOptions.ValidatePlatformAvailability();
 
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSystemBrowserOptions);
-            Parameters.UiParent.WebView2Options = options;
+            Parameters.UiParent.EmbeddedWebviewOptions = options;
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/EmbeddedWebViewOptions.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/EmbeddedWebViewOptions.cs
@@ -18,35 +18,39 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_WEBVIEW2
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 #endif
-    public class WebView2Options
+    public class EmbeddedWebViewOptions
     {
         /// <summary>
-        /// Constructor
         /// </summary>
-        public WebView2Options()
+        public EmbeddedWebViewOptions()
         {
             ValidatePlatformAvailability();
+        }
+
+        internal static EmbeddedWebViewOptions GetDefaultOptions()
+        {
+            return new EmbeddedWebViewOptions();
         }
 
         /// <summary>
         /// Forces a static title to be set on the window hosting the browser. If not configured, the widow's title is set to the web page title.
         /// </summary>
+        /// <remarks>Currently only affects WebView2 browser on Windows.</remarks>
         public string Title { get; set; }
 
         /// <summary>
-        /// 
         /// It is possible for applications to bundle a fixed version of the runtime, and ship it side-by-side.
         /// For this you need to tell MSAL (so it can tell WebView2) where to find the runtime bits by setting this property. If you don't set it, MSAL will attempt to use a system-wide "evergreen" installation of the runtime."
         /// For more details see: https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createasync?view=webview2-dotnet-1.0.705.50
         /// </summary>
-        public string BrowserExecutableFolder { get; set; }
+        public string WebView2BrowserExecutableFolder { get; set; }
 
         internal void LogParameters(ICoreLogger logger)
         {
             logger.Info("WebView2Options configured");
 
             logger.Info($"Title: {Title}");
-            logger.InfoPii($"BrowserExecutableFolder: {BrowserExecutableFolder}", "BrowserExecutableFolder set");
+            logger.InfoPii($"BrowserExecutableFolder: {WebView2BrowserExecutableFolder}", "BrowserExecutableFolder set");
         }
 
         internal static void ValidatePlatformAvailability()

--- a/src/client/Microsoft.Identity.Client/ApiConfig/WebView2Options.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/WebView2Options.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal.Logger;
+using Microsoft.Identity.Client.PlatformsCommon.Factories;
+
+namespace Microsoft.Identity.Client
+{
+    /// <summary>
+    /// Options for using the modern Windows embedded browser WebView2. 
+    /// For more details see https://aka.ms/msal-net-webview2
+    /// </summary>
+#if !SUPPORTS_WEBVIEW2
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+#endif
+    public class WebView2Options
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public WebView2Options()
+        {
+            ValidatePlatformAvailability();
+        }
+
+        /// <summary>
+        /// Forces a static title to be set on the window hosting the browser. If not configured, the widow's title is set to the web page title.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// 
+        /// It is possible for applications to bundle a fixed version of the runtime, and ship it side-by-side.
+        /// For this you need to tell MSAL (so it can tell WebView2) where to find the runtime bits by setting this property. If you don't set it, MSAL will attempt to use a system-wide "evergreen" installation of the runtime."
+        /// For more details see: https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createasync?view=webview2-dotnet-1.0.705.50
+        /// </summary>
+        public string BrowserExecutableFolder { get; set; }
+
+        internal void LogParameters(ICoreLogger logger)
+        {
+            logger.Info("WebView2Options configured");
+
+            logger.Info($"Title: {Title}");
+            logger.InfoPii($"BrowserExecutableFolder: {BrowserExecutableFolder}", "BrowserExecutableFolder set");
+        }
+
+        internal static void ValidatePlatformAvailability()
+        {
+#if !SUPPORTS_WEBVIEW2
+            throw new PlatformNotSupportedException(
+                "WebView2Options API is only supported on .NET Fx, .NET Core and .NET5 ");
+#endif
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
         {
             using (var form = new WinFormsPanelWithWebView2(
                 _parent.OwnerWindow, 
+                _parent?.WebView2Options,
                 _requestContext.Logger, 
                 startUri, 
                 endUri))

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
         {
             using (var form = new WinFormsPanelWithWebView2(
                 _parent.OwnerWindow, 
-                _parent?.WebView2Options,
+                _parent?.EmbeddedWebviewOptions,
                 _requestContext.Logger, 
                 startUri, 
                 endUri))

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
     internal class WinFormsPanelWithWebView2 : Form
     {
         private const int UIWidth = 566;
-        private readonly WebView2Options _webView2Options; // can be null
+        private readonly EmbeddedWebViewOptions _embeddedWebViewOptions; 
         private readonly ICoreLogger _logger;
         private readonly Uri _startUri;
         private readonly Uri _endUri;
@@ -35,12 +35,12 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
 
         public WinFormsPanelWithWebView2(
          object ownerWindow,
-         WebView2Options webView2Options,
+         EmbeddedWebViewOptions embeddedWebViewOptions,
          ICoreLogger logger,
          Uri startUri,
          Uri endUri)
         {
-            _webView2Options = webView2Options; // can be null
+            _embeddedWebViewOptions = embeddedWebViewOptions ?? EmbeddedWebViewOptions.GetDefaultOptions();
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _startUri = startUri ?? throw new ArgumentNullException(nameof(startUri));
             _endUri = endUri ?? throw new ArgumentNullException(nameof(endUri));
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             InitializeComponent();
 
             _webView2.CreationProperties = new CoreWebView2CreationProperties() { 
-                    BrowserExecutableFolder = _webView2Options?.BrowserExecutableFolder 
+                    BrowserExecutableFolder = _embeddedWebViewOptions.WebView2BrowserExecutableFolder 
             };
 
         }
@@ -261,13 +261,13 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             _webView2.CoreWebView2.Settings.IsZoomControlEnabled = false;
             _webView2.CoreWebView2.Settings.IsStatusBarEnabled = true;
 
-            if (_webView2Options?.Title == null)
+            if (_embeddedWebViewOptions.Title == null)
             {
                 _webView2.CoreWebView2.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
             }
             else
             {
-                Text = _webView2Options.Title;
+                Text = _embeddedWebViewOptions.Title;
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
     internal class WinFormsPanelWithWebView2 : Form
     {
         private const int UIWidth = 566;
+        private readonly WebView2Options _webView2Options; // can be null
         private readonly ICoreLogger _logger;
         private readonly Uri _startUri;
         private readonly Uri _endUri;
@@ -34,14 +35,15 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
 
         public WinFormsPanelWithWebView2(
          object ownerWindow,
+         WebView2Options webView2Options,
          ICoreLogger logger,
          Uri startUri,
          Uri endUri)
         {
-            // TODO: title
-            _logger = logger;
-            _startUri = startUri;
-            _endUri = endUri;
+            _webView2Options = webView2Options; // can be null
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _startUri = startUri ?? throw new ArgumentNullException(nameof(startUri));
+            _endUri = endUri ?? throw new ArgumentNullException(nameof(endUri));
 
             if (ownerWindow == null)
             {
@@ -62,6 +64,11 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             }
 
             InitializeComponent();
+
+            _webView2.CreationProperties = new CoreWebView2CreationProperties() { 
+                    BrowserExecutableFolder = _webView2Options?.BrowserExecutableFolder 
+            };
+
         }
 
         public AuthorizationResult DisplayDialogAndInterceptUri()
@@ -253,12 +260,20 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             _webView2.CoreWebView2.Settings.IsScriptEnabled = true;
             _webView2.CoreWebView2.Settings.IsZoomControlEnabled = false;
             _webView2.CoreWebView2.Settings.IsStatusBarEnabled = true;
-            _webView2.CoreWebView2.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
+
+            if (_webView2Options?.Title == null)
+            {
+                _webView2.CoreWebView2.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
+            }
+            else
+            {
+                Text = _webView2Options.Title;
+            }
         }
 
         private void CoreWebView2_DocumentTitleChanged(object sender, object e)
         {
-            this.Text = _webView2.CoreWebView2.DocumentTitle ?? "";
+            Text = _webView2.CoreWebView2.DocumentTitle ?? "";
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client.Platforms.net5win
             }
 
 
-            if (_isWebView2AvailableFunc(coreUIParent?.WebView2Options?.BrowserExecutableFolder))
+            if (_isWebView2AvailableFunc(coreUIParent?.EmbeddedWebviewOptions?.WebView2BrowserExecutableFolder))
             {
                 requestContext.Logger.Info("Using WebView2 embedded browser");
                 return new WebView2WebUi(coreUIParent, requestContext);

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -49,8 +49,16 @@ namespace Microsoft.Identity.Client.Platforms.net5win
 
         private bool IsWebView2Available(string browserExecutableFolder)
         {
-            string wv2Version = CoreWebView2Environment.GetAvailableBrowserVersionString(browserExecutableFolder);
-            return !string.IsNullOrEmpty(wv2Version);
+            try
+            {
+                string wv2Version = CoreWebView2Environment.GetAvailableBrowserVersionString(browserExecutableFolder);
+                return !string.IsNullOrEmpty(wv2Version);
+            }
+            catch (WebView2RuntimeNotFoundException)
+            {
+                return false;
+            }
         }
     }
 }
+

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Identity.Client.Platforms.net5win
 {
     internal class Net5WebUiFactory : IWebUIFactory
     {
-        private readonly Func<bool> _isWebView2AvailableFunc;
+        private readonly Func<string, bool> _isWebView2AvailableFunc;
 
-        public Net5WebUiFactory(Func<bool> isWebView2AvailableForTest = null)
+        public Net5WebUiFactory(Func<string, bool> isWebView2AvailableForTest = null)
         {
             _isWebView2AvailableFunc = isWebView2AvailableForTest ?? IsWebView2Available;
         }
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client.Platforms.net5win
             }
 
 
-            if (_isWebView2AvailableFunc())
+            if (_isWebView2AvailableFunc(coreUIParent?.WebView2Options?.BrowserExecutableFolder))
             {
                 requestContext.Logger.Info("Using WebView2 embedded browser");
                 return new WebView2WebUi(coreUIParent, requestContext);
@@ -47,9 +47,9 @@ namespace Microsoft.Identity.Client.Platforms.net5win
                 " If you are an app developer, please ensure that your app installs the WebView2 runtime https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution");
         }
 
-        private bool IsWebView2Available()
+        private bool IsWebView2Available(string browserExecutableFolder)
         {
-            string wv2Version = CoreWebView2Environment.GetAvailableBrowserVersionString();
+            string wv2Version = CoreWebView2Environment.GetAvailableBrowserVersionString(browserExecutableFolder);
             return !string.IsNullOrEmpty(wv2Version);
         }
     }

--- a/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
+++ b/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Identity.Client.UI
         internal SynchronizationContext SynchronizationContext { get; set; }
 
         internal SystemWebViewOptions SystemWebViewOptions { get; set; }
+        internal WebView2Options WebView2Options { get; set; }
 
 #if MAC
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
+++ b/src/client/Microsoft.Identity.Client/UI/CoreUIParent.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Client.UI
         internal SynchronizationContext SynchronizationContext { get; set; }
 
         internal SystemWebViewOptions SystemWebViewOptions { get; set; }
-        internal WebView2Options WebView2Options { get; set; }
+        internal EmbeddedWebViewOptions EmbeddedWebviewOptions { get; set; }
 
 #if MAC
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/MsalDesktopWebUiTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Arrange
             var webUIFactory = new MsalDesktopWebUiFactory(
                 fallbackToLegacyWebBrowser: false, 
-                isWebView2AvailableForTest: () => true);
+                isWebView2AvailableForTest: (_) => true);
 
 
             // Act
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Arrange
             var webUIFactory = new MsalDesktopWebUiFactory(
                 fallbackToLegacyWebBrowser: true,
-                isWebView2AvailableForTest: () => false);
+                isWebView2AvailableForTest: (_) => false);
 
 
             // Act
@@ -76,7 +76,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Arrange
             var webUIFactory = new MsalDesktopWebUiFactory(
                fallbackToLegacyWebBrowser: false,
-               isWebView2AvailableForTest: () => false);
+               isWebView2AvailableForTest: (_) => false);
 
 
             // Act
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Arrange
             var webUIFactory = new MsalDesktopWebUiFactory(
                fallbackToLegacyWebBrowser: false,
-               isWebView2AvailableForTest: () => true);
+               isWebView2AvailableForTest: (_) => true);
 
             // Act
             var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContext);
@@ -111,7 +111,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             // Arrange
             var webUIFactory = new MsalDesktopWebUiFactory(
               fallbackToLegacyWebBrowser: false,
-              isWebView2AvailableForTest: () => true);
+              isWebView2AvailableForTest: (_) => true);
 
             // Act
             var webUi = webUIFactory.CreateAuthenticationDialog(

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/Net5WebUIFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/Net5WebUIFactoryTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
         public void DefaultEmbedded_WebView2Available()
         {
             // Arrange
-            var webUIFactory = new Net5WebUiFactory(() => true);
+            var webUIFactory = new Net5WebUiFactory((_) => true);
 
 
             // Act
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
         public void DefaultEmbedded_WebView2NotAvailable()
         {
             // Arrange
-            var webUIFactory = new Net5WebUiFactory(() => false);
+            var webUIFactory = new Net5WebUiFactory((_) => false);
 
 
             // Act
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
         public void Embedded()
         {
             // Arrange
-            var webUIFactory = new Net5WebUiFactory(() => true);
+            var webUIFactory = new Net5WebUiFactory((_) => true);
 
             // Act
             var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContext);

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -77,6 +77,7 @@ namespace NetDesktopWinForms
                 // there is no need to construct the PCA with this redirect URI, 
                 // but WAM uses it. We could enforce it.
                 //.WithRedirectUri($"ms-appx-web://microsoft.aad.brokerplugin/{clientId}")
+                .WithRedirectUri("http://localhost")
                 .WithMsaPassthrough(msaPt)
                 .WithLogging((x, y, z) => Debug.WriteLine($"{x} {y}"), LogLevel.Verbose, true)
                 .Build();
@@ -245,6 +246,12 @@ namespace NetDesktopWinForms
             var scopes = GetScopes();
 
             var builder = pca.AcquireTokenInteractive(scopes)
+                .WithUseEmbeddedWebView(true)
+                .WithWebView2Options(
+                new WebView2Options() { 
+                    Title = "Hello world", 
+                    BrowserExecutableFolder = @"C:\Users\bogavril\Downloads\Microsoft.WebView2.FixedVersionRuntime.88.0.705.81.x64\Microsoft.WebView2.FixedVersionRuntime.88.0.705.81.x64"
+                })
                 .WithParentActivityOrWindow(this.Handle);
 
 

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -247,7 +247,7 @@ namespace NetDesktopWinForms
 
             var builder = pca.AcquireTokenInteractive(scopes)
                 .WithUseEmbeddedWebView(true)
-                .WithEmbeddedWebviewOptions(
+                .WithEmbeddedWebViewOptions(
                 new EmbeddedWebViewOptions() { 
                     Title = "Hello world",                     
                 })

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -247,10 +247,9 @@ namespace NetDesktopWinForms
 
             var builder = pca.AcquireTokenInteractive(scopes)
                 .WithUseEmbeddedWebView(true)
-                .WithWebView2Options(
-                new WebView2Options() { 
-                    Title = "Hello world", 
-                    BrowserExecutableFolder = @"C:\Users\bogavril\Downloads\Microsoft.WebView2.FixedVersionRuntime.88.0.705.81.x64\Microsoft.WebView2.FixedVersionRuntime.88.0.705.81.x64"
+                .WithEmbeddedWebviewOptions(
+                new EmbeddedWebViewOptions() { 
+                    Title = "Hello world",                     
                 })
                 .WithParentActivityOrWindow(this.Handle);
 


### PR DESCRIPTION
Expose the ability for developers to set a fixed Title for their WebView2 panel and to use a fixed version WV2, as the installer for the global one needs admin permissions.

Missing unit tests.