### PR TITLE
Fix build issue (Ambiguous reference)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
@@ -17,6 +17,7 @@ using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 
 #if NET5_WIN
 using Microsoft.Identity.Client.Platforms.net5win;
+using AccountsSettingsPaneInterop = Microsoft.Identity.Client.Platforms.net5win.AccountsSettingsPaneInterop;
 #elif DESKTOP || NET_CORE
 using Microsoft.Identity.Client.Platforms;
 #endif

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamProxy.cs
@@ -12,6 +12,7 @@ using System.Threading;
 
 #if NET5_WIN
 using Microsoft.Identity.Client.Platforms.net5win;
+using WebAuthenticationCoreManagerInterop = Microsoft.Identity.Client.Platforms.net5win.WebAuthenticationCoreManagerInterop;
 #elif DESKTOP || NET_CORE
 using Microsoft.Identity.Client.Platforms;
 #endif


### PR DESCRIPTION
Fixes # .
Fixing build error: "WebAuthenticationCoreManagerInterop' is an ambiguous reference between 'Microsoft.Identity.Client.Platforms.net5win.WebAuthenticationCoreManagerInterop' and 'Windows.Security.Authentication.Web.Core.WebAuthenticationCoreManagerInterop"
