### PR TITLE
Trwalke/instance discovery fix

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                         requestContext.Logger.WarningPii(message + "Authority: " + authorityInfo.CanonicalAuthority, message);
 
                         entry = CreateEntryForSingleAuthority(authorityUri);
+                        _networkCacheMetadataProvider.AddMetadata(environment, entry);
                     }
 
                     return entry;

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -68,8 +68,10 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                     continue;
                 }
 
+                //Need to ensure the entry is added to the proper cloud to avoid caching the wrong cloud aliases data.
+                //Example: Caching aliased environments that end with .cn with a key that end in .com or .de
                 //the login-us.microsoftonline.com environment has the same ending as login.microsoftonline.com
-                //so a check for login-us is needed to ensure we are in the correct environment
+                //so a check for login-us is needed to ensure we are in the correct cloud
                 if (    !entry.PreferredNetwork.Contains("login-us") &&
                         ((entry.PreferredNetwork.EndsWith(".com") && originalEnvironment.EndsWith(".com")) ||
                         (entry.PreferredNetwork.EndsWith(".com") && originalEnvironment.EndsWith(".net")))

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                     continue;
                 }
 
+                //the login-us.microsoftonline.com environment has the same ending as login.microsoftonline.com
+                //so a check for login-us is needed to ensure we are in the correct environment
                 if (    !entry.PreferredNetwork.Contains("login-us") &&
                         ((entry.PreferredNetwork.EndsWith(".com") && originalEnvironment.EndsWith(".com")) ||
                         (entry.PreferredNetwork.EndsWith(".com") && originalEnvironment.EndsWith(".net")))
@@ -87,8 +89,14 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 {
                     _networkCacheMetadataProvider.AddMetadata(originalEnvironment, entry);
                 }
-
-                originalEnvironmentCached = true;
+                else if (entry.PreferredNetwork.Contains("login-us") &&
+                        ((entry.PreferredNetwork.EndsWith(".com") && originalEnvironment.EndsWith(".com")) ||
+                        (entry.PreferredNetwork.EndsWith(".com") && originalEnvironment.EndsWith(".net")))
+                   )
+                {
+                    _networkCacheMetadataProvider.AddMetadata(originalEnvironment, entry);
+                }
+                    originalEnvironmentCached = true;
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string AuthorityRegional = "https://" + ProductionPrefRegionalEnvironment + "/" + TenantId + "/";
         public const string AuthorityRegionalInvalidRegion = "https://" + ProductionPrefInvalidRegionEnvironment + "/" + TenantId + "/";
         public const string AuthorityTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + TenantId + "/";
-        public const string AuthorityCommonTenantNotPrefAlias = "https://" + ProductionNotPrefEnvironmentAlias + "/common/";        
+        public const string AuthorityCommonTenantNotPrefAlias = "https://" + ProductionNotPrefEnvironmentAlias + "/common/";
+        public const string AuthorityCommonPpeAuthority = "https://" + PPEEnvironment + "/common/";
 
         public const string PrefCacheAuthorityCommonTenant = "https://" + ProductionPrefCacheEnvironment + "/common/";
         public const string AuthorityOrganizationsTenant = "https://" + ProductionPrefNetworkEnvironment + "/organizations/";

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string ProductionPrefRegionalEnvironment = "centralus.login.microsoft.com";
         public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.login.microsoft.com";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
-        public const string PPEEnvironment = "login.windows-ppe.net";
+        public const string PpeEnvironment = "login.windows-ppe.net";
 
 
         public const string AuthorityNotKnownCommon = "https://sts.access.edu/common/";
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string AuthorityRegionalInvalidRegion = "https://" + ProductionPrefInvalidRegionEnvironment + "/" + TenantId + "/";
         public const string AuthorityTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + TenantId + "/";
         public const string AuthorityCommonTenantNotPrefAlias = "https://" + ProductionNotPrefEnvironmentAlias + "/common/";
-        public const string AuthorityCommonPpeAuthority = "https://" + PPEEnvironment + "/common/";
+        public const string AuthorityCommonPpeAuthority = "https://" + PpeEnvironment + "/common/";
 
         public const string PrefCacheAuthorityCommonTenant = "https://" + ProductionPrefCacheEnvironment + "/common/";
         public const string AuthorityOrganizationsTenant = "https://" + ProductionPrefNetworkEnvironment + "/organizations/";

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
@@ -148,13 +148,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                .ConfigureAwait(false);
 
             MsalAssert.AssertAuthResult(authResult);
-
-            // bug: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2701
-            if (settings.Cloud != Cloud.PPE)
-            {
                 Assert.IsTrue(authResult.AuthenticationResultMetadata.DurationInHttpInMs == 0);
-            }
-
+            
             appCacheRecorder.AssertAccessCounts(2, 1);
             Assert.AreEqual(TokenSource.Cache, authResult.AuthenticationResultMetadata.TokenSource);
             Assert.IsTrue(appCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
     {
         private static readonly AuthorityInfo s_commonAuthority =
             AuthorityInfo.FromAuthorityUri(TestConstants.AuthorityCommonTenant, true);
-        static string s_ppeCommonUri = $@"https://{TestConstants.PPEEnvironment}/{TestConstants.TenantId}";
+        static string s_ppeCommonUri = $@"https://{TestConstants.PpeEnvironment}/{TestConstants.TenantId}";
         private static readonly AuthorityInfo s_ppeAuthority =
           AuthorityInfo.FromAuthorityUri(s_ppeCommonUri, true);
         private static readonly AuthorityInfo s_utidAuthority =

--- a/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
@@ -209,7 +209,6 @@ namespace Microsoft.Identity.Test.Unit
                     .Result;
 
                 Assert.IsNotNull(result);
-                Assert.IsTrue(harness.HttpManager.QueueSize == 0);
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -269,7 +269,6 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                     AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(customPortAuthority);
-                harness.HttpManager.AddInstanceDiscoveryMockHandler(customPortAuthority);
 
                 AuthenticationResult result = app
                     .AcquireTokenInteractive(TestConstants.s_scope)


### PR DESCRIPTION
Fixes # .
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2701

**Changes proposed in this request**
Adding an instance discovery entry to cache when the returned metadata does not include the configured authority's environment.

**Testing**
Unit test, Manual testing

**Performance impact**
Negligible 
