### PR TITLE
[iOS] Do not use the background check in the iOS handler.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/IosHttpClientFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/IosHttpClientFactory.cs
@@ -14,11 +14,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             HttpClient httpClient;
             if (UIDevice.CurrentDevice.CheckSystemVersion(7, 0))
             {
-                var handler = new NSUrlSessionHandler()
-                {
-                    BypassBackgroundSessionCheck = false,
-                };
-
+                var handler = new NSUrlSessionHandler();
                 httpClient = new HttpClient(handler);
                
             }


### PR DESCRIPTION
The iOS NSUrlSessionHandler needed to use a workaround to ensure that
Http requests that were performed by the application did not end up in a
stale situation in which the completion would never be reached. This was
due to https://github.com/xamarin/xamarin-macios/pull/5463

This workound will listen to the UIApplication notifications and would
cancel all the inflight requests. For reference, this happens here:

https://github.com/xamarin/xamarin-macios/blob/main/src/Foundation/NSUrlSessionHandler.cs#L174

As you can see, if we set the property to false, we will get the
notification. This is **not longer needed** as mono fixed the runtime
issue. The Xamairn.iOS team skips that workaround by default as per
this commit:

https://github.com/xamarin/xamarin-macios/commit/b6fbae5cfb90361605e9608b3b7b760337616f0f#diff-1e7e2b8b4f4fe98a485a36c085a0e9cb94f53fa87a3ff11c7c54682cc3b9d514

This library should not be using the workaround because it will have
undesired side effects on applications because they will have
cancelation exceptions that are not expected AND the library does not
provide an API to reuse the HttpClient instance configured by the
client.