### PR TITLE
Fix for #2686 - cache misses / bad authority validation on PPE + regi…

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 
         Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryAsync(
             AuthorityInfo authorityinfo,
-            RequestContext requestContext);
+            RequestContext requestContext, 
+            bool forceValidation=false);
 
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryMetadataEntry.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryMetadataEntry.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Identity.Client.Instance.Discovery
     [Preserve(AllMembers = true)]
     internal sealed class InstanceDiscoveryMetadataEntry
     {
+        public InstanceDiscoveryMetadataEntry()
+        {
+
+        }
         [JsonProperty(PropertyName = "preferred_network")]
         public string PreferredNetwork { get; set; }
 

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryMetadataEntry.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryMetadataEntry.cs
@@ -8,11 +8,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
     [JsonObject]
     [Preserve(AllMembers = true)]
     internal sealed class InstanceDiscoveryMetadataEntry
-    {
-        public InstanceDiscoveryMetadataEntry()
-        {
-
-        }
+    {       
         [JsonProperty(PropertyName = "preferred_network")]
         public string PreferredNetwork { get; set; }
 

--- a/src/client/Microsoft.Identity.Client/Instance/Validation/AadAuthorityValidator.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Validation/AadAuthorityValidator.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Identity.Client.Instance.Validation
                 // MSAL will throw if the instance discovery URI does not respond with a valid json
                 await _requestContext.ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
                                              authorityInfo,
-                                             _requestContext).ConfigureAwait(false);
+                                             _requestContext, 
+                                             forceValidation: true).ConfigureAwait(false);
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -527,6 +527,13 @@ namespace Microsoft.Identity.Client
         public const string B2CAuthorityHostMismatch = "B2C_authority_host_mismatch";
 
         /// <summary>
+        /// The cloud (authority url host) defined at the application level cannot be different than the cloud at the request level.
+        /// <para>What happens?</para>You did not define an authority at the application level, so it defaults to the public cloud (login.microsoft.com), but the authority at the request level is for a different cloud. Only the tenant can be changed at the request level.
+        /// <para>Mitigation</para>Add .WithAuthority("https://login.windows-ppe.net/common) at the application level and specify the tenant at the request level: .WithAuthority("https://login.windows-ppe.net/1234-567-890-12345678). 
+        /// </summary>
+        public const string AuthorityHostMismatch = "authority_host_mismatch";       
+
+        /// <summary>
         /// Duplicate query parameter was found in extraQueryParameters.
         /// <para>What happens?</para> You have used <c>extraQueryParameter</c> of overrides
         /// of token acquisition operations in public client and confidential client application and are passing a parameter which is already present in the
@@ -967,7 +974,6 @@ namespace Microsoft.Identity.Client
         /// <para>Mitigation</para> For troubleshooting details, see https://aka.ms/msal-net-webview2 .
         /// </summary>
         public const string WebView2LoaderNotFound = "webview2loader_not_found";
-
         /// <summary>
         /// <para>What happens?</para>You configured both Regional Authority and Authority Validation. Authority validation is not currently supported for regional authorities.
         /// <para>Mitigation</para>Set the validateAuthority flag to false to use Azure Regional authority. Do not disable authority validation if you read the authority from an untrusted source, 

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -515,6 +515,8 @@ namespace Microsoft.Identity.Client
 
         private async Task<IEnumerable<MsalAccessTokenCacheItem>> FilterByEnvironmentAsync(AuthenticationRequestParameters requestParams, IEnumerable<MsalAccessTokenCacheItem> filteredItems)
         {
+            var logger = requestParams.RequestContext.Logger;
+            
             // at this point we need env aliases, try to get them without a discovery call
             var instanceMetadata = await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
                                      requestParams.AuthorityInfo,
@@ -532,6 +534,11 @@ namespace Microsoft.Identity.Client
 
             if (filteredByPreferredAlias.Any())
             {
+                if (logger.IsLoggingEnabled(LogLevel.Verbose))
+                {
+                    logger.Verbose($"Filtered by preferred alias returning {filteredByPreferredAlias.Count()} tokens");
+                }
+
                 return filteredByPreferredAlias;
             }
 

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string ProductionPrefRegionalEnvironment = "centralus.login.microsoft.com";
         public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.login.microsoft.com";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
+        public const string PPEEnvironment = "login.windows-ppe.net";
+
 
         public const string AuthorityNotKnownCommon = "https://sts.access.edu/common/";
         public const string AuthorityNotKnownTenanted = "https://sts.access.edu/" + Utid + "/";
@@ -71,7 +73,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string AuthorityRegional = "https://" + ProductionPrefRegionalEnvironment + "/" + TenantId + "/";
         public const string AuthorityRegionalInvalidRegion = "https://" + ProductionPrefInvalidRegionEnvironment + "/" + TenantId + "/";
         public const string AuthorityTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + TenantId + "/";
-        public const string AuthorityCommonTenantNotPrefAlias = "https://" + ProductionNotPrefEnvironmentAlias + "/common/";
+        public const string AuthorityCommonTenantNotPrefAlias = "https://" + ProductionNotPrefEnvironmentAlias + "/common/";        
 
         public const string PrefCacheAuthorityCommonTenant = "https://" + ProductionPrefCacheEnvironment + "/common/";
         public const string AuthorityOrganizationsTenant = "https://" + ProductionPrefNetworkEnvironment + "/organizations/";
@@ -81,6 +83,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string AuthorityGuidTenant2 = "https://" + ProductionPrefNetworkEnvironment + "/987654321/";
         public const string AuthorityWindowsNet = "https://" + ProductionPrefCacheEnvironment + "/" + Utid + "/";
         public const string ADFSAuthority = "https://fs.msidlab8.com/adfs/";
+        public const string ADFSAuthority2 = "https://someAdfs.com/adfs/";
 
         public const string B2CSignUpSignIn = "b2c_1_susi";
         public const string B2CProfileWithDot = "b2c.someprofile";

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
     {
         private static readonly AuthorityInfo s_commonAuthority =
             AuthorityInfo.FromAuthorityUri(TestConstants.AuthorityCommonTenant, true);
-        static string s = $@"https://{TestConstants.PPEEnvironment}/{TestConstants.TenantId}";
+        static string s_ppeCommonUri = $@"https://{TestConstants.PPEEnvironment}/{TestConstants.TenantId}";
         private static readonly AuthorityInfo s_ppeAuthority =
-          AuthorityInfo.FromAuthorityUri(s, true);
+          AuthorityInfo.FromAuthorityUri(s_ppeCommonUri, true);
         private static readonly AuthorityInfo s_utidAuthority =
             AuthorityInfo.FromAuthorityUri(TestConstants.AuthorityUtidTenant, true);
         private static readonly AuthorityInfo s_utid2Authority =

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -365,6 +365,7 @@ namespace Microsoft.Identity.Test.Unit
                 var userCacheAccess = app.UserTokenCache.RecordAccess();
 
                 harness.HttpManager.AddMockHandler(CreateTokenResponseHttpHandler(true));
+                
                 AuthenticationResult result = await app
                     .AcquireTokenForClient(TestConstants.s_scope)
                     .WithSendX5C(true)


### PR DESCRIPTION
…onal

Fixes #2686  .


**Changes proposed in this request**
- prevent developers from 
- force validation of non-regionalized env for unknown environments like PPE


**Testing**
Unit tests
I have an int test with PPE as well, will publish it as a separate PR because I need to hide secrets in KV etc. Test runs fine on my machine with a secret in clear.

**Performance impact**
fingers crossed.... there should be no impact on known clouds
