### PR TITLE
Fix automated UI tests

### DIFF
--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
@@ -75,38 +75,13 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         //This corresponds to windows 7, 8, 8.1 and their server equivalents.       
         public static bool CanOSPerformPKeyAuth()
         {
-            var targets = "Targets: ";
-#if NET_CORE
-    targets += "NET_CORE ";
-#endif
-#if NET5_WIN
-    targets += "NET5_WIN ";
-#endif
-#if DESKTOP
-            targets += "DESKTOP ";
-#endif
-#if NETSTANDARD
-    targets += "NETSTANDARD ";
-#endif
-#if ANDROID
-    targets += "ANDROID ";
-#endif
-#if iOS
-    targets += "iOS ";
-#endif
-#if __MOBILE__
-    targets += "__MOBILE__ ";
-#endif
-#if MAC
-    targets += "MAC ";
-#endif
 #if NET_CORE || NET5_WIN || DESKTOP || NETSTANDARD
             try
             {
                 return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
             } catch (Exception ex)
             {
-                throw new MsalException("xamarin", $"Message: {targets}", ex);
+                throw new MsalException("xamarin-ui-tests", $"ERROR TYPE: {ex.GetType().FullName}", ex);
             }
 #else
             return false;

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
@@ -75,8 +75,39 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         //This corresponds to windows 7, 8, 8.1 and their server equivalents.       
         public static bool CanOSPerformPKeyAuth()
         {
-#if NET_CORE || NET5_WIN || DESKTOP || (NETSTANDARD && !(iOS || MAC || ANDROID))
-            return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
+            var targets = "Targets: ";
+#if NET_CORE
+    targets += "NET_CORE ";
+#endif
+#if NET5_WIN
+    targets += "NET5_WIN ";
+#endif
+#if DESKTOP
+            targets += "DESKTOP ";
+#endif
+#if NETSTANDARD
+    targets += "NETSTANDARD ";
+#endif
+#if ANDROID
+    targets += "ANDROID ";
+#endif
+#if iOS
+    targets += "iOS ";
+#endif
+#if __MOBILE__
+    targets += "__MOBILE__ ";
+#endif
+#if MAC
+    targets += "MAC ";
+#endif
+#if NET_CORE || NET5_WIN || DESKTOP || NETSTANDARD
+            try
+            {
+                return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
+            } catch (Exception ex)
+            {
+                throw new MsalException("xamarin", $"Message: {targets}", ex);
+            }
 #else
             return false;
 #endif

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
@@ -75,8 +75,17 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         //This corresponds to windows 7, 8, 8.1 and their server equivalents.       
         public static bool CanOSPerformPKeyAuth()
         {
-#if NET_CORE || NET5_WIN || DESKTOP || (NETSTANDARD && !MOBILE_UI_TESTS)
-            return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
+#if NET_CORE || NET5_WIN || DESKTOP || NETSTANDARD
+            try
+            {
+                return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
+            }
+            catch (DllNotFoundException)
+            {
+                // When running mobile UI tests, NETSTANDARD flag is set (instead of the mobile flags), which results in above method throwing the exception.
+                // Catching the exception and returning false, in this case.
+                return false;
+            }
 #else
             return false;
 #endif

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         //This corresponds to windows 7, 8, 8.1 and their server equivalents.       
         public static bool CanOSPerformPKeyAuth()
         {
-#if NET_CORE || NET5_WIN || DESKTOP || NETSTANDARD
+#if NET_CORE || NET5_WIN || DESKTOP || (NETSTANDARD && !(iOS || MAC || ANDROID))
             return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
 #else
             return false;

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
@@ -79,9 +79,11 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             try
             {
                 return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
-            } catch (Exception ex)
+            } catch (DllNotFoundException)
             {
-                throw new MsalException("xamarin-ui-tests", $"ERROR TYPE: {ex.GetType().FullName}", ex);
+                // When running mobile UI tests, NETSTANDARD flag is set (instead of the mobile flags), which results in above method throwing the exception.
+                // Catching the exception and returning false, in this case.
+                return false;
             }
 #else
             return false;

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DeviceAuthHelper.cs
@@ -75,16 +75,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         //This corresponds to windows 7, 8, 8.1 and their server equivalents.       
         public static bool CanOSPerformPKeyAuth()
         {
-#if NET_CORE || NET5_WIN || DESKTOP || NETSTANDARD
-            try
-            {
-                return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
-            } catch (DllNotFoundException)
-            {
-                // When running mobile UI tests, NETSTANDARD flag is set (instead of the mobile flags), which results in above method throwing the exception.
-                // Catching the exception and returning false, in this case.
-                return false;
-            }
+#if NET_CORE || NET5_WIN || DESKTOP || (NETSTANDARD && !MOBILE_UI_TESTS)
+            return !Platforms.Features.DesktopOs.DesktopOsHelper.IsWin10OrServerEquivalent();
 #else
             return false;
 #endif

--- a/tests/Microsoft.Identity.Test.Android.UIAutomation/Microsoft.Identity.Test.Android.UIAutomation.csproj
+++ b/tests/Microsoft.Identity.Test.Android.UIAutomation/Microsoft.Identity.Test.Android.UIAutomation.csproj
@@ -9,7 +9,6 @@
     <AssemblyName>Microsoft.Identity.Test.UIAutomation</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
-    <DefineConstants>MOBILE_UI_TESTS;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Microsoft.Identity.Test.Android.UIAutomation/Microsoft.Identity.Test.Android.UIAutomation.csproj
+++ b/tests/Microsoft.Identity.Test.Android.UIAutomation/Microsoft.Identity.Test.Android.UIAutomation.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Microsoft.Identity.Test.UIAutomation</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <DefineConstants>MOBILE_UI_TESTS;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Microsoft.Identity.Test.Core.UIAutomation/Microsoft.Identity.Test.UIAutomation.Infrastructure.csproj
+++ b/tests/Microsoft.Identity.Test.Core.UIAutomation/Microsoft.Identity.Test.UIAutomation.Infrastructure.csproj
@@ -10,6 +10,7 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <SignAssembly>false</SignAssembly>
     <TargetFrameworkProfile />
+    <DefineConstants>MOBILE_UI_TESTS;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Microsoft.Identity.Test.Core.UIAutomation/Microsoft.Identity.Test.UIAutomation.Infrastructure.csproj
+++ b/tests/Microsoft.Identity.Test.Core.UIAutomation/Microsoft.Identity.Test.UIAutomation.Infrastructure.csproj
@@ -10,7 +10,6 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <SignAssembly>false</SignAssembly>
     <TargetFrameworkProfile />
-    <DefineConstants>MOBILE_UI_TESTS;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Microsoft.Identity.Test.iOS.UIAutomation/Microsoft.Identity.Test.iOS.UIAutomation.csproj
+++ b/tests/Microsoft.Identity.Test.iOS.UIAutomation/Microsoft.Identity.Test.iOS.UIAutomation.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Test.Microsoft.Identity.iOS.Msal.UIAutomation</RootNamespace>
     <AssemblyName>Test.Microsoft.Identity.iOS.Msal.UIAutomation</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <DefineConstants>MOBILE_UI_TESTS;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Microsoft.Identity.Test.iOS.UIAutomation/Microsoft.Identity.Test.iOS.UIAutomation.csproj
+++ b/tests/Microsoft.Identity.Test.iOS.UIAutomation/Microsoft.Identity.Test.iOS.UIAutomation.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>Test.Microsoft.Identity.iOS.Msal.UIAutomation</RootNamespace>
     <AssemblyName>Test.Microsoft.Identity.iOS.Msal.UIAutomation</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <DefineConstants>MOBILE_UI_TESTS;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
The issue is when running automated mobile UI tests, NETSTANDARD flag is set (instead of the mobile flags), which results in DesktopOsHelper method being called and throwing an error. When running the Xamarin app, the mobile flags are set correctly, so the logic is correct. I tried adding a MOBILE_UI_TESTS flag in UI test projects (d34079242a4ff4a936266de30bca8ecaec45d102) but it didn't work. For now just catching that error and returning false. (Although, adding a tests flag would be better).