### PR TITLE
Bogavril/tc logs

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
@@ -37,15 +37,15 @@ namespace Microsoft.Identity.Client.Cache
 
         void DeleteAccount(MsalAccountCacheKey cacheKey);
 
-        IEnumerable<MsalAccessTokenCacheItem> GetAllAccessTokens();
+        IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens();
 
-        IEnumerable<MsalRefreshTokenCacheItem> GetAllRefreshTokens();
+        IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens();
 
-        IEnumerable<MsalIdTokenCacheItem> GetAllIdTokens();
+        IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens();
 
-        IEnumerable<MsalAccountCacheItem> GetAllAccounts();
+        IReadOnlyList<MsalAccountCacheItem> GetAllAccounts();
 
-        IEnumerable<MsalAppMetadataCacheItem> GetAllAppMetadata();
+        IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata();
 
 
 #if iOS

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidTokenCacheAccessor.cs
@@ -114,22 +114,22 @@ namespace Microsoft.Identity.Client.Platforms.Android
             editor.Apply();
         }
 
-        public IEnumerable<MsalAccessTokenCacheItem> GetAllAccessTokens()
+        public IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens()
         {
             return _accessTokenSharedPreference.All.Values.Cast<string>().Select(x => MsalAccessTokenCacheItem.FromJsonString(x)).ToList();
         }
 
-        public IEnumerable<MsalRefreshTokenCacheItem> GetAllRefreshTokens()
+        public IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens()
         {
             return _refreshTokenSharedPreference.All.Values.Cast<string>().Select(x => MsalRefreshTokenCacheItem.FromJsonString(x)).ToList();
         }
 
-        public IEnumerable<MsalIdTokenCacheItem> GetAllIdTokens()
+        public IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens()
         {
             return _idTokenSharedPreference.All.Values.Cast<string>().Select(x => MsalIdTokenCacheItem.FromJsonString(x)).ToList();
         }
 
-        public IEnumerable<MsalAccountCacheItem> GetAllAccounts()
+        public IReadOnlyList<MsalAccountCacheItem> GetAllAccounts()
         {
             return _accountSharedPreference.All.Values.Cast<string>().Select(x => MsalAccountCacheItem.FromJsonString(x)).ToList();
         }
@@ -178,7 +178,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
             throw new NotImplementedException();
         }
 
-        public IEnumerable<MsalAppMetadataCacheItem> GetAllAppMetadata()
+        public IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()
         {
             throw new NotImplementedException();
         }

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -118,28 +118,28 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             Remove(cacheKey);
         }
 
-        public IEnumerable<MsalAccessTokenCacheItem> GetAllAccessTokens()
+        public IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens()
         {
             return GetPayloadAsString((int)MsalCacheKeys.iOSCredentialAttrType.AccessToken)
                 .Select(x => MsalAccessTokenCacheItem.FromJsonString(x))
                 .ToList();
         }
 
-        public IEnumerable<MsalRefreshTokenCacheItem> GetAllRefreshTokens()
+        public IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens()
         {
             return GetPayloadAsString((int)MsalCacheKeys.iOSCredentialAttrType.RefreshToken)
                 .Select(x => MsalRefreshTokenCacheItem.FromJsonString(x))
                 .ToList();
         }
 
-        public IEnumerable<MsalIdTokenCacheItem> GetAllIdTokens()
+        public IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens()
         {
             return GetPayloadAsString((int)MsalCacheKeys.iOSCredentialAttrType.IdToken)
                 .Select(x => MsalIdTokenCacheItem.FromJsonString(x))
                 .ToList();
         }
 
-        public IEnumerable<MsalAccountCacheItem> GetAllAccounts()
+        public IReadOnlyList<MsalAccountCacheItem> GetAllAccounts()
         {
             return GetPayloadAsString(MsalCacheKeys.iOSAuthorityTypeToAttrType[CacheAuthorityType.MSSTS.ToString()])
                 .Select(x => MsalAccountCacheItem.FromJsonString(x))
@@ -358,7 +358,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             throw new NotImplementedException();
         }
 
-        public IEnumerable<MsalAppMetadataCacheItem> GetAllAppMetadata()
+        public IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()
         {
             throw new NotImplementedException();
         }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryTokenCacheAccessor.cs
@@ -154,27 +154,27 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         #endregion
 
         #region Get All Values
-        public IEnumerable<MsalAccessTokenCacheItem> GetAllAccessTokens()
+        public IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens()
         {
-            return _accessTokenCacheDictionary.Select(kv => kv.Value);
+            return _accessTokenCacheDictionary.Select(kv => kv.Value).ToList();
         }
 
-        public IEnumerable<MsalRefreshTokenCacheItem> GetAllRefreshTokens()
+        public IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens()
         {
             return _refreshTokenCacheDictionary.Select(kv => kv.Value).ToList();
         }
 
-        public IEnumerable<MsalIdTokenCacheItem> GetAllIdTokens()
+        public IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens()
         {
             return _idTokenCacheDictionary.Select(kv => kv.Value).ToList();
         }
 
-        public IEnumerable<MsalAccountCacheItem> GetAllAccounts()
+        public IReadOnlyList<MsalAccountCacheItem> GetAllAccounts()
         {
             return _accountCacheDictionary.Select(kv => kv.Value).ToList();
         }
 
-        public IEnumerable<MsalAppMetadataCacheItem> GetAllAppMetadata()
+        public IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()
         {
             return _appMetadataDictionary.Select(kv => kv.Value).ToList();
         }

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -232,27 +232,27 @@ namespace Microsoft.Identity.Client
             return accounts;
         }
 
-        private IEnumerable<MsalRefreshTokenCacheItem> GetAllRefreshTokensWithNoLocks(bool filterByClientId)
+        private IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokensWithNoLocks(bool filterByClientId)
         {
             var refreshTokens = _accessor.GetAllRefreshTokens();
             return filterByClientId
-                ? refreshTokens.Where(x => x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase))
+                ? refreshTokens.Where(x => x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase)).ToList()
                 : refreshTokens;
         }
 
-        private IEnumerable<MsalAccessTokenCacheItem> GetAllAccessTokensWithNoLocks(bool filterByClientId)
+        private IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokensWithNoLocks(bool filterByClientId)
         {
             var accessTokens = _accessor.GetAllAccessTokens();
             return filterByClientId
-                ? accessTokens.Where(x => x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase))
+                ? accessTokens.Where(x => x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase)).ToList()
                 : accessTokens;
         }
 
-        private IEnumerable<MsalIdTokenCacheItem> GetAllIdTokensWithNoLocks(bool filterByClientId)
+        private IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokensWithNoLocks(bool filterByClientId)
         {
             var idTokens = _accessor.GetAllIdTokens();
             return filterByClientId
-                ? idTokens.Where(x => x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase))
+                ? idTokens.Where(x => x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase)).ToList()
                 : idTokens;
         }
 

--- a/src/client/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
@@ -30,22 +30,22 @@ namespace Microsoft.Identity.Client.Utils
             return set.Any(el => el.Equals(toLookFor, System.StringComparison.OrdinalIgnoreCase));
         }
 
-        internal static IEnumerable<T> FilterWithLogging<T>(
-            this IEnumerable<T> list,
+        internal static IReadOnlyList<T> FilterWithLogging<T>(
+            this IReadOnlyList<T> list,
             Func<T, bool> predicate,
             ICoreLogger logger,
             string logPrefix)
         {
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
             {
-                logger.Verbose($"{logPrefix} - item count before: {list.Count()} ");
+                logger.Verbose($"{logPrefix} - item count before: {list.Count} ");
             }
 
-            list = list.Where(predicate);
+            list = list.Where(predicate).ToList();
 
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
             {
-                logger.Verbose($"{logPrefix} - item count after: {list.Count()} ");
+                logger.Verbose($"{logPrefix} - item count after: {list.Count} ");
             }
 
             return list;


### PR DESCRIPTION
Fixes #2716 

**Changes proposed in this request**
Replace IEnumerable with IReadOnly list to avoid re-execution of filters 
Add more logging
Short-circuit some logic if token_count = 0

**Testing**
perf testing

**Performance impact**
FindAccessTokenAsync for client_creds flow (before and after) does not show any meaningful difference.

before
|                     Method | TokenCacheSize |         Mean |        Error |       StdDev |
|--------------------------- |--------------- |-------------:|-------------:|-------------:|
| 'Different tenants - O(1)' |           1000 |     73.24 us |     1.372 us |     1.468 us |
|  'Different scopes - O(n)' |           1000 | 58,334.41 us | 1,104.858 us | 2,647.169 us |

after
|                     Method | TokenCacheSize |         Mean |        Error |       StdDev |
|--------------------------- |--------------- |-------------:|-------------:|-------------:|
| 'Different tenants - O(1)' |           1000 |     76.41 us |     0.513 us |     0.429 us |
|  'Different scopes - O(n)' |           1000 | 58,034.85 us | 1,149.229 us | 1,951.479 us |



