### PR TITLE
Log error when CCA doesn't use cache serialization.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -74,6 +74,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
 
             authenticationRequestParameters.RequestContext.Logger.InfoPii(messageWithPii, messageWithoutPii);
+
+            if (authenticationRequestParameters.IsConfidentialClient && !CacheManager.TokenCacheInternal.IsTokenCacheSerialized())
+            {
+                authenticationRequestParameters.RequestContext.Logger.Error("The default token cache provided by MSAL is not designed to be performant when used in confidential client applications. Please use token cache serialization. See https://aka.ms/msal-net-cca-token-cache-serialization.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Issue #2461

As discussed with Bogdan, logging this in the `RequestBase` seemed the most appropriate because during CCA/PCA app instance creation/building we don't know yet if the cache is serialized, and we don't have existing way elsewhere to check if app instance is PCA or CCA.