### PR TITLE
Redirect outputs for xdg-open in Linux

### DIFF
--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -611,19 +611,19 @@ namespace Microsoft.Identity.Client
         public const string LoopbackResponseUriMismatch = "loopback_response_uri_mismatch";
 
         /// <summary>
-        /// <para>What happens?</para>MSAL tried to open the browser on Linux using the xdg-open tool, but failed.
+        /// <para>What happens?</para>MSAL tried to open the browser on Linux using the xdg-open, gnome-open, or kfmclient tools, but failed.
         /// <para>Mitigation</para>Make sure you can open a page using xdg-open tool. See https://aka.ms/msal-net-os-browser for details.
         /// </summary>
         public const string LinuxXdgOpen = "linux_xdg_open_failed";
 
         /// <summary>
-        /// The selected webview is not available on this platform. You can switch to a different webview using <see cref="AcquireTokenInteractiveParameterBuilder.WithUseEmbeddedWebView(bool)"/>. See https://aka.ms/msal-net-os-browser for details
+        /// The selected WebView is not available on this platform. You can switch to a different WebView using <see cref="AcquireTokenInteractiveParameterBuilder.WithUseEmbeddedWebView(bool)"/>. See https://aka.ms/msal-net-os-browser for details
         /// </summary>
         public const string WebviewUnavailable = "no_system_webview";
 
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
         /// <summary>
-        /// <para>What happens?</para>You configured MSAL interactive authentication to use an embedded webview and you also configured <see cref="SystemWebViewOptions"/>.
+        /// <para>What happens?</para>You configured MSAL interactive authentication to use an embedded WebView and you also configured <see cref="SystemWebViewOptions"/>.
         /// These are mutually exclusive.
         /// <para>Mitigation</para>Either set <see cref="AcquireTokenInteractiveParameterBuilder.WithUseEmbeddedWebView(bool)"/> to true or do not use
         /// <see cref="AcquireTokenInteractiveParameterBuilder.WithSystemWebViewOptions(SystemWebViewOptions)"/>

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -377,5 +377,7 @@ namespace Microsoft.Identity.Client
                 "The certificate {0} does not have a private key. ",
                 certificateName);
         }
+
+        public const string LinuxOpenToolFailed = "Unable to open a web page using xdg-open, gnome-open, or kfmclient tools. See inner exception for details. Possible causes for this error are: tools are not installed or they cannot open a URL. Make sure you can open a web page by invoking from a terminal: xdg-open https://www.bing.com ";
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -641,7 +641,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         public bool IsBrokerInstalledAndInvokable()
         {
 #if NET_CORE
-            if (!netcore.NetCorePlatformProxy.IsWindowsPlatform())
+            if (!DesktopOsHelper.IsWindows())
             {
                 return false;
             }

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -173,51 +174,65 @@ namespace Microsoft.Identity.Client.Platforms.netcore
 
         public override Task StartDefaultOsBrowserAsync(string url)
         {
-            try
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var psi = new ProcessStartInfo
+                try
                 {
-                    FileName = url,
-                    UseShellExecute = true
-                };
-                Process.Start(psi);
-            }
-            catch
-            {
-                // hack because of this: https://github.com/dotnet/corefx/issues/10361
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    var psi = new ProcessStartInfo
+                    {
+                        FileName = url,
+                        UseShellExecute = true
+                    };
+                    Process.Start(psi);
+                }
+                catch
                 {
+                    // hack because of this: https://github.com/dotnet/corefx/issues/10361
                     url = url.Replace("&", "^&");
                     Process.Start(new ProcessStartInfo("cmd", $"/c start msedge {url}") { CreateNoWindow = true });
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                try
                 {
-                    try
+                    ProcessStartInfo psi = null;
+                    foreach (string openTool in new[] { "xdg-open", "gnome-open", "kfmclient" })
                     {
-                        var psi = new ProcessStartInfo("xdg-open", url)
+                        if (TryGetExecutablePath(openTool, out string openToolPath))
                         {
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                        };
-                        Process.Start(psi);
+                            psi = new ProcessStartInfo(openToolPath, url)
+                            {
+                                RedirectStandardOutput = true,
+                                RedirectStandardError = true
+                            };
+
+                            Process.Start(psi);
+
+                            break;
+                        }
                     }
-                    catch (Exception ex)
+
+                    if (psi == null)
                     {
-                        throw new MsalClientException(
-                            MsalError.LinuxXdgOpen,
-                            "Unable to open a web page using xdg-open. See inner exception for details. Possible causes for this error are: xdg-open is not installed or " +
-                            "it cannot find a way to open an url - make sure you can open a web page by invoking from a terminal: xdg-open https://www.bing.com ",
-                            ex);
+                        throw new Exception("Failed to locate a utility to launch the default web browser.");
                     }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                catch (Exception ex)
                 {
-                    Process.Start("open", url);
+                    throw new MsalClientException(
+                        MsalError.LinuxXdgOpen,
+                        MsalErrorMessage.LinuxOpenToolFailed,
+                        ex);
                 }
-                else
-                {
-                    throw new PlatformNotSupportedException(RuntimeInformation.OSDescription);
-                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Process.Start("open", url);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException(RuntimeInformation.OSDescription);
             }
             return Task.FromResult(0);
 
@@ -228,29 +243,28 @@ namespace Microsoft.Identity.Client.Platforms.netcore
             return PoPProviderFactory.GetOrCreateProvider();
         }
 
-
         /// <summary>
-        ///  Is this a windows platform
+        ///  Is this a Windows platform
         /// </summary>
-        /// <returns>A  value indicating if we are running on windows or not</returns>
+        /// <returns>A  value indicating if we are running on Windows or not</returns>
         public static bool IsWindowsPlatform()
         {
             return Environment.OSVersion.Platform == PlatformID.Win32NT;
         }
 
         /// <summary>
-        /// Is this a MAC platform
+        /// Is this a Mac platform
         /// </summary>
-        /// <returns>A value indicating if we are running on mac or not</returns>
+        /// <returns>A value indicating if we are running on Mac or not</returns>
         public static bool IsMacPlatform()
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         }
 
         /// <summary>
-        /// Is this a linux platform
+        /// Is this a Linux platform
         /// </summary>
-        /// <returns>A  value indicating if we are running on linux or not</returns>
+        /// <returns>A  value indicating if we are running on Linux or not</returns>
         public static bool IsLinuxPlatform()
         {
             return Environment.OSVersion.Platform == PlatformID.Unix;
@@ -263,5 +277,30 @@ namespace Microsoft.Identity.Client.Platforms.netcore
 
         public override bool BrokerSupportsWamAccounts => true;
 
+        /// <summary>
+        /// Searches through PATH variable to find the path to the specified executable.
+        /// </summary>
+        /// <param name="executable">Executable to find the path for.</param>
+        /// <param name="path">Location of the specified executable.</param>
+        /// <returns></returns>
+        private bool TryGetExecutablePath(string executable, out string path)
+        {
+            string pathEnvVar = Environment.GetEnvironmentVariable("PATH");
+            if (pathEnvVar != null)
+            {
+                var paths = pathEnvVar.Split(':');
+                foreach (var basePath in paths)
+                {
+                    path = Path.Combine(basePath, executable);
+                    if (File.Exists(path))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            path = null;
+            return false;
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -194,7 +194,12 @@ namespace Microsoft.Identity.Client.Platforms.netcore
                 {
                     try
                     {
-                        Process.Start("xdg-open", url);
+                        var psi = new ProcessStartInfo("xdg-open", url)
+                        {
+                            RedirectStandardOutput = true,
+                            RedirectStandardError = true,
+                        };
+                        Process.Start(psi);
                     }
                     catch (Exception ex)
                     {

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
 
         private string GetUserPrincipalName(int nameFormat)
         {
-            if (IsWindowsPlatform())
+            if (DesktopOsHelper.IsWindows())
             {
                 uint userNameSize = 0;
                 WindowsNativeMethods.GetUserNameEx(nameFormat, null, ref userNameSize);
@@ -174,7 +174,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
 
         public override Task StartDefaultOsBrowserAsync(string url)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (DesktopOsHelper.IsWindows())
             {
                 try
                 {
@@ -192,7 +192,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
                     Process.Start(new ProcessStartInfo("cmd", $"/c start msedge {url}") { CreateNoWindow = true });
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (DesktopOsHelper.IsLinux())
             {
                 try
                 {
@@ -226,7 +226,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
                         ex);
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            else if (DesktopOsHelper.IsMac())
             {
                 Process.Start("/usr/bin/open", url);
             }
@@ -243,37 +243,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
             return PoPProviderFactory.GetOrCreateProvider();
         }
 
-        /// <summary>
-        ///  Is this a Windows platform
-        /// </summary>
-        /// <returns>A  value indicating if we are running on Windows or not</returns>
-        public static bool IsWindowsPlatform()
-        {
-            return Environment.OSVersion.Platform == PlatformID.Win32NT;
-        }
-
-        /// <summary>
-        /// Is this a Mac platform
-        /// </summary>
-        /// <returns>A value indicating if we are running on Mac or not</returns>
-        public static bool IsMacPlatform()
-        {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-        }
-
-        /// <summary>
-        /// Is this a Linux platform
-        /// </summary>
-        /// <returns>A  value indicating if we are running on Linux or not</returns>
-        public static bool IsLinuxPlatform()
-        {
-            return Environment.OSVersion.Platform == PlatformID.Unix;
-        }
-
-        public override bool CanBrokerSupportSilentAuth()
-        {
-            return true;
-        }
+        public override bool CanBrokerSupportSilentAuth() => true;
 
         public override bool BrokerSupportsWamAccounts => true;
 

--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Process.Start("open", url);
+                Process.Start("/usr/bin/open", url);
             }
             else
             {


### PR DESCRIPTION
Issue #2427

Refactored open browser code. For Linux, added more "open" tools and searching for them in PATH variable.

Tested on Ubuntu, seems to work. Windows also still works.

To do after release:
- Update [Linux section](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/System-Browser-on-.Net-Core#linux-and-mac) in System Browser wiki.