### PR TITLE
Update MSBuild.Sdk.Extras version.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "2.1.2"
+        "MSBuild.Sdk.Extras": "3.0.23"
     }
 }


### PR DESCRIPTION
Newer version of MSBuild.Sdk.Extras fixes the MSB4011 warnings. ([PR](https://github.com/novotnyllc/MSBuildSdkExtras/pull/249) for reference.)