### PR TITLE
Obsolete attribute to GetAccounts for CCA.

### DIFF
--- a/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
@@ -91,5 +91,9 @@ namespace Microsoft.Identity.Client
         /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithExtraScopesToConsent(IEnumerable{string})"/>
         /// </remarks>
         GetAuthorizationRequestUrlParameterBuilder GetAuthorizationRequestUrl(IEnumerable<string> scopes);
+
+        /// <inheritdoc/>
+        [Obsolete("Use GetAccountAsync in web apps and web APIs, and use a token cache serializer for better security and performance. See https://aka.ms/msal-net-cca-token-cache-serialization.")]
+        new Task<IEnumerable<IAccount>> GetAccountsAsync();
     }
 }


### PR DESCRIPTION
Issue #1967

`GetAccountsAsync` in `IConfidentialClientApplication` overwrites one in `IClientApplicationBase`. Adds `obsolete` attribute.