### PR TITLE
Remove null check from CCS APIs

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -114,13 +114,9 @@ namespace Microsoft.Identity.Client
         /// <returns>The builder to chain the .With methods</returns>
         public AcquireTokenByAuthorizationCodeParameterBuilder WithCcsRoutingHint(string userObjectIdentifier, string tenantIdentifier)
         {
-            if (string.IsNullOrEmpty(userObjectIdentifier))
+            if (string.IsNullOrEmpty(userObjectIdentifier) || string.IsNullOrEmpty(tenantIdentifier))
             {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(userObjectIdentifier));
-            }
-            if (string.IsNullOrEmpty(tenantIdentifier))
-            {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(tenantIdentifier));
+                return this;
             }
 
             var ccsRoutingHeader = new Dictionary<string, string>() 
@@ -142,7 +138,7 @@ namespace Microsoft.Identity.Client
         {
             if (string.IsNullOrEmpty(userName))
             {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(userName));
+                return this;
             }
 
             var ccsRoutingHeader = new Dictionary<string, string>()

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -98,13 +98,9 @@ namespace Microsoft.Identity.Client
         /// <returns>The builder to chain the .With methods</returns>
         public AcquireTokenOnBehalfOfParameterBuilder WithCcsRoutingHint(string userObjectIdentifier, string tenantIdentifier)
         {
-            if (string.IsNullOrEmpty(userObjectIdentifier))
+            if (string.IsNullOrEmpty(userObjectIdentifier) || string.IsNullOrEmpty(tenantIdentifier))
             {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(userObjectIdentifier));
-            }
-            if (string.IsNullOrEmpty(tenantIdentifier))
-            {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(tenantIdentifier));
+                return this;
             }
 
             var ccsRoutingHeader = new Dictionary<string, string>()
@@ -126,7 +122,7 @@ namespace Microsoft.Identity.Client
         {
             if (string.IsNullOrEmpty(userName))
             {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(userName));
+                return this;
             }
 
             var ccsRoutingHeader = new Dictionary<string, string>()

--- a/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -111,13 +111,9 @@ namespace Microsoft.Identity.Client
         /// <returns>The builder to chain the .With methods</returns>
         public GetAuthorizationRequestUrlParameterBuilder WithCcsRoutingHint(string userObjectIdentifier, string tenantIdentifier)
         {
-            if (string.IsNullOrEmpty(userObjectIdentifier))
+            if (string.IsNullOrEmpty(userObjectIdentifier) || string.IsNullOrEmpty(tenantIdentifier))
             {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(userObjectIdentifier));
-            }
-            if (string.IsNullOrEmpty(tenantIdentifier))
-            {
-                throw new ArgumentException(MsalErrorMessage.CcsRoutingHintMissing, nameof(tenantIdentifier));
+                return this;
             }
 
             Parameters.CcsRoutingHint = new KeyValuePair<string, string>(userObjectIdentifier, tenantIdentifier) as KeyValuePair<string, string>?;

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -158,12 +158,13 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         }
 
         public static MockHttpMessageHandler AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
-            this MockHttpManager httpManager, string token = "header.payload.signature", string expiresIn = "3599")
+            this MockHttpManager httpManager, string token = "header.payload.signature", string expiresIn = "3599", IDictionary<string, string> unexpectedHttpHeaders = null)
         {
             var handler = new MockHttpMessageHandler()
             {
                 ExpectedMethod = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage(token, expiresIn)
+                ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage(token, expiresIn),
+                UnexpectedRequestHeaders = unexpectedHttpHeaders
             };
 
             httpManager.AddMockHandler(handler);

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         }
 
         public static MockHttpMessageHandler AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
-            this MockHttpManager httpManager, string token = "header.payload.signature", string expiresIn = "3599", IDictionary<string, string> unexpectedHttpHeaders = null)
+            this MockHttpManager httpManager, string token = "header.payload.signature", string expiresIn = "3599", IList<string> unexpectedHttpHeaders = null)
         {
             var handler = new MockHttpMessageHandler()
             {

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public IDictionary<string, string> ExpectedQueryParams { get; set; }
         public IDictionary<string, string> ExpectedPostData { get; set; }
         public IDictionary<string, string> ExpectedRequestHeaders { get; set; }
-        public IDictionary<string, string> UnexpectedRequestHeaders { get; set; }
+        public IList<string> UnexpectedRequestHeaders { get; set; }
 
         public HttpMethod ExpectedMethod { get; set; }
         
@@ -114,11 +114,11 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
 
             if (UnexpectedRequestHeaders != null)
             {
-                foreach (var kvp in UnexpectedRequestHeaders)
+                foreach (var item in UnexpectedRequestHeaders)
                 {
                     Assert.IsTrue(
-                        !request.Headers.Any(h => string.Equals(h.Key, kvp.Key, StringComparison.OrdinalIgnoreCase))
-                        , $"Not expecting a request header with key={kvp.Key} but it was found in the actual request: {request}");
+                        !request.Headers.Any(h => string.Equals(h.Key, item, StringComparison.OrdinalIgnoreCase))
+                        , $"Not expecting a request header with key={item} but it was found in the actual request: {request}");
                 }
             }
 

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public IDictionary<string, string> ExpectedQueryParams { get; set; }
         public IDictionary<string, string> ExpectedPostData { get; set; }
         public IDictionary<string, string> ExpectedRequestHeaders { get; set; }
+        public IDictionary<string, string> UnexpectedRequestHeaders { get; set; }
 
         public HttpMethod ExpectedMethod { get; set; }
         
@@ -108,6 +109,16 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                             string.Equals(h.Key, kvp.Key, StringComparison.OrdinalIgnoreCase) &&
                             string.Equals(h.Value.AsSingleString(), kvp.Value, StringComparison.OrdinalIgnoreCase))
                         , $"Expecting a request header {kvp.Key}: {kvp.Value} but did not find in the actual request: {request}");
+                }
+            }
+
+            if (UnexpectedRequestHeaders != null)
+            {
+                foreach (var kvp in UnexpectedRequestHeaders)
+                {
+                    Assert.IsTrue(
+                        !request.Headers.Any(h => string.Equals(h.Key, kvp.Key, StringComparison.OrdinalIgnoreCase))
+                        , $"Not expecting a request header with key={kvp.Key} but it was found in the actual request: {request}");
                 }
             }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -808,54 +808,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         }
 
         [TestMethod]
-        [DataRow(null, TestConstants.TenantId)]
-        [DataRow(TestConstants.OnPremiseUniqueId, null)]
-        [DataRow(null, null)]
-        [DataRow("", "")]
-        public async Task CcsRoutingHint_ClientInfoHintIncorrect_ThrowsAsync(string oid, string tid)
-        {
-            using (var httpManager = new MockHttpManager())
-            {
-                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                              .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
-                                                              .WithRedirectUri(TestConstants.RedirectUri)
-                                                              .WithClientSecret(TestConstants.ClientSecret)
-                                                              .WithHttpManager(httpManager)
-                                                              .BuildConcrete();
-
-                await Assert.ThrowsExceptionAsync<ArgumentException>(() => app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
-                    .WithPkceCodeVerifier(string.Empty)
-                    .WithCcsRoutingHint(oid, tid)
-                    .ExecuteAsync()).ConfigureAwait(false);
-            }
-        }
-
-        [TestMethod]
-        [DataRow(null)]
-        [DataRow("")]
-        public async Task CcsRoutingHint_UpnHintIncorrect_ThrowsAsync(string upn)
-        {
-            using (var httpManager = new MockHttpManager())
-            {
-                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                              .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
-                                                              .WithRedirectUri(TestConstants.RedirectUri)
-                                                              .WithClientSecret(TestConstants.ClientSecret)
-                                                              .WithHttpManager(httpManager)
-                                                              .BuildConcrete();
-
-                await Assert.ThrowsExceptionAsync<ArgumentException>(() => app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
-                    .WithPkceCodeVerifier(string.Empty)
-                    .WithCcsRoutingHint(upn)
-                    .ExecuteAsync()).ConfigureAwait(false);
-
-                await Assert.ThrowsExceptionAsync<ArgumentException>(() => app.AcquireTokenOnBehalfOf(TestConstants.s_scope, new UserAssertion(TestConstants.DefaultAccessToken))
-                    .WithCcsRoutingHint(upn)
-                    .ExecuteAsync()).ConfigureAwait(false);
-            }
-        }
-
-        [TestMethod]
         public async Task GetAuthorizationRequestUrlWithPKCETestAsync()
         {
             using (var httpManager = new MockHttpManager())

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/OboRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/OboRequestTests.cs
@@ -145,8 +145,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             using (var httpManager = new MockHttpManager())
             {
                 httpManager.AddInstanceDiscoveryMockHandler();
-                var unextraExpectedHeaders = new Dictionary<string, string>() { { Constants.CcsRoutingHintHeader, "" } };
-                AddMockHandlerAadSuccess(httpManager, TestConstants.AuthorityCommonTenant, unextraExpectedHeaders);
+                var extraUnexpectedHeaders = new Dictionary<string, string>() { { Constants.CcsRoutingHintHeader, "" } };
+                AddMockHandlerAadSuccess(httpManager, TestConstants.AuthorityCommonTenant, extraUnexpectedHeaders);
 
                 var cca = ConfidentialClientApplicationBuilder
                                                          .Create(TestConstants.ClientId)

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/OboRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/OboRequestTests.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,13 +24,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             TestCommon.ResetInternalStaticCaches();
         }
 
-        private MockHttpMessageHandler AddMockHandlerAadSuccess(MockHttpManager httpManager, string authority)
+        private MockHttpMessageHandler AddMockHandlerAadSuccess(MockHttpManager httpManager, string authority, IDictionary<string, string> unexpectedHeaders = null)
         {
             var handler = new MockHttpMessageHandler
             {
                 ExpectedUrl = authority + "oauth2/v2.0/token",
                 ExpectedMethod = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                UnexpectedRequestHeaders = unexpectedHeaders
             };
             httpManager.AddMockHandler(handler);
 
@@ -131,6 +135,33 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 Assert.IsNotNull(result);
                 Assert.AreEqual(result.AuthenticationResultMetadata.TokenSource, TokenSource.Cache);
+                Assert.AreEqual("some-access-token", result.AccessToken);
+            }
+        }
+
+        [TestMethod]
+        public async Task AcquireTokenByOboNullCcsTestAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+                var unextraExpectedHeaders = new Dictionary<string, string>() { { Constants.CcsRoutingHintHeader, "" } };
+                AddMockHandlerAadSuccess(httpManager, TestConstants.AuthorityCommonTenant, unextraExpectedHeaders);
+
+                var cca = ConfidentialClientApplicationBuilder
+                                                         .Create(TestConstants.ClientId)
+                                                         .WithClientSecret(TestConstants.ClientSecret)
+                                                         .WithAuthority(TestConstants.AuthorityCommonTenant)
+                                                         .WithHttpManager(httpManager)
+                                                         .BuildConcrete();
+
+                UserAssertion userAssertion = new UserAssertion(TestConstants.DefaultAccessToken);
+                var result = await cca.AcquireTokenOnBehalfOf(TestConstants.s_scope, userAssertion)
+                                      .WithCcsRoutingHint("")
+                                      .WithCcsRoutingHint("", "")
+                                      .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
                 Assert.AreEqual("some-access-token", result.AccessToken);
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/OboRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/OboRequestTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             TestCommon.ResetInternalStaticCaches();
         }
 
-        private MockHttpMessageHandler AddMockHandlerAadSuccess(MockHttpManager httpManager, string authority, IDictionary<string, string> unexpectedHeaders = null)
+        private MockHttpMessageHandler AddMockHandlerAadSuccess(MockHttpManager httpManager, string authority, IList<string> unexpectedHeaders = null)
         {
             var handler = new MockHttpMessageHandler
             {
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             using (var httpManager = new MockHttpManager())
             {
                 httpManager.AddInstanceDiscoveryMockHandler();
-                var extraUnexpectedHeaders = new Dictionary<string, string>() { { Constants.CcsRoutingHintHeader, "" } };
+                var extraUnexpectedHeaders = new List<string>() { { Constants.CcsRoutingHintHeader} };
                 AddMockHandlerAadSuccess(httpManager, TestConstants.AuthorityCommonTenant, extraUnexpectedHeaders);
 
                 var cca = ConfidentialClientApplicationBuilder
@@ -160,6 +160,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                                       .WithCcsRoutingHint("")
                                       .WithCcsRoutingHint("", "")
                                       .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual("some-access-token", result.AccessToken);
+
+                result = await cca.AcquireTokenOnBehalfOf(TestConstants.s_scope, userAssertion)
+                      .WithCcsRoutingHint("")
+                      .WithCcsRoutingHint("", "")
+                      .ExecuteAsync().ConfigureAwait(false);
 
                 Assert.IsNotNull(result);
                 Assert.AreEqual("some-access-token", result.AccessToken);


### PR DESCRIPTION
Fixes # .
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2755

**Changes proposed in this request**
Removes null check from WithCCS apis

**Testing**
Adding unit test

**Performance impact**
None
