### PR TITLE
Update EditorConfig to add copyright file header for new files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ root = true
 # Copied from the .NET Core repo https://github.com/dotnet/corefx/blob/master/.editorconfig
 # NOTE: Requires **VS2019 16.3** or later
 
-#These configuration override the config in the top most SDL editorconfig for a more personalized code style while maintaining required SDL rules
+#These configuration override the config in the top most SDL EditorConfig for a more personalized code style while maintaining required SDL rules
 
 # Default settings:
 # A newline ending every file
@@ -202,6 +202,10 @@ dotnet_diagnostic.Async004.severity = none
 dotnet_diagnostic.Async005.severity = none
 
 dotnet_diagnostic.Async006.severity = none
+
+# IDE0073: Require file header
+dotnet_diagnostic.IDE0073.severity = warning
+file_header_template = Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.
 
 # Do not declare static members on generic types
 dotnet_diagnostic.CA1000.severity = none
@@ -638,7 +642,7 @@ dotnet_diagnostic.CA2229.severity = none
 # Overload operator equals on overriding value type Equals
 dotnet_diagnostic.CA2231.severity = none
 
-# Pass system uri objects instead of strings
+# Pass system URI objects instead of strings
 dotnet_diagnostic.CA2234.severity = none
 
 # Mark all non-serializable fields


### PR DESCRIPTION
Fixes # .
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
Updated EditorConfig to add copyright header to new files. 
Note: If the file doesn't have a header, set the rule to warning, but it doesn't seem to work for existing files.
