### PR TITLE
Add auto-detected region to auth result metadata.

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
@@ -39,5 +39,10 @@ namespace Microsoft.Identity.Client
         /// Time (in ms) MSAL spent for HTTP communication.
         /// </summary>
         public long DurationInHttpInMs { get; set; }
+
+        /// <summary>
+        /// Azure region which was auto-detected.
+        /// </summary>
+        public string AzureRegionAutoDetected { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -96,7 +96,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
                         authenticationResult.AuthenticationResultMetadata.DurationTotalInMs = sw.ElapsedMilliseconds;
                         authenticationResult.AuthenticationResultMetadata.DurationInHttpInMs = apiEvent.DurationInHttpInMs;
-                        authenticationResult.AuthenticationResultMetadata.DurationInCacheInMs = apiEvent.DurationInCacheInMs;                        
+                        authenticationResult.AuthenticationResultMetadata.DurationInCacheInMs = apiEvent.DurationInCacheInMs;
+
+                        authenticationResult.AuthenticationResultMetadata.AzureRegionAutoDetected = Region.RegionManager.AutoDiscoveredRegion;
                         return authenticationResult;
                     }
                     catch (MsalException ex)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RegionalAuthIntegrationTests.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             Assert.IsNotNull(result);
             Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(TestConstants.Region, result.AuthenticationResultMetadata.AzureRegionAutoDetected);
             return result;
         }
 


### PR DESCRIPTION
Fixes #2646.

**Changes proposed in this request**
Add the region which was auto-detected to `AuthenticationResult.AuthenticationResultMetadata`.

**Testing**
Tested manually with regional test app. Updated some unit tests.