### PR TITLE
Added property to configuration to force HTTPS in the redirect_uri re…

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Identity.Client
 
 
         public ClientCredentialWrapper ClientCredential { get; internal set; }
+
+        /// <summary>
+        /// Requires that even if the host is detected to use HTTP, the redirect_url value should use HTTPS.
+        /// </summary>
+        public bool ForceHttpsOnRedirectUrl { get; internal set; }
         public string ClientSecret { get; internal set; }
         public string SignedClientAssertion { get; internal set; }
         public Func<string> SignedClientAssertionDelegate { get; internal set; }

--- a/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
@@ -109,6 +109,11 @@ namespace Microsoft.Identity.Client
         bool LegacyCacheCompatibilityEnabled { get; }
 
         /// <summary>
+        /// Requires that even if the host is detected to use HTTP, the redirect_url value should use HTTPS.
+        /// </summary>
+        bool ForceHttpsOnRedirectUrl {get; }
+
+        /// <summary>
         /// </summary>
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile


### PR DESCRIPTION
I run microservices on Service Fabric using HTTP so as to avoid having to maintain short-lived certificates on the various underlying nodes. The web-facing microservices are exposed to the public internet only through Azure App Gateway in order to handle SSL offloading (and thus provide a single point where the certificates need to be maintained). Thus, any HTTPS request goes App Gateway -> (unwrap SSL) -> send HTTP request to microservice -> reply with HTTP -> (wrap SSL) -> App Gateway replies via HTTPS to caller.

This works fine until I introduce Microsoft Authentication into the picture. Upon attempted authentication, the redirect_uri that's created appears to be based on the protocol configured to be in use by the host, so the non-configurable request to AAD looks like "redirect_uri=http://example.com". AAD app registrations understandably only allow `http://` to be used with localhost and `https://` for all other domains, so this fails with "AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application" when I attempt to log into my microservice (even if it's otherwise accessible if the URL were to use HTTPS via App Gateway).

This pull request (along with another I'll update this PR with to another Microsoft repo in a moment) introduces a boolean option to allow the developer to force the use of HTTPS in the ultimately created redirect_uri value so that my service otherwise running HTTP will instead create a value of "redirect_uri=https://example.com" in the AAD request, which _can_ be properly registered with AAD and will otherwise work. This boolean defaults to false so it only impacts users that explicitly set it, so it doesn't introduce any breaking changes.

I'd be happy to make any changes as necessary to accommodate the addition of this function.