### PR TITLE
Set IndexSource to true (by default) for symbol publishing

### DIFF
--- a/build/template-publish-packages-and-symbols.yaml
+++ b/build/template-publish-packages-and-symbols.yaml
@@ -34,5 +34,4 @@ steps:
   displayName: 'Publish symbols'
   inputs:
     SearchPattern: '${{ parameters.SymbolPublishWildcard }}'
-    IndexSources: false
     SymbolServerType: TeamServices


### PR DESCRIPTION
Suggested to be enabled in 1ES [wiki](https://www.1eswiki.com/wiki/Using_Azure_DevOps_Symbols#Source_Indexing) and [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/index-sources-publish-symbols?view=azure-devops).

> Indexing source code enables you to use your .pdb symbol files to debug an app on a machine other than the one you used to build the app. For example, you can debug an app built by a build agent from a dev machine that does not have the source code.