### PR TITLE
Fixing performance test project

### DIFF
--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Test.Performance
 
             await _ccaTokensDifferByTenant.AcquireTokenForClient(new[] { "scope" })
               .WithForceRefresh(false)
-              .WithAuthority($"https://login.microsoft.com/{tenant}")
+              .WithAuthority($"https://login.microsoftonline.com/{tenant}")
               .ExecuteAsync()
               .ConfigureAwait(false);
         }
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Test.Performance
 
             await _ccaTokensDifferByScope.AcquireTokenForClient(new[] { scope })
               .WithForceRefresh(false)
-              .WithAuthority($"https://login.microsoft.com/tid")
+              .WithAuthority($"https://login.microsoftonline.com/tid")
               .ExecuteAsync()
               .ConfigureAwait(false);
         }


### PR DESCRIPTION
Fixes # .
Fix for performance test

Error: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> Microsoft.Identity.Client.MsalClientException: You did not define an authority at the application level, so it defaults to the https://login.microsoftonline.com/common.

However, the request is for a different cloud login.microsoft.com. This is not supported - the app and the request must target the same cloud.

**Changes proposed in this request**
Correct Authority

**Testing**
Manual testing of performance app

**Performance impact**
None
