### PR TITLE
CCS Header updates for interactive request

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Constants.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Client.Internal
 
         public const string UserRealmMsaDomainName = "live.com";
 
-        public const string CCSRoutingHintHeader = "X-AnchorMailbox";
+        public const string CcsRoutingHintHeader = "X-AnchorMailbox";
 
         public static string FormatEnterpriseRegistrationOnPremiseUri(string domain)
         {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return dict;
         }
 
-        protected override KeyValuePair<string, string>? GetCCSHeader(IDictionary<string, string> additionalBodyParameters)
+        protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
             return null;
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return dict;
         }
 
-        protected override KeyValuePair<string, string>? GetCCSHeader(IDictionary<string, string> additionalBodyParameters)
+        protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
             return null;
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/IntegratedWindowsAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/IntegratedWindowsAuthRequest.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);
         }
 
-        protected override KeyValuePair<string, string>? GetCCSHeader(IDictionary<string, string> additionalBodyParameters)
+        protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
-            return GetCCSUpnHeader(_integratedWindowsAuthParameters.Username);
+            return GetCcsUpnHeader(_integratedWindowsAuthParameters.Username);
         }
 
         private async Task<UserAssertion> FetchAssertionFromWsTrustAsync()

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 var clientInfo = ClientInfo.CreateFromJson(_clientInfo);
 
                 _tokenClient.AddHeaderToClient(Constants.CcsRoutingHintHeader,
-                                               CoreHelpers.GetCcsClientInfoheader(clientInfo.UniqueObjectIdentifier,
+                                               CoreHelpers.GetCcsClientInfoHeader(clientInfo.UniqueObjectIdentifier,
                                                                                   clientInfo.UniqueTenantIdentifier));
             }
             else if (!string.IsNullOrEmpty(_interactiveParameters.LoginHint))

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
@@ -65,16 +65,22 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             if (!string.IsNullOrEmpty(_clientInfo))
             {
-                var decodedClientInfo = Base64UrlHelpers.DecodeToString(_clientInfo);
-
-                var clientInfo = JsonHelper.DeserializeFromJson<ClientInfo>(decodedClientInfo);
-
-                _tokenClient.AddHeaderToClient(Constants.CCSRoutingHintHeader, CoreHelpers.GetCCSClientInfoheader(clientInfo.UniqueObjectIdentifier, clientInfo.UniqueTenantIdentifier));
+                AddCCSClientInfoHeaderToTokenClient();
             }
             else if (!string.IsNullOrEmpty(_interactiveParameters.LoginHint))
             {
                 _tokenClient.AddHeaderToClient(Constants.CCSRoutingHintHeader, CoreHelpers.GetCCSUpnHeader(_interactiveParameters.LoginHint));
             }
+        }
+
+        private void AddCCSClientInfoHeaderToTokenClient()
+        {
+            var decodedClientInfo = Base64UrlHelpers.DecodeToString(_clientInfo);
+            var clientInfo = JsonHelper.DeserializeFromJson<ClientInfo>(decodedClientInfo);
+
+            _tokenClient.AddHeaderToClient(Constants.CCSRoutingHintHeader,
+                                           CoreHelpers.GetCCSClientInfoheader(clientInfo.UniqueObjectIdentifier, 
+                                                                              clientInfo.UniqueTenantIdentifier));
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public Task<MsalTokenResponse> FetchTokensAsync(CancellationToken cancellationToken)
         {
-            AddCCSHeadersToTokenClient();
+            AddCcsHeadersToTokenClient();
             return _tokenClient.SendTokenRequestAsync(GetBodyParameters());
         }
 
@@ -61,25 +61,20 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return dict;
         }
 
-        private void AddCCSHeadersToTokenClient()
+        private void AddCcsHeadersToTokenClient()
         {
             if (!string.IsNullOrEmpty(_clientInfo))
             {
-                AddCCSClientInfoHeaderToTokenClient();
+                var clientInfo = ClientInfo.CreateFromJson(_clientInfo);
+
+                _tokenClient.AddHeaderToClient(Constants.CcsRoutingHintHeader,
+                                               CoreHelpers.GetCcsClientInfoheader(clientInfo.UniqueObjectIdentifier,
+                                                                                  clientInfo.UniqueTenantIdentifier));
             }
             else if (!string.IsNullOrEmpty(_interactiveParameters.LoginHint))
             {
-                _tokenClient.AddHeaderToClient(Constants.CCSRoutingHintHeader, CoreHelpers.GetCCSUpnHeader(_interactiveParameters.LoginHint));
+                _tokenClient.AddHeaderToClient(Constants.CcsRoutingHintHeader, CoreHelpers.GetCcsUpnHeader(_interactiveParameters.LoginHint));
             }
-        }
-
-        private void AddCCSClientInfoHeaderToTokenClient()
-        {
-            var clientInfo = ClientInfo.CreateFromJson(_clientInfo);
-
-            _tokenClient.AddHeaderToClient(Constants.CCSRoutingHintHeader,
-                                           CoreHelpers.GetCCSClientInfoheader(clientInfo.UniqueObjectIdentifier, 
-                                                                              clientInfo.UniqueTenantIdentifier));
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeExchangeComponent.cs
@@ -75,8 +75,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private void AddCCSClientInfoHeaderToTokenClient()
         {
-            var decodedClientInfo = Base64UrlHelpers.DecodeToString(_clientInfo);
-            var clientInfo = JsonHelper.DeserializeFromJson<ClientInfo>(decodedClientInfo);
+            var clientInfo = ClientInfo.CreateFromJson(_clientInfo);
 
             _tokenClient.AddHeaderToClient(Constants.CCSRoutingHintHeader,
                                            CoreHelpers.GetCCSClientInfoheader(clientInfo.UniqueObjectIdentifier, 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -193,8 +193,8 @@ namespace Microsoft.Identity.Client.Internal
                 //The CCS header is used by the CCS service to help route requests to resources in Azure during requests to speed up authentication.
                 //It consists of either the ObjectId.TenantId or the upn of the account signign in.
                 //See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2525
-                string OidCCSHeader = CoreHelpers.GetCCSUpnHeader(_interactiveParameters.LoginHint);
-                authorizationRequestParameters[Constants.CCSRoutingHintHeader] = OidCCSHeader;
+                string OidCcsHeader = CoreHelpers.GetCcsUpnHeader(_interactiveParameters.LoginHint);
+                authorizationRequestParameters[Constants.CcsRoutingHintHeader] = OidCcsHeader;
             }
 
             if (_requestParams.RequestContext.CorrelationId != Guid.Empty)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Client.Internal
             _serviceBundle = _requestParams.RequestContext.ServiceBundle;
         }
 
-        public async Task<Tuple<string, string>> FetchAuthCodeAndPkceVerifierAsync(
+        public async Task<Tuple<AuthorizationResult, string>> FetchAuthCodeAndPkceVerifierAsync(
             CancellationToken cancellationToken)
         {
             var webUi = CreateWebAuthenticationDialog();
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client.Internal
             return result.Item1;
         }
 
-        private async Task<Tuple<string, string>> FetchAuthCodeAndPkceInternalAsync(
+        private async Task<Tuple<AuthorizationResult, string>> FetchAuthCodeAndPkceInternalAsync(
             IWebUI webUi,
             CancellationToken cancellationToken)
         {
@@ -83,9 +83,8 @@ namespace Microsoft.Identity.Client.Internal
 
                 VerifyAuthorizationResult(authorizationResult, state);
 
-                return new Tuple<string, string>(authorizationResult.Code, codeVerifier);
+                return new Tuple<AuthorizationResult, string>(authorizationResult, codeVerifier);
             }
-
         }
 
         private Tuple<Uri, string> CreateAuthorizationUriWithCodeChallenge(
@@ -120,6 +119,7 @@ namespace Microsoft.Identity.Client.Internal
                 requestParameters[OAuth2Parameter.State] = state;
             }
 
+            requestParameters[OAuth2Parameter.ClientInfo] = "1";
             UriBuilder builder = CreateInteractiveRequestParameters(requestParameters);
 
             return new Tuple<Uri, string, string>(builder.Uri, state, codeVerifier);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/IAuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/IAuthCodeRequestComponent.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Client.Internal
 {
     internal interface IAuthCodeRequestComponent
     {
-        Task<Tuple<string, string>> FetchAuthCodeAndPkceVerifierAsync(CancellationToken cancellationToken);
+        Task<Tuple<AuthorizationResult, string>> FetchAuthCodeAndPkceVerifierAsync(CancellationToken cancellationToken);
 
         Uri GetAuthorizationUriWithoutPkce();
     }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
@@ -134,7 +134,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
             AuthorizationResult authResult = result.Item1;
             string authCode = authResult.Code;
             string pkceCodeVerifier = result.Item2;
-            string clientInfo = authResult.Client_info;
 
             if (BrokerInteractiveRequestComponent.IsBrokerRequiredAuthCode(authCode, out string brokerInstallUri))
             {
@@ -149,7 +148,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     _interactiveParameters,
                     authCode,
                     pkceCodeVerifier,
-                    clientInfo);
+                    authResult.ClientInfo);
 
             return await authCodeExchangeComponent.FetchTokensAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
@@ -131,8 +131,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 .ConfigureAwait(false);
 
             _logger.Info("An authorization code was retrieved from the /authorize endpoint. ");
-            string authCode = result.Item1;
+            AuthorizationResult authResult = result.Item1;
+            string authCode = authResult.Code;
             string pkceCodeVerifier = result.Item2;
+            string clientInfo = authResult.Client_info;
 
             if (BrokerInteractiveRequestComponent.IsBrokerRequiredAuthCode(authCode, out string brokerInstallUri))
             {
@@ -146,7 +148,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     _requestParams,
                     _interactiveParameters,
                     authCode,
-                    pkceCodeVerifier);
+                    pkceCodeVerifier,
+                    clientInfo);
 
             return await authCodeExchangeComponent.FetchTokensAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return dict;
         }
 
-        protected override KeyValuePair<string, string>? GetCCSHeader(IDictionary<string, string> additionalBodyParameters)
+        protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
             return null;
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 {
                     var userObjectId = AuthenticationRequestParameters.Account.HomeAccountId.ObjectId;
                     var userTenantID = AuthenticationRequestParameters.Account.HomeAccountId.TenantId;
-                    string OidCcsHeader = CoreHelpers.GetCcsClientInfoheader(userObjectId, userTenantID);
+                    string OidCcsHeader = CoreHelpers.GetCcsClientInfoHeader(userObjectId, userTenantID);
 
                     return new KeyValuePair<string, string>(Constants.CcsRoutingHintHeader, OidCcsHeader);
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -254,10 +254,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
             string scopes = GetOverridenScopes(AuthenticationRequestParameters.Scope).AsSingleString();
             var tokenClient = new TokenClient(AuthenticationRequestParameters);
 
-            var CCSHeader = GetCCSHeader(additionalBodyParameters);
-            if (CCSHeader != null && !string.IsNullOrEmpty(CCSHeader.Value.Key))
+            var CcsHeader = GetCcsHeader(additionalBodyParameters);
+            if (CcsHeader != null && !string.IsNullOrEmpty(CcsHeader.Value.Key))
             {
-                tokenClient.AddHeaderToClient(CCSHeader.Value.Key, CCSHeader.Value.Value);
+                tokenClient.AddHeaderToClient(CcsHeader.Value.Key, CcsHeader.Value.Value);
             }
 
             return tokenClient.SendTokenRequestAsync(
@@ -270,7 +270,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         //The CCS header is used by the CCS service to help route requests to resources in Azure during requests to speed up authentication.
         //It consists of either the ObjectId.TenantId or the upn of the account signign in.
         //See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2525
-        protected virtual KeyValuePair<string, string>? GetCCSHeader(IDictionary<string, string> additionalBodyParameters)
+        protected virtual KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
             if (AuthenticationRequestParameters?.Account?.HomeAccountId != null)
             {
@@ -278,34 +278,34 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 {
                     var userObjectId = AuthenticationRequestParameters.Account.HomeAccountId.ObjectId;
                     var userTenantID = AuthenticationRequestParameters.Account.HomeAccountId.TenantId;
-                    string OidCCSHeader = CoreHelpers.GetCCSClientInfoheader(userObjectId, userTenantID);
+                    string OidCcsHeader = CoreHelpers.GetCcsClientInfoheader(userObjectId, userTenantID);
 
-                    return new KeyValuePair<string, string>(Constants.CCSRoutingHintHeader, OidCCSHeader);
+                    return new KeyValuePair<string, string>(Constants.CcsRoutingHintHeader, OidCcsHeader);
                 }
 
                 if (!String.IsNullOrEmpty(AuthenticationRequestParameters.Account.Username))
                 {
-                    return GetCCSUpnHeader(AuthenticationRequestParameters.Account.Username);
+                    return GetCcsUpnHeader(AuthenticationRequestParameters.Account.Username);
                 }
             }
 
             if (additionalBodyParameters.ContainsKey(OAuth2Parameter.Username))
             {
-                return GetCCSUpnHeader(additionalBodyParameters[OAuth2Parameter.Username]);
+                return GetCcsUpnHeader(additionalBodyParameters[OAuth2Parameter.Username]);
             }
             
             if (!String.IsNullOrEmpty(AuthenticationRequestParameters.LoginHint))
             {
-                return GetCCSUpnHeader (AuthenticationRequestParameters.LoginHint);
+                return GetCcsUpnHeader (AuthenticationRequestParameters.LoginHint);
             }
 
             return new KeyValuePair<string, string>();
         }
 
-        protected KeyValuePair<string, string>? GetCCSUpnHeader(string upnHeader)
+        protected KeyValuePair<string, string>? GetCcsUpnHeader(string upnHeader)
         {
-            string OidCCSHeader = CoreHelpers.GetCCSUpnHeader(upnHeader);
-            return new KeyValuePair<string, string>?(new KeyValuePair<string, string>(Constants.CCSRoutingHintHeader, OidCCSHeader));
+            string OidCcsHeader = CoreHelpers.GetCcsUpnHeader(upnHeader);
+            return new KeyValuePair<string, string>?(new KeyValuePair<string, string>(Constants.CcsRoutingHintHeader, OidCcsHeader));
         }
 
         private void LogRequestStarted(AuthenticationRequestParameters authenticationRequestParameters)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
@@ -133,9 +133,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return dict;
         }
 
-        protected override KeyValuePair<string, string>? GetCCSHeader(IDictionary<string, string> additionalBodyParameters)
+        protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
-            return GetCCSUpnHeader(_usernamePasswordParameters.Username);
+            return GetCcsUpnHeader(_usernamePasswordParameters.Username);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/UI/AuthorizationResult.cs
+++ b/src/client/Microsoft.Identity.Client/UI/AuthorizationResult.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Client.UI
 
             if (uriParams.ContainsKey(TokenResponseClaim.ClientInfo))
             {
-                result.Client_info = uriParams[TokenResponseClaim.ClientInfo];
+                result.ClientInfo = uriParams[TokenResponseClaim.ClientInfo];
             }
 
             if (uriParams.ContainsKey(TokenResponseClaim.Code))
@@ -143,7 +143,7 @@ namespace Microsoft.Identity.Client.UI
         [JsonProperty]
         public string CloudInstanceHost { get; set; }
 
-        public string Client_info { get; set; }
+        public string ClientInfo { get; set; }
 
         /// <summary>
         /// A string that is added to each Authorization Request and is expected to be sent back along with the

--- a/src/client/Microsoft.Identity.Client/UI/AuthorizationResult.cs
+++ b/src/client/Microsoft.Identity.Client/UI/AuthorizationResult.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Identity.Client.UI
                 result.CloudInstanceHost = uriParams[TokenResponseClaim.CloudInstanceHost];
             }
 
+            if (uriParams.ContainsKey(TokenResponseClaim.ClientInfo))
+            {
+                result.Client_info = uriParams[TokenResponseClaim.ClientInfo];
+            }
+
             if (uriParams.ContainsKey(TokenResponseClaim.Code))
             {
                 result.Code = uriParams[TokenResponseClaim.Code];
@@ -137,6 +142,8 @@ namespace Microsoft.Identity.Client.UI
 
         [JsonProperty]
         public string CloudInstanceHost { get; set; }
+
+        public string Client_info { get; set; }
 
         /// <summary>
         /// A string that is added to each Authorization Request and is expected to be sent back along with the

--- a/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Identity.Client.Utils
 
         internal static string GetCCSClientInfoheader(string userObjectId, string userTenantID)
         {
-            return (string.IsNullOrEmpty(userObjectId) || string.IsNullOrEmpty(userTenantID)) ? string.Empty : $@"oid:{userObjectId}@{userTenantID}";
+            return (string.IsNullOrEmpty(userObjectId) || string.IsNullOrEmpty(userTenantID)) ? string.Empty : $@"Oid:{userObjectId}@{userTenantID}";
         }
 
         internal static string GetCCSUpnHeader(string upn)

--- a/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Identity.Client.Utils
             messageBuilder.Append(value);
         }
 
-        internal static string GetCcsClientInfoheader(string userObjectId, string userTenantID)
+        internal static string GetCcsClientInfoHeader(string userObjectId, string userTenantID)
         {
             return (string.IsNullOrEmpty(userObjectId) || string.IsNullOrEmpty(userTenantID)) ? string.Empty : $@"Oid:{userObjectId}@{userTenantID}";
         }

--- a/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
@@ -238,12 +238,12 @@ namespace Microsoft.Identity.Client.Utils
             messageBuilder.Append(value);
         }
 
-        internal static string GetCCSClientInfoheader(string userObjectId, string userTenantID)
+        internal static string GetCcsClientInfoheader(string userObjectId, string userTenantID)
         {
             return (string.IsNullOrEmpty(userObjectId) || string.IsNullOrEmpty(userTenantID)) ? string.Empty : $@"Oid:{userObjectId}@{userTenantID}";
         }
 
-        internal static string GetCCSUpnHeader(string upn)
+        internal static string GetCcsUpnHeader(string upn)
         {
             return string.IsNullOrEmpty(upn)? string.Empty : $@"UPN:{upn}";
         }

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -117,14 +117,14 @@ namespace Microsoft.Identity.Test.Common
             };
         }
 
-        public static KeyValuePair<string, IEnumerable<string>> GetCCSHeaderFromSnifferFactory(HttpSnifferClientFactory factory)
+        public static KeyValuePair<string, IEnumerable<string>> GetCcsHeaderFromSnifferFactory(HttpSnifferClientFactory factory)
         {
             if (factory.RequestsAndResponses.Any())
             {
                 var (req, res) = factory.RequestsAndResponses.Single(x => x.Item1.RequestUri.AbsoluteUri.Contains("oauth2/v2.0/token") &&
                 x.Item2.StatusCode == HttpStatusCode.OK);
 
-                return req.Headers.Single(h => h.Key == Constants.CCSRoutingHintHeader);
+                return req.Headers.Single(h => h.Key == Constants.CcsRoutingHintHeader);
             }
 
             throw new MsalClientException("Could not find CCS Header in sniffer factory.");

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -117,17 +117,17 @@ namespace Microsoft.Identity.Test.Common
             };
         }
 
-        public static string GetCCSHeader(HttpSnifferClientFactory factory)
+        public static KeyValuePair<string, IEnumerable<string>> GetCCSHeaderFromSnifferFactory(HttpSnifferClientFactory factory)
         {
             if (factory.RequestsAndResponses.Any())
             {
                 var (req, res) = factory.RequestsAndResponses.Single(x => x.Item1.RequestUri.AbsoluteUri.Contains("oauth2/v2.0/token") &&
                 x.Item2.StatusCode == HttpStatusCode.OK);
 
-                return req.Headers.Single(h => h.Key == Constants.CCSRoutingHintHeader).Value.FirstOrDefault();
+                return req.Headers.Single(h => h.Key == Constants.CCSRoutingHintHeader);
             }
 
-            return string.Empty;
+            throw new MsalClientException("Could not find CCS Header in sniffer factory.");
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Reflection;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
@@ -113,6 +115,19 @@ namespace Microsoft.Identity.Test.Common
                 authority)
             {                
             };
+        }
+
+        public static string GetCCSHeader(HttpSnifferClientFactory factory)
+        {
+            if (factory.RequestsAndResponses.Any())
+            {
+                var (req, res) = factory.RequestsAndResponses.Single(x => x.Item1.RequestUri.AbsoluteUri.Contains("oauth2/v2.0/token") &&
+                x.Item2.StatusCode == HttpStatusCode.OK);
+
+                return req.Headers.Single(h => h.Key == Constants.CCSRoutingHintHeader).Value.FirstOrDefault();
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.IsNotNull(authResult.IdToken);
             Assert.IsTrue(string.Equals(labResponse.User.Upn, authResult.Account.Username, StringComparison.InvariantCultureIgnoreCase));
             AssertTelemetryHeaders(factory, false, labResponse);
-            AssertCCSRoutingInformationIsSent(factory, labResponse);
+            AssertCcsRoutingInformationIsSent(factory, labResponse);
             // If test fails with "user needs to consent to the application, do an interactive request" error,
             // Do the following:
             // 1) Add in code to pull the user's password before creating the SecureString, and put a breakpoint there.
@@ -290,10 +290,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // 4) After successful log-in, remove the password line you added in with step 1, and run the integration test again.
         }
 
-        private void AssertCCSRoutingInformationIsSent(HttpSnifferClientFactory factory, LabResponse labResponse)
+        private void AssertCcsRoutingInformationIsSent(HttpSnifferClientFactory factory, LabResponse labResponse)
         {
-            var CCSHeader = TestCommon.GetCCSHeaderFromSnifferFactory(factory);
-            Assert.AreEqual($"X-AnchorMailbox:UPN:{labResponse.User.Upn}", $"{CCSHeader.Key}:{CCSHeader.Value.FirstOrDefault()}");
+            var CcsHeader = TestCommon.GetCcsHeaderFromSnifferFactory(factory);
+            Assert.AreEqual($"X-AnchorMailbox:UPN:{labResponse.User.Upn}", $"{CcsHeader.Key}:{CcsHeader.Value.FirstOrDefault()}");
         }
 
         private void AssertTelemetryHeaders(HttpSnifferClientFactory factory, bool IsFailure, LabResponse labResponse)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
@@ -292,8 +292,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private void AssertCCSRoutingInformationIsSent(HttpSnifferClientFactory factory, LabResponse labResponse)
         {
-            string CCSHeader = TestCommon.GetCCSHeader(factory);
-            Assert.AreEqual(CoreHelpers.GetCCSUpnHeader(labResponse.User.Upn), CCSHeader);
+            var CCSHeader = TestCommon.GetCCSHeaderFromSnifferFactory(factory);
+            Assert.AreEqual($"X-AnchorMailbox:UPN:{labResponse.User.Upn}", $"{CCSHeader.Key}:{CCSHeader.Value.FirstOrDefault()}");
         }
 
         private void AssertTelemetryHeaders(HttpSnifferClientFactory factory, bool IsFailure, LabResponse labResponse)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
@@ -292,11 +292,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private void AssertCCSRoutingInformationIsSent(HttpSnifferClientFactory factory, LabResponse labResponse)
         {
-            var (req, res) = factory.RequestsAndResponses.Single(x => x.Item1.RequestUri.AbsoluteUri == labResponse.Lab.Authority + "organizations/oauth2/v2.0/token" &&
-            x.Item2.StatusCode == HttpStatusCode.OK);
-
-            var CCSHeader = req.Headers.Single(h => h.Key == Constants.CCSRoutingHintHeader).Value.FirstOrDefault();
-
+            string CCSHeader = TestCommon.GetCCSHeader(factory);
             Assert.AreEqual(CoreHelpers.GetCCSUpnHeader(labResponse.User.Upn), CCSHeader);
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/InteractiveFlowTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/InteractiveFlowTests.cs
@@ -277,10 +277,8 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
             {
                 return;
             }
-            var (req, res) = factory.RequestsAndResponses.Single(x => x.Item1.RequestUri.AbsoluteUri.Contains("oauth2/v2.0/token") &&
-            x.Item2.StatusCode == HttpStatusCode.OK);
 
-            var CCSHeader = req.Headers.Single(h => h.Key == Constants.CCSRoutingHintHeader).Value.FirstOrDefault();
+            var CCSHeader = TestCommon.GetCCSHeader(factory);
 
             if (!String.IsNullOrEmpty(CCSHeader))
             {

--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/InteractiveFlowTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/InteractiveFlowTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         }
 
         [TestMethod]
-        public async Task ValidateCCSHeadersForInteractiveAuthCodeFlowAsync()
+        public async Task ValidateCcsHeadersForInteractiveAuthCodeFlowAsync()
         {
             HttpSnifferClientFactory factory = null;
             LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
@@ -201,10 +201,10 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
                .ConfigureAwait(false);
 
 
-            var CCSHeader = TestCommon.GetCCSHeaderFromSnifferFactory(factory);
+            var CcsHeader = TestCommon.GetCcsHeaderFromSnifferFactory(factory);
             var userObjectId = labResponse.User.ObjectId;
             var userTenantID = labResponse.User.TenantId;
-            Assert.AreEqual($"X-AnchorMailbox:Oid:{userObjectId}@{userTenantID}", $"{CCSHeader.Key}:{CCSHeader.Value.FirstOrDefault()}");
+            Assert.AreEqual($"X-AnchorMailbox:Oid:{userObjectId}@{userTenantID}", $"{CcsHeader.Key}:{CcsHeader.Value.FirstOrDefault()}");
 
             Assert.IsNotNull(authResult);
             Assert.IsNotNull(authResult.AccessToken);
@@ -271,7 +271,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
                 .ExecuteAsync(new CancellationTokenSource(_interactiveAuthTimeout).Token)
                 .ConfigureAwait(false);
             userCacheAccess.AssertAccessCounts(2, 3);
-            AssertCCSRoutingInformationIsSent(factory, labResponse);
+            AssertCcsRoutingInformationIsSent(factory, labResponse);
 
             account = await MsalAssert.AssertSingleAccountAsync(labResponse, pca, result).ConfigureAwait(false);
             userCacheAccess.AssertAccessCounts(3, 3);
@@ -297,38 +297,38 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
 
             await MsalAssert.AssertSingleAccountAsync(labResponse, pca, result).ConfigureAwait(false);
             Assert.IsFalse(userCacheAccess.LastAfterAccessNotificationArgs.IsApplicationCache);
-            AssertCCSRoutingInformationIsSent(factory, labResponse);
+            AssertCcsRoutingInformationIsSent(factory, labResponse);
 
             return result;
         }
 
-        private void AssertCCSRoutingInformationIsSent(HttpSnifferClientFactory factory, LabResponse labResponse)
+        private void AssertCcsRoutingInformationIsSent(HttpSnifferClientFactory factory, LabResponse labResponse)
         {
             if (labResponse.User.FederationProvider != FederationProvider.None)
             {
                 return;
             }
 
-            var CCSHeader = TestCommon.GetCCSHeaderFromSnifferFactory(factory);
+            var CcsHeader = TestCommon.GetCcsHeaderFromSnifferFactory(factory);
 
-            if (!String.IsNullOrEmpty(CCSHeader.Value?.FirstOrDefault()))
+            if (!String.IsNullOrEmpty(CcsHeader.Value?.FirstOrDefault()))
             {
-                ValidateCCSHeader(CCSHeader, labResponse);
+                ValidateCcsHeader(CcsHeader, labResponse);
             }
         }
 
-        private void ValidateCCSHeader(KeyValuePair<string, IEnumerable<string>> CCSHeader, LabResponse labResponse)
+        private void ValidateCcsHeader(KeyValuePair<string, IEnumerable<string>> CcsHeader, LabResponse labResponse)
         {
-            var ccsHeaderValue = CCSHeader.Value.FirstOrDefault();
+            var ccsHeaderValue = CcsHeader.Value.FirstOrDefault();
             if (ccsHeaderValue.Contains("upn"))
             {
-                Assert.AreEqual($"X-AnchorMailbox:UPN:{labResponse.User.Upn}", $"{CCSHeader.Key}:{ccsHeaderValue}");
+                Assert.AreEqual($"X-AnchorMailbox:UPN:{labResponse.User.Upn}", $"{CcsHeader.Key}:{ccsHeaderValue}");
             }
             else
             {
                 var userObjectId = labResponse.User.ObjectId;
                 var userTenantID = labResponse.User.TenantId;
-                Assert.AreEqual($"X-AnchorMailbox:Oid:{userObjectId}@{userTenantID}", $"{CCSHeader.Key}:{ccsHeaderValue}");
+                Assert.AreEqual($"X-AnchorMailbox:Oid:{userObjectId}@{userTenantID}", $"{CcsHeader.Key}:{ccsHeaderValue}");
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 app.ServiceBundle.ConfigureMockWebUI();
                 var userCacheAccess = app.UserTokenCache.RecordAccess();
                 var extraExpectedHeaders = TestConstants.ExtraHttpHeader;
-                extraExpectedHeaders.Add(Constants.CCSRoutingHintHeader, CoreHelpers.GetCCSUpnHeader(TestConstants.s_user.Username));
+                extraExpectedHeaders.Add(Constants.CcsRoutingHintHeader, CoreHelpers.GetCcsUpnHeader(TestConstants.s_user.Username));
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant, null, null, false, null, extraExpectedHeaders);
 
                 Guid correlationId = Guid.NewGuid();

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/IntegratedWindowsAuthUsernamePasswordTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             using (var httpManager = new MockHttpManager())
             {
                 httpManager.AddInstanceDiscoveryMockHandler();
-                var expectedRequestHeaders = new Dictionary<string, string> { { Constants.CCSRoutingHintHeader, CoreHelpers.GetCCSUpnHeader(TestConstants.s_user.Username) } };
+                var expectedRequestHeaders = new Dictionary<string, string> { { Constants.CcsRoutingHintHeader, CoreHelpers.GetCcsUpnHeader(TestConstants.s_user.Username) } };
 
                 MockHttpMessageHandler realmDiscoveryHandler = AddMockHandlerDefaultUserRealmDiscovery(httpManager);
                 AddMockHandlerWsTrustWindowsTransport(httpManager);

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -59,7 +60,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 // Arrange - important for test
                 requestParams.AppConfig.IsBrokerEnabled = false;
-                var authCodeResult = new Tuple<string, string>("some_auth_code", "pkce_verifier");
+                var authCodeResult = new Tuple<AuthorizationResult, string>(new AuthorizationResult() { Code= "some_auth_code" }, "pkce_verifier");
                 _authCodeRequestComponentOverride.FetchAuthCodeAndPkceVerifierAsync(CancellationToken.None)
                     .Returns(Task.FromResult(authCodeResult));
 
@@ -189,7 +190,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     .Returns((MsalTokenResponse)null);
                 
                 // web UI can deal with this
-                var authCodeResult = new Tuple<string, string>("some_auth_code", "pkce_verifier");
+                var authCodeResult = new Tuple<AuthorizationResult, string>(new AuthorizationResult() { Code = "some_auth_code" }, "pkce_verifier");
                 _authCodeRequestComponentOverride.FetchAuthCodeAndPkceVerifierAsync(CancellationToken.None)
                     .Returns(Task.FromResult(authCodeResult));
                 _authCodeExchangeComponentOverride.FetchTokensAsync(CancellationToken.None)
@@ -253,7 +254,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 requestParams.AppConfig.IsBrokerEnabled = false;
 
                 // web UI starts the flow, but the auth code shows Evo needs the broker
-                var authCodeResult = new Tuple<string, string>(AuthCodeWithAppLink, "pkce_verifier");
+                var authCodeResult = new Tuple<AuthorizationResult, string>(new AuthorizationResult() { Code = AuthCodeWithAppLink }, "pkce_verifier");
                 _authCodeRequestComponentOverride.FetchAuthCodeAndPkceVerifierAsync(CancellationToken.None)
                     .Returns(Task.FromResult(authCodeResult));
 

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
@@ -300,7 +300,5 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         {
             mockHttpManager.AddInstanceDiscoveryMockHandler();
         }
-
-   
     }
 }


### PR DESCRIPTION
Adding ccs header for interactive request using client info.

Fixes # .
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2525

**Changes proposed in this request**
Adding ccs header for interactive request using client info.
Requesting client info from authorize endpoint

**Testing**
existing integration tests cover scenario

**Performance impact**
Minor. For interactive flow only
