### PR TITLE
Allow apps to disable the cache semaphore

### DIFF
--- a/src/client/Microsoft.Identity.Client/Account.cs
+++ b/src/client/Microsoft.Identity.Client/Account.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Identity.Client
         /// <summary>        
         /// The same account can exist in its home tenant and also as a guest in multiple other tenants. 
         /// A <see cref="TenantProfile"/> is derived from the ID token for that tenant.
+        /// </summary>
         public IEnumerable<TenantProfile> TenantProfiles { get; }      
 
         internal IDictionary<string, string> WamAccountIds { get; }

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Client
         internal int ConfidentialClientCredentialCount;
 
         public bool LegacyCacheCompatibilityEnabled { get; internal set; } = true;
-        public bool CacheSyncronizationEnabled { get; internal set; } = true;
+        public bool CacheSynchronizationEnabled { get; internal set; } = true;
 
 
         #region Region

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Identity.Client
         public string IosKeychainSecurityGroup { get; internal set; }
 
         public bool IsBrokerEnabled { get; internal set; }
+
         public WindowsBrokerOptions WindowsBrokerOptions { get; set; }
 
         public Func<CoreUIParent, ApplicationConfiguration, ICoreLogger, IBroker> BrokerCreatorFunc { get; set; }
@@ -95,8 +96,10 @@ namespace Microsoft.Identity.Client
         internal int ConfidentialClientCredentialCount;
 
         public bool LegacyCacheCompatibilityEnabled { get; internal set; } = true;
+        public bool CacheSyncronizationEnabled { get; internal set; } = true;
 
-#region Region
+
+        #region Region
         public string AzureRegion { get; set; }
 #endregion
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -224,9 +224,9 @@ namespace Microsoft.Identity.Client
         /// True by default, but subject to change.
         /// Not recommended for apps that call RemoveAsync
         /// </remarks>
-        public ConfidentialClientApplicationBuilder WithCacheSynchronization(bool enableCacheSyncronization)
+        public ConfidentialClientApplicationBuilder WithCacheSynchronization(bool enableCacheSynchronization)
         {          
-            Config.CacheSyncronizationEnabled = enableCacheSyncronization;
+            Config.CacheSynchronizationEnabled = enableCacheSynchronization;
 
             return this;
         }

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Identity.Client
         /// True by default, but subject to change.
         /// Not recommended for apps that call RemoveAsync
         /// </remarks>
-        public ConfidentialClientApplicationBuilder WithCacheSyncronization(bool enableCacheSyncronization)
+        public ConfidentialClientApplicationBuilder WithCacheSynchronization(bool enableCacheSyncronization)
         {          
             Config.CacheSyncronizationEnabled = enableCacheSyncronization;
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -213,6 +213,24 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+
+        /// <summary>
+        /// When set to <c>true</c>, MSAL will lock cache access at the <see cref="ConfidentialClientApplication"/> level, i.e.
+        /// the block of code between BeforeAccessAsync and AfterAccessAsync callbacks will be syncronized. 
+        /// Apps can set this flag to <c>false</c> to enable an optimistic cache locking strategy, which may result in better performance, especially 
+        /// when ConfidentialClientApplication objects are reused.
+        /// </summary>
+        /// <remarks>
+        /// True by default, but subject to change.
+        /// Not recommended for apps that call RemoveAsync
+        /// </remarks>
+        public ConfidentialClientApplicationBuilder WithCacheSyncronization(bool enableCacheSyncronization)
+        {          
+            Config.CacheSyncronizationEnabled = enableCacheSyncronization;
+
+            return this;
+        }
+
         internal ConfidentialClientApplicationBuilder WithAppTokenCacheInternalForTest(ITokenCacheInternal tokenCacheInternal)
         {
             Config.AppTokenCacheInternalForTest = tokenCacheInternal;

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationOptions.cs
@@ -32,5 +32,17 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-region-discovery for more details.        
         /// </remarks>
         public string AzureRegion { get; set; }
+
+        /// <summary>
+        /// When set to <c>true</c>, MSAL will lock cache access at the <see cref="ConfidentialClientApplication"/> level, i.e.
+        /// the block of code between BeforeAccessAsync and AfterAccessAsync callbacks will be syncronized. 
+        /// Apps can set this flag to <c>false</c> to enable an optimistic cache locking strategy, which may result in better performance, especially 
+        /// when ConfidentialClientApplication objects are reused.
+        /// </summary>
+        /// <remarks>
+        /// True by default, but subject to change.
+        /// Not recommended for apps that call RemoveAsync
+        /// </remarks>
+        public bool EnableCacheSynchronization { get; set; } = true;
     }
 }

--- a/src/client/Microsoft.Identity.Client/Cache/AdalCacheOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/AdalCacheOperations.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Identity.Client.Cache
             {
                 BinaryWriter writer = new BinaryWriter(stream);
                 writer.Write(SchemaVersion);
-                logger.Info(string.Format(CultureInfo.CurrentCulture, "Serializing token cache with {0} items. ",
-                    tokenCacheDictionary.Count));
+                logger.Info($"[AdalCacheOperations] Serializing token cache with {tokenCacheDictionary.Count} items. ");
 
                 writer.Write(tokenCacheDictionary.Count);
                 foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> kvp in tokenCacheDictionary)
@@ -59,7 +58,7 @@ namespace Microsoft.Identity.Client.Cache
                 int blobSchemaVersion = reader.ReadInt32();
                 if (blobSchemaVersion != SchemaVersion)
                 {
-                    logger.Warning("The version of the persistent state of the cache does not match the current schema, so skipping deserialization. ");
+                    logger.Warning("[AdalCacheOperations] The version of the persistent state of the cache does not match the current schema, so skipping deserialization. ");
                     return dictionary;
                 }
 
@@ -77,7 +76,7 @@ namespace Microsoft.Identity.Client.Cache
                     dictionary[key] = resultEx;
                 }
 
-                logger.Info(string.Format(CultureInfo.CurrentCulture, "Deserialized {0} items to token cache. ", count));
+                logger.Info($"[AdalCacheOperations] Deserialized {dictionary.Count} items to ADAL token cache. ");
             }
 
             return dictionary;

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Identity.Client.Cache
                         TokenType = cacheEventType
                     };
 
-                    _requestParams.RequestContext.Logger.Verbose("[Cache Session Manager] Waiting for cache semaphore");
+                    _requestParams.RequestContext.Logger.Verbose($"[Cache Session Manager] Enterering the cache semaphore. Count { TokenCacheInternal.Semaphore.CurrentCount}");
                     await TokenCacheInternal.Semaphore.WaitAsync(_requestParams.RequestContext.UserCancellationToken).ConfigureAwait(false);
                     _requestParams.RequestContext.Logger.Verbose("[Cache Session Manager] Entered cache semaphore");
 

--- a/src/client/Microsoft.Identity.Client/ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/ITokenCacheInternal.cs
@@ -12,12 +12,13 @@ using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client
 {
     internal interface ITokenCacheInternal : ITokenCache, ITokenCacheSerializer
     {
-        SemaphoreSlim Semaphore { get; }
+        OptionalSemaphoreSlim Semaphore { get; }
         ILegacyCachePersistence LegacyPersistence { get; }
         ITokenCacheAccessor Accessor { get; }
 
@@ -41,13 +42,6 @@ namespace Microsoft.Identity.Client
 
         Task<IDictionary<string, TenantProfile>> GetTenantProfilesAsync(AuthenticationRequestParameters requestParameters, string homeAccountId);
 
-        #endregion
-
-        #region For test
-        Task<IEnumerable<MsalAccessTokenCacheItem>> GetAllAccessTokensAsync(bool filterByClientId);
-        Task<IEnumerable<MsalRefreshTokenCacheItem>> GetAllRefreshTokensAsync(bool filterByClientId);
-        Task<IEnumerable<MsalIdTokenCacheItem>> GetAllIdTokensAsync(bool filterByClientId);
-        Task<IEnumerable<MsalAccountCacheItem>> GetAllAccountsAsync();
         #endregion
 
         void RemoveMsalAccountWithNoLocks(IAccount account, RequestContext requestContext);
@@ -79,7 +73,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// MSAL adds serialziation for UWP and also for ConfidentialClient app token cache. 
-        /// If the app developer provides their own serialization, this flags is true
+        /// If the app developer provides their own serialization, this flags is false
         /// </summary>
         bool UsesDefaultSerialization { get; }
 

--- a/src/client/Microsoft.Identity.Client/MigrationAid/TokenCache.MigrationAid.cs
+++ b/src/client/Microsoft.Identity.Client/MigrationAid/TokenCache.MigrationAid.cs
@@ -146,8 +146,10 @@ namespace Microsoft.Identity.Client
         public CacheData SerializeUnifiedAndAdalCache()
         {
             GuardOnMobilePlatforms();
+            this.ServiceBundle.ApplicationLogger.Info($"[ADAL Caching] Legacy SerializeUnifiedAndAdalCache being called. Getting semaphore {_semaphoreSlim.CurrentCount}.");
             // reads the underlying in-memory dictionary and dumps out the content as a JSON
             _semaphoreSlim.Wait();
+            this.ServiceBundle.ApplicationLogger.Info("[ADAL Caching] Acquired semaphore");
             try
             {
                 var serializedUnifiedCache = Serialize();
@@ -177,7 +179,11 @@ namespace Microsoft.Identity.Client
         public void DeserializeUnifiedAndAdalCache(CacheData cacheData)
         {
             GuardOnMobilePlatforms();
+            this.ServiceBundle.ApplicationLogger.Info($"[ADAL Caching] Legacy SerializeUnifiedAndAdalCache being called. Acquiring semaphore {_semaphoreSlim.CurrentCount}");
+
             _semaphoreSlim.Wait();
+            this.ServiceBundle.ApplicationLogger.Info("[ADAL Caching] Acquired semaphore");
+
             try
             {
                 Deserialize(cacheData.UnifiedState);

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Identity.Client
                     instanceDiscoveryMetadata.PreferredNetwork,
                     wamAccountIds,
                     tenantProfiles?.Values);
-            requestParams.RequestContext.Logger.Verbose("[SaveTokenResponseAsync] Entering token cache semaphore. ");
+            requestParams.RequestContext.Logger.Verbose($"[SaveTokenResponseAsync] Entering token cache semaphore. Count {_semaphoreSlim.CurrentCount}.");
             await _semaphoreSlim.WaitAsync(requestParams.RequestContext.UserCancellationToken).ConfigureAwait(false);
             requestParams.RequestContext.Logger.Verbose("[SaveTokenResponseAsync] Entered token cache semaphore. ");
 
@@ -208,7 +208,7 @@ namespace Microsoft.Identity.Client
                                 instanceDiscoveryMetadata.PreferredCache);
 
                         CacheFallbackOperations.WriteAdalRefreshToken(
-                            Logger,
+                            requestParams.RequestContext.Logger,
                             LegacyCachePersistence,
                             msalRefreshTokenCacheItem,
                             msalIdTokenCacheItem,
@@ -677,7 +677,7 @@ namespace Microsoft.Identity.Client
                 var aliases = metadata.Aliases;
 
                 return CacheFallbackOperations.GetRefreshToken(
-                    Logger,
+                    requestParams.RequestContext.Logger,
                     LegacyCachePersistence,
                     aliases,
                     requestParams.AppConfig.ClientId,
@@ -792,7 +792,7 @@ namespace Microsoft.Identity.Client
             if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled)
             {
                 adalUsersResult = CacheFallbackOperations.GetAllAdalUsersForMsal(
-                    Logger,
+                    logger,
                     LegacyCachePersistence,
                     ClientId);
                 allEnvironmentsInCache.UnionWith(adalUsersResult.GetAdalUserEnviroments());
@@ -911,61 +911,11 @@ namespace Microsoft.Identity.Client
             return tenantProfiles;
         }
 
-        async Task<IEnumerable<MsalRefreshTokenCacheItem>> ITokenCacheInternal.GetAllRefreshTokensAsync(bool filterByClientId)
-        {
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                return GetAllRefreshTokensWithNoLocks(filterByClientId);
-            }
-            finally
-            {
-                _semaphoreSlim.Release();
-            }
-        }
-
-        async Task<IEnumerable<MsalAccessTokenCacheItem>> ITokenCacheInternal.GetAllAccessTokensAsync(bool filterByClientId)
-        {
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                return GetAllAccessTokensWithNoLocks(filterByClientId);
-            }
-            finally
-            {
-                _semaphoreSlim.Release();
-            }
-        }
-
-        async Task<IEnumerable<MsalIdTokenCacheItem>> ITokenCacheInternal.GetAllIdTokensAsync(bool filterByClientId)
-        {
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                return GetAllIdTokensWithNoLocks(filterByClientId);
-            }
-            finally
-            {
-                _semaphoreSlim.Release();
-            }
-        }
-
-        async Task<IEnumerable<MsalAccountCacheItem>> ITokenCacheInternal.GetAllAccountsAsync()
-        {
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                return _accessor.GetAllAccounts();
-            }
-            finally
-            {
-                _semaphoreSlim.Release();
-            }
-        }
-
         async Task ITokenCacheInternal.RemoveAccountAsync(IAccount account, RequestContext requestContext)
         {
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
+            requestContext.Logger.Verbose($"[RemoveAccountAsync] Entering token cache semaphore. Count {_semaphoreSlim.CurrentCount}");
+            await _semaphoreSlim.WaitAsync(requestContext.UserCancellationToken).ConfigureAwait(false);            
+            requestContext.Logger.Verbose("[RemoveAccountAsync] Entered token cache semaphore");
 
             try
             {
@@ -994,7 +944,7 @@ namespace Microsoft.Identity.Client
                     tokenCacheInternal.RemoveMsalAccountWithNoLocks(account, requestContext);
                     if (ServiceBundle.Config.LegacyCacheCompatibilityEnabled)
                     {
-                        RemoveAdalUser(account);
+                        RemoveAdalUser(account, requestContext.Logger);
                     }
                 }
                 finally

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Client
                 throw new ArgumentNullException(nameof(serviceBundle));   
 
             // useRealSemaphore= false for MyApps and potentially for all apps when using non-singleton MSAL
-            _semaphoreSlim =  new OptionalSemaphoreSlim(useRealSemaphore: serviceBundle.Config.CacheSyncronizationEnabled); 
+            _semaphoreSlim =  new OptionalSemaphoreSlim(useRealSemaphore: serviceBundle.Config.CacheSynchronizationEnabled); 
 
             var proxy = serviceBundle?.PlatformProxy ?? PlatformProxyFactory.CreatePlatformProxy(null);
             _accessor = proxy.CreateTokenCacheAccessor();

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -38,9 +38,7 @@ namespace Microsoft.Identity.Client
         private readonly IFeatureFlags _featureFlags;
         private readonly ITokenCacheAccessor _accessor;
         private bool _usesDefaultSerialization = false;
-        private volatile bool _hasStateChanged;
-
-        private ICoreLogger Logger => ServiceBundle.ApplicationLogger;
+        private volatile bool _hasStateChanged;        
 
         internal IServiceBundle ServiceBundle { get; }
         internal ILegacyCachePersistence LegacyCachePersistence { get; set; }
@@ -54,11 +52,9 @@ namespace Microsoft.Identity.Client
 
         bool ITokenCacheInternal.UsesDefaultSerialization => _usesDefaultSerialization;
 
-
-        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
-
-        SemaphoreSlim ITokenCacheInternal.Semaphore => _semaphoreSlim;
-
+        private readonly OptionalSemaphoreSlim _semaphoreSlim;
+        OptionalSemaphoreSlim ITokenCacheInternal.Semaphore => _semaphoreSlim;
+        
         /// <summary>
         /// Constructor of a token cache. This constructor is left for compatibility with MSAL 2.x.
         /// The recommended way to get a cache is by using <see cref="IClientApplicationBase.UserTokenCache"/>
@@ -71,6 +67,9 @@ namespace Microsoft.Identity.Client
 
         internal TokenCache(IServiceBundle serviceBundle, bool isApplicationTokenCache, ICacheSerializationProvider optionalDefaultSerializer = null)
         {
+            // useRealSemaphore= false for MyApps and potentially for all apps when using non-singleton MSAL
+            _semaphoreSlim =  new OptionalSemaphoreSlim(useRealSemaphore: serviceBundle.Config.CacheSyncronizationEnabled); 
+
             var proxy = serviceBundle?.PlatformProxy ?? PlatformProxyFactory.CreatePlatformProxy(null);
             _accessor = proxy.CreateTokenCacheAccessor();
             _featureFlags = proxy.GetFeatureFlags();
@@ -261,10 +260,10 @@ namespace Microsoft.Identity.Client
             return allRefreshTokens.Any(rt => rt.IsFRT);
         }
 
-        private void RemoveAdalUser(IAccount account)
+        private void RemoveAdalUser(IAccount account, ICoreLogger logger)
         {
             CacheFallbackOperations.RemoveAdalUser(
-                Logger,
+                logger,
                 LegacyCachePersistence,
                 ClientId,
                 account.Username,

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -67,6 +67,9 @@ namespace Microsoft.Identity.Client
 
         internal TokenCache(IServiceBundle serviceBundle, bool isApplicationTokenCache, ICacheSerializationProvider optionalDefaultSerializer = null)
         {
+            if (serviceBundle == null) 
+                throw new ArgumentNullException(nameof(serviceBundle));   
+
             // useRealSemaphore= false for MyApps and potentially for all apps when using non-singleton MSAL
             _semaphoreSlim =  new OptionalSemaphoreSlim(useRealSemaphore: serviceBundle.Config.CacheSyncronizationEnabled); 
 

--- a/src/client/Microsoft.Identity.Client/Utils/OptionalSemaphoreSlim.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/OptionalSemaphoreSlim.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Utils
+{
+    /// <summary>
+    /// An object that either wraps a SemaphoreSlim for syncronization or ignores syncronization completely and just keeps track of Wait / Release operations.
+    /// </summary>
+    internal class OptionalSemaphoreSlim
+    {
+        private readonly bool _useRealSemaphore;
+        private int _noLockCurrentCount;
+        private SemaphoreSlim _semaphoreSlim;
+
+        public int CurrentCount
+        {
+            get
+            {
+                return _useRealSemaphore ? _semaphoreSlim.CurrentCount : _noLockCurrentCount;
+            }
+        }
+
+        public OptionalSemaphoreSlim(bool useRealSemaphore)
+        {
+            _useRealSemaphore = useRealSemaphore;
+            if (_useRealSemaphore)
+            {
+                _semaphoreSlim = new SemaphoreSlim(1, 1);
+            }
+            _noLockCurrentCount = 1;
+        }
+
+        public void Release()
+        {
+            if (_useRealSemaphore)
+            {
+                _semaphoreSlim.Release();
+            }
+            else
+            {
+                Interlocked.Increment(ref _noLockCurrentCount);
+            }
+        }
+
+        public Task WaitAsync(CancellationToken cancellationToken)
+        {
+            if (_useRealSemaphore)
+            {
+                return _semaphoreSlim.WaitAsync(cancellationToken);
+            }
+            else
+            {
+                Interlocked.Decrement(ref _noLockCurrentCount);
+                return Task.FromResult(true);
+            }
+        }
+        
+        public void Wait()
+        {
+            if (_useRealSemaphore)
+            {
+                _semaphoreSlim.Wait();
+            }
+            else
+            {
+                Interlocked.Decrement(ref _noLockCurrentCount);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/InMemoryTokenCache.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/InMemoryTokenCache.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         private byte[] _cacheData;
         private bool _shouldClearExistingCache;
         private bool _withOperationDelay;
-        private const int OperationDelayInMs = 1000;
+        private const int OperationDelayInMs = 100;
 
         public InMemoryTokenCache(bool withOperationDelay = false, bool shouldClearExistingCache = true)
         {

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -253,11 +253,9 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             accessor.SaveAccount(accountCacheItem);
         }
 
-        public static async void ExpireAccessTokens(ITokenCacheInternal tokenCache)
+        public static void ExpireAccessTokens(ITokenCacheInternal tokenCache)
         {
-            var allAccessTokens = await tokenCache
-                .GetAllAccessTokensAsync(true)
-                .ConfigureAwait(true);
+            var allAccessTokens = tokenCache.Accessor.GetAllAccessTokens();
 
             foreach (MsalAccessTokenCacheItem atItem in allAccessTokens)
             {
@@ -277,20 +275,20 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             TokenCacheHelper.UpdateRefreshTokenUserAssertions(app.UserTokenCacheInternal);
         }
 
-        public static async void UpdateAccessTokenUserAssertions(ITokenCacheInternal tokenCache, string assertion = "SomeAssertion")
+        public static void UpdateAccessTokenUserAssertions(ITokenCacheInternal tokenCache, string assertion = "SomeAssertion")
         {
-            var atItems = await tokenCache.GetAllAccessTokensAsync(true).ConfigureAwait(false);
+            var allAccessTokens = tokenCache.Accessor.GetAllAccessTokens();
 
-            foreach (var atItem in atItems)
+            foreach (var atItem in allAccessTokens)
             {
                 atItem.UserAssertionHash = assertion;
                 tokenCache.AddAccessTokenCacheItem(atItem);
             }
         }
 
-        public static async void UpdateRefreshTokenUserAssertions(ITokenCacheInternal tokenCache, string assertion = "SomeAssertion")
+        public static void  UpdateRefreshTokenUserAssertions(ITokenCacheInternal tokenCache, string assertion = "SomeAssertion")
         {
-            var rtItems = await tokenCache.GetAllRefreshTokensAsync(true).ConfigureAwait(false);
+            var rtItems = tokenCache.Accessor.GetAllRefreshTokens();            
 
             foreach (var rtItem in rtItems)
             {

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests2.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests2.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AssertLastHttpContent("refresh_token");
 
             //creating second app with no refresh tokens
-            var atItems = await confidentialApp.UserTokenCacheInternal.GetAllAccessTokensAsync(true).ConfigureAwait(false);
+            var atItems = confidentialApp.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
             var confidentialApp2 = ConfidentialClientApplicationBuilder
                 .Create(confidentialClientID)
                 .WithAuthority(new Uri(oboHost + authResult.TenantId), true)

--- a/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 // make sure that all cache entities are stored with "preferred_cache" environment
                 // (it is taken from metadata in instance discovery response)
-                await ValidateCacheEntitiesEnvironmentAsync(app.UserTokenCacheInternal, TestConstants.ProductionPrefCacheEnvironment).ConfigureAwait(false);
+                ValidateCacheEntitiesEnvironment(app.UserTokenCacheInternal, TestConstants.ProductionPrefCacheEnvironment);
 
                 // silent request targeting at, should return at from cache for any environment alias
                 foreach (var envAlias in TestConstants.s_prodEnvAliases)
@@ -147,28 +147,28 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
-        private async Task ValidateCacheEntitiesEnvironmentAsync(ITokenCacheInternal cache, string expectedEnvironment)
+        private void ValidateCacheEntitiesEnvironment(ITokenCacheInternal cache, string expectedEnvironment)
         {
             ICoreLogger logger = Substitute.For<ICoreLogger>();
-            IEnumerable<Client.Cache.Items.MsalAccessTokenCacheItem> accessTokens = await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false);
+            IEnumerable<Client.Cache.Items.MsalAccessTokenCacheItem> accessTokens = cache.Accessor.GetAllAccessTokens();
             foreach (Client.Cache.Items.MsalAccessTokenCacheItem at in accessTokens)
             {
                 Assert.AreEqual(expectedEnvironment, at.Environment);
             }
 
-            IEnumerable<Client.Cache.Items.MsalRefreshTokenCacheItem> refreshTokens = await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false);
+            IEnumerable<Client.Cache.Items.MsalRefreshTokenCacheItem> refreshTokens = cache.Accessor.GetAllRefreshTokens();
             foreach (Client.Cache.Items.MsalRefreshTokenCacheItem rt in refreshTokens)
             {
                 Assert.AreEqual(expectedEnvironment, rt.Environment);
             }
 
-            IEnumerable<Client.Cache.Items.MsalIdTokenCacheItem> idTokens = await cache.GetAllIdTokensAsync(true).ConfigureAwait(false);
+            IEnumerable<Client.Cache.Items.MsalIdTokenCacheItem> idTokens = cache.Accessor.GetAllIdTokens();
             foreach (Client.Cache.Items.MsalIdTokenCacheItem id in idTokens)
             {
                 Assert.AreEqual(expectedEnvironment, id.Environment);
             }
 
-            IEnumerable<Client.Cache.Items.MsalAccountCacheItem> accounts = await cache.GetAllAccountsAsync().ConfigureAwait(false);
+            IEnumerable<Client.Cache.Items.MsalAccountCacheItem> accounts = cache.Accessor.GetAllAccounts();
             foreach (Client.Cache.Items.MsalAccountCacheItem account in accounts)
             {
                 Assert.AreEqual(expectedEnvironment, account.Environment);

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
@@ -637,23 +637,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         }
 
         #endregion // JSON SERIALIZATION TESTS
-
-        [TestMethod]
-        [Ignore("Waiting on python to update target to be space-delimited strings instead of array")]
-        [DeploymentItem(@"Resources\cachecompat_python.bin")]
-        public void TestPythonCacheSerializationInterop()
-        {
-            var accessor = new InMemoryTokenCacheAccessor(Substitute.For<ICoreLogger>());
-            var s = new TokenCacheJsonSerializer(accessor);
-            string pythonBinFilePath = ResourceHelper.GetTestResourceRelativePath("cachecompat_python.bin");
-            byte[] bytes = File.ReadAllBytes(pythonBinFilePath);
-            s.Deserialize(bytes, false);
-
-            Assert.AreEqual(0, accessor.GetAllAccessTokens().Count());
-            Assert.AreEqual(0, accessor.GetAllRefreshTokens().Count());
-            Assert.AreEqual(0, accessor.GetAllIdTokens().Count());
-            Assert.AreEqual(0, accessor.GetAllAccounts().Count());
-        }
+       
 
         [TestMethod]
         [DeploymentItem(@"Resources\cachecompat_dotnet_dictionary.bin")]

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             string jsonContent = File.ReadAllText(jsonFilePath);
             byte[] cache = Encoding.UTF8.GetBytes(jsonContent);
 
-            var tokenCache = new TokenCache(null, true);
+            var tokenCache = new TokenCache(TestCommon.CreateDefaultServiceBundle(), true);
             tokenCache.SetBeforeAccess(notificationArgs =>
             {
                 notificationArgs.TokenCache.DeserializeMsalV3(cache);

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSyncronizationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSyncronizationTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.CacheTests
+{
+    [TestClass]
+    public class CacheSyncronizationTests : TestBase
+    {
+
+        [TestMethod]
+        [Timeout(1000)]
+        public async Task DisableInternalSemaphore_Async()
+        {
+            await RunSemaphoreTestAsync(true).ConfigureAwait(false);
+            await RunSemaphoreTestAsync(false).ConfigureAwait(false);
+        }
+
+        private async Task RunSemaphoreTestAsync(bool useCacheSyncronization)
+        {
+            using (var harness = base.CreateTestHarness())
+            {
+                MockHttpManager httpManager = harness.HttpManager;
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                ConfidentialClientApplication app =
+                    ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithAuthority(TestConstants.AuthorityUtidTenant)
+                                                              .WithCacheSyncronization(useCacheSyncronization)
+                                                              .WithHttpManager(httpManager)
+                                                              .BuildConcrete();
+
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                BlockingCache inMemoryTokenCache = new BlockingCache();
+                inMemoryTokenCache.Bind(app.AppTokenCache);
+
+                // Seed the cache with a token
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+                Assert.IsTrue(result.AuthenticationResultMetadata.TokenSource == TokenSource.IdentityProvider);
+
+
+                var blockingTask = RunAsync(inMemoryTokenCache, app, true);
+                var nonBlockingTask1 = RunAsync(inMemoryTokenCache, app, false);
+                var nonBlockingTask2 = RunAsync(inMemoryTokenCache, app, false);
+
+                int res = Task.WaitAny(new[] { blockingTask, nonBlockingTask1, nonBlockingTask2 }, 100);
+
+
+                if (useCacheSyncronization)
+                {
+                    Assert.AreEqual(-1, res, "WaitAny should have timed out, all tasks are blocked when the first call is blocking");
+                }
+                else
+                {
+                    Assert.AreNotEqual(-1, res, "WaitAny should have NOT timed out, the 2 non-blocking tasks should be allowed to complete");
+                    Assert.IsTrue(nonBlockingTask1.IsCompleted);
+                    Assert.IsTrue(nonBlockingTask2.IsCompleted);
+                    Assert.IsFalse(blockingTask.IsCompleted, "The blocking task should still be blocked");
+                    Assert.IsTrue(nonBlockingTask1.Result.AuthenticationResultMetadata.TokenSource == TokenSource.Cache);
+                    Assert.IsTrue(nonBlockingTask2.Result.AuthenticationResultMetadata.TokenSource == TokenSource.Cache);
+                }
+            }
+        }
+
+        private static async Task<AuthenticationResult> RunAsync(BlockingCache cache, IConfidentialClientApplication app, bool block = false)
+        {
+            cache.BlockAccess = block;
+            return await app.AcquireTokenForClient(TestConstants.s_scope.ToArray()).ExecuteAsync().ConfigureAwait(false);
+        }
+
+        public class BlockingCache
+        {
+            private byte[] _cacheData;
+
+
+            public bool BlockAccess { get; set; } = false;
+
+            public async Task BeforeAccessNotificationAsync(TokenCacheNotificationArgs args)
+            {
+                if (BlockAccess)
+                {
+                    // completely blocked
+                    await Task.Delay(10000).ConfigureAwait(false);
+                    Assert.Fail("Test error - waiting too long in a test");
+                }
+
+                args.TokenCache.DeserializeMsalV3(_cacheData);
+            }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            public async Task AfterAccessNotificationAsync(TokenCacheNotificationArgs args)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+            {
+
+                // if the access operation resulted in a cache update
+                if (args.HasStateChanged)
+                {
+                    _cacheData = args.TokenCache.SerializeMsalV3();
+                }
+            }
+
+            public void Bind(ITokenCache tokenCache)
+            {
+                tokenCache.SetBeforeAccessAsync(BeforeAccessNotificationAsync);
+                tokenCache.SetAfterAccessAsync(AfterAccessNotificationAsync);
+            }
+
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSyncronizationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSyncronizationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                               .WithClientSecret(TestConstants.ClientSecret)
                                                               .WithAuthority(TestConstants.AuthorityUtidTenant)
-                                                              .WithCacheSyncronization(useCacheSyncronization)
+                                                              .WithCacheSynchronization(useCacheSyncronization)
                                                               .WithHttpManager(httpManager)
                                                               .BuildConcrete();
 

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Test.Common.Mocks;
@@ -358,7 +359,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             // Arrange
             var userTokenCacheInternal = Substitute.For<ITokenCacheInternal>();
-            var semaphore = new SemaphoreSlim(1, 1);
+            var semaphore = new OptionalSemaphoreSlim(true);
             userTokenCacheInternal.Semaphore.Returns(semaphore);
 
             var cca = ConfidentialClientApplicationBuilder
@@ -399,7 +400,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             // Arrange
             var appTokenCache = Substitute.For<ITokenCacheInternal>();
-            var semaphore = new SemaphoreSlim(1, 1);
+            var semaphore = new OptionalSemaphoreSlim(true);
             appTokenCache.Semaphore.Returns(semaphore);
 
             appTokenCache.FindAccessTokenAsync(default).ReturnsForAnyArgs(TokenCacheHelper.CreateAccessTokenItem());

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -946,8 +946,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual(1, cache.Accessor.GetAllRefreshTokens().Count());
             Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
 
-            Assert.AreEqual("refresh-token-2", (await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false)).First().Secret);
-            Assert.AreEqual("access-token-2", (await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false)).First().Secret);
+            Assert.AreEqual("refresh-token-2", (cache.Accessor.GetAllRefreshTokens()).First().Secret);
+            Assert.AreEqual("access-token-2", (cache.Accessor.GetAllAccessTokens()).First().Secret);
         }
 
         [TestMethod]
@@ -977,8 +977,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             Assert.AreEqual(1, cache.Accessor.GetAllRefreshTokens().Count());
             Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
-            Assert.AreEqual("refresh-token-2", (await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false)).First().Secret);
-            Assert.AreEqual("access-token-2", (await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false)).First().Secret);
+            Assert.AreEqual("refresh-token-2", (cache.Accessor.GetAllRefreshTokens()).First().Secret);
+            Assert.AreEqual("access-token-2", (cache.Accessor.GetAllAccessTokens()).First().Secret);
         }
 
         [TestMethod]
@@ -1006,8 +1006,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual(1, cache.Accessor.GetAllRefreshTokens().Count());
             Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
 
-            Assert.AreEqual("refresh-token-2", (await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false)).First().Secret);
-            Assert.AreEqual("access-token-2", (await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false)).First().Secret);
+            Assert.AreEqual("refresh-token-2", (cache.Accessor.GetAllRefreshTokens()).First().Secret);
+            Assert.AreEqual("access-token-2", (cache.Accessor.GetAllAccessTokens()).First().Secret);
         }
 
         [TestMethod]
@@ -1086,7 +1086,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual(1, cache.Accessor.GetAllRefreshTokens().Count());
             Assert.AreEqual(2, cache.Accessor.GetAllAccessTokens().Count());
 
-            Assert.AreEqual("refresh-token-2", (await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false)).First().Secret);
+            Assert.AreEqual("refresh-token-2", (cache.Accessor.GetAllRefreshTokens()).First().Secret);
         }
 
 
@@ -1142,7 +1142,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual(1, cache.Accessor.GetAllRefreshTokens().Count());
             Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
 
-            var atItem = (await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false)).First();
+            var atItem = (cache.Accessor.GetAllAccessTokens()).First();
             Assert.AreEqual(response.AccessToken, atItem.Secret);
             Assert.AreEqual(TestConstants.AuthorityTestTenant, atItem.Authority);
             Assert.AreEqual(TestConstants.ClientId, atItem.ClientId);
@@ -1151,7 +1151,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // todo add test for idToken serialization
             // Assert.AreEqual(response.IdToken, atItem.RawIdToken);
 
-            var rtItem = (await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false)).First();
+            var rtItem = (cache.Accessor.GetAllRefreshTokens()).First();
             Assert.AreEqual(response.RefreshToken, rtItem.Secret);
             Assert.AreEqual(TestConstants.ClientId, rtItem.ClientId);
             Assert.AreEqual(TestConstants.s_userIdentifier, rtItem.HomeAccountId);

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
@@ -197,15 +197,15 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             Assert.IsNotNull(result);
 
-            await ValidateAtAsync(app.UserTokenCacheInternal).ConfigureAwait(false);
-            await ValidateRtAsync(app.UserTokenCacheInternal).ConfigureAwait(false);
-            await ValidateIdTokenAsync(app.UserTokenCacheInternal).ConfigureAwait(false);
-            await ValidateAccountAsync(app.UserTokenCacheInternal).ConfigureAwait(false);
+            ValidateAt(app.UserTokenCacheInternal);
+            ValidateRt(app.UserTokenCacheInternal);
+            ValidateIdToken(app.UserTokenCacheInternal);
+            ValidateAccount(app.UserTokenCacheInternal);
         }
 
-        private async Task ValidateAtAsync(ITokenCacheInternal cache)
+        private void ValidateAt(ITokenCacheInternal cache)
         {
-            var atList = (await cache.GetAllAccessTokensAsync(false).ConfigureAwait(false)).ToList();
+            var atList = cache.Accessor.GetAllAccessTokens().ToList();
             Assert.AreEqual(1, atList.Count);
 
             var actualPayload = JsonConvert.DeserializeObject<JObject>(atList.First().ToJsonString());
@@ -230,7 +230,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     Assert.AreEqual(expectedPropValue, actualPropValue);
                 }
             }
-            var atCacheItem = (await cache.GetAllAccessTokensAsync(true).ConfigureAwait(false)).First();
+            var atCacheItem = cache.Accessor.GetAllAccessTokens().First();
             var key = atCacheItem.GetKey();
 
             Assert.AreEqual(_expectedAtCacheKey, key.ToString());
@@ -242,13 +242,13 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.AccessToken, key.iOSType);
         }
 
-        private async Task ValidateRtAsync(ITokenCacheInternal cache)
+        private void ValidateRt(ITokenCacheInternal cache)
         {
             // TODO: NEED TO LOOK INTO HOW TO HANDLE THIS TEST
             //ValidateCacheEntityValue
             //    (ExpectedRtCacheValue, cache.GetAllRefreshTokenCacheItems(requestContext));
 
-            var rtCacheItem = (await cache.GetAllRefreshTokensAsync(true).ConfigureAwait(false)).First();
+            var rtCacheItem = cache.Accessor.GetAllRefreshTokens().First();
             var key = rtCacheItem.GetKey();
 
             Assert.AreEqual(_expectedRtCacheKey, key.ToString());
@@ -259,13 +259,13 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.RefreshToken, key.iOSType);
         }
 
-        private async Task ValidateIdTokenAsync(ITokenCacheInternal cache)
+        private void ValidateIdToken(ITokenCacheInternal cache)
         {
             // TODO: NEED TO LOOK INTO HOW TO HANDLE THIS TEST
             //ValidateCacheEntityValue
             //    (ExpectedIdTokenCacheValue, cache.GetAllIdTokenCacheItems(requestContext));
 
-            var idTokenCacheItem = (await cache.GetAllIdTokensAsync(true).ConfigureAwait(false)).First();
+            var idTokenCacheItem = cache.Accessor.GetAllIdTokens().First();
             var key = idTokenCacheItem.GetKey();
 
             Assert.AreEqual(_expectedIdTokenCacheKey, key.ToString());
@@ -276,13 +276,13 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.IdToken, key.iOSType);
         }
 
-        private async Task ValidateAccountAsync(ITokenCacheInternal cache)
+        private void ValidateAccount(ITokenCacheInternal cache)
         {
             // TODO: NEED TO LOOK INTO HOW TO HANDLE THIS TEST
             //ValidateCacheEntityValue
             //    (ExpectedAccountCacheValue, cache.GetAllAccountCacheItems(requestContext));
 
-            var accountCacheItem = (await cache.GetAllAccountsAsync().ConfigureAwait(false)).First();
+            var accountCacheItem = cache.Accessor.GetAllAccounts().First();
             var key = accountCacheItem.GetKey();
 
             Assert.AreEqual(_expectedAccountCacheKey, key.ToString());

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
@@ -123,38 +123,40 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         [TestMethod]
         [Description("Test unified token cache")]
-        public async Task AAD_CacheFormatValidationTestAsync()
+        public void AAD_CacheFormatValidationTest()
         {
             using (var harness = CreateTestHarness())
             {
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("AADTestData.txt"));
                 Init(harness.HttpManager);
-                await RunCacheFormatValidationAsync(harness).ConfigureAwait(false);
+
+                RunCacheFormatValidation(harness);
             }
         }
 
         [TestMethod]
         [Description("Test unified token cache")]
-        public async Task MSA_CacheFormatValidationTestAsync()
+        public void MSA_CacheFormatValidationTest()
         {
             using (var harness = CreateTestHarness())
             {
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("MSATestData.txt"));
                 Init(harness.HttpManager);
-                await RunCacheFormatValidationAsync(harness).ConfigureAwait(false);
+
+                RunCacheFormatValidation(harness);
             }
         }
 
         [TestMethod]
         [Description("Test unified token cache")]
         [Ignore] // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1037
-        public async Task B2C_NoTenantId_CacheFormatValidationTestAsync()
+        public void B2C_NoTenantId_CacheFormatValidationTest()
         {
             using (var harness = CreateTestHarness())
             {
                 TestCommon.ResetInternalStaticCaches();
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("B2CNoTenantIdTestData.txt"));
-                await RunCacheFormatValidationAsync(harness).ConfigureAwait(false);
+                RunCacheFormatValidation(harness);
             }
         }
 
@@ -163,16 +165,16 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [Ignore]
         // it is not yet decided what version of tenant id should be used
         // test data generated based on GUID, Msal uses tenantId from passed in authotiry
-        public async Task B2C_WithTenantId_CacheFormatValidationTestAsync()
+        public void B2C_WithTenantId_CacheFormatValidationTest()
         {
             using (var harness = CreateTestHarness())
             {
                 IntitTestData(ResourceHelper.GetTestResourceRelativePath("B2CWithTenantIdTestData.txt"));
-                await RunCacheFormatValidationAsync(harness).ConfigureAwait(false);
+                RunCacheFormatValidation(harness);
             }
         }
 
-        private async Task RunCacheFormatValidationAsync(MockHttpAndServiceBundle harness)
+        private void RunCacheFormatValidation(MockHttpAndServiceBundle harness)
         {
             PublicClientApplication app = PublicClientApplicationBuilder
                                           .Create(_clientId)

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 
-                var accessTokens = await app.AppTokenCacheInternal.GetAllAccessTokensAsync(true).ConfigureAwait(false);
+                var accessTokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
                 var accessTokenInCache = accessTokens
                                          .Where(item => ScopeHelper.ScopeContains(item.ScopeSet, TestConstants.s_scope))
                                          .ToList().FirstOrDefault();
@@ -1054,7 +1054,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual(TokenRetrievedFromNetCall, result.AccessToken);
 
                 // make sure token in Cache was updated
-                var accessTokens = await app.AppTokenCacheInternal.GetAllAccessTokensAsync(true).ConfigureAwait(false);
+                var accessTokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
                 var accessTokenInCache = accessTokens
                                          .Where(item => ScopeHelper.ScopeContains(item.ScopeSet, TestConstants.s_scope))
                                          .ToList().FirstOrDefault();

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/FociTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/FociTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 // Remove account from app B
                 await _appB.RemoveAsync(accB.Single()).ConfigureAwait(false);
 
-                var tokens = await _appA.UserTokenCacheInternal.GetAllRefreshTokensAsync(false).ConfigureAwait(false);
+                var tokens = _appA.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();
 
                 Assert.IsTrue( 
                     !string.IsNullOrEmpty(tokens.Single().FamilyId),
@@ -252,8 +252,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 // Remove account from app B
                 await _appB.RemoveAsync(accB.Single()).ConfigureAwait(false);
 
-                var tokens = await _appB.UserTokenCacheInternal.GetAllRefreshTokensAsync(true).ConfigureAwait(false);
-                var accounts = await _appB.UserTokenCacheInternal.GetAllAccountsAsync().ConfigureAwait(false);
+                var tokens = _appB.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();
+                var accounts = _appB.UserTokenCacheInternal.Accessor.GetAllAccounts();
 
                 Assert.IsFalse(tokens.Any(), "Should not be any tokens");
                 Assert.IsFalse(accounts.Any(), "should not be any accounts");

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        public async Task ExpiredTokenRefreshFlowTestAsync()
+        public void ExpiredTokenRefreshFlowTest()
         {
             using (var harness = new MockHttpTestHarness(TestConstants.AuthorityHomeTenant))
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 };
 
                 // set access tokens as expired
-                foreach (var accessItem in (await harness.Cache.GetAllAccessTokensAsync(true).ConfigureAwait(false)))
+                foreach (var accessItem in harness.Cache.Accessor.GetAllAccessTokens())
                 {
                     accessItem.ExpiresOnUnixTimestamp =
                         ((long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds)

--- a/tests/devapps/DesktopTestApp/MainForm.cs
+++ b/tests/devapps/DesktopTestApp/MainForm.cs
@@ -403,17 +403,17 @@ namespace DesktopTestApp
             Trace.WriteLine("Accounts: " + acc.Count());
 
             cachePageTableLayout.RowCount = 0;
-            var allRefreshTokens = await _publicClientHandler
+            var allRefreshTokens = _publicClientHandler
                 .PublicClientApplication
                 .UserTokenCacheInternal
-                .GetAllRefreshTokensAsync(true)
-                .ConfigureAwait(true);
+                .Accessor
+                .GetAllRefreshTokens();
 
-            var allAccessTokens = await _publicClientHandler
+            var allAccessTokens = _publicClientHandler
                 .PublicClientApplication
                 .UserTokenCacheInternal
-                .GetAllAccessTokensAsync(true)
-                .ConfigureAwait(true);
+                .Accessor
+                .GetAllAccessTokens();
 
             foreach (MsalRefreshTokenCacheItem rtItem in allRefreshTokens)
             {

--- a/tests/devapps/XamarinDev/XamarinDev/CachePage.xaml.cs
+++ b/tests/devapps/XamarinDev/XamarinDev/CachePage.xaml.cs
@@ -25,28 +25,28 @@ namespace XamarinDev
             var tokenCache = App.MsalPublicClient.UserTokenCacheInternal;
 
             IDictionary<string, MsalAccessTokenCacheItem> accessTokens = new Dictionary<string, MsalAccessTokenCacheItem>();
-            foreach (var accessItem in (await tokenCache.GetAllAccessTokensAsync(true).ConfigureAwait(false)))
+            foreach (var accessItem in tokenCache.Accessor.GetAllAccessTokens())
             {
                 accessTokens.Add(accessItem.GetKey().ToString(), accessItem);
             }
             accessTokenCacheItems.ItemsSource = accessTokens;
 
             IDictionary<string, MsalRefreshTokenCacheItem> refreshTokens = new Dictionary<string, MsalRefreshTokenCacheItem>();
-            foreach (var refreshItem in (await tokenCache.GetAllRefreshTokensAsync(true).ConfigureAwait(false)))
+            foreach (var refreshItem in tokenCache.Accessor.GetAllRefreshTokens())
             {
                 refreshTokens.Add(refreshItem.GetKey().ToString(), refreshItem);
             }
             refreshTokenCacheItems.ItemsSource = refreshTokens;
 
             IDictionary<string, MsalIdTokenCacheItem> idTokens = new Dictionary<string, MsalIdTokenCacheItem>();
-            foreach (var idItem in (await tokenCache.GetAllIdTokensAsync(true).ConfigureAwait(false)))
+            foreach (var idItem in tokenCache.Accessor.GetAllIdTokens())
             {
                 idTokens.Add(idItem.GetKey().ToString(), idItem);
             }
             idTokenCacheItems.ItemsSource = idTokens;
 
             IDictionary<string, MsalAccountCacheItem> accounts = new Dictionary<string, MsalAccountCacheItem>();
-            foreach (var accountItem in (await tokenCache.GetAllAccountsAsync().ConfigureAwait(false)))
+            foreach (var accountItem in tokenCache.Accessor.GetAllAccounts())
             {
                 accounts.Add(accountItem.GetKey().ToString(), accountItem);
             }


### PR DESCRIPTION
One of the fixes related to https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2443 / MyApps
Disables the internal cache semaphore, which allows requests to bypass other requests that timeout.