### PR TITLE
Add IsBrokerAvailable, IsEmbeddedWebviewAvailable and IsUserInteractive

### DIFF
--- a/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Identity.Client.Desktop
             _isWebView2AvailableFunc = isWebView2AvailableForTest ?? IsWebView2Available;
         }
 
-        public bool IsSystemWebViewAvailable => IsDesktopSession;
+        public bool IsSystemWebViewAvailable => IsUserInteractive;
 
-        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+        public bool IsUserInteractive => DesktopOsHelper.IsUserInteractive();
 
-        public bool IsEmbeddedWebviewAvailable => IsDesktopSession && IsWebView2Available();
+        public bool IsEmbeddedWebViewAvailable => IsUserInteractive && IsWebView2Available();
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 

--- a/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client.Desktop
 
         public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
 
-        public bool IsEmbeddedWebviewAvailable => throw new NotImplementedException();
+        public bool IsEmbeddedWebviewAvailable => IsDesktopSession && IsWebView2Available();
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client.Desktop
         }
 
 
-        private bool IsWebView2Available(string browserExecutableFolder)
+        private bool IsWebView2Available(string browserExecutableFolder = null)
         {
             try
             {

--- a/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/MsalDesktopWebUiFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
@@ -24,7 +25,11 @@ namespace Microsoft.Identity.Client.Desktop
             _isWebView2AvailableFunc = isWebView2AvailableForTest ?? IsWebView2Available;
         }
 
-        public bool IsSystemWebViewAvailable => true;
+        public bool IsSystemWebViewAvailable => IsDesktopSession;
+
+        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+
+        public bool IsEmbeddedWebviewAvailable => throw new NotImplementedException();
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 

--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Identity.Client
         /// <returns>A <see cref="PublicClientApplicationBuilder"/> from which to set more
         /// parameters, and to create a public client application instance</returns>
         /// <remarks>If your app uses .NET classic or .NET Core 3.x, and you wish to use the Windows broker, 
-        /// please install the nuget package Microsoft.Identity.Client.Desktop and call .WithWindowsBroker(true)</remarks>
+        /// please install the nuget package Microsoft.Identity.Client.Desktop and call .WithDesktopFeatures()</remarks>
         public PublicClientApplicationBuilder WithBroker(bool enableBroker = true)
         {
 #if NET45
@@ -276,6 +276,23 @@ namespace Microsoft.Identity.Client
             return WithParentFunc(() => (object)windowFunc());
         }
 #endif
+
+        /// <summary>
+        /// Returns true if a broker can be used. 
+        /// </summary>
+        /// <remarks>
+        /// On Windows, the broker (WAM) can be used on Win10 and is always installed. See https://aka.ms/msal-net-wam
+        /// On Mac, Linux and older versions of Windows a broker is not available.
+        /// If your application is .NET5, please use the target .net5.0-windows10.0.17763.0 for all Windows versions and target net5.0 to target Linux and Mac.
+        /// If your application is .NET classic or .NET Core 3.1 and you wish to use the Windows Broker, please install Microsoft.Identity.Client.Desktop first and call WithDesktopFeatures().
+        /// 
+        /// On mobile, the device must be Intune joined and Authenticator or Company Portal must be installed. See https://aka.ms/msal-brokers
+        /// </remarks>
+        public bool IsBrokerAvailable()
+        {            
+            return PlatformProxyFactory.CreatePlatformProxy(null)
+                .CreateBroker(base.Config, null).IsBrokerInstalledAndInvokable();
+        }
 
         /// <summary>
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/Extensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensions.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client
+{
+    /// <summary>
+    /// Extension methods
+    /// </summary>
+    public static class Extensions // TODO MSAL5: move these to their parent types
+    {
+        /// <summary>
+        /// Returns true if MSAL can use a system browser.
+        /// </summary>
+        /// <remarks>
+        /// On Windows, Mac and Linux a system browser can always be used, except in cases where there is no UI, e.g. SSH connection.
+        /// On Android, the browser must support tabs.
+        /// </remarks>
+        public static bool IsSystemWebViewAvailable(this IPublicClientApplication publicClientApplication)
+        {
+            if (publicClientApplication is PublicClientApplication pca)
+            {
+                return pca.IsSystemWebViewAvailable;
+            }
+
+            throw new ArgumentException("This extension method is only available for the PublicClientApplication implementation " +
+                "of the IPublicClientApplication interface.");
+
+        }
+
+        /// <summary>
+        /// Returns true if MSAL can use an embedded webview (browser). 
+        /// </summary>
+        /// <remarks>
+        /// Currently there are no embedded webviews on Mac and Linux. On Windows, app developers or users should install 
+        /// the WebView2 runtime and this property will inform if the runtime is available, see https://aka.ms/msal-net-webview2
+        /// </remarks>
+        public static bool IsEmbeddedWebViewAvailable(this IPublicClientApplication publicClientApplication)
+        {
+            if (publicClientApplication is PublicClientApplication pca)
+            {
+                return pca.IsEmbeddedWebViewAvailable();
+            }
+
+            throw new ArgumentException("This extension method is only available for the PublicClientApplication implementation " +
+                "of the IPublicClientApplication interface.");
+        }
+
+        /// <summary>
+        /// Returns false when the program runs in headless OS, for example when SSH-ed into a Linux machine.
+        /// Browsers (webviews) and brokers cannot be used if there is no UI support. Instead, please use <see cref="PublicClientApplication.AcquireTokenWithDeviceCode(IEnumerable{string}, Func{DeviceCodeResult, Task})"/>
+        /// </summary>
+        public static bool IsDesktopSession(this IPublicClientApplication publicClientApplication)
+        {
+            if (publicClientApplication is PublicClientApplication pca)
+            {
+                return pca.IsDesktopSession();
+            }
+
+            throw new ArgumentException("This extension method is only available for the PublicClientApplication implementation " +
+                "of the IPublicClientApplication interface.");
+        }
+
+        /// <summary>
+        /// Returns the certificate used to create this <see cref="ConfidentialClientApplication"/>, if any.
+        /// </summary>
+        public static X509Certificate2 GetCertificate(this IConfidentialClientApplication confidentialClientApplication)
+        {
+
+            if (confidentialClientApplication is ConfidentialClientApplication cca)
+            {
+                return cca.Certificate;
+            }
+
+            throw new ArgumentException("This extension method is only available for the ConfidentialClientApplication implementation " +
+                "of the IConfidentialClientApplication interface.");
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Extensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensions.cs
@@ -65,6 +65,25 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// Returns true if a broker can be used. 
+        /// </summary>
+        /// <remarks>
+        /// On Windows, the broker (WAM) can be used on Win10 and is always installed.
+        /// On Mac, Linux and older versions of Windows a broker is not available.
+        /// On mobile, the device must be Intune joined and Authenticator or Company Portal must be installed.
+        /// </remarks>
+        public static bool IsBrokerAvailable(this IPublicClientApplication publicClientApplication)
+        {
+            if (publicClientApplication is PublicClientApplication pca)
+            {
+                return pca.IsBrokerAvailable();
+            }
+
+            throw new ArgumentException("This extension method is only available for the PublicClientApplication implementation " +
+                "of the IPublicClientApplication interface.");
+        }
+
+        /// <summary>
         /// Returns the certificate used to create this <see cref="ConfidentialClientApplication"/>, if any.
         /// </summary>
         public static X509Certificate2 GetCertificate(this IConfidentialClientApplication confidentialClientApplication)

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -7,10 +7,10 @@
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
     <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
     <TargetFrameworkUap>uap10.0</TargetFrameworkUap>
-    <!--<TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
+    <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
 
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac)</TargetFrameworks>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -7,10 +7,10 @@
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
     <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
     <TargetFrameworkUap>uap10.0</TargetFrameworkUap>
-    <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
+    <!--<TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
 
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac)</TargetFrameworks>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -58,6 +58,7 @@
     <!-- Need to include / exclude / remove cs files manually so that they are present in both assemblies -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NoWarn>$(NoWarn);CS8002;NU5131;</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
   </PropertyGroup>
 
@@ -121,13 +122,13 @@
     <None Include="$(PathToMsalSources)\**\*.cs;$(PathToMsalSources)\**\*.xml;$(PathToMsalSources)\**\*.axml" Exclude="$(PathToMsalSources)\obj\**\*.*;$(PathToMsalSources)\bin\**\*.*" />
     <!-- Manually include the cs files -->
     <Compile Include="$(PathToMsalSources)\**\*.cs" Exclude="$(PathToMsalSources)\obj\**\*.*" />
-    <Compile Remove="$(PathToMsalSources)\Platforms\**\*.*;$(PathToMsalSources)\Resources\*.cs" />
-
+    <Compile Remove="$(PathToMsalSources)\Platforms\**\*.*;$(PathToMsalSources)\Resources\*.cs" />    
     <EmbeddedResource Include="$(PathToMsalSources)\Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
     <Compile Include="$(PathToMsalSources)\Platforms\netstandard13\**\*.cs" LinkBase="Platforms\netstandard13" />
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\DesktopOs\**\*.cs" />
 
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
@@ -147,7 +148,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetCore)' ">
     <Compile Include="$(PathToMsalSources)\Platforms\netcore\**\*.cs" LinkBase="Platforms\netcore" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\DefaultOSBrowser\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Platforms\Features\win32\**\*.cs" />
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\DesktopOs\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNet5Win)' ">
@@ -157,8 +158,8 @@
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WamBroker\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsLegacyWebUi\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WebView2WebUi\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Platforms\Features\win32\**\*.cs" />
-
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\DesktopOs\**\*.cs" />
+    
     <!-- This package reference is here to fix a bug in the WinRT interop. 
     It should not be required after the December release of .NET 5 SDK -->
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.1.0" />
@@ -176,7 +177,7 @@
     <Compile Include="$(PathToMsalSources)\Platforms\netdesktop\**\*.cs" LinkBase="Platforms\netdesktop" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\DefaultOSBrowser\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsLegacyWebUi\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Platforms\Features\win32\**\*.cs" />
+    <Compile Include="$(PathToMsalSources)\Platforms\Features\DesktopOs\**\*.cs" />
 
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/client/Microsoft.Identity.Client/OsCapabilitiesExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/OsCapabilitiesExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Identity.Client
         /// Instead, please use <see cref="PublicClientApplication.AcquireTokenWithDeviceCode(IEnumerable{string}, Func{DeviceCodeResult, Task})"/>
         /// or <see cref="PublicClientApplication.AcquireTokenByIntegratedWindowsAuth(IEnumerable{string})"/>
         /// </summary>
-        public static bool IsDesktopSession(this IPublicClientApplication publicClientApplication)
+        public static bool IsUserInteractive(this IPublicClientApplication publicClientApplication)
         {
             if (publicClientApplication is PublicClientApplication pca)
             {

--- a/src/client/Microsoft.Identity.Client/OsCapabilitiesExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/OsCapabilitiesExtensions.cs
@@ -68,24 +68,7 @@ namespace Microsoft.Identity.Client
                 "of the IPublicClientApplication interface.");
         }
 
-        /// <summary>
-        /// Returns true if a broker can be used. 
-        /// </summary>
-        /// <remarks>
-        /// On Windows, the broker (WAM) can be used on Win10 and is always installed. See https://aka.ms/msal-net-wam
-        /// On Mac, Linux and older versions of Windows a broker is not available.
-        /// On mobile, the device must be Intune joined and Authenticator or Company Portal must be installed. See https://aka.ms/msal-brokers
-        /// </remarks>
-        public static bool IsBrokerAvailable(this IPublicClientApplication publicClientApplication)
-        {
-            if (publicClientApplication is PublicClientApplication pca)
-            {
-                return pca.IsBrokerAvailable();
-            }
-
-            throw new ArgumentException("This extension method is only available for the PublicClientApplication implementation " +
-                "of the IPublicClientApplication interface.");
-        }
+       
 
         /// <summary>
         /// Returns the certificate used to create this <see cref="ConfidentialClientApplication"/>, if any.

--- a/src/client/Microsoft.Identity.Client/OsCapabilitiesExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/OsCapabilitiesExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
@@ -10,7 +12,7 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// Extension methods
     /// </summary>
-    public static class Extensions // TODO MSAL5: move these to their parent types
+    public static class OsCapabilitiesExtensions // TODO MSAL5: move these to their parent types
     {
         /// <summary>
         /// Returns true if MSAL can use a system browser.
@@ -51,13 +53,15 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Returns false when the program runs in headless OS, for example when SSH-ed into a Linux machine.
-        /// Browsers (webviews) and brokers cannot be used if there is no UI support. Instead, please use <see cref="PublicClientApplication.AcquireTokenWithDeviceCode(IEnumerable{string}, Func{DeviceCodeResult, Task})"/>
+        /// Browsers (webviews) and brokers cannot be used if there is no UI support. 
+        /// Instead, please use <see cref="PublicClientApplication.AcquireTokenWithDeviceCode(IEnumerable{string}, Func{DeviceCodeResult, Task})"/>
+        /// or <see cref="PublicClientApplication.AcquireTokenByIntegratedWindowsAuth(IEnumerable{string})"/>
         /// </summary>
         public static bool IsDesktopSession(this IPublicClientApplication publicClientApplication)
         {
             if (publicClientApplication is PublicClientApplication pca)
             {
-                return pca.IsDesktopSession();
+                return pca.IsUserInteractive();
             }
 
             throw new ArgumentException("This extension method is only available for the PublicClientApplication implementation " +
@@ -68,9 +72,9 @@ namespace Microsoft.Identity.Client
         /// Returns true if a broker can be used. 
         /// </summary>
         /// <remarks>
-        /// On Windows, the broker (WAM) can be used on Win10 and is always installed.
+        /// On Windows, the broker (WAM) can be used on Win10 and is always installed. See https://aka.ms/msal-net-wam
         /// On Mac, Linux and older versions of Windows a broker is not available.
-        /// On mobile, the device must be Intune joined and Authenticator or Company Portal must be installed.
+        /// On mobile, the device must be Intune joined and Authenticator or Company Portal must be installed. See https://aka.ms/msal-brokers
         /// </remarks>
         public static bool IsBrokerAvailable(this IPublicClientApplication publicClientApplication)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidWebUIFactory.cs
@@ -56,6 +56,10 @@ namespace Microsoft.Identity.Client.Platforms.Android
             }
         }
 
+        public bool IsDesktopSession => true;
+
+        public bool IsEmbeddedWebviewAvailable => true;
+
         private static bool IsBrowserWithCustomTabSupportAvailable()
         {
             Intent customTabServiceIntent = new Intent(CustomTabService);

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidWebUIFactory.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Identity.Client.Platforms.Android
             }
         }
 
-        public bool IsDesktopSession => true;
+        public bool IsUserInteractive => true;
 
-        public bool IsEmbeddedWebviewAvailable => true;
+        public bool IsEmbeddedWebViewAvailable => true;
 
         private static bool IsBrowserWithCustomTabSupportAvailable()
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -73,7 +76,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 #endif
         }
 
-        private static unsafe bool IsWindowsDesktopSession()
+        private static unsafe bool IsInteractiveSessionWindows()
         {
             // Environment.UserInteractive is hard-coded to return true for POSIX and Windows platforms on .NET Core 2.x and 3.x.
             // In .NET 5 the implementation on Windows has been 'fixed', but still POSIX versions always return true.
@@ -100,7 +103,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 
         }
 
-        private static bool IsMacDesktopSession()
+        private static bool IsInteractiveSessionMac()
         {
             // Get information about the current session
             int error = SecurityFramework.SessionGetInfo(SecurityFramework.CallerSecuritySession, out int id, out var sessionFlags);
@@ -112,27 +115,27 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
             }
 
             // Fall-through and check if X11 is available on macOS
-            return IsLinuxDesktopSession();
+            return IsInteractiveSessionLinux();
         }
 
-        private static bool IsLinuxDesktopSession()
+        private static bool IsInteractiveSessionLinux()
         {
             return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY"));
         }
 
-        public static bool IsDesktopSession()
+        public static bool IsUserInteractive()
         {
             if (IsWindows())
             {
-                return IsWindowsDesktopSession();
+                return IsInteractiveSessionWindows();
             }
             if (IsMac())
             {
-                return IsMacDesktopSession();
+                return IsInteractiveSessionMac();
             }
             if (IsLinux())
             {
-                return IsLinuxDesktopSession();
+                return IsInteractiveSessionLinux();
             }
 
             throw new PlatformNotSupportedException();

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
+{
+    internal static class DesktopOsHelper
+    {
+        public static bool IsWindows()
+        {
+#if DESKTOP
+            return Environment.OSVersion.Platform == PlatformID.Win32NT;
+#else
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+        }
+
+        public static bool IsLinux()
+        {
+#if DESKTOP
+            return Environment.OSVersion.Platform == PlatformID.Unix;
+#else
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+#endif
+        }
+
+        public static bool IsMac()
+        {
+#if DESKTOP
+            return Environment.OSVersion.Platform == PlatformID.MacOSX;
+#else
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#endif
+        }
+
+        private static unsafe bool IsWindowsDesktopSession()
+        {
+            // Environment.UserInteractive is hard-coded to return true for POSIX and Windows platforms on .NET Core 2.x and 3.x.
+            // In .NET 5 the implementation on Windows has been 'fixed', but still POSIX versions always return true.
+            //
+            // This code is lifted from the .NET 5 targeting dotnet/runtime implementation for Windows:
+            // https://github.com/dotnet/runtime/blob/cf654f08fb0078a96a4e414a0d2eab5e6c069387/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L125-L145
+
+            // Per documentation of GetProcessWindowStation, this handle should not be closed
+            IntPtr handle = User32.GetProcessWindowStation();
+            if (handle != IntPtr.Zero)
+            {
+                USEROBJECTFLAGS flags = default;
+                uint dummy = 0;
+                if (User32.GetUserObjectInformation(handle, User32.UOI_FLAGS, &flags,
+                    (uint)sizeof(USEROBJECTFLAGS), ref dummy))
+                {
+                    return (flags.dwFlags & User32.WSF_VISIBLE) != 0;
+                }
+            }
+
+            // If we can't determine, return true optimistically
+            // This will include cases like Windows Nano which do not expose WindowStations
+            return true;
+
+        }
+
+        private static bool IsMacDesktopSession()
+        {
+            // Get information about the current session
+            int error = SecurityFramework.SessionGetInfo(SecurityFramework.CallerSecuritySession, out int id, out var sessionFlags);
+
+            // Check if the session supports Quartz
+            if (error == 0 && (sessionFlags & SessionAttributeBits.SessionHasGraphicAccess) != 0)
+            {
+                return true;
+            }
+
+            // Fall-through and check if X11 is available on macOS
+            return IsLinuxDesktopSession();
+        }
+
+        private static bool IsLinuxDesktopSession()
+        {
+            return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DISPLAY"));
+        }
+
+        public static bool IsDesktopSession()
+        {
+            if (IsWindows())
+            {
+                return IsWindowsDesktopSession();
+            }
+            if (IsMac())
+            {
+                return IsMacDesktopSession();
+            }
+            if (IsLinux())
+            {
+                return IsLinuxDesktopSession();
+            }
+
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 
             string OSInfo = (string)reg.GetValue("ProductName");
 
-            if (OSInfo.IndexOf("Windows 10", StringComparison.InvariantCultureIgnoreCase) > 0
-                || OSInfo.IndexOf("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase) > 0
-                || OSInfo.IndexOf("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase) > 0)
+            if (OSInfo.Contains("Windows 10", StringComparison.InvariantCultureIgnoreCase) ||
+                OSInfo.Contains("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase) ||
+                OSInfo.Contains("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase))
             {                
                 return true;
             }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
@@ -18,6 +18,44 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 #endif
         }
 
+        private static bool IsWin10OrServerEquivalentInternal()
+        {
+            //Environment.OSVersion as it will return incorrect information on some operating systems
+            //For more information on how to acquire the current OS version from the registry
+            //See (https://stackoverflow.com/a/61914068)
+#if DESKTOP
+            var reg = Win32.Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+
+            string OSInfo = (string)reg.GetValue("ProductName");
+
+            if (OSInfo.IndexOf("Windows", StringComparison.InvariantCultureIgnoreCase) >= 0
+                && OSInfo.IndexOf("Windows 10", StringComparison.InvariantCultureIgnoreCase) < 0
+                && OSInfo.IndexOf("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase) < 0
+                && OSInfo.IndexOf("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase) < 0)
+            {                
+                return true;
+            }
+#else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                && !RuntimeInformation.OSDescription.Contains("Windows 10", StringComparison.InvariantCultureIgnoreCase)
+                && !RuntimeInformation.OSDescription.Contains("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase)
+                && !RuntimeInformation.OSDescription.Contains("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase))
+            {               
+                return true;
+            }
+#endif
+     
+            return false;
+        }
+
+        private static Lazy<bool> s_win10OrServerEquivalentLazy = new Lazy<bool>(
+            () => IsWin10OrServerEquivalentInternal());
+
+        public static bool IsWin10OrServerEquivalent()
+        {
+            return s_win10OrServerEquivalentLazy.Value;
+        }
+
         public static bool IsLinux()
         {
 #if DESKTOP

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 {
@@ -37,9 +38,9 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
             }
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                && !RuntimeInformation.OSDescription.Contains("Windows 10", StringComparison.InvariantCultureIgnoreCase)
-                && !RuntimeInformation.OSDescription.Contains("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase)
-                && !RuntimeInformation.OSDescription.Contains("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase))
+                && !RuntimeInformation.OSDescription.Contains("Windows 10", StringComparison.OrdinalIgnoreCase)
+                && !RuntimeInformation.OSDescription.Contains("Windows Server 2016", StringComparison.OrdinalIgnoreCase)
+                && !RuntimeInformation.OSDescription.Contains("Windows Server 2019", StringComparison.OrdinalIgnoreCase))
             {               
                 return true;
             }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
@@ -30,16 +30,15 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
             string OSInfo = (string)reg.GetValue("ProductName");
 
             if (OSInfo.IndexOf("Windows 10", StringComparison.InvariantCultureIgnoreCase) > 0
-                && OSInfo.IndexOf("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase) > 0
-                && OSInfo.IndexOf("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase) > 0)
+                || OSInfo.IndexOf("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase) > 0
+                || OSInfo.IndexOf("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase) > 0)
             {                
                 return true;
             }
 #else
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                && RuntimeInformation.OSDescription.Contains("Windows 10", StringComparison.OrdinalIgnoreCase)
-                && RuntimeInformation.OSDescription.Contains("Windows Server 2016", StringComparison.OrdinalIgnoreCase)
-                && RuntimeInformation.OSDescription.Contains("Windows Server 2019", StringComparison.OrdinalIgnoreCase))
+            if (RuntimeInformation.OSDescription.Contains("Windows 10", StringComparison.OrdinalIgnoreCase)
+                || RuntimeInformation.OSDescription.Contains("Windows Server 2016", StringComparison.OrdinalIgnoreCase)
+                || RuntimeInformation.OSDescription.Contains("Windows Server 2019", StringComparison.OrdinalIgnoreCase))
             {               
                 return true;
             }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/DesktopOsHelper.cs
@@ -29,18 +29,17 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 
             string OSInfo = (string)reg.GetValue("ProductName");
 
-            if (OSInfo.IndexOf("Windows", StringComparison.InvariantCultureIgnoreCase) >= 0
-                && OSInfo.IndexOf("Windows 10", StringComparison.InvariantCultureIgnoreCase) < 0
-                && OSInfo.IndexOf("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase) < 0
-                && OSInfo.IndexOf("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase) < 0)
+            if (OSInfo.IndexOf("Windows 10", StringComparison.InvariantCultureIgnoreCase) > 0
+                && OSInfo.IndexOf("Windows Server 2016", StringComparison.InvariantCultureIgnoreCase) > 0
+                && OSInfo.IndexOf("Windows Server 2019", StringComparison.InvariantCultureIgnoreCase) > 0)
             {                
                 return true;
             }
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                && !RuntimeInformation.OSDescription.Contains("Windows 10", StringComparison.OrdinalIgnoreCase)
-                && !RuntimeInformation.OSDescription.Contains("Windows Server 2016", StringComparison.OrdinalIgnoreCase)
-                && !RuntimeInformation.OSDescription.Contains("Windows Server 2019", StringComparison.OrdinalIgnoreCase))
+                && RuntimeInformation.OSDescription.Contains("Windows 10", StringComparison.OrdinalIgnoreCase)
+                && RuntimeInformation.OSDescription.Contains("Windows Server 2016", StringComparison.OrdinalIgnoreCase)
+                && RuntimeInformation.OSDescription.Contains("Windows Server 2019", StringComparison.OrdinalIgnoreCase))
             {               
                 return true;
             }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/MacNativeMethods.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/MacNativeMethods.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/MacNativeMethods.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/MacNativeMethods.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
+{
+    // https://developer.apple.com/documentation/security/keychain_services/keychain_items
+    internal static class SecurityFramework
+    {
+        private const string SecurityFrameworkLib = "/System/Library/Frameworks/Security.framework/Security";
+
+        public static readonly IntPtr Handle;
+        public static readonly IntPtr kSecClass;
+        public static readonly IntPtr kSecMatchLimit;
+        public static readonly IntPtr kSecReturnAttributes;
+        public static readonly IntPtr kSecReturnRef;
+        public static readonly IntPtr kSecReturnPersistentRef;
+        public static readonly IntPtr kSecClassGenericPassword;
+        public static readonly IntPtr kSecMatchLimitOne;
+        public static readonly IntPtr kSecMatchItemList;
+        public static readonly IntPtr kSecAttrLabel;
+        public static readonly IntPtr kSecAttrAccount;
+        public static readonly IntPtr kSecAttrService;
+        public static readonly IntPtr kSecValueRef;
+        public static readonly IntPtr kSecValueData;
+        public static readonly IntPtr kSecReturnData;
+
+        static SecurityFramework()
+        {
+            Handle = LibSystem.dlopen(SecurityFrameworkLib, 0);
+
+            kSecClass = LibSystem.GetGlobal(Handle, "kSecClass");
+            kSecMatchLimit = LibSystem.GetGlobal(Handle, "kSecMatchLimit");
+            kSecReturnAttributes = LibSystem.GetGlobal(Handle, "kSecReturnAttributes");
+            kSecReturnRef = LibSystem.GetGlobal(Handle, "kSecReturnRef");
+            kSecReturnPersistentRef = LibSystem.GetGlobal(Handle, "kSecReturnPersistentRef");
+            kSecClassGenericPassword = LibSystem.GetGlobal(Handle, "kSecClassGenericPassword");
+            kSecMatchLimitOne = LibSystem.GetGlobal(Handle, "kSecMatchLimitOne");
+            kSecMatchItemList = LibSystem.GetGlobal(Handle, "kSecMatchItemList");
+            kSecAttrLabel = LibSystem.GetGlobal(Handle, "kSecAttrLabel");
+            kSecAttrAccount = LibSystem.GetGlobal(Handle, "kSecAttrAccount");
+            kSecAttrService = LibSystem.GetGlobal(Handle, "kSecAttrService");
+            kSecValueRef = LibSystem.GetGlobal(Handle, "kSecValueRef");
+            kSecValueData = LibSystem.GetGlobal(Handle, "kSecValueData");
+            kSecReturnData = LibSystem.GetGlobal(Handle, "kSecReturnData");
+        }
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SessionGetInfo(int session, out int sessionId, out SessionAttributeBits attributes);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecAccessCreate(IntPtr descriptor, IntPtr trustedList, out IntPtr accessRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemCreateFromContent(IntPtr itemClass, IntPtr attrList, uint length,
+            IntPtr data, IntPtr keychainRef, IntPtr initialAccess, out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainAddGenericPassword(
+            IntPtr keychain,
+            uint serviceNameLength,
+            string serviceName,
+            uint accountNameLength,
+            string accountName,
+            uint passwordLength,
+            byte[] passwordData,
+            out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainFindGenericPassword(
+            IntPtr keychainOrArray,
+            uint serviceNameLength,
+            string serviceName,
+            uint accountNameLength,
+            string accountName,
+            out uint passwordLength,
+            out IntPtr passwordData,
+            out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int SecKeychainItemCopyAttributesAndData(
+            IntPtr itemRef,
+            IntPtr info,
+            IntPtr itemClass,
+            SecKeychainAttributeList** attrList,
+            uint* dataLength,
+            void** data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemModifyAttributesAndData(
+            IntPtr itemRef,
+            IntPtr attrList, // SecKeychainAttributeList*
+            uint length,
+            byte[] data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemDelete(
+            IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemFreeContent(
+            IntPtr attrList, // SecKeychainAttributeList*
+            IntPtr data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemFreeAttributesAndData(
+            IntPtr attrList, // SecKeychainAttributeList*
+            IntPtr data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecItemCopyMatching(IntPtr query, out IntPtr result);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemCopyFromPersistentReference(IntPtr persistentItemRef, out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemCopyContent(IntPtr itemRef, IntPtr itemClass, IntPtr attrList,
+            out uint length, out IntPtr outData);
+
+        public const int CallerSecuritySession = -1;
+
+        // https://developer.apple.com/documentation/security/1542001-security_framework_result_codes
+        public const int OK = 0;
+        public const int ErrorSecNoSuchKeychain = -25294;
+        public const int ErrorSecInvalidKeychain = -25295;
+        public const int ErrorSecAuthFailed = -25293;
+        public const int ErrorSecDuplicateItem = -25299;
+        public const int ErrorSecItemNotFound = -25300;
+        public const int ErrorSecInteractionNotAllowed = -25308;
+        public const int ErrorSecInteractionRequired = -25315;
+        public const int ErrorSecNoSuchAttr = -25303;
+  
+    }
+
+    [Flags]
+    internal enum SessionAttributeBits
+    {
+        SessionIsRoot = 0x0001,
+        SessionHasGraphicAccess = 0x0010,
+        SessionHasTty = 0x0020,
+        SessionIsRemote = 0x1000,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SecKeychainAttributeInfo
+    {
+        public uint Count;
+        public IntPtr Tag; // uint* (SecKeychainAttrType*)
+        public IntPtr Format; // uint* (CssmDbAttributeFormat*)
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SecKeychainAttributeList
+    {
+        public uint Count;
+        public IntPtr Attributes; // SecKeychainAttribute*
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SecKeychainAttribute
+    {
+        public SecKeychainAttrType Tag;
+        public uint Length;
+        public IntPtr Data;
+    }
+
+    internal enum CssmDbAttributeFormat : uint
+    {
+        String = 0,
+        SInt32 = 1,
+        UInt32 = 2,
+        BigNum = 3,
+        Real = 4,
+        TimeDate = 5,
+        Blob = 6,
+        MultiUInt32 = 7,
+        Complex = 8
+    };
+
+    internal enum SecKeychainAttrType : uint
+    {
+        // https://developer.apple.com/documentation/security/secitemattr/accountitemattr
+        AccountItem = 1633903476,
+    }
+
+    internal static class LibSystem
+    {
+        private const string LibSystemLib = "/System/Library/Frameworks/System.framework/System";
+
+        [DllImport(LibSystemLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr dlopen(string name, int flags);
+
+        [DllImport(LibSystemLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+        public static IntPtr GetGlobal(IntPtr handle, string symbol)
+        {
+            IntPtr ptr = dlsym(handle, symbol);
+            var structure = Marshal.PtrToStructure(ptr, typeof(IntPtr));
+
+            return (IntPtr)structure;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/MacNativeMethods.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/MacNativeMethods.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
         public const int ErrorSecInteractionNotAllowed = -25308;
         public const int ErrorSecInteractionRequired = -25315;
         public const int ErrorSecNoSuchAttr = -25303;
-  
+
     }
 
     [Flags]
@@ -199,8 +199,11 @@ namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
         public static IntPtr GetGlobal(IntPtr handle, string symbol)
         {
             IntPtr ptr = dlsym(handle, symbol);
+#if NET45
             var structure = Marshal.PtrToStructure(ptr, typeof(IntPtr));
-
+#else
+            var structure = Marshal.PtrToStructure<IntPtr>(ptr);
+#endif
             return (IntPtr)structure;
         }
     }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/StaTaskScheduler.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/StaTaskScheduler.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+#if !NETSTANDARD
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -8,9 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-// Moving the code to the library's main namespace
-
-namespace Microsoft.Identity.Client.Platforms.Features.Win32
+namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 {
     // This IDisposable class doe not need to implement Dispose method in standard way, because it is sealed.
     // If it ever needs to become inheritable, it should follow the standard pattern as desribed in http://msdn.microsoft.com/en-us/library/fs2xkftw(v=vs.110).aspx.
@@ -114,3 +112,4 @@ namespace Microsoft.Identity.Client.Platforms.Features.Win32
         }
     }
 }
+#endif

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeDpiHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeDpiHelper.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.Identity.Client.Platforms.Features.Win32;
 
-namespace Microsoft.Identity.Client.Platforms.Features.Win32
+namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 {
-    internal static class NativeDpiHelper
-        
+    internal static class WindowsDpiHelper
     {
-        static NativeDpiHelper()
+        static WindowsDpiHelper()
         {
             const double DefaultDpi = 96.0;
 
@@ -57,4 +55,5 @@ namespace Microsoft.Identity.Client.Platforms.Features.Win32
         internal static extern bool IsProcessDPIAware();
     }
 }
+
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeMethods.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeMethods.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace Microsoft.Identity.Client.PlatformsCommon.Shared
+namespace Microsoft.Identity.Client.Platforms.Features.DesktopOs
 {
     internal static class WindowsNativeMethods
     {
@@ -93,5 +93,27 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             public readonly short wProcessorLevel;
             public readonly short wProcessorRevision;
         }
+    }
+
+    internal static class User32
+    {
+        private const string LibraryName = "user32.dll";
+
+        public const int UOI_FLAGS = 1;
+        public const int WSF_VISIBLE = 0x0001;
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern IntPtr GetProcessWindowStation();
+
+        [DllImport(LibraryName, EntryPoint = "GetUserObjectInformation", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern unsafe bool GetUserObjectInformation(IntPtr hObj, int nIndex, void* pvBuffer, uint nLength, ref uint lpnLengthNeeded);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct USEROBJECTFLAGS
+    {
+        public int fInherit;
+        public int fReserved;
+        public int dwFlags;
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
@@ -9,7 +9,10 @@ using Windows.Security.Authentication.Web.Core;
 using Windows.Security.Credentials;
 using Windows.UI.ApplicationSettings;
 using System.Runtime.InteropServices;
-using Microsoft.Identity.Client.PlatformsCommon.Shared;
+
+#if !UAP10_0
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
+#endif
 
 #if NET5_WIN
 using Microsoft.Identity.Client.Platforms.net5win;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -14,7 +14,6 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.PlatformsCommon.Shared;
 using Microsoft.Identity.Client.UI;
 using Windows.Foundation.Metadata;
 using Windows.Security.Authentication.Web.Core;
@@ -22,6 +21,9 @@ using Windows.Security.Credentials;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Instance.Discovery;
+#if !UAP10_0
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
+#endif
 
 #if DESKTOP || NET5_WIN
 using System.Runtime.InteropServices;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.Features.WamBroker;
-using Microsoft.Identity.Client.Platforms.Features.Win32;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.Platforms.Features.Win32;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Web.WebView2.Core;
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
                     : Screen.PrimaryScreen;
 
                 // Window height is set to 70% of the screen height.
-                int uiHeight = (int)(Math.Max(screen.WorkingArea.Height, 160) * 70.0 / NativeDpiHelper.ZoomPercent);
+                int uiHeight = (int)(Math.Max(screen.WorkingArea.Height, 160) * 70.0 / WindowsDpiHelper.ZoomPercent);
                 var webBrowserPanel = new Panel();
                 webBrowserPanel.SuspendLayout();
                 SuspendLayout();

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/CustomWebBrowser.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/CustomWebBrowser.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using Microsoft.Identity.Client.Platforms.Features.Win32;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 
 namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 {
@@ -135,7 +135,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
                 info.dwDoubleClick = 0;
                 info.dwFlags = DOCHOSTUIFLAG_NO3DOUTERBORDER | DOCHOSTUIFLAG_DISABLE_SCRIPT_INACTIVE;
 
-                if (NativeDpiHelper.IsProcessDPIAware())
+                if (WindowsDpiHelper.IsProcessDPIAware())
                 {
                     info.dwFlags |= DOCHOSTUIFLAG_DPI_AWARE;
                 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebUI.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.Platforms.Features.Win32;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialog.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialog.cs
@@ -5,7 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using Microsoft.Identity.Client.Platforms.Features.Win32;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
@@ -86,8 +86,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 
         private void SetBrowserZoom()
         {
-            int windowsZoomPercent = NativeDpiHelper.ZoomPercent;
-            if (NativeDpiHelper.IsProcessDPIAware() && 100 != windowsZoomPercent && !_zoomed)
+            int windowsZoomPercent = WindowsDpiHelper.ZoomPercent;
+            if (WindowsDpiHelper.IsProcessDPIAware() && 100 != windowsZoomPercent && !_zoomed)
             {
                 // There is a bug in some versions of the IE browser control that causes it to
                 // ignore scaling unless it is changed.

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
@@ -9,7 +9,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.Platforms.Features.Win32;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Client.Utils;
 
@@ -305,7 +305,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
                     : Screen.PrimaryScreen;
 
                 // Window height is set to 70% of the screen height.
-                int uiHeight = (int)(Math.Max(screen.WorkingArea.Height, 160) * 70.0 / NativeDpiHelper.ZoomPercent);
+                int uiHeight = (int)(Math.Max(screen.WorkingArea.Height, 160) * 70.0 / WindowsDpiHelper.ZoomPercent);
                 _webBrowserPanel = new Panel();
                 _webBrowserPanel.SuspendLayout();
                 SuspendLayout();

--- a/src/client/Microsoft.Identity.Client/Platforms/Mac/MacUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Mac/MacUIFactory.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Identity.Client.Platforms.Mac
     {
         public bool IsSystemWebViewAvailable => true;
 
-        public bool IsDesktopSession => true; 
+        public bool IsUserInteractive => true; 
 
-        public bool IsEmbeddedWebviewAvailable => true;
+        public bool IsEmbeddedWebViewAvailable => true;
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/Mac/MacUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Mac/MacUIFactory.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Identity.Client.Platforms.Mac
     {
         public bool IsSystemWebViewAvailable => true;
 
+        public bool IsDesktopSession => true; 
+
+        public bool IsEmbeddedWebviewAvailable => true;
+
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {
             if (webViewPreference == WebViewPreference.System)

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/IosWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/IosWebUIFactory.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Identity.Client.Platforms.iOS
     internal class IosWebUIFactory : IWebUIFactory
     {
         public bool IsSystemWebViewAvailable => true;
+        public bool IsDesktopSession => true;
+        public bool IsEmbeddedWebviewAvailable => true;
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/IosWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/IosWebUIFactory.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Identity.Client.Platforms.iOS
     internal class IosWebUIFactory : IWebUIFactory
     {
         public bool IsSystemWebViewAvailable => true;
-        public bool IsDesktopSession => true;
-        public bool IsEmbeddedWebviewAvailable => true;
+        public bool IsUserInteractive => true;
+        public bool IsEmbeddedWebViewAvailable => true;
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
@@ -21,7 +22,11 @@ namespace Microsoft.Identity.Client.Platforms.net5win
             _isWebView2AvailableFunc = isWebView2AvailableForTest ?? IsWebView2Available;
         }
 
-        public bool IsSystemWebViewAvailable => true;
+        public bool IsSystemWebViewAvailable => IsDesktopSession;
+
+        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+
+        public bool IsEmbeddedWebviewAvailable => throw new NotImplementedException();
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference useEmbeddedWebView, RequestContext requestContext)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Identity.Client.Platforms.net5win
             _isWebView2AvailableFunc = isWebView2AvailableForTest ?? IsWebView2Available;
         }
 
-        public bool IsSystemWebViewAvailable => IsDesktopSession;
+        public bool IsSystemWebViewAvailable => IsUserInteractive;
 
-        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+        public bool IsUserInteractive => DesktopOsHelper.IsUserInteractive();
 
-        public bool IsEmbeddedWebviewAvailable => 
-            IsDesktopSession &&
+        public bool IsEmbeddedWebViewAvailable => 
+            IsUserInteractive &&
             IsWebView2Available(null); // Look for the globally available WebView2 runtime
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference useEmbeddedWebView, RequestContext requestContext)

--- a/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net5win/Net5WebUiFactory.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Identity.Client.Platforms.net5win
 
         public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
 
-        public bool IsEmbeddedWebviewAvailable => throw new NotImplementedException();
+        public bool IsEmbeddedWebviewAvailable => 
+            IsDesktopSession &&
+            IsWebView2Available(null); // Look for the globally available WebView2 runtime
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference useEmbeddedWebView, RequestContext requestContext)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -14,6 +14,7 @@ using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Broker;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.Platforms.Shared.NetStdCore;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Client.Platforms.Shared.NetStdCore
 
         public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
 
-        public bool IsEmbeddedWebviewAvailable => throw new System.NotImplementedException();
+        public bool IsEmbeddedWebviewAvailable => false; 
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Identity.Client.Platforms.Shared.NetStdCore
 {
     internal class NetCoreWebUIFactory : IWebUIFactory
     {
-        public bool IsSystemWebViewAvailable => IsDesktopSession;
+        public bool IsSystemWebViewAvailable => IsUserInteractive;
 
-        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+        public bool IsUserInteractive => DesktopOsHelper.IsUserInteractive();
 
-        public bool IsEmbeddedWebviewAvailable => false; 
+        public bool IsEmbeddedWebViewAvailable => false; 
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCoreWebUIFactory.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.UI;
 
@@ -10,7 +11,11 @@ namespace Microsoft.Identity.Client.Platforms.Shared.NetStdCore
 {
     internal class NetCoreWebUIFactory : IWebUIFactory
     {
-        public bool IsSystemWebViewAvailable => true;
+        public bool IsSystemWebViewAvailable => IsDesktopSession;
+
+        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+
+        public bool IsEmbeddedWebviewAvailable => throw new System.NotImplementedException();
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent, 

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopPlatformProxy.cs
@@ -22,6 +22,7 @@ using Microsoft.Identity.Client.AuthScheme.PoP;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.net45.Http;
 using Microsoft.Identity.Client.Internal.Broker;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 
 namespace Microsoft.Identity.Client.Platforms.net45
 {

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
             }
         }
 
-        public bool IsEmbeddedWebviewAvailable => throw new System.NotImplementedException();
+        public bool IsEmbeddedWebviewAvailable => IsDesktopSession; // WebBrowser control is always available
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent,

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi;
 using Microsoft.Identity.Client.Platforms.Shared.Desktop.OsBrowser;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
@@ -12,11 +13,21 @@ namespace Microsoft.Identity.Client.Platforms.net45
 {
     internal class NetDesktopWebUIFactory : IWebUIFactory
     {
-        public bool IsSystemWebViewAvailable => true;
+        public bool IsSystemWebViewAvailable => IsDesktopSession;
+
+        public bool IsDesktopSession
+        {
+            get
+            {
+                return DesktopOsHelper.IsDesktopSession();
+            }
+        }
+
+        public bool IsEmbeddedWebviewAvailable => throw new System.NotImplementedException();
 
         public IWebUI CreateAuthenticationDialog(
-            CoreUIParent coreUIParent, 
-            WebViewPreference useEmbeddedWebView, 
+            CoreUIParent coreUIParent,
+            WebViewPreference useEmbeddedWebView,
             RequestContext requestContext)
         {
             if (coreUIParent.UseHiddenBrowser)

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopWebUIFactory.cs
@@ -13,17 +13,11 @@ namespace Microsoft.Identity.Client.Platforms.net45
 {
     internal class NetDesktopWebUIFactory : IWebUIFactory
     {
-        public bool IsSystemWebViewAvailable => IsDesktopSession;
+        public bool IsSystemWebViewAvailable => IsUserInteractive;
 
-        public bool IsDesktopSession
-        {
-            get
-            {
-                return DesktopOsHelper.IsDesktopSession();
-            }
-        }
+        public bool IsUserInteractive => DesktopOsHelper.IsUserInteractive();
 
-        public bool IsEmbeddedWebviewAvailable => IsDesktopSession; // WebBrowser control is always available
+        public bool IsEmbeddedWebViewAvailable => IsUserInteractive; // WebBrowser control is always available
 
         public IWebUI CreateAuthenticationDialog(
             CoreUIParent coreUIParent,

--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13PlatformProxy.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
             return new InMemoryTokenCacheAccessor(Logger);
         }
 
-        protected override IWebUIFactory CreateWebUiFactory() => new WebUIFactory();
+        protected override IWebUIFactory CreateWebUiFactory() => new NetStandard13WebUiFactory();
         protected override ICryptographyManager InternalGetCryptographyManager() => new NetStandard13CryptographyManager();
         protected override IPlatformLogger InternalGetPlatformLogger() => new EventSourcePlatformLogger();
 

--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13WebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13WebUIFactory.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
     {
         public bool IsSystemWebViewAvailable => false;
 
-        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+        public bool IsUserInteractive => DesktopOsHelper.IsUserInteractive();
 
-        public bool IsEmbeddedWebviewAvailable => false;
+        public bool IsEmbeddedWebViewAvailable => false;
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13WebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13WebUIFactory.cs
@@ -4,14 +4,19 @@
 using System;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.netstandard13
 {
-    internal class WebUIFactory : IWebUIFactory
+    internal class NetStandard13WebUiFactory : IWebUIFactory
     {
         public bool IsSystemWebViewAvailable => false;
+
+        public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
+
+        public bool IsEmbeddedWebviewAvailable => throw new NotImplementedException();
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13WebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard13/NetStandard13WebUIFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Client.Platforms.netstandard13
 
         public bool IsDesktopSession => DesktopOsHelper.IsDesktopSession();
 
-        public bool IsEmbeddedWebviewAvailable => throw new NotImplementedException();
+        public bool IsEmbeddedWebviewAvailable => false;
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Identity.Client.Platforms.uap
     {
         public bool IsSystemWebViewAvailable => false;
 
+        public bool IsDesktopSession => true;
+
+        public bool IsEmbeddedWebviewAvailable => true;
+
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {
             if (webViewPreference == WebViewPreference.System)

--- a/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/uap/UapWebUIFactory.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Identity.Client.Platforms.uap
     {
         public bool IsSystemWebViewAvailable => false;
 
-        public bool IsDesktopSession => true;
+        public bool IsUserInteractive => true;
 
-        public bool IsEmbeddedWebviewAvailable => true;
+        public bool IsEmbeddedWebViewAvailable => true;
 
         public IWebUI CreateAuthenticationDialog(CoreUIParent coreUIParent, WebViewPreference webViewPreference, RequestContext requestContext)
         {

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
@@ -77,10 +77,10 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         //This corresponds to windows 7, 8, 8.1 and their server equivalents.       
         public static bool CanOSPerformPKeyAuth()
         {
-#if WINDOWS_APP
-            return false;
-#else
+#if NET_CORE || NET5_WIN || DESKTOP
             return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
+#else
+            return false;
 #endif
         }
     }

--- a/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -77,16 +77,16 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         public bool IsEmbeddedWebViewAvailable()
         {
-            return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsEmbeddedWebviewAvailable;
+            return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsEmbeddedWebViewAvailable;
         }
 
         /// <summary>
         /// Returns false when the program runs in headless OS, for example when SSH-ed into a Linux machine.
         /// Browsers (webviews) and brokers cannot be used if there is no UI support. Instead, please use <see cref="PublicClientApplication.AcquireTokenWithDeviceCode(IEnumerable{string}, Func{DeviceCodeResult, Task})"/>
         /// </summary>
-        public bool IsDesktopSession()
+        public bool IsUserInteractive()
         {
-            return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsDesktopSession;
+            return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsUserInteractive;
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Client
         }
 
         private const string CurrentOSAccountDescriptor = "current_os_account";
-        private static IAccount s_currentOsAccount = 
+        private static IAccount s_currentOsAccount =
             new Account(CurrentOSAccountDescriptor, null, null, null);
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client
         /// On Windows, Mac and Linux a system browser can always be used, except in cases where there is no UI, e.g. SSH connection.
         /// On Android, the browser must support tabs.
         /// </remarks>
-        public bool IsSystemWebViewAvailable
+        public bool IsSystemWebViewAvailable // TODO MSAL5: consolidate these helpers in the interface
         {
             get
             {
@@ -73,29 +73,34 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <remarks>
         /// Currently there are no embedded webviews on Mac and Linux. On Windows, app developers or users should install 
-        /// the WebView2 runtime and this helper will inform if the runtime is available, see https://aka.ms/msal-net-webview2
+        /// the WebView2 runtime and this property will inform if the runtime is available, see https://aka.ms/msal-net-webview2
         /// </remarks>
-        public bool IsEmbeddedWebViewAvailable
+        public bool IsEmbeddedWebViewAvailable()
         {
-            get
-            {
-                return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsEmbeddedWebviewAvailable;
-            }
+            return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsEmbeddedWebviewAvailable;
         }
 
         /// <summary>
         /// Returns false when the program runs in headless OS, for example when SSH-ed into a Linux machine.
         /// Browsers (webviews) and brokers cannot be used if there is no UI support. Instead, please use <see cref="PublicClientApplication.AcquireTokenWithDeviceCode(IEnumerable{string}, Func{DeviceCodeResult, Task})"/>
         /// </summary>
-        /// <remarks>
-        /// In cases where the library cannot reliably detect if a desktop session is available, this helper will return true.
-        /// </remarks>
-        public bool IsDesktopSession
+        public bool IsDesktopSession()
         {
-            get
-            {
-                return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsDesktopSession;
-            }
+            return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsDesktopSession;
+        }
+
+        /// <summary>
+        /// Returns true if a broker can be used. 
+        /// </summary>
+        /// <remarks>
+        /// On Windows, the broker (WAM) can be used on Win10 and is always installed.
+        /// On Mac, Linux and older versions of Windows a broker is not available.
+        /// On mobile, the device must be Intune joined and Authenticator or Company Portal must be installed.
+        /// </remarks>
+        public bool IsBrokerAvailable()
+        {
+            return
+                ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null).IsBrokerInstalledAndInvokable();
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -54,13 +54,47 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        ///
+        /// Returns true if MSAL can use a system browser.
         /// </summary>
+        /// <remarks>
+        /// On Windows, Mac and Linux a system browser can always be used, except in cases where there is no UI, e.g. SSH connection.
+        /// On Android, the browser must support tabs.
+        /// </remarks>
         public bool IsSystemWebViewAvailable
         {
             get
             {
                 return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsSystemWebViewAvailable;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if MSAL can use an embedded webview (browser). 
+        /// </summary>
+        /// <remarks>
+        /// Currently there are no embedded webviews on Mac and Linux. On Windows, app developers or users should install 
+        /// the WebView2 runtime and this helper will inform if the runtime is available, see https://aka.ms/msal-net-webview2
+        /// </remarks>
+        public bool IsEmbeddedWebViewAvailable
+        {
+            get
+            {
+                return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsEmbeddedWebviewAvailable;
+            }
+        }
+
+        /// <summary>
+        /// Returns false when the program runs in headless OS, for example when SSH-ed into a Linux machine.
+        /// Browsers (webviews) and brokers cannot be used if there is no UI support. Instead, please use <see cref="PublicClientApplication.AcquireTokenWithDeviceCode(IEnumerable{string}, Func{DeviceCodeResult, Task})"/>
+        /// </summary>
+        /// <remarks>
+        /// In cases where the library cannot reliably detect if a desktop session is available, this helper will return true.
+        /// </remarks>
+        public bool IsDesktopSession
+        {
+            get
+            {
+                return ServiceBundle.PlatformProxy.GetWebUiFactory(ServiceBundle.Config).IsDesktopSession;
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/UI/IWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/UI/IWebUIFactory.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Identity.Client.UI
             RequestContext requestContext);
 
         bool IsSystemWebViewAvailable { get; }
-        
+        bool IsDesktopSession { get; }
+        bool IsEmbeddedWebviewAvailable { get; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/UI/IWebUIFactory.cs
+++ b/src/client/Microsoft.Identity.Client/UI/IWebUIFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Client.UI
             RequestContext requestContext);
 
         bool IsSystemWebViewAvailable { get; }
-        bool IsDesktopSession { get; }
-        bool IsEmbeddedWebviewAvailable { get; }
+        bool IsUserInteractive { get; }
+        bool IsEmbeddedWebViewAvailable { get; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Utils/StringExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/StringExtensions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Client.Utils
             return sb.ToString();
         }
 
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || DESKTOP
         /// <summary>
         /// Culture aware Contains
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/Utils/StringExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/StringExtensions.cs
@@ -63,6 +63,16 @@ namespace Microsoft.Identity.Client.Utils
 
             return sb.ToString();
         }
+
+#if NETSTANDARD1_3
+        /// <summary>
+        /// Culture aware Contains
+        /// </summary>
+        public static bool Contains(this string source, string toCheck, StringComparison comp)
+        {
+            return source != null && toCheck != null && source.IndexOf(toCheck, comp) >= 0;
+        }
+#endif
     }
 }
 

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -6,7 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Identity.Client;
+#if !NET5_WIN
+using Microsoft.Identity.Client.Desktop;
+#endif
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.PlatformsCommon.Factories;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -589,5 +593,37 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             CollectionAssert.AreEquivalent(new string[] { "cp1", "cp2" }, app.AppConfig.ClientCapabilities.ToList());
         }
+
+#if NET5_WIN
+        [TestMethod]
+        public void IsBrokerAvailable_net5()
+        {
+            var appBuilder = PublicClientApplicationBuilder
+                    .Create(TestConstants.ClientId);
+
+            Assert.AreEqual(DesktopOsHelper.IsWin10OrServerEquivalent(), appBuilder.IsBrokerAvailable());
+        }
+#endif
+
+#if DESKTOP || NET_CORE
+        [TestMethod]
+        public void IsBrokerAvailable_OldDotNet()
+        {
+            var builder1 = PublicClientApplicationBuilder
+                    .Create(TestConstants.ClientId);
+                    
+
+            // broker is not available out of the box
+            Assert.AreEqual(false, builder1.IsBrokerAvailable());
+
+            var builder2 = PublicClientApplicationBuilder
+                   .Create(TestConstants.ClientId)
+                   .WithDesktopFeatures();
+                   
+
+            // broker is not available out of the box
+            Assert.AreEqual(DesktopOsHelper.IsWin10OrServerEquivalent(), builder2.IsBrokerAvailable());
+        }
+#endif
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
@@ -83,38 +83,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 _msaPassthroughHandler);
         }
 
-#if NET5_WIN
-        [TestMethod]
-        public void IsBrokerAvailable_net5()
-        {
-            var app = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .Build();
 
-            Assert.AreEqual(DesktopOsHelper.IsWin10OrServerEquivalent(), app.IsBrokerAvailable());
-        }
-#endif
-
-#if DESKTOP || NET_CORE
-        [TestMethod]
-        public void IsBrokerAvailable_OldDotNet()
-        {
-            var app1 = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .Build();
-
-            // broker is not available out of the box
-            Assert.AreEqual(false, app1.IsBrokerAvailable());
-
-            var app2 = PublicClientApplicationBuilder
-                   .Create(TestConstants.ClientId)
-                   .WithDesktopFeatures()
-                   .Build();
-
-            // broker is not available out of the box
-            Assert.AreEqual(DesktopOsHelper.IsWin10OrServerEquivalent(), app2.IsBrokerAvailable());
-        }
-#endif
 
         [TestMethod]
         public void HandleInstallUrl_Throws()

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Constants;
@@ -80,6 +81,16 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.AreEqual("https://fs.contoso.com/adfs/", app.Authority);
             Assert.AreEqual(TestConstants.ClientId, app.AppConfig.ClientId);
             Assert.AreEqual(TestConstants.RedirectUri, app.AppConfig.RedirectUri);
+        }
+
+        [TestMethod]
+        public void IsBrokerAvailable()
+        {
+            var app = PublicClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .Build();
+
+            Assert.AreEqual(app.IsBrokerAvailable(), DesktopOsHelper.IsWin10OrServerEquivalent());
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
@@ -83,15 +83,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.AreEqual(TestConstants.RedirectUri, app.AppConfig.RedirectUri);
         }
 
-        [TestMethod]
-        public void IsBrokerAvailable()
-        {
-            var app = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .Build();
-
-            Assert.AreEqual(app.IsBrokerAvailable(), DesktopOsHelper.IsWin10OrServerEquivalent());
-        }
+       
 
         [TestMethod]
         public async Task NoStateReturnedTestAsync()

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -93,7 +93,11 @@ namespace NetCoreTestApp
             while (true)
             {
                 Console.Clear();
-
+                Console.ForegroundColor = ConsoleColor.DarkYellow;
+                Console.WriteLine($"" +
+                    $"IsDesktopSession: {pca.IsDesktopSession()}, " +
+                    $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
+                    $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
                 Console.WriteLine("Authority: " + GetAuthority());
                 await DisplayAccountsAsync(pca).ConfigureAwait(false);
 

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -98,7 +98,7 @@ namespace NetCoreTestApp
                 Console.Clear();
                 Console.ForegroundColor = ConsoleColor.DarkYellow;
                 Console.WriteLine($"" +
-                    $"IsDesktopSession: {pca.IsDesktopSession()}, " +
+                    $"IsDesktopSession: {pca.IsUserInteractive()}, " +
                     $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
                     $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
                     

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -61,13 +61,16 @@ namespace NetCoreTestApp
 
         private static IPublicClientApplication CreatePca()
         {
-            IPublicClientApplication pca = PublicClientApplicationBuilder
+            var pcaBuilder = PublicClientApplicationBuilder
                             .Create(s_clientIdForPublicApp)
                             .WithAuthority(GetAuthority())
                             .WithLogging(Log, LogLevel.Verbose, true)
                             .WithExperimentalFeatures()
-                            .WithWindowsBroker()
-                            .WithRedirectUri("http://localhost") // required for DefaultOsBrowser
+                            .WithDesktopFeatures();
+
+            Console.WriteLine($"IsBrokerAvailable: {pcaBuilder.IsBrokerAvailable()}");
+            
+            var pca = pcaBuilder.WithRedirectUri("http://localhost") // required for DefaultOsBrowser
                             .Build();
 
             pca.UserTokenCache.SetBeforeAccess(notificationArgs =>
@@ -97,8 +100,8 @@ namespace NetCoreTestApp
                 Console.WriteLine($"" +
                     $"IsDesktopSession: {pca.IsDesktopSession()}, " +
                     $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
-                    $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}" + 
-                    $"IsBrokerAvailable: {pca.IsBrokerAvailable()}" );
+                    $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
+                    
                 Console.WriteLine("Authority: " + GetAuthority());
                 await DisplayAccountsAsync(pca).ConfigureAwait(false);
 

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -97,7 +97,8 @@ namespace NetCoreTestApp
                 Console.WriteLine($"" +
                     $"IsDesktopSession: {pca.IsDesktopSession()}, " +
                     $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
-                    $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
+                    $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}" + 
+                    $"IsBrokerAvailable: {pca.IsBrokerAvailable()}" );
                 Console.WriteLine("Authority: " + GetAuthority());
                 await DisplayAccountsAsync(pca).ConfigureAwait(false);
 

--- a/tests/devapps/NetFxConsoleTestApp/Program.cs
+++ b/tests/devapps/NetFxConsoleTestApp/Program.cs
@@ -126,9 +126,12 @@ namespace NetFx
             var builder = PublicClientApplicationBuilder
                             .Create(s_clientIdForPublicApp)
                             .WithAuthority(GetAuthority())
+#if NET47
+                    .WithDesktopFeatures()
+#endif
                             .WithLogging(Log, LogLevel.Verbose, true);
-                            //.WithClientCapabilities(new[] { "llt" })
-                            //.WithRedirectUri("http://localhost"); // required for DefaultOsBrowser
+
+            Console.WriteLine($"IsBrokerAvailable: {builder.IsBrokerAvailable()}");
 
             if (s_useBroker)
             {
@@ -139,9 +142,7 @@ namespace NetFx
                     .WithParentActivityOrWindow(c)
                     .WithExperimentalFeatures()
                     
-#if NET47
-                    .WithWindowsBroker(true)
-#endif
+
                     .WithBroker(true);
             }
 
@@ -185,8 +186,8 @@ namespace NetFx
                 Console.WriteLine($"" +
                      $"IsDesktopSession: {pca.IsDesktopSession()}, " +
                      $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
-                     $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}" +
-                     $"IsBrokerAvailable: {pca.IsBrokerAvailable()}");
+                     $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
+                     
                 Console.WriteLine("Authority: " + GetAuthority());
                 Console.WriteLine("Use WAM: " + s_useBroker);
                 await DisplayAccountsAsync(pca).ConfigureAwait(false);

--- a/tests/devapps/NetFxConsoleTestApp/Program.cs
+++ b/tests/devapps/NetFxConsoleTestApp/Program.cs
@@ -184,7 +184,7 @@ namespace NetFx
 
                 Console.ForegroundColor = ConsoleColor.DarkYellow;
                 Console.WriteLine($"" +
-                     $"IsDesktopSession: {pca.IsDesktopSession()}, " +
+                     $"IsDesktopSession: {pca.IsUserInteractive()}, " +
                      $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
                      $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
                      

--- a/tests/devapps/NetFxConsoleTestApp/Program.cs
+++ b/tests/devapps/NetFxConsoleTestApp/Program.cs
@@ -183,9 +183,10 @@ namespace NetFx
 
                 Console.ForegroundColor = ConsoleColor.DarkYellow;
                 Console.WriteLine($"" +
-                    $"IsDesktopSession: {pca.IsDesktopSession()}, " +
-                    $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
-                    $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
+                     $"IsDesktopSession: {pca.IsDesktopSession()}, " +
+                     $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
+                     $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}" +
+                     $"IsBrokerAvailable: {pca.IsBrokerAvailable()}");
                 Console.WriteLine("Authority: " + GetAuthority());
                 Console.WriteLine("Use WAM: " + s_useBroker);
                 await DisplayAccountsAsync(pca).ConfigureAwait(false);

--- a/tests/devapps/NetFxConsoleTestApp/Program.cs
+++ b/tests/devapps/NetFxConsoleTestApp/Program.cs
@@ -92,6 +92,9 @@ namespace NetFx
             Console.ResetColor();
             Console.BackgroundColor = ConsoleColor.Black;
             var pca = CreatePca();
+
+           
+
             await RunConsoleAppLogicAsync(pca).ConfigureAwait(false);
         }
 
@@ -178,6 +181,11 @@ namespace NetFx
             {
                 Console.Clear();
 
+                Console.ForegroundColor = ConsoleColor.DarkYellow;
+                Console.WriteLine($"" +
+                    $"IsDesktopSession: {pca.IsDesktopSession()}, " +
+                    $"IsEmbeddedWebViewAvailable: {pca.IsEmbeddedWebViewAvailable()} " +
+                    $"IsEmbeddedWebViewAvailable: {pca.IsSystemWebViewAvailable()}");
                 Console.WriteLine("Authority: " + GetAuthority());
                 Console.WriteLine("Use WAM: " + s_useBroker);
                 await DisplayAccountsAsync(pca).ConfigureAwait(false);


### PR DESCRIPTION
IsDesktopSession returns false is the OS is headless, e.g. SSH into Linux. Cross-plat implementation for this taken from GCM core repo. 

IsSystemWebviewAvailable / IsEmbeddedWebViewAvailable depend on IsDesktopSessiopn.

Minimal unit tests since this is highly environmental, i.e. build agents can run either with UI or without depending on configuration or default settings. Tests would not have value / i.e. not catch anything.

Fixes #2458 and https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2120