### PR TITLE
Use preferred_network and skip discovery for known clouds

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityManager.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Client.Instance
         private Authority _currentAuthority;
 
         bool _instanceDiscoveryAndValidationExecuted = false;
-      
+
         public AuthorityManager(RequestContext requestContext, Authority initialAuthority)
         {
             _requestContext = requestContext;
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Instance
 
 
         private InstanceDiscoveryMetadataEntry _metadata;
-        public async Task<InstanceDiscoveryMetadataEntry> GetInstanceDisoveryEntryAsync()
+        public async Task<InstanceDiscoveryMetadataEntry> GetInstanceDiscoveryEntryAsync()
         {
             await RunInstanceDiscoveryAndValidationAsync().ConfigureAwait(false);
             return _metadata;
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Client.Instance
         {
             if (!_instanceDiscoveryAndValidationExecuted)
             {
-                // This will make a network call unless instance discovery is cached, but this ok
+                // This will make a network call unless instance discovery is cached, but this OK
                 // GetAccounts and AcquireTokenSilent do not need this
                 _metadata = await
                                 _requestContext.ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client.Instance
         {
             s_validatedEnvironments.Clear();
         }
-      
+
         private async Task ValidateAuthorityAsync(Authority authority)
         {
             // race conditions could occur here, where multiple requests validate the authority at the same time

--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityManager.cs
@@ -37,13 +37,21 @@ namespace Microsoft.Identity.Client.Instance
 
         public Authority Authority => _currentAuthority;
 
+
+        private InstanceDiscoveryMetadataEntry _metadata;
+        public async Task<InstanceDiscoveryMetadataEntry> GetInstanceDisoveryEntryAsync()
+        {
+            await RunInstanceDiscoveryAndValidationAsync().ConfigureAwait(false);
+            return _metadata;
+        }
+
         public async Task RunInstanceDiscoveryAndValidationAsync()
         {
             if (!_instanceDiscoveryAndValidationExecuted)
             {
                 // This will make a network call unless instance discovery is cached, but this ok
                 // GetAccounts and AcquireTokenSilent do not need this
-                InstanceDiscoveryMetadataEntry metadata = await
+                _metadata = await
                                 _requestContext.ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(
                                     _initialAuthority.AuthorityInfo,
                                     _requestContext)
@@ -51,7 +59,7 @@ namespace Microsoft.Identity.Client.Instance
 
                 _currentAuthority = Authority.CreateAuthorityWithEnvironment(
                                     _initialAuthority.AuthorityInfo,
-                                    metadata.PreferredNetwork);
+                                    _metadata.PreferredNetwork);
 
                 // We can only validate the initial environment, not regional environments
                 await ValidateAuthorityAsync(_initialAuthority).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -117,6 +117,18 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             return s_knownEnvironments.Contains(environment);
         }
 
+        public static bool TryGetKnownEnviromentPrefferedNetwork(string environment, out string preferredNetworkEnvironment)
+        {
+            if (s_knownEntries.TryGetValue(environment, out var entry))
+            {
+                preferredNetworkEnvironment = entry.PreferredNetwork;
+                return true;
+            }
+
+            preferredNetworkEnvironment = null;
+            return false;
+        }
+
         public static IDictionary<string, InstanceDiscoveryMetadataEntry> GetAllEntriesForTest()
         {
             return s_knownEntries;

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Utils;
 
@@ -117,7 +116,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             return s_knownEnvironments.Contains(environment);
         }
 
-        public static bool TryGetKnownEnviromentPrefferedNetwork(string environment, out string preferredNetworkEnvironment)
+        public static bool TryGetKnownEnviromentPreferredNetwork(string environment, out string preferredNetworkEnvironment)
         {
             if (s_knownEntries.TryGetValue(environment, out var entry))
             {

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionDiscoveryProvider.cs
@@ -27,11 +27,7 @@ namespace Microsoft.Identity.Client.Region
                 return null;
             }
 
-            // already regionalized
-            if (authority.Host.StartsWith(region))
-            {
-                return CreateEntry(requestContext.ServiceBundle.Config.AuthorityInfo.Host, authority.Host);
-            }
+            
 
             string regionalEnv = GetRegionalizedEnviroment(authority, region);
             return CreateEntry(authority.Host, regionalEnv);
@@ -49,15 +45,16 @@ namespace Microsoft.Identity.Client.Region
 
         private string GetRegionalizedEnviroment(Uri authority, string region)
         {
-            var builder = new UriBuilder(authority);
+            string host = authority.Host;
 
-            // special rule for Global cloud
-            if (KnownMetadataProvider.IsPublicEnvironment(authority.Host))
+            // Regional business rule - use the PrefferedNetwork value for public and soverign clouds
+            // but do not do instance discovery for it - rely on cached values only
+            if (KnownMetadataProvider.TryGetKnownEnviromentPrefferedNetwork(host, out var preferredNetworkEnv))
             {
-                return $"{region}.login.microsoft.com";
+                host = preferredNetworkEnv;
             }
 
-            return $"{region}.{builder.Host}";
+            return $"{region}.{host}";
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionDiscoveryProvider.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Identity.Client.Region
     internal class RegionDiscoveryProvider : IRegionDiscoveryProvider
     {
         private readonly IRegionManager _regionManager;
+        public const string PublicEnvForRegional = "r.login.microsoftonline.com";
 
         public RegionDiscoveryProvider(IHttpManager httpManager, bool clearCache)
         {
@@ -45,7 +46,13 @@ namespace Microsoft.Identity.Client.Region
 
         private string GetRegionalizedEnviroment(Uri authority, string region)
         {
+
             string host = authority.Host;
+
+            if (KnownMetadataProvider.IsPublicEnvironment(host))
+            {
+                return $"{region}.{PublicEnvForRegional}";
+            }
 
             // Regional business rule - use the PrefferedNetwork value for public and soverign clouds
             // but do not do instance discovery for it - rely on cached values only

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client
             // Do a full instance discovery when saving tokens (if not cached),
             // so that the PreferredNetwork environment is up to date.
             InstanceDiscoveryMetadataEntry instanceDiscoveryMetadata =
-                await requestParams.AuthorityManager.GetInstanceDisoveryEntryAsync().ConfigureAwait(false);
+                await requestParams.AuthorityManager.GetInstanceDiscoveryEntryAsync().ConfigureAwait(false);
 
             #region Create Cache Objects
             if (!string.IsNullOrEmpty(response.AccessToken))

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -55,11 +55,8 @@ namespace Microsoft.Identity.Client
 
             // Do a full instance discovery when saving tokens (if not cached),
             // so that the PreferredNetwork environment is up to date.
-            InstanceDiscoveryMetadataEntry instanceDiscoveryMetadata = await ServiceBundle.InstanceDiscoveryManager
-                                .GetMetadataEntryAsync(
-                                    requestParams.Authority.AuthorityInfo,
-                                    requestParams.RequestContext)
-                                .ConfigureAwait(false);
+            InstanceDiscoveryMetadataEntry instanceDiscoveryMetadata =
+                await requestParams.AuthorityManager.GetInstanceDisoveryEntryAsync().ConfigureAwait(false);
 
             #region Create Cache Objects
             if (!string.IsNullOrEmpty(response.AccessToken))

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Identity.Test.Unit
 
         public const string ProductionPrefNetworkEnvironment = "login.microsoftonline.com";
         public const string ProductionPrefCacheEnvironment = "login.windows.net";
-        public const string ProductionPrefRegionalEnvironment = "centralus.login.microsoftonline.com";
-        public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.login.microsoftonline.com";
+        public const string ProductionPrefRegionalEnvironment = "centralus.r.login.microsoftonline.com";
+        public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.r.login.microsoftonline.com";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
         public const string PpeEnvironment = "login.windows-ppe.net";
 

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Identity.Test.Unit
 
         public const string ProductionPrefNetworkEnvironment = "login.microsoftonline.com";
         public const string ProductionPrefCacheEnvironment = "login.windows.net";
-        public const string ProductionPrefRegionalEnvironment = "centralus.login.microsoft.com";
-        public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.login.microsoft.com";
+        public const string ProductionPrefRegionalEnvironment = "centralus.login.microsoftonline.com";
+        public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.login.microsoftonline.com";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
         public const string PpeEnvironment = "login.windows-ppe.net";
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             ["allowestsrnonmsi"] = "true"
         };
 
-        private const string RegionalHost = "centralus.login.microsoft.com";
+        private const string RegionalHost = "centralus.r.login.microsoftonline.com";
         private const string GlobalHost = "login.microsoftonline.com";
         private IConfidentialClientApplication _confidentialClientApplication;
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
                 new Uri("https://login.microsoftonline.com/common/"), _testRequestContext).ConfigureAwait(false);
 
             Assert.IsNotNull(regionalMetadata);
-            Assert.AreEqual("centralus.login.microsoftonline.com", regionalMetadata.PreferredNetwork);
+            Assert.AreEqual($"centralus.{RegionDiscoveryProvider.PublicEnvForRegional}", regionalMetadata.PreferredNetwork);
 
             Assert.AreEqual(TestConstants.Region, _testRequestContext.ApiEvent.RegionUsed);
             Assert.AreEqual((int)RegionAutodetectionSource.FailedAutoDiscovery, _testRequestContext.ApiEvent.RegionAutodetectionSource);
@@ -140,7 +140,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
             InstanceDiscoveryMetadataEntry regionalMetadata = await _regionDiscoveryProvider.GetMetadataAsync(new Uri("https://login.microsoftonline.com/common/"), _testRequestContext).ConfigureAwait(false);
 
             Assert.IsNotNull(regionalMetadata);
-            Assert.AreEqual("centralus.login.microsoftonline.com", regionalMetadata.PreferredNetwork);
+            Assert.AreEqual($"centralus.{RegionDiscoveryProvider.PublicEnvForRegional}", regionalMetadata.PreferredNetwork);
             Assert.AreEqual(TestConstants.Region, _testRequestContext.ApiEvent.RegionUsed);
             Assert.AreEqual((int)RegionAutodetectionSource.EnvVariable, _testRequestContext.ApiEvent.RegionAutodetectionSource);
             Assert.AreEqual((int)RegionOutcome.UserProvidedValid, _testRequestContext.ApiEvent.RegionOutcome);
@@ -158,7 +158,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
                 _testRequestContext).ConfigureAwait(false);
 
             Assert.IsNotNull(regionalMetadata);
-            Assert.AreEqual("user_region.login.microsoftonline.com", regionalMetadata.PreferredNetwork);
+            Assert.AreEqual($"user_region.{RegionDiscoveryProvider.PublicEnvForRegional}", regionalMetadata.PreferredNetwork);
             Assert.AreEqual("user_region", _testRequestContext.ApiEvent.RegionUsed);
             Assert.AreEqual((int)RegionAutodetectionSource.EnvVariable, _testRequestContext.ApiEvent.RegionAutodetectionSource);
             Assert.AreEqual((int)RegionOutcome.UserProvidedInvalid, _testRequestContext.ApiEvent.RegionOutcome);
@@ -348,9 +348,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
         {
             InstanceDiscoveryMetadataEntry expectedEntry = new InstanceDiscoveryMetadataEntry()
             {
-                Aliases = new[] { $"{region}.login.microsoftonline.com", "login.microsoftonline.com" },
+                Aliases = new[] { $"{region}.{RegionDiscoveryProvider.PublicEnvForRegional}", "login.microsoftonline.com" },
                 PreferredCache = "login.microsoftonline.com",
-                PreferredNetwork = $"{region}.login.microsoftonline.com"
+                PreferredNetwork = $"{region}.{RegionDiscoveryProvider.PublicEnvForRegional}"
             };
 
             CollectionAssert.AreEquivalent(expectedEntry.Aliases, entry.Aliases);

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
                 new Uri("https://login.microsoftonline.com/common/"), _testRequestContext).ConfigureAwait(false);
 
             Assert.IsNotNull(regionalMetadata);
-            Assert.AreEqual("centralus.login.microsoft.com", regionalMetadata.PreferredNetwork);
+            Assert.AreEqual("centralus.login.microsoftonline.com", regionalMetadata.PreferredNetwork);
 
             Assert.AreEqual(TestConstants.Region, _testRequestContext.ApiEvent.RegionUsed);
             Assert.AreEqual((int)RegionAutodetectionSource.FailedAutoDiscovery, _testRequestContext.ApiEvent.RegionAutodetectionSource);
@@ -140,7 +140,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
             InstanceDiscoveryMetadataEntry regionalMetadata = await _regionDiscoveryProvider.GetMetadataAsync(new Uri("https://login.microsoftonline.com/common/"), _testRequestContext).ConfigureAwait(false);
 
             Assert.IsNotNull(regionalMetadata);
-            Assert.AreEqual("centralus.login.microsoft.com", regionalMetadata.PreferredNetwork);
+            Assert.AreEqual("centralus.login.microsoftonline.com", regionalMetadata.PreferredNetwork);
             Assert.AreEqual(TestConstants.Region, _testRequestContext.ApiEvent.RegionUsed);
             Assert.AreEqual((int)RegionAutodetectionSource.EnvVariable, _testRequestContext.ApiEvent.RegionAutodetectionSource);
             Assert.AreEqual((int)RegionOutcome.UserProvidedValid, _testRequestContext.ApiEvent.RegionOutcome);
@@ -158,7 +158,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
                 _testRequestContext).ConfigureAwait(false);
 
             Assert.IsNotNull(regionalMetadata);
-            Assert.AreEqual("user_region.login.microsoft.com", regionalMetadata.PreferredNetwork);
+            Assert.AreEqual("user_region.login.microsoftonline.com", regionalMetadata.PreferredNetwork);
             Assert.AreEqual("user_region", _testRequestContext.ApiEvent.RegionUsed);
             Assert.AreEqual((int)RegionAutodetectionSource.EnvVariable, _testRequestContext.ApiEvent.RegionAutodetectionSource);
             Assert.AreEqual((int)RegionOutcome.UserProvidedInvalid, _testRequestContext.ApiEvent.RegionOutcome);
@@ -348,9 +348,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
         {
             InstanceDiscoveryMetadataEntry expectedEntry = new InstanceDiscoveryMetadataEntry()
             {
-                Aliases = new[] { $"{region}.login.microsoft.com", "login.microsoftonline.com" },
+                Aliases = new[] { $"{region}.login.microsoftonline.com", "login.microsoftonline.com" },
                 PreferredCache = "login.microsoftonline.com",
-                PreferredNetwork = $"{region}.login.microsoft.com"
+                PreferredNetwork = $"{region}.login.microsoftonline.com"
             };
 
             CollectionAssert.AreEquivalent(expectedEntry.Aliases, entry.Aliases);

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/RegionDiscoveryProviderTests.cs
@@ -162,25 +162,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
             Assert.AreEqual("user_region", _testRequestContext.ApiEvent.RegionUsed);
             Assert.AreEqual((int)RegionAutodetectionSource.EnvVariable, _testRequestContext.ApiEvent.RegionAutodetectionSource);
             Assert.AreEqual((int)RegionOutcome.UserProvidedInvalid, _testRequestContext.ApiEvent.RegionOutcome);
-        }
-
-        [TestMethod]
-        public async Task SuccessfulResponseFromRegionalizedAuthorityAsync()
-        {
-            var regionalizedAuthority = new Uri($"https://{TestConstants.Region}.login.microsoft.com/common/");
-            _testRequestContext.ServiceBundle.Config.AzureRegion = ConfidentialClientApplication.AttemptRegionDiscovery;
-
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
-
-            // In the instance discovery flow, GetMetadataAsync is always called with a known authority first, then with regionalized.
-            await _regionDiscoveryProvider.GetMetadataAsync(new Uri("https://login.microsoftonline.com/common/"), _testRequestContext).ConfigureAwait(false);
-            InstanceDiscoveryMetadataEntry regionalMetadata = await _regionDiscoveryProvider.GetMetadataAsync(regionalizedAuthority, _testRequestContext).ConfigureAwait(false);
-
-            ValidateInstanceMetadata(regionalMetadata);
-            Assert.AreEqual(TestConstants.Region, _testRequestContext.ApiEvent.RegionUsed);
-            Assert.AreEqual((int)RegionAutodetectionSource.EnvVariable, _testRequestContext.ApiEvent.RegionAutodetectionSource);
-            Assert.AreEqual((int)RegionOutcome.AutodetectSuccess, _testRequestContext.ApiEvent.RegionOutcome);
-        }
+        }    
 
         [DataTestMethod]
         [DataRow("Region with spaces")]

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -298,10 +298,10 @@ namespace Microsoft.Identity.Test.Unit
         [DataRow("login.microsoftonline.us", "login.microsoftonline.us")]
         [DataRow("login.usgovcloudapi.net", "login.microsoftonline.us")]
         [DataRow("login-us.microsoftonline.com", "login-us.microsoftonline.com")]
-        [DataRow("login.windows.net", "login.microsoftonline.com")]
-        [DataRow("login.microsoft.com", "login.microsoftonline.com")]
-        [DataRow("sts.windows.net", "login.microsoftonline.com")]
-        [DataRow("login.microsoftonline.com", "login.microsoftonline.com")]
+        [DataRow("login.windows.net", "r.login.microsoftonline.com")]
+        [DataRow("login.microsoft.com", "r.login.microsoftonline.com")]
+        [DataRow("sts.windows.net", "r.login.microsoftonline.com")]
+        [DataRow("login.microsoftonline.com", "r.login.microsoftonline.com")]
         public async Task PublicAndSovereignCloud_UsesPreferredNetwork_AndNoDiscovery_Async(string inputEnv, string expectedEnv)
         {
             try
@@ -533,7 +533,7 @@ namespace Microsoft.Identity.Test.Unit
             return new MockHttpMessageHandler()
             {
                 ExpectedUrl = expectRegional ?
-                    $"https://{TestConstants.Region}.login.microsoftonline.com/common/oauth2/v2.0/token" :
+                    $"https://{TestConstants.Region}.r.login.microsoftonline.com/common/oauth2/v2.0/token" :
                     "https://login.microsoftonline.com/common/oauth2/v2.0/token",
                 ExpectedMethod = HttpMethod.Post,
                 ResponseMessage = CreateResponse(true)

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -3,7 +3,6 @@
 
 #if !ANDROID && !iOS && !WINDOWS_APP 
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -350,7 +349,6 @@ namespace Microsoft.Identity.Test.Unit
             {
                 Environment.SetEnvironmentVariable("REGION_NAME", null);
             }
-
         }
 
         private static async Task RunPpeTestAsync(bool validateAuthority, bool authorityIsValid)


### PR DESCRIPTION
Fixes #2777 #2778 

1. Ensure instance discovery does not occur on known clouds (this was happening already, but added some tests)
2. Use "preferred_network" value for known clouds


**Testing**
unit

**Performance impact**
reduce number of http calls -> better perf
also removed a string comparison
