### PR TITLE
Jennyf/pkce - public API example

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Identity.Client
             CommonParameters.CorrelationId = CommonParameters.UseCorrelationIdFromUser ? CommonParameters.UserProvidedCorrelationId : Guid.NewGuid();
         }
 
-        internal void ValidateUseOfExpirementalFeature([System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        internal void ValidateUseOfExperimentalFeature([System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
         {
             if (!ServiceBundle.Config.ExperimentalFeaturesEnabled)
             {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         public T WithProofOfPossession(PoPAuthenticationConfiguration popAuthenticationConfiguration)
         {
-            ValidateUseOfExpirementalFeature();
+            ValidateUseOfExperimentalFeature();
 
             CommonParameters.PopAuthenticationConfiguration = popAuthenticationConfiguration ?? throw new ArgumentNullException(nameof(popAuthenticationConfiguration));
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -34,24 +34,17 @@ namespace Microsoft.Identity.Client
         internal static AcquireTokenByAuthorizationCodeParameterBuilder Create(
             IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor,
             IEnumerable<string> scopes, 
-            string authorizationCode,
-            string PkceCodeVerifier = null)
+            string authorizationCode)
         {
             ConfidentialClientApplication.GuardMobileFrameworks();
 
             return new AcquireTokenByAuthorizationCodeParameterBuilder(confidentialClientApplicationExecutor)
-                   .WithScopes(scopes).WithAuthorizationCode(authorizationCode).WithCodeVerifier(PkceCodeVerifier);
+                   .WithScopes(scopes).WithAuthorizationCode(authorizationCode);
         }
 
         private AcquireTokenByAuthorizationCodeParameterBuilder WithAuthorizationCode(string authorizationCode)
         {
             Parameters.AuthorizationCode = authorizationCode;
-            return this;
-        }
-
-        private AcquireTokenByAuthorizationCodeParameterBuilder WithCodeVerifier(string PkceCodeVerifier)
-        {
-            Parameters.PkceCodeVerifier = PkceCodeVerifier;
             return this;
         }
 
@@ -93,6 +86,19 @@ namespace Microsoft.Identity.Client
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);
             Parameters.SendX5C = withSendX5C;
+            return this;
+        }
+
+        /// <summary>
+        /// Used to secure authorization code grant via Proof of Key for Code Exchange (PKCE).
+        /// See (https://tools.ietf.org/html/rfc7636) for more details.
+        /// </summary>
+        /// <param name="PkceCodeVerifier">A dynamically created cryptographically random key used to provide proof of possession for the authorization code.
+        /// </param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public AcquireTokenByAuthorizationCodeParameterBuilder WithCodeVerifier(string PkceCodeVerifier)
+        {
+            Parameters.PkceCodeVerifier = PkceCodeVerifier;
             return this;
         }
     }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Identity.Client
         public AcquireTokenSilentParameterBuilder WithProofOfPossession(PoPAuthenticationConfiguration popAuthenticationConfiguration)
         {
             ConfidentialClientApplication.GuardMobileFrameworks();
-            ValidateUseOfExpirementalFeature();
+            ValidateUseOfExperimentalFeature();
 
             CommonParameters.PopAuthenticationConfiguration = popAuthenticationConfiguration ?? throw new ArgumentNullException(nameof(popAuthenticationConfiguration));
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
@@ -118,7 +118,16 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 requestParameters,
                 authorizationRequestUrlParameters.ToInteractiveParameters());
 
-            return handler.GetAuthorizationUriWithoutPkce();
+            if (authorizationRequestUrlParameters.CodeVerifier != null)
+            {
+                return handler.GetAuthorizationUriWithPkce(
+                    authorizationRequestUrlParameters.CodeVerifier,
+                    authorizationRequestUrlParameters.CodeChallengeMethod);
+            }
+            else
+            {
+                return handler.GetAuthorizationUriWithoutPkce();
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
@@ -120,9 +120,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
 
             if (authorizationRequestUrlParameters.CodeVerifier != null)
             {
-                return handler.GetAuthorizationUriWithPkce(
-                    authorizationRequestUrlParameters.CodeVerifier,
-                    authorizationRequestUrlParameters.CodeChallengeMethod);
+                return handler.GetAuthorizationUriWithPkce(authorizationRequestUrlParameters.CodeVerifier);
             }
             else
             {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -90,15 +90,10 @@ namespace Microsoft.Identity.Client
         /// https://tools.ietf.org/html/rfc7636
         /// </summary>
         /// <param name="codeVerifier">High-entropy cryptographic random STRING. If null, MSAL.NET will generate it.</param>
-        /// <param name="codeChallengeMethod">The method used to encode the code verifier for the code challenge parameter. Can be one
-        /// of plain or S256. If excluded, code challenge is assumed to be plaintext.</param>
         /// <returns></returns>
-        public GetAuthorizationRequestUrlParameterBuilder WithPkce(
-            ref string codeVerifier,
-            CodeChallengeMethod codeChallengeMethod = CodeChallengeMethod.Plain)
+        public GetAuthorizationRequestUrlParameterBuilder WithPkce(out string codeVerifier)
         {
-            Parameters.CodeVerifier = codeVerifier ?? ServiceBundle.PlatformProxy.CryptographyManager.GenerateCodeVerifier();
-            Parameters.CodeChallengeMethod = codeChallengeMethod;
+            Parameters.CodeVerifier = codeVerifier = ServiceBundle.PlatformProxy.CryptographyManager.GenerateCodeVerifier();
             return this;
         }
 
@@ -139,20 +134,5 @@ namespace Microsoft.Identity.Client
         {
             return ApiEvent.ApiIds.GetAuthorizationRequestUrl;
         }
-    }
-
-    /// <summary>
-    /// Enum values for CodeChallengeMethod
-    /// </summary>
-    public enum CodeChallengeMethod
-    {
-        /// <summary>
-        /// Default.
-        /// </summary>
-        Plain = 0,
-        /// <summary>
-        /// S256.
-        /// </summary>
-        S256 = 1,
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -84,6 +84,24 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+        /// <summary>
+        /// Used to secure authorization code grant via Proof of Key for Code Exchange (PKCE).
+        /// For more information, see the PKCE RCF:
+        /// https://tools.ietf.org/html/rfc7636
+        /// </summary>
+        /// <param name="codeVerifier">high-entropy cryptographic random STRING.</param>
+        /// <param name="codeChallengeMethod">The method used to encode the code verifier for the code challenge parameter. Can be one
+        /// of plain or S256. If excluded, code challenge is assumed to be plaintext.</param>
+        /// <returns></returns>
+        public GetAuthorizationRequestUrlParameterBuilder WithPkce(
+            string codeVerifier,
+            CodeChallengeMethod codeChallengeMethod = CodeChallengeMethod.Plain)
+        {
+            Parameters.CodeVerifier = codeVerifier ?? throw new ArgumentNullException(nameof(codeVerifier));
+            Parameters.CodeChallengeMethod = codeChallengeMethod;
+            return this;
+        }
+
         /// <inheritdoc />
         internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {
@@ -121,5 +139,20 @@ namespace Microsoft.Identity.Client
         {
             return ApiEvent.ApiIds.GetAuthorizationRequestUrl;
         }
+    }
+
+    /// <summary>
+    /// Enum values for CodeChallengeMethod
+    /// </summary>
+    public enum CodeChallengeMethod
+    {
+        /// <summary>
+        /// Default.
+        /// </summary>
+        Plain = 0,
+        /// <summary>
+        /// S256.
+        /// </summary>
+        S256 = 1,
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -89,15 +89,15 @@ namespace Microsoft.Identity.Client
         /// For more information, see the PKCE RCF:
         /// https://tools.ietf.org/html/rfc7636
         /// </summary>
-        /// <param name="codeVerifier">high-entropy cryptographic random STRING.</param>
+        /// <param name="codeVerifier">High-entropy cryptographic random STRING. If null, MSAL.NET will generate it.</param>
         /// <param name="codeChallengeMethod">The method used to encode the code verifier for the code challenge parameter. Can be one
         /// of plain or S256. If excluded, code challenge is assumed to be plaintext.</param>
         /// <returns></returns>
         public GetAuthorizationRequestUrlParameterBuilder WithPkce(
-            string codeVerifier,
+            string codeVerifier = null,
             CodeChallengeMethod codeChallengeMethod = CodeChallengeMethod.Plain)
         {
-            Parameters.CodeVerifier = codeVerifier ?? throw new ArgumentNullException(nameof(codeVerifier));
+            Parameters.CodeVerifier = codeVerifier ?? ServiceBundle.PlatformProxy.CryptographyManager.GenerateCodeVerifier();
             Parameters.CodeChallengeMethod = codeChallengeMethod;
             return this;
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Client
         /// of plain or S256. If excluded, code challenge is assumed to be plaintext.</param>
         /// <returns></returns>
         public GetAuthorizationRequestUrlParameterBuilder WithPkce(
-            string codeVerifier = null,
+            ref string codeVerifier,
             CodeChallengeMethod codeChallengeMethod = CodeChallengeMethod.Plain)
         {
             Parameters.CodeVerifier = codeVerifier ?? ServiceBundle.PlatformProxy.CryptographyManager.GenerateCodeVerifier();

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public IAccount Account { get; set; }
         public ICustomWebUi CustomWebUi { get; set; }
         public string CodeVerifier { get; set; }
-        public CodeChallengeMethod CodeChallengeMethod { get; set; }
 
         public void LogParameters(ICoreLogger logger)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public string LoginHint { get; set; }
         public IAccount Account { get; set; }
         public ICustomWebUi CustomWebUi { get; set; }
+        public string CodeVerifier { get; set; }
+        public CodeChallengeMethod CodeChallengeMethod { get; set; }
 
         public void LogParameters(ICoreLogger logger)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/GetAuthorizationRequestUrlParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/GetAuthorizationRequestUrlParameters.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public IEnumerable<string> ExtraScopesToConsent { get; set; }
         public string LoginHint { get; set; }
         public string CodeVerifier { get; set; }
-        public CodeChallengeMethod CodeChallengeMethod { get; set; }
 
         public AcquireTokenInteractiveParameters ToInteractiveParameters()
         {
@@ -25,8 +24,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 LoginHint = LoginHint,
                 Prompt = Prompt.SelectAccount,
                 UseEmbeddedWebView = WebViewPreference.NotSpecified,
-                CodeVerifier = CodeVerifier,
-                CodeChallengeMethod = CodeChallengeMethod
+                CodeVerifier = CodeVerifier
             };
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/GetAuthorizationRequestUrlParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/GetAuthorizationRequestUrlParameters.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public IAccount Account { get; set; }
         public IEnumerable<string> ExtraScopesToConsent { get; set; }
         public string LoginHint { get; set; }
+        public string CodeVerifier { get; set; }
+        public CodeChallengeMethod CodeChallengeMethod { get; set; }
 
         public AcquireTokenInteractiveParameters ToInteractiveParameters()
         {
@@ -22,7 +24,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 ExtraScopesToConsent = ExtraScopesToConsent,
                 LoginHint = LoginHint,
                 Prompt = Prompt.SelectAccount,
-                UseEmbeddedWebView = WebViewPreference.NotSpecified
+                UseEmbeddedWebView = WebViewPreference.NotSpecified,
+                CodeVerifier = CodeVerifier,
+                CodeChallengeMethod = CodeChallengeMethod
             };
         }
 

--- a/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -62,8 +62,6 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
         /// <param name="authorizationCode">The authorization code received from the service authorization endpoint.</param>
-        /// <param name="pkceCodeVerifier">A dynamically created cryptographically random key used to provide proof of possession for the <paramref name="authorizationCode"/>.
-        /// Adding this parameter will enable PKCE. See (https://tools.ietf.org/html/rfc7636). </param>
         /// <returns>A builder enabling you to add optional parameters before executing the token request</returns>
         /// <remarks>You can set optional parameters by chaining the builder with:
         /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithAuthority(string, bool)"/>,
@@ -77,8 +75,7 @@ namespace Microsoft.Identity.Client
             return AcquireTokenByAuthorizationCodeParameterBuilder.Create(
                 ClientExecutorFactory.CreateConfidentialClientExecutor(this),
                 scopes,
-                authorizationCode,
-                pkceCodeVerifier);
+                authorizationCode);
         }
 
         /// <summary>
@@ -139,8 +136,6 @@ namespace Microsoft.Identity.Client
         /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithLoginHint(string)"/>
         /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithExtraQueryParameters(Dictionary{string, string})"/>
         /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithExtraScopesToConsent(IEnumerable{string})"/>
-        /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithCodeChallenge(string)"/>
-        /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithCodeChallengeMethod(string)"/>
         /// </remarks>
         public GetAuthorizationRequestUrlParameterBuilder GetAuthorizationRequestUrl(
             IEnumerable<string> scopes)

--- a/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -71,10 +71,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             string authorizationCode)
         {
-            return AcquireTokenByAuthorizationCodeParameterBuilder.Create(
-                ClientExecutorFactory.CreateConfidentialClientExecutor(this),
-                scopes,
-                authorizationCode);
+            return AcquireTokenByAuthorizationCode(scopes, authorizationCode, null);
         }
 
         /// <summary>
@@ -164,6 +161,8 @@ namespace Microsoft.Identity.Client
         /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithLoginHint(string)"/>
         /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithExtraQueryParameters(Dictionary{string, string})"/>
         /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithExtraScopesToConsent(IEnumerable{string})"/>
+        /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithCodeChallenge(string)"/>
+        /// <see cref="GetAuthorizationRequestUrlParameterBuilder.WithCodeChallengeMethod(string)"/>
         /// </remarks>
         public GetAuthorizationRequestUrlParameterBuilder GetAuthorizationRequestUrl(
             IEnumerable<string> scopes)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -50,13 +50,9 @@ namespace Microsoft.Identity.Client.Internal
             return result.Item1;
         }
 
-        public Uri GetAuthorizationUriWithPkce(
-            string codeVerifier,
-            CodeChallengeMethod codeChallengeMethod)
+        public Uri GetAuthorizationUriWithPkce(string codeVerifier)
         {
-            var result = CreateAuthorizationUriWithCodeChallenge(
-                codeVerifier,
-                codeChallengeMethod);
+            var result = CreateAuthorizationUriWithCodeChallenge(codeVerifier);
             return result.Item1;
         }
 
@@ -92,26 +88,18 @@ namespace Microsoft.Identity.Client.Internal
 
         }
 
-        private Tuple<Uri, string, string> CreateAuthorizationUriWithCodeChallenge(
-            string codeVerifier,
-            CodeChallengeMethod codeChallengeMethod)
+        private Tuple<Uri, string> CreateAuthorizationUriWithCodeChallenge(
+            string codeVerifier)
         {
             IDictionary<string, string> requestParameters = CreateAuthorizationRequestParameters();
-            if (codeChallengeMethod == CodeChallengeMethod.Plain)
-            {
-                requestParameters[OAuth2Parameter.CodeChallenge] = codeVerifier;
-                requestParameters[OAuth2Parameter.CodeChallengeMethod] = "plain";
-            }
-            else
-            {
-                string codeChallenge = _serviceBundle.PlatformProxy.CryptographyManager.CreateBase64UrlEncodedSha256Hash(codeVerifier);
-                requestParameters[OAuth2Parameter.CodeChallenge] = codeChallenge;
-                requestParameters[OAuth2Parameter.CodeChallengeMethod] = OAuth2Value.CodeChallengeMethodValue;
-            }
+
+            string codeChallenge = _serviceBundle.PlatformProxy.CryptographyManager.CreateBase64UrlEncodedSha256Hash(codeVerifier);
+            requestParameters[OAuth2Parameter.CodeChallenge] = codeChallenge;
+            requestParameters[OAuth2Parameter.CodeChallengeMethod] = OAuth2Value.CodeChallengeMethodValue;
 
             UriBuilder builder = CreateInteractiveRequestParameters(requestParameters);
 
-            return new Tuple<Uri, string, string>(builder.Uri, null, codeVerifier);
+            return new Tuple<Uri, string>(builder.Uri, codeVerifier);
         }
 
         private Tuple<Uri, string, string> CreateAuthorizationUri(bool addPkceAndState = false)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -50,6 +50,16 @@ namespace Microsoft.Identity.Client.Internal
             return result.Item1;
         }
 
+        public Uri GetAuthorizationUriWithPkce(
+            string codeVerifier,
+            CodeChallengeMethod codeChallengeMethod)
+        {
+            var result = CreateAuthorizationUriWithCodeChallenge(
+                codeVerifier,
+                codeChallengeMethod);
+            return result.Item1;
+        }
+
         private async Task<Tuple<string, string>> FetchAuthCodeAndPkceInternalAsync(
             IWebUI webUi,
             CancellationToken cancellationToken)
@@ -82,6 +92,28 @@ namespace Microsoft.Identity.Client.Internal
 
         }
 
+        private Tuple<Uri, string, string> CreateAuthorizationUriWithCodeChallenge(
+            string codeVerifier,
+            CodeChallengeMethod codeChallengeMethod)
+        {
+            IDictionary<string, string> requestParameters = CreateAuthorizationRequestParameters();
+            if (codeChallengeMethod == CodeChallengeMethod.Plain)
+            {
+                requestParameters[OAuth2Parameter.CodeChallenge] = codeVerifier;
+                requestParameters[OAuth2Parameter.CodeChallengeMethod] = "plain";
+            }
+            else
+            {
+                string codeChallenge = _serviceBundle.PlatformProxy.CryptographyManager.CreateBase64UrlEncodedSha256Hash(codeVerifier);
+                requestParameters[OAuth2Parameter.CodeChallenge] = codeChallenge;
+                requestParameters[OAuth2Parameter.CodeChallengeMethod] = OAuth2Value.CodeChallengeMethodValue;
+            }
+
+            UriBuilder builder = CreateInteractiveRequestParameters(requestParameters);
+
+            return new Tuple<Uri, string, string>(builder.Uri, null, codeVerifier);
+        }
+
         private Tuple<Uri, string, string> CreateAuthorizationUri(bool addPkceAndState = false)
         {
             IDictionary<string, string> requestParameters = CreateAuthorizationRequestParameters();
@@ -91,15 +123,22 @@ namespace Microsoft.Identity.Client.Internal
             if (addPkceAndState)
             {
                 codeVerifier = _serviceBundle.PlatformProxy.CryptographyManager.GenerateCodeVerifier();
-                string codeVerifierHash = _serviceBundle.PlatformProxy.CryptographyManager.CreateBase64UrlEncodedSha256Hash(codeVerifier);
+                string codeChallenge = _serviceBundle.PlatformProxy.CryptographyManager.CreateBase64UrlEncodedSha256Hash(codeVerifier);
 
-                requestParameters[OAuth2Parameter.CodeChallenge] = codeVerifierHash;
+                requestParameters[OAuth2Parameter.CodeChallenge] = codeChallenge;
                 requestParameters[OAuth2Parameter.CodeChallengeMethod] = OAuth2Value.CodeChallengeMethodValue;
 
                 state = Guid.NewGuid().ToString() + Guid.NewGuid().ToString();
                 requestParameters[OAuth2Parameter.State] = state;
             }
 
+            UriBuilder builder = CreateInteractiveRequestParameters(requestParameters);
+
+            return new Tuple<Uri, string, string>(builder.Uri, state, codeVerifier);
+        }
+
+        private UriBuilder CreateInteractiveRequestParameters(IDictionary<string, string> requestParameters)
+        {
             // Add uid/utid values to QP if user object was passed in.
             if (_interactiveParameters.Account != null)
             {
@@ -126,8 +165,7 @@ namespace Microsoft.Identity.Client.Internal
             string qp = requestParameters.ToQueryParameter();
             var builder = new UriBuilder(new Uri(_requestParams.Endpoints.AuthorizationEndpoint));
             builder.AppendQueryParameters(qp);
-
-            return new Tuple<Uri, string, string>(builder.Uri, state, codeVerifier);
+            return builder;
         }
 
         private Dictionary<string, string> CreateAuthorizationRequestParameters(Uri redirectUriOverride = null)

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string ImdsUrl = "http://169.254.169.254/metadata/instance/compute/location";
 
         public const string UserAssertion = "fake_access_token";
+        public const string CodeVerifier = "someCodeVerifier";
 
         //This value is only for testing purposes. It is for a certificate that is not used for anything other than running tests
         public const string _defaultx5cValue = @"MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMj


### PR DESCRIPTION
from @jmprieur:

## Option 1: let MSAL.NET generate a code verifier

```csharp
// Get the authorization URL
string codeVerifier = null;
url = await cca.GetAuthorizationRequestUrl(scopes)
   .WithPkce(ref codeVerifier)
   .ExecuteAsync()
...
// use the authorization request URL to let the user sign-in, which provides the code
...
// and redeem the code
 cca.AcquireTokenByAuthorizationCode(scopes, code, codeVerifier)
   .ExecuteAsync();
```

## Option 2: I know how to generate a code verifier

```CSharp
// I generate myself the code verifier (with my own algorithm)
string codeVerifier = GenerateMyHomeGrownSpecialCodeVerifier();

// Get the authorization URL
url = await cca.GetAuthorizationRequestUrl(scopes)
    .WithPkce(ref codeVerifier)
    .ExecuteAsync();
...
// use the authorization request URL to let the user sign-in, which provides the code
...
// and redeem the code
cca.AcquireTokenByAuthorizationCode(scopes, code, codeVerifier)
    .ExecuteAsync();
```