### PR TITLE
Add token expiry to token cache notification args

### DIFF
--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -210,11 +210,11 @@ namespace Microsoft.Identity.Client
                     ITokenCacheInternal tokenCacheInternal = this;
                     if (tokenCacheInternal.IsTokenCacheSerialized())
                     {
-                        DateTime? cacheExpiry = null;
+                        DateTimeOffset? cacheExpiry = null;
 
                         if (requestParams.IsClientCredentialRequest)
                         {
-                            cacheExpiry = CanculateSuggestedCacheKey();
+                            cacheExpiry = CanculateSuggestedCacheExpiry();
                         }
 
                         var args = new TokenCacheNotificationArgs(
@@ -246,15 +246,11 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        private DateTime? CanculateSuggestedCacheKey()
+        private DateTimeOffset? CanculateSuggestedCacheExpiry()
         {
             IEnumerable<MsalAccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensWithNoLocks(true).ToList();
             var unixCacheExpiry = tokenCacheItems.Max(item => item.ExpiresOnUnixTimestamp);
-
-            DateTime suggestedCacheExpiry = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
-            suggestedCacheExpiry = suggestedCacheExpiry.AddSeconds(Convert.ToDouble(unixCacheExpiry)).ToLocalTime();
-
-            return (DateTime?)suggestedCacheExpiry;
+            return (DateTimeOffset?)CoreHelpers.UnixTimestampStringToDateTime(unixCacheExpiry);
         }
 
         private string GetTenantId(IdToken idToken, AuthenticationRequestParameters requestParams)

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -246,11 +246,11 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        private DateTimeOffset? CalculateSuggestedCacheExpiry()
+        private DateTimeOffset CalculateSuggestedCacheExpiry()
         {
             IEnumerable<MsalAccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensWithNoLocks(true);
             var unixCacheExpiry = tokenCacheItems.Max(item => item.ExpiresOnUnixTimestamp);
-            return (DateTimeOffset?)CoreHelpers.UnixTimestampStringToDateTime(unixCacheExpiry);
+            return (DateTimeOffset)CoreHelpers.UnixTimestampStringToDateTime(unixCacheExpiry);
         }
 
         private string GetTenantId(IdToken idToken, AuthenticationRequestParameters requestParams)

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -212,9 +212,9 @@ namespace Microsoft.Identity.Client
                     {
                         DateTimeOffset? cacheExpiry = null;
 
-                        if (requestParams.IsClientCredentialRequest)
+                        if (!_accessor.GetAllRefreshTokens().Any())
                         {
-                            cacheExpiry = CanculateSuggestedCacheExpiry();
+                            cacheExpiry = CalculateSuggestedCacheExpiry();
                         }
 
                         var args = new TokenCacheNotificationArgs(
@@ -246,9 +246,9 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        private DateTimeOffset? CanculateSuggestedCacheExpiry()
+        private DateTimeOffset? CalculateSuggestedCacheExpiry()
         {
-            IEnumerable<MsalAccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensWithNoLocks(true).ToList();
+            IEnumerable<MsalAccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensWithNoLocks(true);
             var unixCacheExpiry = tokenCacheItems.Max(item => item.ExpiresOnUnixTimestamp);
             return (DateTimeOffset?)CoreHelpers.UnixTimestampStringToDateTime(unixCacheExpiry);
         }

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Identity.Client
 
         /// <Summary>
         /// Suggested value of the expiry, to help determining the cache eviction time. 
-        /// This value is <b>only</b> set on the <code>OnAfterAcces</code> delegate, on a cache write
+        /// This value is <b>only</b> set on the <code>OnAfterAccess</code> delegate, on a cache write
         /// operation (that is when <code>args.HasStateChanged</code> is <code>true</code>) and when the cache write 
         /// is triggered from the <code>AcquireTokenForClient</code> method. In all other cases it's <code>null</code>, as there is a refresh token, and therefore the
         /// access tokens are refreshable.

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Client
             bool hasTokens,
             CancellationToken cancellationToken,
             string suggestedCacheKey = null,
-            DateTime? suggestedCacheExpiry = null)
+            DateTimeOffset? suggestedCacheExpiry = null)
         {
             TokenCache = tokenCacheSerializer;
             ClientId = clientId;
@@ -105,6 +105,6 @@ namespace Microsoft.Identity.Client
         /// is triggered from the <code>AcquireTokenForClient</code> method. In all other cases it's <code>null</code>, as there is a refresh token, and therefore the
         /// access tokens are refreshable.
         /// </Summary> 
-        public DateTime? SuggestedCacheExpiry { get; private set; }
+        public DateTimeOffset? SuggestedCacheExpiry { get; private set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 
 namespace Microsoft.Identity.Client
@@ -21,7 +22,8 @@ namespace Microsoft.Identity.Client
             bool isAppCache, 
             bool hasTokens,
             CancellationToken cancellationToken,
-            string suggestedCacheKey = null)
+            string suggestedCacheKey = null,
+            DateTime? suggestedCacheExpiry = null)
         {
             TokenCache = tokenCacheSerializer;
             ClientId = clientId;
@@ -31,6 +33,7 @@ namespace Microsoft.Identity.Client
             HasTokens = hasTokens;
             SuggestedCacheKey = suggestedCacheKey;
             CancellationToken = cancellationToken;
+            SuggestedCacheExpiry = suggestedCacheExpiry;
         }
 
         /// <summary>
@@ -94,5 +97,14 @@ namespace Microsoft.Identity.Client
         /// along to the custom token cache implementation.
         /// </summary>
         public CancellationToken CancellationToken { get; }
+
+        /// <Summary>
+        /// Suggested value of the expiry, to help determining the cache eviction time. 
+        /// This value is <b>only</b> set on the <code>OnAfterAcces</code> delegate, on a cache write
+        /// operation (that is when <code>args.HasStateChanged</code> is <code>true</code>) and when the cache write 
+        /// is triggered from the <code>AcquireTokenForClient</code> method. In all other cases it's <code>null</code>, as there is a refresh token, and therefore the
+        /// access tokens are refreshable.
+        /// </Summary> 
+        public DateTime? SuggestedCacheExpiry { get; private set; }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -255,15 +255,10 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return CreateFailureMessage(HttpStatusCode.BadRequest, string.Empty);
         }
 
-        public static HttpResponseMessage CreateSuccessfulClientCredentialTokenResponseMessage()
-        {
-            return CreateSuccessfulClientCredentialTokenResponseMessage("header.payload.signature");
-        }
-
-        public static HttpResponseMessage CreateSuccessfulClientCredentialTokenResponseMessage(string token)
+        public static HttpResponseMessage CreateSuccessfulClientCredentialTokenResponseMessage(string token = "header.payload.signature", string expiry = "3599")
         {
             return CreateSuccessResponseMessage(
-                "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"access_token\":\"" + token + "\"}");
+                "{\"token_type\":\"Bearer\",\"expires_in\":\"" + expiry + "\",\"access_token\":\"" + token + "\"}");
         }
 
         public static HttpResponseMessage CreateSuccessTokenResponseMessage(string uniqueId, string displayableId, string[] scope, bool foci = false)

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -171,6 +171,21 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return handler;
         }
 
+        public static MockHttpMessageHandler CreateSuccessfulClientCredentialTokenResponseWithExpiry(
+            this MockHttpManager httpManager, string expiresIn = "3599")
+        {
+            var handler = new MockHttpMessageHandler()
+            {
+                ExpectedMethod = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
+                "{\"token_type\":\"Bearer\",\"expires_in\":\"" + expiresIn + "\",\"access_token\":\"header.payload.signature\"}")
+            };
+
+            httpManager.AddMockHandler(handler);
+
+            return handler;
+        }
+
         public static void AddFailingRequest(this MockHttpManager httpManager, Exception exceptionToThrow)
         {
             httpManager.AddMockHandler(

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -158,27 +158,12 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         }
 
         public static MockHttpMessageHandler AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
-            this MockHttpManager httpManager)
+            this MockHttpManager httpManager, string token = "header.payload.signature", string expiresIn = "3599")
         {
             var handler = new MockHttpMessageHandler()
             {
                 ExpectedMethod = HttpMethod.Post,
                 ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage()
-            };
-
-            httpManager.AddMockHandler(handler);
-
-            return handler;
-        }
-
-        public static MockHttpMessageHandler CreateSuccessfulClientCredentialTokenResponseWithExpiry(
-            this MockHttpManager httpManager, string expiresIn = "3599")
-        {
-            var handler = new MockHttpMessageHandler()
-            {
-                ExpectedMethod = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessResponseMessage(
-                "{\"token_type\":\"Bearer\",\"expires_in\":\"" + expiresIn + "\",\"access_token\":\"header.payload.signature\"}")
             };
 
             httpManager.AddMockHandler(handler);

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             var handler = new MockHttpMessageHandler()
             {
                 ExpectedMethod = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage()
+                ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage(token, expiresIn)
             };
 
             httpManager.AddMockHandler(handler);

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -18,6 +18,7 @@ using Microsoft.Identity.Client.PlatformsCommon.Factories;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Test.Unit;
 using NSubstitute;
+using static Microsoft.Identity.Client.TelemetryCore.Internal.Events.ApiEvent;
 
 namespace Microsoft.Identity.Test.Common
 {
@@ -91,11 +92,13 @@ namespace Microsoft.Identity.Test.Common
             IServiceBundle serviceBundle,
             Authority authority = null,
             HashSet<string> scopes = null,
-            RequestContext requestContext = null)
+            RequestContext requestContext = null,
+            ApiIds apiID = ApiIds.None)
         {
             var commonParameters = new AcquireTokenCommonParameters
             {
                 Scopes = scopes ?? TestConstants.s_scope,
+                ApiId = apiID
             };
 
             authority = authority ?? Authority.CreateAuthority(TestConstants.AuthorityTestTenant);

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Test.Performance
         private AuthenticationRequestParameters _requestParams;
         private IServiceBundle _serviceBundle;
 
-        [Params(1000)]
+        [Params(10000)]
         public int TokenCacheSize { get; set; }
 
         [GlobalSetup]
@@ -52,12 +52,6 @@ namespace Microsoft.Identity.Test.Performance
                 .WithRedirectUri(TestConstants.RedirectUri)
                 .WithClientSecret(TestConstants.ClientSecret)
                 .BuildConcrete();
-
-            PopulateAppCache(_ccaTokensDifferByTenant, TokenDifference.ByTenant, TokenCacheSize);
-
-            _serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isLegacyCacheEnabled: false);
-            _response = TestConstants.CreateMsalTokenResponse(TestConstants.Utid);
-            _requestParams = TestCommon.CreateAuthenticationRequestParameters(_serviceBundle, null, null, null, ApiIds.AcquireTokenForClient);
         }
 
         /// <summary>
@@ -93,15 +87,6 @@ namespace Microsoft.Identity.Test.Performance
               .WithAuthority($"https://login.microsoftonline.com/tid")
               .ExecuteAsync()
               .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// This is a test to validate the performance impact of calculating the TokenCacheNotificationArgs.SuggestedCacheExpiry when saving an access token.
-        /// </summary>
-        [Benchmark(Description = "Token cache expiry - O(n)")]
-        public async Task CaclulateTokenCacheExpiryTestTestAsync()
-        {
-            await _ccaTokensDifferByScope.AppTokenCacheInternal.SaveTokenResponseAsync(_requestParams, _response).ConfigureAwait(false);
         }
 
         private enum TokenDifference

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Test.Performance
         private AuthenticationRequestParameters _requestParams;
         private IServiceBundle _serviceBundle;
 
-        [Params(3000)]
+        [Params(1000)]
         public int TokenCacheSize { get; set; }
 
         [GlobalSetup]
@@ -96,9 +96,8 @@ namespace Microsoft.Identity.Test.Performance
         }
 
         /// <summary>
-        /// 
+        /// This is a test to validate the performance impact of calculating the TokenCacheNotificationArgs.SuggestedCacheExpiry when saving an access token.
         /// </summary>
-        /// <returns></returns>
         [Benchmark(Description = "Token cache expiry - O(n)")]
         public async Task CaclulateTokenCacheExpiryTestTestAsync()
         {

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientLargeCacheTests.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Identity.Test.Performance
         ConfidentialClientApplication _ccaTokensDifferByTenant;
         private MsalTokenResponse _response;
         private AuthenticationRequestParameters _requestParams;
-        private RequestContext _requestContext;
+        private IServiceBundle _serviceBundle;
 
-        [Params(1000)]
+        [Params(3000)]
         public int TokenCacheSize { get; set; }
 
         [GlobalSetup]
@@ -55,10 +55,9 @@ namespace Microsoft.Identity.Test.Performance
 
             PopulateAppCache(_ccaTokensDifferByTenant, TokenDifference.ByTenant, TokenCacheSize);
 
-            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isLegacyCacheEnabled: false);
-            _requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
+            _serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isLegacyCacheEnabled: false);
             _response = TestConstants.CreateMsalTokenResponse(TestConstants.Utid);
-            _requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle, null, null, null, ApiIds.AcquireTokenForClient);
+            _requestParams = TestCommon.CreateAuthenticationRequestParameters(_serviceBundle, null, null, null, ApiIds.AcquireTokenForClient);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes # .
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2486

**Changes proposed in this request**
Adds SuggestedCacheExpiry to the TokenCacheNotificationArgs

**Testing**
Manual testing
Unit test

**Performance impact**
Negligible performance impact
