### PR TITLE
ValidateAuthority must be false when using regional

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -232,6 +232,15 @@ namespace Microsoft.Identity.Client
             {
                 throw new InvalidOperationException(MsalErrorMessage.InvalidRedirectUriReceived(Config.RedirectUri));
             }
+
+            if (!string.IsNullOrEmpty(Config.AzureRegion) && Config.AuthorityInfo.ValidateAuthority == true)
+            {
+                throw new MsalClientException(
+                    MsalError.RegionalAuthorityValidation,
+                    "You configured both Regional Authority and Authority Validation. Authority validation is not currently supported for regional Azure authorities." +
+                    "You can set the validateAuthority flag to false to use Azure Regional authority. Do not disable authority validation if you read the authority from a potentially unstrusted source, " +
+                    "for example from the WWWAuthenticate header of an HTTP request that resulted in a 401 response." );                    
+            }
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -6,11 +6,11 @@
 
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
     <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
-    <TargetFrameworkUap>uap10.0</TargetFrameworkUap>
+    <!--<TargetFrameworkUap>uap10.0</TargetFrameworkUap>
     <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
 
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac)</TargetFrameworks>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -6,11 +6,11 @@
 
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
     <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
-    <!--<TargetFrameworkUap>uap10.0</TargetFrameworkUap>
+    <TargetFrameworkUap>uap10.0</TargetFrameworkUap>
     <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
 
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop45);$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkUap);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac)</TargetFrameworks>

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -950,5 +950,14 @@ namespace Microsoft.Identity.Client
         ///  or the app developer can install the WebView2 runtime https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution
         /// </summary>
         public const string WebView2NotInstalled = "webview2_runtime_not_installed";
+
+
+        /// <summary>
+        /// <para>What happens?</para>You configured both Regional Authority and Authority Validation. Authority validation is not currently supported for regional authorities.
+        /// <para>Mitigation</para>Set the validateAuthority flag to false to use Azure Regional authority. Do not disable authority validation if you read the authority from a potentially unstrusted source, 
+        /// for example from the WWWAuthenticate header of an HTTP request that resulted in a 401 response. 
+        ///  </summary>
+        public const string RegionalAuthorityValidation = "regional_autority_validation";
+
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
@@ -125,19 +125,13 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
            AuthenticationResult result)
         {
             Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-        }
-
-        private void AssertTokenSource_IsCache(
-           AuthenticationResult result)
-        {
-            Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
-        }
+        }       
 
         private IConfidentialClientApplication BuildCCA(HttpSnifferClientFactory factory, string region = ConfidentialClientApplication.AttemptRegionDiscovery)
         {
             var builder = ConfidentialClientApplicationBuilder.Create(PublicCloudConfidentialClientID)
                 .WithClientAssertion(GetSignedClientAssertionUsingMsalInternal(PublicCloudConfidentialClientID, GetClaims()))
-                .WithAuthority(PublicCloudTestAuthority)
+                .WithAuthority(PublicCloudTestAuthority, false)
                 .WithTestLogging()
                 .WithExperimentalFeatures(true)
                 .WithHttpClientFactory(factory);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Region;
 using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -286,11 +287,27 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        [TestMethod]
+        public void ValidateAuthorityTest()
+        {
+            var ex = AssertException.Throws<MsalClientException>(
+                () => ConfidentialClientApplicationBuilder
+                                  .Create(TestConstants.ClientId)
+                                  .WithAuthority(
+                                        new System.Uri(ClientApplicationBase.DefaultAuthority) /* validate is true by default */)
+                                  .WithClientSecret(TestConstants.ClientSecret)
+                                  .WithAzureRegion()
+                                  .Build());
+
+            Assert.AreEqual(MsalError.RegionalAuthorityValidation, ex.ErrorCode);
+            
+        }
+
         private static IConfidentialClientApplication CreateCca(MockHttpManager httpManager, string region)
         {
             var builder = ConfidentialClientApplicationBuilder
                                  .Create(TestConstants.ClientId)
-                                 .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority))
+                                 .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), false)
                                  .WithRedirectUri(TestConstants.RedirectUri)
                                  .WithHttpManager(httpManager)
                                  .WithClientSecret(TestConstants.ClientSecret);

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                 case AcquireTokenForClientOutcome.Success:
 
                     var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                       .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId)
+                       .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId, false)
                        .WithClientSecret(TestConstants.ClientSecret)
                        .WithHttpManager(_harness.HttpManager)
                        .WithAzureRegion()
@@ -209,7 +209,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     tokenRequestHandler = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(authority: TestConstants.AuthorityTenant);
 
                     var app2 = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId)
+                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId, false)
                      .WithClientSecret(TestConstants.ClientSecret)
                      .WithHttpManager(_harness.HttpManager)
                      .WithAzureRegion()
@@ -230,7 +230,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
 
                     var app3 = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId)
+                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId, false)
                      .WithClientSecret(TestConstants.ClientSecret)
                      .WithHttpManager(_harness.HttpManager)
                      .WithAzureRegion(TestConstants.Region)
@@ -248,7 +248,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     correlationId = Guid.NewGuid();
 
                     var app5 = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.TenantId, false)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(_harness.HttpManager)
                     .WithAzureRegion()

--- a/tests/devapps/RegionalTestApp/Program.cs
+++ b/tests/devapps/RegionalTestApp/Program.cs
@@ -179,7 +179,7 @@ namespace TestApp
             };
 
             var builder = ConfidentialClientApplicationBuilder.Create(clientId)
-                .WithAuthority("https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47")
+                .WithAuthority("https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47", false)
                 .WithCertificate(certificate)
                 .WithLogging(Log, LogLevel.Verbose, true);
 


### PR DESCRIPTION
When using regional authorities, they are not validated and as such, `validateAuthority` should be set to false explicitly to drive expectations. 

A regionalized authority is seen as invalid by ESTS, e.g. `westus.microsoft.com` is not valid. So there is no support for validating the regionalized authority.

There is however support to validate the original authority, i.e. `login.microsoftonline.com` or whatever is passed in. And we could assume that if original authority is valid, then `region + original env` is also valid. This would be an improvement over the existing implemenattion and should be treated separately.
