### PR TITLE
Ignoring failing test

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
+        [Ignore] //See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2781
         public async Task InvalidRegion_GoesToInvalidAuthority_Async()
         {
             // Arrange


### PR DESCRIPTION
Ignoring regional test InvalidRegion_GoesToInvalidAuthority_Async
See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2781

Fixes # .
Ignoring regional test InvalidRegion_GoesToInvalidAuthority_Async

**Changes proposed in this request**
Ignoring regional test InvalidRegion_GoesToInvalidAuthority_Async
