### PR TITLE
Add UserCancellationToken to CacheNotificationArgs

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Identity.Client.Cache
                                        hasStateChanged: false,
                                        TokenCacheInternal.IsApplicationCache,
                                        hasTokens: TokenCacheInternal.HasTokensNoLocks(),
+                                       _requestParams.RequestContext.UserCancellationToken,
                                        suggestedCacheKey: key);
 
                                     stopwatch.Start();
@@ -141,6 +142,7 @@ namespace Microsoft.Identity.Client.Cache
                                        hasStateChanged: false,
                                        TokenCacheInternal.IsApplicationCache,
                                        hasTokens: TokenCacheInternal.HasTokensNoLocks(),
+                                       _requestParams.RequestContext.UserCancellationToken,
                                        suggestedCacheKey: key);
 
                                     stopwatch.Reset();

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -97,9 +97,9 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Returns all the available <see cref="IAccount">accounts</see> in the user token cache for the application.
         /// </summary>
-        public Task<IEnumerable<IAccount>> GetAccountsAsync()
+        public async Task<IEnumerable<IAccount>> GetAccountsAsync()
         {
-            return GetAccountsAsync(default(CancellationToken));
+            return await GetAccountsAsync(default(CancellationToken)).ConfigureAwait(false);
         }
 
         // TODO: MSAL 5 - add cancellationToken to the interface
@@ -117,9 +117,9 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="userFlow">The identifier is the user flow being targeted by the specific B2C authority/>.
         /// </param>
-        public Task<IEnumerable<IAccount>> GetAccountsAsync(string userFlow)
+        public async Task<IEnumerable<IAccount>> GetAccountsAsync(string userFlow)
         {
-            return GetAccountsAsync(userFlow, default(CancellationToken));
+            return await GetAccountsAsync(userFlow, default(CancellationToken)).ConfigureAwait(false);
         }
 
         // TODO: MSAL 5 - add cancellationToken to the interface
@@ -166,18 +166,18 @@ namespace Microsoft.Identity.Client
         /// value of the <see cref="AccountId.Identifier"/> property of <see cref="AccountId"/>.
         /// You typically get the account id from an <see cref="IAccount"/> by using the <see cref="IAccount.HomeAccountId"/> property>
         /// </param>
-        public Task<IAccount> GetAccountAsync(string accountId)
+        public async Task<IAccount> GetAccountAsync(string accountId)
         {
-            return GetAccountAsync(accountId, default(CancellationToken));
+            return await GetAccountAsync(accountId, default(CancellationToken)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Removes all tokens in the cache for the specified account.
         /// </summary>
         /// <param name="account">Instance of the account that needs to be removed</param>
-        public Task RemoveAsync(IAccount account)
+        public async Task RemoveAsync(IAccount account)
         {
-            return RemoveAsync(account);
+            await RemoveAsync(account).ConfigureAwait(false);
         }
 
         // TODO: MSAL 5 - add cancellationToken to the interface

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Identity.Client
         /// <param name="account">Instance of the account that needs to be removed</param>
         public async Task RemoveAsync(IAccount account)
         {
-            await RemoveAsync(account).ConfigureAwait(false);
+            await RemoveAsync(account, default(CancellationToken)).ConfigureAwait(false);
         }
 
         // TODO: MSAL 5 - add cancellationToken to the interface

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Identity.Client
             return GetAccountsAsync(default(CancellationToken));
         }
 
-        // TODO: MSAL 5 - add it to the interface
+        // TODO: MSAL 5 - add cancellationToken to the interface
         /// <summary>
         /// Returns all the available <see cref="IAccount">accounts</see> in the user token cache for the application.
         /// </summary>
@@ -122,7 +122,7 @@ namespace Microsoft.Identity.Client
             return GetAccountsAsync(userFlow, default(CancellationToken));
         }
 
-        // TODO: MSAL 5 - add it to the interface
+        // TODO: MSAL 5 - add cancellationToken to the interface
         /// <summary>
         /// Get the <see cref="IAccount"/> collection by its identifier among the accounts available in the token cache,
         /// based on the user flow. This is for Azure AD B2C scenarios.
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Client
                     userFlow, StringComparison.OrdinalIgnoreCase));
         }
 
-        // TODO: MSAL 5 - add it to the interface
+        // TODO: MSAL 5 - add cancellationToken to the interface
         /// <summary>
         /// Get the <see cref="IAccount"/> by its identifier among the accounts available in the token cache.
         /// </summary>
@@ -180,7 +180,7 @@ namespace Microsoft.Identity.Client
             return RemoveAsync(account);
         }
 
-        // TODO: MSAL 5 - add it to the interface
+        // TODO: MSAL 5 - add cancellationToken to the interface
 
         /// <summary>
         /// Removes all tokens in the cache for the specified account.

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -15,6 +15,7 @@ using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Cache.CacheImpl;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
+using System.Threading;
 
 namespace Microsoft.Identity.Client
 {
@@ -96,9 +97,18 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Returns all the available <see cref="IAccount">accounts</see> in the user token cache for the application.
         /// </summary>
-        public async Task<IEnumerable<IAccount>> GetAccountsAsync()
+        public Task<IEnumerable<IAccount>> GetAccountsAsync()
         {
-            return await GetAccountsInternalAsync(ApiIds.GetAccounts).ConfigureAwait(false);
+            return GetAccountsAsync(default(CancellationToken));
+        }
+
+        // TODO: MSAL 5 - add it to the interface
+        /// <summary>
+        /// Returns all the available <see cref="IAccount">accounts</see> in the user token cache for the application.
+        /// </summary>
+        public async Task<IEnumerable<IAccount>> GetAccountsAsync(CancellationToken cancellationToken = default)
+        {
+            return await GetAccountsInternalAsync(ApiIds.GetAccounts, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -107,18 +117,46 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="userFlow">The identifier is the user flow being targeted by the specific B2C authority/>.
         /// </param>
-        public async Task<IEnumerable<IAccount>> GetAccountsAsync(string userFlow)
+        public Task<IEnumerable<IAccount>> GetAccountsAsync(string userFlow)
+        {
+            return GetAccountsAsync(userFlow, default(CancellationToken));
+        }
+
+        // TODO: MSAL 5 - add it to the interface
+        /// <summary>
+        /// Get the <see cref="IAccount"/> collection by its identifier among the accounts available in the token cache,
+        /// based on the user flow. This is for Azure AD B2C scenarios.
+        /// </summary>
+        /// <param name="userFlow">The identifier is the user flow being targeted by the specific B2C authority/>.
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token </param>
+        public async Task<IEnumerable<IAccount>> GetAccountsAsync(string userFlow, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(userFlow))
             {
                 throw new ArgumentException($"{nameof(userFlow)} should not be null or whitespace", nameof(userFlow));
             }
 
-            var accounts = await GetAccountsInternalAsync(ApiIds.GetAccountsByUserFlow).ConfigureAwait(false);
+            var accounts = await GetAccountsInternalAsync(ApiIds.GetAccountsByUserFlow, null, cancellationToken).ConfigureAwait(false);
 
             return accounts.Where(acc =>
                 acc.HomeAccountId.ObjectId.EndsWith(
                     userFlow, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // TODO: MSAL 5 - add it to the interface
+        /// <summary>
+        /// Get the <see cref="IAccount"/> by its identifier among the accounts available in the token cache.
+        /// </summary>
+        /// <param name="accountId">Account identifier. The identifier is typically the
+        /// value of the <see cref="AccountId.Identifier"/> property of <see cref="AccountId"/>.
+        /// You typically get the account id from an <see cref="IAccount"/> by using the <see cref="IAccount.HomeAccountId"/> property>
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token </param>
+        public async Task<IAccount> GetAccountAsync(string accountId, CancellationToken cancellationToken = default)
+        {
+            var accounts = await GetAccountsInternalAsync(ApiIds.GetAccountById, accountId, cancellationToken).ConfigureAwait(false);
+            return accounts.SingleOrDefault();
         }
 
         /// <summary>
@@ -128,19 +166,30 @@ namespace Microsoft.Identity.Client
         /// value of the <see cref="AccountId.Identifier"/> property of <see cref="AccountId"/>.
         /// You typically get the account id from an <see cref="IAccount"/> by using the <see cref="IAccount.HomeAccountId"/> property>
         /// </param>
-        public async Task<IAccount> GetAccountAsync(string accountId)
+        public Task<IAccount> GetAccountAsync(string accountId)
         {
-            var accounts = await GetAccountsInternalAsync(ApiIds.GetAccountById, accountId).ConfigureAwait(false);            
-            return accounts.SingleOrDefault();
+            return GetAccountAsync(accountId, default(CancellationToken));
         }
 
         /// <summary>
         /// Removes all tokens in the cache for the specified account.
         /// </summary>
         /// <param name="account">Instance of the account that needs to be removed</param>
-        public async Task RemoveAsync(IAccount account)
+        public Task RemoveAsync(IAccount account)
         {
-            RequestContext requestContext = CreateRequestContext(Guid.NewGuid());
+            return RemoveAsync(account);
+        }
+
+        // TODO: MSAL 5 - add it to the interface
+
+        /// <summary>
+        /// Removes all tokens in the cache for the specified account.
+        /// </summary>
+        /// <param name="account">Instance of the account that needs to be removed</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task RemoveAsync(IAccount account, CancellationToken cancellationToken = default)
+        {
+            RequestContext requestContext = CreateRequestContext(Guid.NewGuid(), cancellationToken);            
 
             if (account != null && UserTokenCacheInternal != null)
             {
@@ -149,15 +198,17 @@ namespace Microsoft.Identity.Client
 
             if (AppConfig.IsBrokerEnabled && ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth())
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var broker = ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null);
                 await broker.RemoveAccountAsync(ServiceBundle.Config, account).ConfigureAwait(false);
             }
         }
 
-        private async Task<IEnumerable<IAccount>> GetAccountsInternalAsync(ApiIds apiId, string homeAccountIdFilter = null)
+        private async Task<IEnumerable<IAccount>> GetAccountsInternalAsync(ApiIds apiId, string homeAccountIdFilter, CancellationToken cancellationToken)
         {
             Guid correlationId = Guid.NewGuid();
-            RequestContext requestContext = CreateRequestContext(correlationId);
+            RequestContext requestContext = CreateRequestContext(correlationId, cancellationToken);
             requestContext.ApiEvent = new ApiEvent(requestContext.Logger, requestContext.ServiceBundle.PlatformProxy.CryptographyManager, correlationId.ToString());
             requestContext.ApiEvent.ApiId = apiId;
 
@@ -179,7 +230,7 @@ namespace Microsoft.Identity.Client
                 authParameters);
 
             var accountsFromCache = await cacheSessionManager.GetAccountsAsync().ConfigureAwait(false);
-            var accountsFromBroker = await GetAccountsFromBrokerAsync(homeAccountIdFilter, cacheSessionManager).ConfigureAwait(false);
+            var accountsFromBroker = await GetAccountsFromBrokerAsync(homeAccountIdFilter, cacheSessionManager, cancellationToken).ConfigureAwait(false);
             accountsFromCache = accountsFromCache ?? Enumerable.Empty<IAccount>();
             accountsFromBroker = accountsFromBroker ?? Enumerable.Empty<IAccount>();
 
@@ -192,7 +243,8 @@ namespace Microsoft.Identity.Client
 
         private async Task<IEnumerable<IAccount>> GetAccountsFromBrokerAsync(
             string homeAccountIdFilter,
-            ICacheSessionManager cacheSessionManager)
+            ICacheSessionManager cacheSessionManager, 
+            CancellationToken cancellationToken)
         {
             if (AppConfig.IsBrokerEnabled && ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth())
             {
@@ -214,7 +266,7 @@ namespace Microsoft.Identity.Client
                             StringComparison.OrdinalIgnoreCase));
                 }
 
-                brokerAccounts = await FilterBrokerAccountsByEnvAsync(brokerAccounts).ConfigureAwait(false);
+                brokerAccounts = await FilterBrokerAccountsByEnvAsync(brokerAccounts, cancellationToken).ConfigureAwait(false);
                 return brokerAccounts;
             }
 
@@ -222,7 +274,7 @@ namespace Microsoft.Identity.Client
         }
 
         // Not all brokers return the accounts only for the given env
-        private async Task<IEnumerable<IAccount>> FilterBrokerAccountsByEnvAsync(IEnumerable<IAccount> brokerAccounts)
+        private async Task<IEnumerable<IAccount>> FilterBrokerAccountsByEnvAsync(IEnumerable<IAccount> brokerAccounts, CancellationToken cancellationToken)
         {
             ServiceBundle.DefaultLogger.Verbose($"Filtering broker accounts by env. Before filtering: " + brokerAccounts.Count());
 
@@ -233,7 +285,7 @@ namespace Microsoft.Identity.Client
             var instanceMetadata = await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
                 AuthorityInfo,
                 allEnvs,
-                CreateRequestContext(Guid.NewGuid())).ConfigureAwait(false);
+                CreateRequestContext(Guid.NewGuid(), cancellationToken)).ConfigureAwait(false);
 
 
             brokerAccounts = brokerAccounts.Where(acc => instanceMetadata.Aliases.ContainsOrdinalIgnoreCase(acc.Environment));
@@ -269,9 +321,9 @@ namespace Microsoft.Identity.Client
         // This implementation should ONLY be called for cases where we aren't participating in
         // MATS telemetry but still need a requestcontext/logger, such as "GetAccounts()".
         // For service calls, the request context should be created in the **Executor classes as part of request execution.
-        private RequestContext CreateRequestContext(Guid correlationId)
+        private RequestContext CreateRequestContext(Guid correlationId, CancellationToken cancellationToken)
         {
-            return new RequestContext(ServiceBundle, correlationId);
+            return new RequestContext(ServiceBundle, correlationId, cancellationToken);
         }
 
 #endregion

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Identity.Client
                             hasStateChanged: true,
                             tokenCacheInternal.IsApplicationCache,
                             hasTokens: tokenCacheInternal.HasTokensNoLocks(),
+                            requestParams.RequestContext.UserCancellationToken,
                             suggestedCacheKey: suggestedWebCacheKey);
 
                         Stopwatch sw = Stopwatch.StartNew();
@@ -216,6 +217,7 @@ namespace Microsoft.Identity.Client
                             hasStateChanged: true,
                             tokenCacheInternal.IsApplicationCache,
                             tokenCacheInternal.HasTokensNoLocks(),
+                            requestParams.RequestContext.UserCancellationToken,
                             suggestedCacheKey: suggestedWebCacheKey);
 
                         Stopwatch sw = Stopwatch.StartNew();
@@ -835,6 +837,7 @@ namespace Microsoft.Identity.Client
                             true,
                             tokenCacheInternal.IsApplicationCache,
                             tokenCacheInternal.HasTokensNoLocks(),
+                            requestContext.UserCancellationToken,
                             account.HomeAccountId.Identifier);
 
                         await tokenCacheInternal.OnBeforeAccessAsync(args).ConfigureAwait(false);
@@ -858,6 +861,7 @@ namespace Microsoft.Identity.Client
                             true,
                             tokenCacheInternal.IsApplicationCache,
                             hasTokens: tokenCacheInternal.HasTokensNoLocks(),
+                            requestContext.UserCancellationToken,
                             account.HomeAccountId.Identifier);
 
                         await tokenCacheInternal.OnAfterAccessAsync(afterAccessArgs).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
+
 namespace Microsoft.Identity.Client
 {
     /// <summary>
@@ -18,6 +20,7 @@ namespace Microsoft.Identity.Client
             bool hasStateChanged,
             bool isAppCache, 
             bool hasTokens,
+            CancellationToken userCancellationToken,
             string suggestedCacheKey = null)
         {
             TokenCache = tokenCacheSerializer;
@@ -27,6 +30,7 @@ namespace Microsoft.Identity.Client
             IsApplicationCache = isAppCache;
             HasTokens = hasTokens;
             SuggestedCacheKey = suggestedCacheKey;
+            UserCancellationToken = userCancellationToken;
         }
 
         /// <summary>
@@ -84,5 +88,7 @@ namespace Microsoft.Identity.Client
         /// MSAL takes into consideration access tokens expiration when computing this flag, but not refresh token expiration, which is not known to MSAL.7
         /// </remarks>
         public bool HasTokens { get; }
+
+        public CancellationToken UserCancellationToken { get; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Client
             bool hasStateChanged,
             bool isAppCache, 
             bool hasTokens,
-            CancellationToken userCancellationToken,
+            CancellationToken cancellationToken,
             string suggestedCacheKey = null)
         {
             TokenCache = tokenCacheSerializer;
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Client
             IsApplicationCache = isAppCache;
             HasTokens = hasTokens;
             SuggestedCacheKey = suggestedCacheKey;
-            UserCancellationToken = userCancellationToken;
+            CancellationToken = cancellationToken;
         }
 
         /// <summary>
@@ -81,14 +81,18 @@ namespace Microsoft.Identity.Client
         public string SuggestedCacheKey { get; }
 
         /// <summary>
-        /// 
+        /// Is true when at least one non-expired access token exists in the cache. 
         /// </summary>
-        /// <remarks>
-        /// If this flag is false in the OnAfterAccessAsync notification, the token cache can be deleted.        
-        /// MSAL takes into consideration access tokens expiration when computing this flag, but not refresh token expiration, which is not known to MSAL.7
+        /// <remarks>  
+        /// If this flag is false in the OnAfterAccessAsync notification, the *application* token cache - used by client_credentials flow / AcquireTokenForClient -  can be deleted.        
+        /// MSAL takes into consideration access tokens expiration when computing this flag, but not refresh token expiration, which is not known to MSAL.
         /// </remarks>
         public bool HasTokens { get; }
 
-        public CancellationToken UserCancellationToken { get; }
+        /// <summary>
+        /// The cancellation token that was passed to AcquireToken* flow via ExecuteAsync(CancellationToken). Can be passed
+        /// along to the custom token cache implementation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                                        hasStateChanged: false,
                                        true,
                                        hasTokens: true,
-                                       userCancellationToken: CancellationToken.None,
+                                       cancellationToken: CancellationToken.None,
                                        suggestedCacheKey: key);
             app.AppTokenCacheInternal.OnBeforeAccessAsync(args).GetAwaiter().GetResult();
         }     

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Cache.Items;
@@ -43,6 +44,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                                        hasStateChanged: false,
                                        true,
                                        hasTokens: true,
+                                       userCancellationToken: CancellationToken.None,
                                        suggestedCacheKey: key);
             app.AppTokenCacheInternal.OnBeforeAccessAsync(args).GetAwaiter().GetResult();
         }     

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Identity.Client;
@@ -143,6 +144,7 @@ namespace Microsoft.Identity.Test.Performance
                                      hasStateChanged: false,
                                      true,
                                      hasTokens: true,
+                                     userCancellationToken: CancellationToken.None,
                                      suggestedCacheKey: key);
             cca.AppTokenCacheInternal.OnBeforeAccessAsync(args).GetAwaiter().GetResult();
 

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Test.Performance
                                      hasStateChanged: false,
                                      true,
                                      hasTokens: true,
-                                     userCancellationToken: CancellationToken.None,
+                                     cancellationToken: CancellationToken.None,
                                      suggestedCacheKey: key);
             cca.AppTokenCacheInternal.OnBeforeAccessAsync(args).GetAwaiter().GetResult();
 

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
@@ -490,7 +491,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 cache = notificationArgs.TokenCache.SerializeMsalV3();
             });
 
-            var notification = new TokenCacheNotificationArgs(tokenCache, null, null, false, false, true);
+            var notification = new TokenCacheNotificationArgs(tokenCache, null, null, false, false, true, CancellationToken.None);
             await (tokenCache as ITokenCacheInternal).OnBeforeAccessAsync(notification).ConfigureAwait(false);
             await (tokenCache as ITokenCacheInternal).OnAfterAccessAsync(notification).ConfigureAwait(false);
             (tokenCache as ITokenCacheInternal).Accessor.AssertItemCount(5, 4, 3, 3, 3);

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .ExecuteAsync(cancellationTokenSource.Token)
                     .ConfigureAwait(false);
 
-                await Task.Delay(1000).ConfigureAwait(false);
+                cancellationTokenSource.Cancel();
                 Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.HasTokens);
                 Assert.IsNotNull(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken);
                 Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken.CanBeCanceled);

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         }
 
         [TestMethod]
-        public async Task TestCancellationTokenAsync()
+        public async Task TestCancellationTokenPropagatesAsync()
         {
             using (var _harness = CreateTestHarness())
             {
@@ -289,22 +289,49 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();
                 var cacheAccessRecorder = app.UserTokenCache.RecordAccess();
 
-                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(10000);
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-                await app
-                    .AcquireTokenInteractive(TestConstants.s_scope)
-                    .ExecuteAsync(cancellationTokenSource.Token)
-                    .ConfigureAwait(false);
+                var accounts = app.GetAccountsAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+                AssertCancellationToken(cacheAccessRecorder, cancellationTokenSource);
+                cacheAccessRecorder.AssertAccessCounts(expectedReads: 1, expectedWrites: 0);
 
-                Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.HasTokens);
-                Assert.IsNotNull(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken);
-                Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken.CanBeCanceled);
-                Assert.IsFalse(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken.IsCancellationRequested);
+                try
+                {
+                    await app
+                      .AcquireTokenSilent(TestConstants.s_scope, new Account("a.b", "upn", "login.microsoft.com"))
+                      .ExecuteAsync(cancellationTokenSource.Token)
+                      .ConfigureAwait(false);
+                    AssertCancellationToken(cacheAccessRecorder, cancellationTokenSource);
+                    cacheAccessRecorder.AssertAccessCounts(expectedReads: 2, expectedWrites: 0);
+                }
+                catch (MsalUiRequiredException)
+                {
+                    await app
+                        .AcquireTokenInteractive(TestConstants.s_scope)
+                        .ExecuteAsync(cancellationTokenSource.Token)
+                        .ConfigureAwait(false);
+                }
+
+                AssertCancellationToken(cacheAccessRecorder, cancellationTokenSource, write: true);
+                cacheAccessRecorder.AssertAccessCounts(expectedReads: 2, expectedWrites: 1);
+            }
+        }
+
+        private static void AssertCancellationToken(TokenCacheAccessRecorder cacheAccessRecorder, CancellationTokenSource cancellationTokenSource, bool write = false)
+        {
+            Assert.AreEqual(cancellationTokenSource.Token, cacheAccessRecorder.LastAfterAccessNotificationArgs.CancellationToken);
+            Assert.IsFalse(default(CancellationToken) == cacheAccessRecorder.LastAfterAccessNotificationArgs.CancellationToken);
+            Assert.AreEqual(cancellationTokenSource.Token, cacheAccessRecorder.LastBeforeAccessNotificationArgs.CancellationToken);
+            Assert.IsFalse(default(CancellationToken) == cacheAccessRecorder.LastBeforeAccessNotificationArgs.CancellationToken);
+            if (write)
+            {
+                Assert.AreEqual(cancellationTokenSource.Token, cacheAccessRecorder.LastBeforeWriteNotificationArgs.CancellationToken);
+                Assert.IsFalse(default(CancellationToken) == cacheAccessRecorder.LastBeforeWriteNotificationArgs.CancellationToken);
             }
         }
 
         [TestMethod]
-        public async Task TestCancelledCancellationTokenAsync()
+        public async Task MsalOperationCanBeCancelledFromTheCacheAsync()
         {
             using (var _harness = CreateTestHarness())
             {
@@ -314,55 +341,17 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .WithHttpManager(_harness.HttpManager)
                     .BuildConcrete();
 
-                app.ServiceBundle.ConfigureMockWebUI(
-                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
-                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
-                _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();
-                var cacheAccessRecorder = app.UserTokenCache.RecordAccess();
+                app.UserTokenCache.SetBeforeAccess(notificationArgs =>
+                {
+                    throw new OperationCanceledException();
+                });
 
-                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(1000);
 
-                await app
-                    .AcquireTokenInteractive(TestConstants.s_scope)
-                    .ExecuteAsync(cancellationTokenSource.Token)
-                    .ConfigureAwait(false);
-
-                cancellationTokenSource.Cancel();
-                Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.HasTokens);
-                Assert.IsNotNull(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken);
-                Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken.CanBeCanceled);
-                Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken.IsCancellationRequested);
+                await AssertException.TaskThrowsAsync<OperationCanceledException>(() => app.GetAccountsAsync()).ConfigureAwait(false);
             }
         }
 
-        [TestMethod]
-        public async Task TestNoneCancellationTokenAsync()
-        {
-            using (var _harness = CreateTestHarness())
-            {
-                // Arrange
-                PublicClientApplication app = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .WithHttpManager(_harness.HttpManager)
-                    .BuildConcrete();
-
-                app.ServiceBundle.ConfigureMockWebUI(
-                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
-                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
-                _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();
-                var cacheAccessRecorder = app.UserTokenCache.RecordAccess();
-
-                await app
-                    .AcquireTokenInteractive(TestConstants.s_scope)
-                    .ExecuteAsync(CancellationToken.None)
-                    .ConfigureAwait(false);
-
-                Assert.IsTrue(cacheAccessRecorder.LastAfterAccessNotificationArgs.HasTokens);
-                Assert.IsNotNull(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken);
-                Assert.IsFalse(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken.CanBeCanceled);
-                Assert.IsFalse(cacheAccessRecorder.LastAfterAccessNotificationArgs.UserCancellationToken.IsCancellationRequested);
-            }
-        }
+    
 
         [TestMethod]
         public async Task GetAccounts_DoesNotFireNotifications_WhenTokenCacheIsNotSerialized_Async()
@@ -453,7 +442,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                .BuildConcrete();
 
             Assert.IsTrue(
-                (cca.AppTokenCache as ITokenCacheInternal).IsTokenCacheSerialized(), 
+                (cca.AppTokenCache as ITokenCacheInternal).IsTokenCacheSerialized(),
                 "The app token cache, used by AcquireTokenForClient, is serialized by default");
             Assert.IsFalse((cca.UserTokenCache as ITokenCacheInternal).IsTokenCacheSerialized());
 

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-                var accounts = app.GetAccountsAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+                var accounts = await app.GetAccountsAsync(cancellationTokenSource.Token).ConfigureAwait(false);
                 AssertCancellationToken(cacheAccessRecorder, cancellationTokenSource);
                 cacheAccessRecorder.AssertAccessCounts(expectedReads: 1, expectedWrites: 0);
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -18,7 +18,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Identity.Test.Unit
 {
     [TestClass]
-    [DeploymentItem(@"Resources\local-imds-response.json")]
     public class ConfidentialClientWithRegionTests : TestBase
     {
        

--- a/tests/devapps/NetFxConsoleTestApp/Program.cs
+++ b/tests/devapps/NetFxConsoleTestApp/Program.cs
@@ -447,7 +447,8 @@ namespace NetFx
                                 null,
                                 true,
                                 false,
-                                true);
+                                true,
+                                CancellationToken.None);
 
                             await tokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);
 

--- a/tests/devapps/WAM/UWPWam/MainPage.xaml.cs
+++ b/tests/devapps/WAM/UWPWam/MainPage.xaml.cs
@@ -91,7 +91,6 @@ namespace UWP_standalone
             var pca = CreatePublicClient();
             var tokenCacheInternal = pca.UserTokenCache as ITokenCacheInternal;
 
-
             TokenCacheNotificationArgs args =
                  new TokenCacheNotificationArgs(
                  pca.UserTokenCache as ITokenCacheInternal,
@@ -99,7 +98,8 @@ namespace UWP_standalone
                  null,
                  true,
                  false,
-                 true);
+                 true,
+                 CancellationToken.None);
 
             await tokenCacheInternal.OnBeforeAccessAsync(args).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes # .
#2551 

**Changes proposed in this request**
Add UserCancellationToken from the request context to [TokenCacheNotificationArgs.cs](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2658/files#diff-b0faf05b6dd32a06c308fcd6ddc4ccbaaf7379349017eb821f9701820a06e5f4R23)
Updated calling methods to pass in UserCancellationToken

**Testing**
Added unit tests [TokenCacheNotificationTests.cs](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2658/files#diff-cf04432db495972478d12c22d59cd3f47b88964cb0ebe9358cb23c1cad119546R275)

**Performance impact**
No
