### PR TITLE
Verify auto discovered region does not contain space

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Region/RegionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/RegionManager.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Identity.Client.Region
         {
             string region = Environment.GetEnvironmentVariable("REGION_NAME");
 
-            if (!string.IsNullOrEmpty(region))
+            if (!string.IsNullOrEmpty(region) && !region.Contains(" "))
             {
                 logger.Info($"[Region discovery] Region found in environment variable: {region}.");
                 return new RegionInfo(region, RegionAutodetectionSource.EnvVariable);
@@ -186,7 +186,7 @@ namespace Microsoft.Identity.Client.Region
                         .ConfigureAwait(false); // Call again with updated version
                 }
 
-                if (response.StatusCode == HttpStatusCode.OK && !response.Body.IsNullOrEmpty())
+                if (response.StatusCode == HttpStatusCode.OK && !response.Body.IsNullOrEmpty() && !response.Body.Contains(" "))
                 {
                     region = response.Body;
 


### PR DESCRIPTION
Verify the region from the env variable does not contain space - space in the region will most likely indicates full region name is used, which is not valid as only short region names are accepted.


I did not write down the Fixed # because I am not sure this would be the entire fix at your end

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->
