### PR TITLE
Using android.support.customtabs for android api 29+

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
@@ -36,13 +36,8 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
 
         // this is used to check if anything can open custom tabs.
         // Must use the classic support. Leaving the reference AndroidX intent
-#if __ANDROID_29__
-        private readonly string _customTabsServiceAction =
-            "androidx.browser.customtabs.action.CustomTabsService";
-#else
         private readonly string _customTabsServiceAction =
             "android.support.customtabs.action.CustomTabsService";
-#endif
 
         private string _requestUrl;
         private int _requestId;


### PR DESCRIPTION
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2418
The proper way to support custom tabs on android 29+ is to use the new custom tab intent as described [here](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent).

While trying out the new CustomTabsIntent, the custom tab shows up but our code does not capture the auth response. It will take a bit of work in MSAL to get this to happen so in the meantime we can use the android.support.customtabs implemented in this PR

Tested on andoridX and 11