### PR TITLE
Enabling mexDocument to search for wsdl:definition node in federation metadata XML

### DIFF
--- a/src/client/Microsoft.Identity.Client/WsTrust/MexDocument.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/MexDocument.cs
@@ -230,22 +230,29 @@ namespace Microsoft.Identity.Client.WsTrust
 
         private IEnumerable<XElement> FindElements(XContainer mexDocument, XNamespace xNamespace, string element)
         {
-            IEnumerable<XElement> bindingElements = mexDocument.Elements().First().Elements(xNamespace + element);
+            IEnumerable<XElement> xmlElements = mexDocument.Elements()?.First()?.Elements(xNamespace + element);
 
-            //Unable to find metadata information in root node. Attempting to search document.
-            if (bindingElements.Count() == 0)
+            if (xmlElements == null)
             {
-                bindingElements = mexDocument.Elements().DescendantsAndSelf().Elements(xNamespace + element);
+                throw new MsalClientException(
+                MsalError.ParsingWsMetadataExchangeFailed,
+                MsalErrorMessage.ParsingMetadataDocumentFailed + $" Could not find XML data.");
+            }
 
-                if (bindingElements.Count() == 0)
+            if (!xmlElements.Any())
+            {
+                //Unable to find metadata information in root node. Attempting to search document.
+                xmlElements = mexDocument.Elements().DescendantsAndSelf().Elements(xNamespace + element);
+
+                if (!xmlElements.Any())
                 {
                     throw new MsalClientException(
                     MsalError.ParsingWsMetadataExchangeFailed,
-                    MsalErrorMessage.ParsingMetadataDocumentFailed + $" Could not parse {element} data.");
+                    MsalErrorMessage.ParsingMetadataDocumentFailed + $" Could not find element {element}.");
                 }
             }
 
-            return bindingElements;
+            return xmlElements;
         }
 
         private void AddPolicy(XElement policy, UserAuthType policyAuthType)

--- a/src/client/Microsoft.Identity.Client/WsTrust/MexDocument.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/MexDocument.cs
@@ -80,6 +80,20 @@ namespace Microsoft.Identity.Client.WsTrust
         private void ReadPolicies(XContainer mexDocument)
         {
             IEnumerable<XElement> policyElements = mexDocument.Elements().First().Elements(XmlNamespace.Wsp + "Policy");
+
+            //Unable to find policy information in root node. Attempting to search document for policy information
+            if (policyElements.Count() == 0)
+            {
+                policyElements = mexDocument.Elements().DescendantsAndSelf().Elements(XmlNamespace.Wsp + "Policy");
+
+                if (policyElements.Count() == 0)
+                {
+                    throw new MsalClientException(
+                    MsalError.ParsingWsMetadataExchangeFailed,
+                    MsalErrorMessage.ParsingMetadataDocumentFailed + " Could not parse policy data.");
+                }
+            }
+
             foreach (XElement policy in policyElements)
             {
                 XElement exactlyOnePolicy = policy.Elements(XmlNamespace.Wsp + "ExactlyOne").FirstOrDefault();
@@ -136,6 +150,20 @@ namespace Microsoft.Identity.Client.WsTrust
         private void ReadPolicyBindings(XContainer mexDocument)
         {
             IEnumerable<XElement> bindingElements = mexDocument.Elements().First().Elements(XmlNamespace.Wsdl + "binding");
+
+            //Unable to find binding information in root node. Attempting to search document for binding information
+            if (bindingElements.Count() == 0)
+            {
+                bindingElements = mexDocument.Elements().DescendantsAndSelf().Elements(XmlNamespace.Wsdl + "binding");
+
+                if (bindingElements.Count() == 0)
+                {
+                    throw new MsalClientException(
+                    MsalError.ParsingWsMetadataExchangeFailed,
+                    MsalErrorMessage.ParsingMetadataDocumentFailed + " Could not parse binding data.");
+                }
+            }
+
             foreach (XElement binding in bindingElements)
             {
                 IEnumerable<XElement> policyReferences = binding.Elements(XmlNamespace.Wsp + "PolicyReference");
@@ -194,7 +222,24 @@ namespace Microsoft.Identity.Client.WsTrust
 
         private void SetPolicyEndpointAddresses(XContainer mexDocument)
         {
-            XElement serviceElement = mexDocument.Elements().First().Elements(XmlNamespace.Wsdl + "service").First();
+            XElement serviceElement = null;
+            IEnumerable<XElement> serviceElements = mexDocument.Elements().First().Elements(XmlNamespace.Wsdl + "service");
+            
+            //Unable to find service information in root node. Attempting to search document for service information
+            if (serviceElements.Count() == 0)
+            {
+                serviceElements = mexDocument.Elements().DescendantsAndSelf().Elements(XmlNamespace.Wsdl + "service");
+
+                if (serviceElements.Count() == 0)
+                {
+                    throw new MsalClientException(
+                    MsalError.ParsingWsMetadataExchangeFailed,
+                    MsalErrorMessage.ParsingMetadataDocumentFailed + " Could not parse service data.");
+                }
+            }
+            
+            serviceElement = serviceElements.First();
+
             IEnumerable<XElement> portElements = serviceElement.Elements(XmlNamespace.Wsdl + "port");
             foreach (XElement port in portElements)
             {

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -288,6 +288,51 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             }
         }
 
+        [TestMethod]
+        [DeploymentItem(@"Resources\TestMex3rdParty.xml")]
+        [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
+        public async Task AcquireTokenByIntegratedWindowsAuth3rdPartyIDPTestAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                MockHttpMessageHandler realmDiscoveryHandler = AddMockHandlerDefaultUserRealmDiscovery(httpManager);
+                AddMockHandlerWsTrustWindowsTransport(httpManager);
+                MockHttpMessageHandler mockTokenRequestHttpHandler = AddMockHandlerAadSuccess(httpManager, TestConstants.AuthorityCommonTenant);
+                mockTokenRequestHttpHandler.ExpectedQueryParams = TestConstants.ExtraQueryParameters;
+                mockTokenRequestHttpHandler.ExpectedPostData = new Dictionary<string, string> { { OAuth2Parameter.Claims, TestConstants.Claims } };
+                string federationMetadata = File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("TestMex3rdParty.xml"));
+
+                //Using 3rd party federation metadata
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                        .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                                                        .WithHttpManager(httpManager)
+                                                        .WithExtraQueryParameters(TestConstants.ExtraQueryParameters)
+                                                        .WithTelemetry(new TraceTelemetryConfig())
+                                                        .BuildConcrete();
+
+                AuthenticationResult result = await app
+                    .AcquireTokenByIntegratedWindowsAuth(TestConstants.s_scope)
+                                                        .WithClaims(TestConstants.Claims)
+                                                        .WithUsername(TestConstants.s_user.Username)
+                                                        .WithFederationMetadata(federationMetadata)
+                                                        .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual("some-access-token", result.AccessToken);
+                Assert.IsNotNull(result.Account);
+                Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
+                Assert.IsNotNull(realmDiscoveryHandler.ActualRequestMessage.Headers);
+                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessage.Headers.ToString(), TestConstants.XClientSku,
+                    "Client info header should contain " + TestConstants.XClientSku,
+                    StringComparison.OrdinalIgnoreCase);
+                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessage.Headers.ToString(), TestConstants.XClientVer,
+                    "Client info header should contain " + TestConstants.XClientVer,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
         [DeploymentItem(@"Resources\TestMex.xml")]
         [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
         public async Task AcquireTokenByIntegratedWindowsAuthMetadataTestAsync()

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -244,54 +244,12 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-
         [DeploymentItem(@"Resources\TestMex.xml")]
-        [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
-        public async Task AcquireTokenByIntegratedWindowsAuthTestAsync()
-        {
-            using (var httpManager = new MockHttpManager())
-            {
-                httpManager.AddInstanceDiscoveryMockHandler();
-
-                MockHttpMessageHandler realmDiscoveryHandler = AddMockHandlerDefaultUserRealmDiscovery(httpManager);
-                AddMockHandlerWsTrustWindowsTransport(httpManager);
-                MockHttpMessageHandler mockTokenRequestHttpHandler = AddMockHandlerAadSuccess(httpManager, TestConstants.AuthorityCommonTenant);
-                mockTokenRequestHttpHandler.ExpectedQueryParams = TestConstants.ExtraQueryParameters;
-                mockTokenRequestHttpHandler.ExpectedPostData = new Dictionary<string, string> { { OAuth2Parameter.Claims, TestConstants.Claims } };
-                string federationMetadata = File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("TestMex.xml"));
-
-                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                        .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
-                                                        .WithHttpManager(httpManager)
-                                                        .WithExtraQueryParameters(TestConstants.ExtraQueryParameters)
-                                                        .WithTelemetry(new TraceTelemetryConfig())
-                                                        .BuildConcrete();
-
-                AuthenticationResult result = await app
-                    .AcquireTokenByIntegratedWindowsAuth(TestConstants.s_scope)
-                                                        .WithClaims(TestConstants.Claims)
-                                                        .WithUsername(TestConstants.s_user.Username)
-                                                        .WithFederationMetadata(federationMetadata)
-                                                        .ExecuteAsync().ConfigureAwait(false);
-
-                Assert.IsNotNull(result);
-                Assert.AreEqual("some-access-token", result.AccessToken);
-                Assert.IsNotNull(result.Account);
-                Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
-                Assert.IsNotNull(realmDiscoveryHandler.ActualRequestMessage.Headers);
-                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessage.Headers.ToString(), TestConstants.XClientSku,
-                    "Client info header should contain " + TestConstants.XClientSku,
-                    StringComparison.OrdinalIgnoreCase);
-                StringAssert.Contains(realmDiscoveryHandler.ActualRequestMessage.Headers.ToString(), TestConstants.XClientVer,
-                    "Client info header should contain " + TestConstants.XClientVer,
-                    StringComparison.OrdinalIgnoreCase);
-            }
-        }
-
-        [TestMethod]
         [DeploymentItem(@"Resources\TestMex3rdParty.xml")]
         [DeploymentItem(@"Resources\WsTrustResponse13.xml")]
-        public async Task AcquireTokenByIntegratedWindowsAuth3rdPartyIDPTestAsync()
+        [DataRow("TestMex.xml")]
+        [DataRow("TestMex3rdParty.xml")]
+        public async Task AcquireTokenByIntegratedWindowsAuth3rdPartyIDPTestAsync(string federationMetadataFilePath)
         {
             using (var httpManager = new MockHttpManager())
             {
@@ -302,7 +260,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 MockHttpMessageHandler mockTokenRequestHttpHandler = AddMockHandlerAadSuccess(httpManager, TestConstants.AuthorityCommonTenant);
                 mockTokenRequestHttpHandler.ExpectedQueryParams = TestConstants.ExtraQueryParameters;
                 mockTokenRequestHttpHandler.ExpectedPostData = new Dictionary<string, string> { { OAuth2Parameter.Claims, TestConstants.Claims } };
-                string federationMetadata = File.ReadAllText(ResourceHelper.GetTestResourceRelativePath("TestMex3rdParty.xml"));
+                string federationMetadata = File.ReadAllText(ResourceHelper.GetTestResourceRelativePath(federationMetadataFilePath));
 
                 //Using 3rd party federation metadata
                 PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)

--- a/tests/Microsoft.Identity.Test.Unit/Resources/TestMex3rdParty.xml
+++ b/tests/Microsoft.Identity.Test.Unit/Resources/TestMex3rdParty.xml
@@ -1,0 +1,920 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="https://www.w3.org/2003/05/soap-envelope">
+  <s:Header></s:Header>
+  <s:Body>
+    <wsdl:definitions name="SecurityTokenService" targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:trust="http://docs.oasis-open.org/ws-sx/ws-trust/200512" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+      <wsp:Policy wsu:Id="CustomBinding_IWSTrustFeb2005Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <http:NegotiateAuthentication xmlns:http="http://schemas.microsoft.com/ws/06/2004/policy/http" />
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="false" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="false" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                    <sp:RequireThumbprintReference />
+                    <sp:WssX509V3Token10 />
+                  </wsp:Policy>
+                </sp:X509Token>
+                <mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:MustSupportRefThumbprint />
+              </wsp:Policy>
+            </sp:Wss11>
+            <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust10>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="true" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrustFeb2005Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="false" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                    <sp:WssUsernameToken10 />
+                  </wsp:Policy>
+                </sp:UsernameToken>
+              </wsp:Policy>
+            </sp:SignedSupportingTokens>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust10>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="CustomBinding_IWSTrustFeb2005Async1_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="false" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic128 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:KerberosToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Once">
+                  <wsp:Policy>
+                    <sp:WssGssKerberosV5ApReqToken11 />
+                  </wsp:Policy>
+                </sp:KerberosToken>
+                <mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust10>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="false" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:IssuedToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <sp:RequestSecurityTokenTemplate>
+                    <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey</t:KeyType>
+                    <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>
+                    <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</t:SignatureAlgorithm>
+                    <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>
+                    <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>
+                  </sp:RequestSecurityTokenTemplate>
+                  <wsp:Policy>
+                    <sp:RequireInternalReference />
+                  </wsp:Policy>
+                </sp:IssuedToken>
+                <mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust10>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="false" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:IssuedToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <sp:RequestSecurityTokenTemplate>
+                    <t:KeyType>http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey</t:KeyType>
+                    <t:KeySize>256</t:KeySize>
+                    <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptWith>
+                    <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</t:SignatureAlgorithm>
+                    <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>
+                    <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>
+                  </sp:RequestSecurityTokenTemplate>
+                  <wsp:Policy>
+                    <sp:RequireInternalReference />
+                  </wsp:Policy>
+                </sp:IssuedToken>
+                <mssp:RsaToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true" xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust10>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="CustomBinding_IWSTrust13Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic128 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:KerberosToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Once">
+                  <wsp:Policy>
+                    <sp:WssGssKerberosV5ApReqToken11 />
+                  </wsp:Policy>
+                </sp:KerberosToken>
+                <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust13>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrust13Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:X509Token sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                    <sp:RequireThumbprintReference />
+                    <sp:WssX509V3Token10 />
+                  </wsp:Policy>
+                </sp:X509Token>
+                <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:MustSupportRefThumbprint />
+              </wsp:Policy>
+            </sp:Wss11>
+            <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust13>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrust13Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:SignedEncryptedSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:UsernameToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                    <sp:WssUsernameToken10 />
+                  </wsp:Policy>
+                </sp:UsernameToken>
+              </wsp:Policy>
+            </sp:SignedEncryptedSupportingTokens>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust13>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrust13Async_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+                  <sp:RequestSecurityTokenTemplate>
+                    <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey</trust:KeyType>
+                    <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>
+                    <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>
+                    <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</trust:SignatureAlgorithm>
+                    <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>
+                    <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>
+                  </sp:RequestSecurityTokenTemplate>
+                  <wsp:Policy>
+                    <sp:RequireInternalReference />
+                  </wsp:Policy>
+                </sp:IssuedToken>
+                <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust13>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrust13Async1_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+                <sp:IncludeTimestamp />
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+                  <sp:RequestSecurityTokenTemplate>
+                    <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/SymmetricKey</trust:KeyType>
+                    <trust:KeySize>256</trust:KeySize>
+                    <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>
+                    <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptWith>
+                    <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</trust:SignatureAlgorithm>
+                    <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>
+                    <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>
+                  </sp:RequestSecurityTokenTemplate>
+                  <wsp:Policy>
+                    <sp:RequireInternalReference />
+                  </wsp:Policy>
+                </sp:IssuedToken>
+                <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true" />
+                <sp:SignedParts>
+                  <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing" />
+                </sp:SignedParts>
+              </wsp:Policy>
+            </sp:EndorsingSupportingTokens>
+            <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy />
+            </sp:Wss11>
+            <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+              <wsp:Policy>
+                <sp:MustSupportIssuedTokens />
+                <sp:RequireClientEntropy />
+                <sp:RequireServerEntropy />
+              </wsp:Policy>
+            </sp:Trust13>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsp:Policy wsu:Id="CustomBinding_IWSTrust13Async1_policy">
+        <wsp:ExactlyOne>
+          <wsp:All>
+            <http:NegotiateAuthentication xmlns:http="http://schemas.microsoft.com/ws/06/2004/policy/http" />
+            <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+              <wsp:Policy>
+                <sp:TransportToken>
+                  <wsp:Policy>
+                    <sp:HttpsToken RequireClientCertificate="false" />
+                  </wsp:Policy>
+                </sp:TransportToken>
+                <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                    <sp:Basic256 />
+                  </wsp:Policy>
+                </sp:AlgorithmSuite>
+                <sp:Layout>
+                  <wsp:Policy>
+                    <sp:Strict />
+                  </wsp:Policy>
+                </sp:Layout>
+              </wsp:Policy>
+            </sp:TransportBinding>
+            <wsaw:UsingAddressing />
+          </wsp:All>
+        </wsp:ExactlyOne>
+      </wsp:Policy>
+      <wsdl:types>
+        <xsd:schema targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice/Imports">
+          <xsd:import schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd0" namespace="http://schemas.microsoft.com/Message" />
+          <xsd:import schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd1" namespace="http://schemas.xmlsoap.org/ws/2005/02/trust" />
+          <xsd:import schemaLocation="https://msft.sts.microsoft.com/adfs/services/trust/mex?xsd=xsd2" namespace="http://docs.oasis-open.org/ws-sx/ws-trust/200512" />
+        </xsd:schema>
+      </wsdl:types>
+      <wsdl:message name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage">
+        <wsdl:part name="request" element="t:RequestSecurityToken" />
+      </wsdl:message>
+      <wsdl:message name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage">
+        <wsdl:part name="TrustFeb2005IssueAsyncResult" element="t:RequestSecurityTokenResponse" />
+      </wsdl:message>
+      <wsdl:message name="IWSTrust13Async_Trust13IssueAsync_InputMessage">
+        <wsdl:part name="request" element="trust:RequestSecurityToken" />
+      </wsdl:message>
+      <wsdl:message name="IWSTrust13Async_Trust13IssueAsync_OutputMessage">
+        <wsdl:part name="Trust13IssueAsyncResult" element="trust:RequestSecurityTokenResponseCollection" />
+      </wsdl:message>
+      <wsdl:portType name="IWSTrustFeb2005Async">
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <wsdl:input wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage" />
+          <wsdl:output wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue" message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage" />
+        </wsdl:operation>
+      </wsdl:portType>
+      <wsdl:portType name="IWSTrust13Async">
+        <wsdl:operation name="Trust13IssueAsync">
+          <wsdl:input wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" message="tns:IWSTrust13Async_Trust13IssueAsync_InputMessage" />
+          <wsdl:output wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal" message="tns:IWSTrust13Async_Trust13IssueAsync_OutputMessage" />
+        </wsdl:operation>
+      </wsdl:portType>
+      <wsdl:binding name="CustomBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+        <wsp:PolicyReference URI="#CustomBinding_IWSTrustFeb2005Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+        <wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+        <wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="UserNameWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+        <wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrustFeb2005Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="CustomBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+        <wsp:PolicyReference URI="#CustomBinding_IWSTrustFeb2005Async1_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+        <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+        <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="TrustFeb2005IssueAsync">
+          <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="CustomBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+        <wsp:PolicyReference URI="#CustomBinding_IWSTrust13Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Trust13IssueAsync">
+          <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="CertificateWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+        <wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrust13Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Trust13IssueAsync">
+          <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="UserNameWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+        <wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrust13Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Trust13IssueAsync">
+          <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+        <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrust13Async_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Trust13IssueAsync">
+          <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async1" type="tns:IWSTrust13Async">
+        <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrust13Async1_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Trust13IssueAsync">
+          <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:binding name="CustomBinding_IWSTrust13Async1" type="tns:IWSTrust13Async">
+        <wsp:PolicyReference URI="#CustomBinding_IWSTrust13Async1_policy" />
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Trust13IssueAsync">
+          <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document" />
+          <wsdl:input>
+            <soap12:body use="literal" />
+          </wsdl:input>
+          <wsdl:output>
+            <soap12:body use="literal" />
+          </wsdl:output>
+        </wsdl:operation>
+      </wsdl:binding>
+      <wsdl:service name="SecurityTokenService">
+        <wsdl:port name="CustomBinding_IWSTrustFeb2005Async" binding="tns:CustomBinding_IWSTrustFeb2005Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/windowstransport" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/windowstransport</wsa10:Address>
+            <Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+              <Spn>HOST/adfsintf0-30.gtm.corp.microsoft.com</Spn>
+            </Identity>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async" binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/certificatemixed" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/certificatemixed</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async1" binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async1">
+          <soap12:address location="https://msft.sts.microsoft.com:49443/adfs/services/trust/2005/certificatetransport" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com:49443/adfs/services/trust/2005/certificatetransport</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="UserNameWSTrustBinding_IWSTrustFeb2005Async" binding="tns:UserNameWSTrustBinding_IWSTrustFeb2005Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="CustomBinding_IWSTrustFeb2005Async1" binding="tns:CustomBinding_IWSTrustFeb2005Async1">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/kerberosmixed" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/kerberosmixed</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async" binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1" binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="CustomBinding_IWSTrust13Async" binding="tns:CustomBinding_IWSTrust13Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/kerberosmixed" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/kerberosmixed</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="CertificateWSTrustBinding_IWSTrust13Async" binding="tns:CertificateWSTrustBinding_IWSTrust13Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/certificatemixed" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/certificatemixed</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="UserNameWSTrustBinding_IWSTrust13Async" binding="tns:UserNameWSTrustBinding_IWSTrust13Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async" binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async1" binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async1">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256</wsa10:Address>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+        <wsdl:port name="CustomBinding_IWSTrust13Async1" binding="tns:CustomBinding_IWSTrust13Async1">
+          <soap12:address location="https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport" />
+          <wsa10:EndpointReference>
+            <wsa10:Address>https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport</wsa10:Address>
+            <Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+              <Spn>HOST/adfsintf0-30.gtm.corp.microsoft.com</Spn>
+            </Identity>
+          </wsa10:EndpointReference>
+        </wsdl:port>
+      </wsdl:service>
+    </wsdl:definitions>
+  </s:Body>
+</s:Envelope>


### PR DESCRIPTION
Fixes # .
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2665

**Changes proposed in this request**
Enabling mexDocument to search for wsdl:definition node in federation metadata XML
Added proper exception for federation metadata parsing
Added unit test

**Testing**
Added unit test

**Performance impact**
None
