### PR TITLE
When merging cache and broker accounts, check resulting collection.

### DIFF
--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Client
 
             foreach (IAccount account in brokerAccounts)
             {
-                if (!cacheAccounts.Any(x => x.HomeAccountId.Equals(account.HomeAccountId))) // AccountId is equatable
+                if (!allAccounts.Any(x => x.HomeAccountId.Equals(account.HomeAccountId))) // AccountId is equatable
                 {
                     allAccounts.Add(account);
                 }


### PR DESCRIPTION
Issue #2434.

When merging broker accounts into a resulting collection with cached accounts, check the resulting collection, instead of the original cached one, for duplicates.

Also add test that adds two identical accounts to broker, then calls `GetAccountAsync`.

Wasn't able to repro the bug. Performed general testing with Xamarin dev app and broker.