### PR TITLE
ConfidentalClientApplicationBuilder WithSendX5C

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Identity.Client
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
+        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenByAuthorizationCodeParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -85,11 +85,11 @@ namespace Microsoft.Identity.Client
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
-        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenByAuthorizationCodeParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);
-            Parameters.SendX5C = withSendX5C;
+            Parameters.SendX5C = withSendX5C; 
+            Parameters.SetPerRequestX5C = true;
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
@@ -68,11 +68,11 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
-        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenByRefreshTokenParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);
-            Parameters.SendX5C = withSendX5C;
+            Parameters.SendX5C = withSendX5C; 
+            Parameters.SetPerRequestX5C = true;
             return this;
         }
     }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByRefreshTokenParameterBuilder.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
+        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenByRefreshTokenParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Identity.Client
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
+        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenForClientParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C, withSendX5C);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -64,11 +64,11 @@ namespace Microsoft.Identity.Client
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
-        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenForClientParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C, withSendX5C);
-            Parameters.SendX5C = withSendX5C;
+            Parameters.SendX5C = withSendX5C; 
+            Parameters.SetPerRequestX5C = true;
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Identity.Client
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
+        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenOnBehalfOfParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C, withSendX5C);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -62,11 +62,11 @@ namespace Microsoft.Identity.Client
         /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
         /// The default is <c>false</c></param>
         /// <returns>The builder to chain the .With methods</returns>
-        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenOnBehalfOfParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C, withSendX5C);
-            Parameters.SendX5C = withSendX5C;
+            Parameters.SendX5C = withSendX5C; 
+            Parameters.SetPerRequestX5C = true;
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
+        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -108,11 +108,11 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CONFIDENTIAL_CLIENT
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
 #endif
-        [System.Obsolete("Set SendX5C once for this application using WithSendX5C on the ConfidentialClientApplicationBuilder object.", false)]
         public AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
         {
             CommonParameters.AddApiTelemetryFeature(ApiTelemetryFeature.WithSendX5C);
-            Parameters.SendX5C = withSendX5C;
+            Parameters.SendX5C = withSendX5C;            
+            Parameters.SetPerRequestX5C = true;
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
 
             requestContext.Logger.Info(LogMessages.UsingXScopesForRefreshTokenRequest(commonParameters.Scopes.Count()));
 
-            requestParameters.SendX5C = refreshTokenParameters.SendX5C;
+            requestParameters.SendX5C = refreshTokenParameters.SetPerRequestX5C ? refreshTokenParameters.SendX5C : _clientApplicationBase.AppConfig.SendX5C;
 
             var handler = new ByRefreshTokenRequest(ServiceBundle, requestParameters, refreshTokenParameters);
             return await handler.RunAsync(CancellationToken.None).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ConfidentialClientExecutor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 commonParameters,
                 requestContext,
                 _confidentialClientApplication.UserTokenCacheInternal).ConfigureAwait(false);
-            requestParams.SendX5C = authorizationCodeParameters.SendX5C;
+            requestParams.SendX5C = authorizationCodeParameters.SetPerRequestX5C ? authorizationCodeParameters.SendX5C : _confidentialClientApplication.AppConfig.SendX5C;
 
             var handler = new ConfidentialAuthCodeRequest(
                 ServiceBundle,
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 requestContext,
                 _confidentialClientApplication.AppTokenCacheInternal).ConfigureAwait(false);
        
-            requestParams.SendX5C = clientParameters.SendX5C;
+            requestParams.SendX5C = clientParameters.SetPerRequestX5C ? clientParameters.SendX5C : _confidentialClientApplication.AppConfig.SendX5C;
             
             var handler = new ClientCredentialRequest(
                 ServiceBundle,
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 requestContext,
                 _confidentialClientApplication.UserTokenCacheInternal).ConfigureAwait(false);
 
-            requestParams.SendX5C = onBehalfOfParameters.SendX5C;
+            requestParams.SendX5C = onBehalfOfParameters.SetPerRequestX5C ? onBehalfOfParameters.SendX5C : _confidentialClientApplication.AppConfig.SendX5C;
             requestParams.UserAssertion = onBehalfOfParameters.UserAssertion;
 
             var handler = new OnBehalfOfRequest(

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByAuthorizationCodeParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByAuthorizationCodeParameters.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         public string PkceCodeVerifier { get; set; }
 
-        public bool? SendX5C { get; set; }
+        public bool SendX5C { get; set; } 
+
+        internal bool SetPerRequestX5C = false;
 
         public void LogParameters(ICoreLogger logger)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByAuthorizationCodeParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByAuthorizationCodeParameters.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         public string PkceCodeVerifier { get; set; }
 
-        public bool SendX5C { get; set; }
+        public bool? SendX5C { get; set; }
 
         public void LogParameters(ICoreLogger logger)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByRefreshTokenParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByRefreshTokenParameters.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     {
         public string RefreshToken { get; set; }
 
-        public bool SendX5C { get; set; }
+        public bool? SendX5C { get; set; }
 
         public void LogParameters(ICoreLogger logger)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByRefreshTokenParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenByRefreshTokenParameters.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     {
         public string RefreshToken { get; set; }
 
-        public bool? SendX5C { get; set; }
+        public bool SendX5C { get; set; } 
+        
+        internal bool SetPerRequestX5C = false;
 
         public void LogParameters(ICoreLogger logger)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         /// <summary>
         /// </summary>
-        public bool SendX5C { get; set; }
+        public bool? SendX5C { get; set; }
 
         /// <inheritdoc />
         public void LogParameters(ICoreLogger logger)

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         /// <summary>
         /// </summary>
-        public bool? SendX5C { get; set; }
+        public bool SendX5C { get; set; } 
+        
+        internal bool SetPerRequestX5C = false;
 
         /// <inheritdoc />
         public void LogParameters(ICoreLogger logger)

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         {
             var builder = new StringBuilder();
             builder.AppendLine("=== OnBehalfOfParameters ===");
-            builder.AppendLine("Send: " + SendX5C);
+            builder.AppendLine("SendX5C: " + SendX5C);
             builder.AppendLine("ForceRefresh: " + ForceRefresh);
             logger.Info(builder.ToString());
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     internal class AcquireTokenOnBehalfOfParameters : IAcquireTokenParameters
     {
         public UserAssertion UserAssertion { get; set; }
-        public bool SendX5C { get; set;}
+        public bool? SendX5C { get; set;}
         public bool ForceRefresh { get; set; }
 
         /// <inheritdoc />

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     internal class AcquireTokenOnBehalfOfParameters : IAcquireTokenParameters
     {
         public UserAssertion UserAssertion { get; set; }
-        public bool? SendX5C { get; set;}
+        public bool SendX5C { get; set; }
+        
+        internal bool SetPerRequestX5C = false;
         public bool ForceRefresh { get; set; }
 
         /// <inheritdoc />
@@ -17,7 +19,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         {
             var builder = new StringBuilder();
             builder.AppendLine("=== OnBehalfOfParameters ===");
-            builder.AppendLine("SendX5C: " + SendX5C);
+            builder.AppendLine("Send: " + SendX5C);
             builder.AppendLine("ForceRefresh: " + ForceRefresh);
             logger.Info(builder.ToString());
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public bool ForceRefresh { get; set; }
         public string LoginHint { get; set; }
         public IAccount Account { get; set; }
-        public bool? SendX5C { get; set; }
+        public bool SendX5C { get; set; } 
+        
+        internal bool SetPerRequestX5C = false;
 
         /// <inheritdoc />
         public void LogParameters(ICoreLogger logger)

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public bool ForceRefresh { get; set; }
         public string LoginHint { get; set; }
         public IAccount Account { get; set; }
-        public bool SendX5C { get; set; }
+        public bool? SendX5C { get; set; }
 
         /// <inheritdoc />
         public void LogParameters(ICoreLogger logger)

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Identity.Client
         public string SignedClientAssertion { get; internal set; }
         public Func<string> SignedClientAssertionDelegate { get; internal set; }
         public X509Certificate2 ClientCredentialCertificate { get; internal set; }
+        public bool SendX5C { get; internal set; }
         public IDictionary<string, string> ClaimsToSign { get; internal set; }
         public bool MergeWithDefaultClaims { get; internal set; }
         internal int ConfidentialClientCredentialCount;

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -97,6 +97,55 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+
+        /// <summary>
+        /// Sets the certificate associated with the application
+        /// </summary>
+        /// <param name="certificate">The X509 certificate used as credentials to prove the identity of the application to Azure AD.</param>
+        /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
+        /// The default is <c>false</c></param>
+        /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys. </remarks>
+        public ConfidentialClientApplicationBuilder WithCertificate(X509Certificate2 certificate, bool withSendX5C)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            if (!certificate.HasPrivateKey)
+            {
+                throw new MsalClientException(MsalError.CertWithoutPrivateKey, MsalErrorMessage.CertMustHavePrivateKey(nameof(certificate)));
+            }
+
+            Config.ClientCredentialCertificate = certificate;
+            Config.ConfidentialClientCredentialCount++;
+            return WithSendX5C(withSendX5C);
+        }
+
+        /// <summary>
+        /// Specifies if the x5c claim (public key of the certificate) should be sent to the STS.
+        /// Sending the x5c enables application developers to achieve easy certificate roll-over in Azure AD:
+        /// this method will send the public certificate to Azure AD along with all STS requests,
+        /// so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
+        /// This saves the application admin from the need to explicitly manage the certificate rollover
+        /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni
+        /// </summary>
+        /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
+        /// The default is <c>false</c></param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public ConfidentialClientApplicationBuilder WithSendX5C(bool withSendX5C)
+        {
+            // Default is not to send X5C, so if called with false, this is a no-op. 
+            if (!withSendX5C)
+            {
+                return this;
+            }
+
+            Config.SendX5C= withSendX5C;
+            Config.ConfidentialClientCredentialCount++;
+            return this;
+        }
+
         /// <summary>
         /// Sets the certificate associated with the application along with the specific claims to sign.
         /// By default, this will merge the <paramref name="claimsToSign"/> with the default required set of claims needed for authentication.
@@ -105,7 +154,8 @@ namespace Microsoft.Identity.Client
         /// <param name="certificate">The X509 certificate used as credentials to prove the identity of the application to Azure AD.</param>
         /// <param name="claimsToSign">The claims to be signed by the provided certificate.</param>
         /// <param name="mergeWithDefaultClaims">Determines whether or not to merge <paramref name="claimsToSign"/> with the default claims required for authentication.</param>
-        /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys. </remarks>
+        /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys. If 
+        /// Using SNI, ensure that you call WithSendX5C as well.</remarks>
         public ConfidentialClientApplicationBuilder WithClientClaims(X509Certificate2 certificate, IDictionary<string, string> claimsToSign, bool mergeWithDefaultClaims = true)
         {
             if (certificate == null)

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -79,33 +79,10 @@ namespace Microsoft.Identity.Client
         /// Sets the certificate associated with the application
         /// </summary>
         /// <param name="certificate">The X509 certificate used as credentials to prove the identity of the application to Azure AD.</param>
+        /// <param name="withSendX5C"> Specifies if the x5c claim (public key of the certificate) should be sent to the STS for Subject Name and 
+        /// Issuer certificate authentication. The default is <c>false</c></param>
         /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys. </remarks>
-        public ConfidentialClientApplicationBuilder WithCertificate(X509Certificate2 certificate)
-        {
-            if (certificate == null)
-            {
-                throw new ArgumentNullException(nameof(certificate));
-            }
-
-            if (!certificate.HasPrivateKey)
-            {
-                throw new MsalClientException(MsalError.CertWithoutPrivateKey, MsalErrorMessage.CertMustHavePrivateKey(nameof(certificate)));
-            }
-
-            Config.ClientCredentialCertificate = certificate;
-            Config.ConfidentialClientCredentialCount++;
-            return this;
-        }
-
-
-        /// <summary>
-        /// Sets the certificate associated with the application
-        /// </summary>
-        /// <param name="certificate">The X509 certificate used as credentials to prove the identity of the application to Azure AD.</param>
-        /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
-        /// The default is <c>false</c></param>
-        /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys. </remarks>
-        public ConfidentialClientApplicationBuilder WithCertificate(X509Certificate2 certificate, bool withSendX5C)
+        public ConfidentialClientApplicationBuilder WithCertificate(X509Certificate2 certificate, bool withSendX5C = false)
         {
             if (certificate == null)
             {
@@ -130,9 +107,8 @@ namespace Microsoft.Identity.Client
         /// This saves the application admin from the need to explicitly manage the certificate rollover
         /// (either via portal or PowerShell/CLI operation). For details see https://aka.ms/msal-net-sni
         /// </summary>
-        /// <param name="withSendX5C"><c>true</c> if the x5c should be sent. Otherwise <c>false</c>.
-        /// The default is <c>false</c></param>
-        /// <returns>The builder to chain the .With methods</returns>
+        /// <param name="withSendX5C"> Determines if the x5c claim should be sent in the header, for Subject Name and Issuer certificate use.
+        /// The default for all applications is <c>false</c></param>
         public ConfidentialClientApplicationBuilder WithSendX5C(bool withSendX5C)
         {
             // Default is not to send X5C, so if called with false, this is a no-op. 
@@ -142,7 +118,6 @@ namespace Microsoft.Identity.Client
             }
 
             Config.SendX5C= withSendX5C;
-            Config.ConfidentialClientCredentialCount++;
             return this;
         }
 
@@ -154,9 +129,10 @@ namespace Microsoft.Identity.Client
         /// <param name="certificate">The X509 certificate used as credentials to prove the identity of the application to Azure AD.</param>
         /// <param name="claimsToSign">The claims to be signed by the provided certificate.</param>
         /// <param name="mergeWithDefaultClaims">Determines whether or not to merge <paramref name="claimsToSign"/> with the default claims required for authentication.</param>
-        /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys. If 
-        /// using SNI, ensure that you call WithSendX5C as well.</remarks>
-        public ConfidentialClientApplicationBuilder WithClientClaims(X509Certificate2 certificate, IDictionary<string, string> claimsToSign, bool mergeWithDefaultClaims = true)
+        /// <param name="withSendX5C"> Specifies if the x5c claim (public key of the certificate) should be sent to the STS for Subject Name and 
+        /// Issuer certificate authentication. The default is <c>false</c></param>
+        /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys.</remarks>
+        public ConfidentialClientApplicationBuilder WithClientClaims(X509Certificate2 certificate, IDictionary<string, string> claimsToSign, bool mergeWithDefaultClaims = true, bool withSendX5C = false)
         {
             if (certificate == null)
             {
@@ -172,7 +148,7 @@ namespace Microsoft.Identity.Client
             Config.ClaimsToSign = claimsToSign;
             Config.MergeWithDefaultClaims = mergeWithDefaultClaims;
             Config.ConfidentialClientCredentialCount++;
-            return this;
+            return WithSendX5C(withSendX5C);
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Identity.Client
         /// <param name="claimsToSign">The claims to be signed by the provided certificate.</param>
         /// <param name="mergeWithDefaultClaims">Determines whether or not to merge <paramref name="claimsToSign"/> with the default claims required for authentication.</param>
         /// <remarks>You should use certificates with a private key size of at least 2048 bytes. Future versions of this library might reject certificates with smaller keys. If 
-        /// Using SNI, ensure that you call WithSendX5C as well.</remarks>
+        /// using SNI, ensure that you call WithSendX5C as well.</remarks>
         public ConfidentialClientApplicationBuilder WithClientClaims(X509Certificate2 certificate, IDictionary<string, string> claimsToSign, bool mergeWithDefaultClaims = true)
         {
             if (certificate == null)

--- a/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IAppConfig.cs
@@ -124,6 +124,13 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// </summary>
+#if !SUPPORTS_CONFIDENTIAL_CLIENT
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]  // hide confidential client on mobile
+#endif
+        bool SendX5C { get; }
+
+        /// <summary>
+        /// </summary>
         Func<object> ParentActivityOrWindowFunc { get; }
 
 #if WINDOWS_APP

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
@@ -104,12 +104,13 @@ namespace Microsoft.Identity.Client.Internal
 
         #region TestBuilders
         //The following builders methods are intended for testing
-        public static ClientCredentialWrapper CreateWithCertificate(X509Certificate2 certificate, IDictionary<string, string> claimsToSign = null)
+        public static ClientCredentialWrapper CreateWithCertificate(X509Certificate2 certificate, IDictionary<string, string> claimsToSign = null, bool withSendX5C=false)
         {
             ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
             applicationConfiguration.ClientCredentialCertificate = certificate;
             applicationConfiguration.ConfidentialClientCredentialCount = 1;
             applicationConfiguration.ClaimsToSign = claimsToSign;
+            applicationConfiguration.SendX5C = withSendX5C;
 
             return new ClientCredentialWrapper(applicationConfiguration);
         }
@@ -144,7 +145,7 @@ namespace Microsoft.Identity.Client.Internal
             ICryptographyManager cryptographyManager,
             string clientId,
             Authority authority,
-            bool? perRequestSendX5C)
+            bool? perRequestSendX5C = null)
         {
             using (logger.LogMethodDuration())
             {
@@ -173,7 +174,7 @@ namespace Microsoft.Identity.Client.Internal
                             tokenEndpoint,
                             ClaimsToSign,
                             AppendDefaultClaims);
-                        string assertion = jwtToken.Sign(this, perRequestSendX5C??this.SendX5C);
+                        string assertion = jwtToken.Sign(this, perRequestSendX5C ?? SendX5C);
 
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, assertion);

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
@@ -76,12 +76,10 @@ namespace Microsoft.Identity.Client.Internal
             {
                 case ConfidentialClientAuthenticationType.ClientCertificate:
                     Certificate = config.ClientCredentialCertificate;
-                    SendX5C = config.SendX5C;
                     break;
                 case ConfidentialClientAuthenticationType.ClientCertificateWithClaims:
                     Certificate = config.ClientCredentialCertificate;
                     ClaimsToSign = config.ClaimsToSign;
-                    SendX5C = config.SendX5C;
                     break;
                 case ConfidentialClientAuthenticationType.ClientSecret:
                     Secret = config.ClientSecret;
@@ -137,7 +135,6 @@ namespace Microsoft.Identity.Client.Internal
         internal bool AppendDefaultClaims { get;  }
         internal ConfidentialClientAuthenticationType AuthenticationType { get;  }
         internal IDictionary<string, string> ClaimsToSign { get; }
-        internal bool SendX5C;
 
         public void AddConfidentialClientParameters(
             OAuth2Client oAuth2Client,
@@ -145,7 +142,7 @@ namespace Microsoft.Identity.Client.Internal
             ICryptographyManager cryptographyManager,
             string clientId,
             Authority authority,
-            bool? perRequestSendX5C = null)
+            bool sendX5C)
         {
             using (logger.LogMethodDuration())
             {
@@ -159,7 +156,7 @@ namespace Microsoft.Identity.Client.Internal
                            clientId,
                            tokenEndpoint);
 
-                        string assertion2 = jwtToken2.Sign(this, perRequestSendX5C ?? SendX5C);
+                        string assertion2 = jwtToken2.Sign(this, sendX5C);
 
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, assertion2);
@@ -174,7 +171,7 @@ namespace Microsoft.Identity.Client.Internal
                             tokenEndpoint,
                             ClaimsToSign,
                             AppendDefaultClaims);
-                        string assertion = jwtToken.Sign(this, perRequestSendX5C ?? SendX5C);
+                        string assertion = jwtToken.Sign(this, sendX5C);
 
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, assertion);

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredentialWrapper.cs
@@ -76,10 +76,12 @@ namespace Microsoft.Identity.Client.Internal
             {
                 case ConfidentialClientAuthenticationType.ClientCertificate:
                     Certificate = config.ClientCredentialCertificate;
+                    SendX5C = config.SendX5C;
                     break;
                 case ConfidentialClientAuthenticationType.ClientCertificateWithClaims:
                     Certificate = config.ClientCredentialCertificate;
                     ClaimsToSign = config.ClaimsToSign;
+                    SendX5C = config.SendX5C;
                     break;
                 case ConfidentialClientAuthenticationType.ClientSecret:
                     Secret = config.ClientSecret;
@@ -134,6 +136,7 @@ namespace Microsoft.Identity.Client.Internal
         internal bool AppendDefaultClaims { get;  }
         internal ConfidentialClientAuthenticationType AuthenticationType { get;  }
         internal IDictionary<string, string> ClaimsToSign { get; }
+        internal bool SendX5C;
 
         public void AddConfidentialClientParameters(
             OAuth2Client oAuth2Client,
@@ -141,7 +144,7 @@ namespace Microsoft.Identity.Client.Internal
             ICryptographyManager cryptographyManager,
             string clientId,
             Authority authority,
-            bool sendX5C)
+            bool? perRequestSendX5C)
         {
             using (logger.LogMethodDuration())
             {
@@ -155,7 +158,7 @@ namespace Microsoft.Identity.Client.Internal
                            clientId,
                            tokenEndpoint);
 
-                        string assertion2 = jwtToken2.Sign(this, sendX5C);
+                        string assertion2 = jwtToken2.Sign(this, perRequestSendX5C ?? SendX5C);
 
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, assertion2);
@@ -170,7 +173,7 @@ namespace Microsoft.Identity.Client.Internal
                             tokenEndpoint,
                             ClaimsToSign,
                             AppendDefaultClaims);
-                        string assertion = jwtToken.Sign(this, sendX5C);
+                        string assertion = jwtToken.Sign(this, perRequestSendX5C??this.SendX5C);
 
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
                         oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, assertion);

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Identity.Client.Internal
         [Preserve(AllMembers = true)]
         internal sealed class JWTHeaderWithCertificate : JWTHeader
         {
-            public JWTHeaderWithCertificate(ClientCredentialWrapper credential, bool sendCertificate)
+            public JWTHeaderWithCertificate(ClientCredentialWrapper credential, bool? sendCertificate = null)
                 : base(credential)
             {
                 X509CertificateThumbprint = Credential.Thumbprint;
@@ -197,7 +197,9 @@ namespace Microsoft.Identity.Client.Internal
 
                 X509CertificatePublicCertValue = null;
 
-                if (!sendCertificate)
+                bool perRequestSendX5C = sendCertificate ?? credential.SendX5C;
+
+                if (!perRequestSendX5C)
                 {
                     return;
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Identity.Client.Internal
 
                 X509CertificatePublicCertValue = null;
 
-                bool perRequestSendX5C = sendCertificate ?? credential.SendX5C;
+                bool perRequestSendX5C = sendCertificate ?? credential?.SendX5C ?? false;
 
                 if (!perRequestSendX5C)
                 {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         // TODO: ideally, these can come from the particular request instance and not be in RequestBase since it's not valid for all requests.
 
 
-        // TODO: ideally, this can come from the particular request instance and not be in RequestBase since it's not valid for all requests.
+        // This should be set on a per-application basis, but can be overridden on a per-request basis should it be needed. 
         public bool? SendX5C { get; set; }
 
         public string LoginHint

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
 
         // TODO: ideally, this can come from the particular request instance and not be in RequestBase since it's not valid for all requests.
-        public bool SendX5C { get; set; }
+        public bool? SendX5C { get; set; }
 
         public string LoginHint
         {
@@ -181,7 +181,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             builder.AppendLine("Authority - " + AuthorityInfo?.CanonicalAuthority);
             builder.AppendLine("ApiId - " + ApiId);
             builder.AppendLine("IsConfidentialClient - " + IsConfidentialClient);
+#pragma warning disable CS0612 // Type or member is obsolete
             builder.AppendLine("SendX5C - " + SendX5C);
+#pragma warning restore CS0612 // Type or member is obsolete
             builder.AppendLine("LoginHint - " + LoginHint);
             builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
             builder.AppendLine("HomeAccountId - " + HomeAccountId);
@@ -198,7 +200,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
             builder.AppendLine("ApiId - " + ApiId);
             builder.AppendLine("IsConfidentialClient - " + IsConfidentialClient);
+#pragma warning disable CS0612 // Type or member is obsolete
             builder.AppendLine("SendX5C - " + SendX5C);
+#pragma warning restore CS0612 // Type or member is obsolete
             builder.AppendLine("LoginHint ? " + !string.IsNullOrEmpty(LoginHint));
             builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
             builder.AppendLine("HomeAccountId - " + !string.IsNullOrEmpty(HomeAccountId));

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -183,9 +183,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             builder.AppendLine("Authority - " + AuthorityInfo?.CanonicalAuthority);
             builder.AppendLine("ApiId - " + ApiId);
             builder.AppendLine("IsConfidentialClient - " + IsConfidentialClient);
-#pragma warning disable CS0612 // Type or member is obsolete
             builder.AppendLine("SendX5C - " + SendX5C);
-#pragma warning restore CS0612 // Type or member is obsolete
             builder.AppendLine("LoginHint - " + LoginHint);
             builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
             builder.AppendLine("HomeAccountId - " + HomeAccountId);
@@ -202,9 +200,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
             builder.AppendLine("ApiId - " + ApiId);
             builder.AppendLine("IsConfidentialClient - " + IsConfidentialClient);
-#pragma warning disable CS0612 // Type or member is obsolete
             builder.AppendLine("SendX5C - " + SendX5C);
-#pragma warning restore CS0612 // Type or member is obsolete
             builder.AppendLine("LoginHint ? " + !string.IsNullOrEmpty(LoginHint));
             builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
             builder.AppendLine("HomeAccountId - " + !string.IsNullOrEmpty(HomeAccountId));

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -124,7 +124,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
 
         // This should be set on a per-application basis, but can be overridden on a per-request basis should it be needed. 
-        public bool? SendX5C { get; set; }
+        public bool SendX5C { get; set; } 
+        
+        internal bool SetPerRequestX5C = false;
 
         public string LoginHint
         {

--- a/src/client/Microsoft.Identity.Client/OAuth2/TokenClient.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/TokenClient.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Identity.Client.OAuth2
                     _serviceBundle.PlatformProxy.CryptographyManager,                    
                     _requestParams.AppConfig.ClientId,
                     _requestParams.Authority,
-                    _requestParams.SendX5C);           
+                    _requestParams.SetPerRequestX5C ? _requestParams.SendX5C : _requestParams.AppConfig.SendX5C);           
             }
 
             _oAuth2Client.AddBodyParameter(OAuth2Parameter.Scope, scopes);

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -199,8 +199,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                     var manager = new Client.Platforms.net45.NetDesktopCryptographyManager();
 #endif
             var jwtToken = new Client.Internal.JsonWebToken(manager, clientId, TestConstants.ClientCredentialAudience, claims);
-            var clientCredential = ClientCredentialWrapper.CreateWithCertificate(GetCertificate(), claims);
-            return jwtToken.Sign(clientCredential, false);
+            var clientCredential = ClientCredentialWrapper.CreateWithCertificate(GetCertificate(), claims, false);
+            return jwtToken.Sign(clientCredential);
         }
 
         private static X509Certificate2 GetCertificate(bool useRSACert = false)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
@@ -263,8 +263,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var manager = new Client.Platforms.net45.NetDesktopCryptographyManager();
 #endif
             var jwtToken = new Client.Internal.JsonWebToken(manager, clientId, TestConstants.ClientCredentialAudience, claims);
-            var clientCredential = ClientCredentialWrapper.CreateWithCertificate(GetCertificate(), claims);
-            return jwtToken.Sign(clientCredential, false);
+            var clientCredential = ClientCredentialWrapper.CreateWithCertificate(GetCertificate(), claims, false);
+            return jwtToken.Sign(clientCredential);
         }
 
         private static X509Certificate2 GetCertificate(bool useRSACert = false)

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
-                    .WithCertificate(certificate)
+                    .WithCertificate(certificate, true)
                     .BuildConcrete();
 
                 var appCacheAccess = app.AppTokenCache.RecordAccess();
@@ -110,7 +110,6 @@ namespace Microsoft.Identity.Test.Unit
                 harness.HttpManager.AddMockHandler(CreateTokenResponseHttpHandlerWithX5CValidation(true));
                 AuthenticationResult result = await app
                     .AcquireTokenForClient(TestConstants.s_scope)
-                    .WithSendX5C(true)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 
@@ -151,7 +150,7 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
-                    .WithCertificate(certificate)
+                    .WithCertificate(certificate, true)
                     .BuildConcrete();
 
                 var appCacheAccess = app.AppTokenCache.RecordAccess();
@@ -163,7 +162,6 @@ namespace Microsoft.Identity.Test.Unit
                 harness.HttpManager.AddMockHandler(CreateTokenResponseHttpHandlerWithX5CValidation(false));
                 AuthenticationResult result = await app
                     .AcquireTokenOnBehalfOf(TestConstants.s_scope, userAssertion)
-                    .WithSendX5C(true)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
                 Assert.IsNotNull(result.AccessToken);
@@ -202,7 +200,7 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
-                    .WithCertificate(certificate)
+                    .WithCertificate(certificate, true)
                     .BuildConcrete();
 
                 var appCacheAccess = app.AppTokenCache.RecordAccess();
@@ -214,7 +212,6 @@ namespace Microsoft.Identity.Test.Unit
                 harness.HttpManager.AddMockHandler(CreateTokenResponseHttpHandlerWithX5CValidation(false));
                 AuthenticationResult result = await app
                     .AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
-                    .WithSendX5C(true)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
                 Assert.IsNotNull(result.AccessToken);
@@ -241,7 +238,7 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
-                    .WithCertificate(certificate)
+                    .WithCertificate(certificate, true)
                     .BuildConcrete();
 
                 var appCacheAccess = app.AppTokenCache.RecordAccess();
@@ -253,7 +250,6 @@ namespace Microsoft.Identity.Test.Unit
                 harness.HttpManager.AddMockHandler(CreateTokenResponseHttpHandlerWithX5CValidation(false));
                 AuthenticationResult result = await ((IByRefreshToken)app)
                     .AcquireTokenByRefreshToken(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
-                    .WithSendX5C(true)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
                 Assert.IsNotNull(result.AccessToken);
@@ -284,7 +280,8 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(new System.Uri("https://login.microsoftonline.com/my-utid"),true)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
-                    .WithCertificate(certificate).BuildConcrete();
+                    .WithCertificate(certificate, true).
+                    BuildConcrete();
 
                 TokenCacheHelper.PopulateCacheWithOneAccessToken(app.UserTokenCacheInternal.Accessor);
                 var appCacheAccess = app.AppTokenCache.RecordAccess();
@@ -306,7 +303,6 @@ namespace Microsoft.Identity.Test.Unit
                     .AcquireTokenSilent(
                         new[] { "someTestScope"},
                         new Account(TestConstants.s_userIdentifier, TestConstants.DisplayableId, null))
-                    .WithSendX5C(true)
                     .WithForceRefresh(true)
                     .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
 
@@ -324,9 +320,9 @@ namespace Microsoft.Identity.Test.Unit
         [Description("Check the JWTHeader when sendCert is true")]
         public void CheckJWTHeaderWithCertTrueTest()
         {
-            var credential = GenerateClientAssertionCredential();
+            var credential = GenerateClientAssertionCredential(true);
 
-            var header = new JWTHeaderWithCertificate(credential, true);
+            var header = new JWTHeaderWithCertificate(credential);
 
             Assert.IsNotNull(header.X509CertificatePublicCertValue);
             Assert.IsNotNull(header.X509CertificateThumbprint);
@@ -336,9 +332,9 @@ namespace Microsoft.Identity.Test.Unit
         [Description("Check the JWTHeader when sendCert is false")]
         public void CheckJWTHeaderWithCertFalseTest()
         {
-            var credential = GenerateClientAssertionCredential();
+            var credential = GenerateClientAssertionCredential(false);
 
-            var header = new JWTHeaderWithCertificate(credential, false);
+            var header = new JWTHeaderWithCertificate(credential);
 
             Assert.IsNull(header.X509CertificatePublicCertValue);
             Assert.IsNotNull(header.X509CertificateThumbprint);
@@ -359,7 +355,7 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
-                    .WithCertificate(certificate)
+                    .WithCertificate(certificate, true)
                     .BuildConcrete();
 
                 var appCacheAccess = app.AppTokenCache.RecordAccess();
@@ -369,7 +365,6 @@ namespace Microsoft.Identity.Test.Unit
                 
                 AuthenticationResult result = await app
                     .AcquireTokenForClient(TestConstants.s_scope)
-                    .WithSendX5C(true)
                     .ExecuteAsync(CancellationToken.None)
                     .ConfigureAwait(false);
 
@@ -391,12 +386,12 @@ namespace Microsoft.Identity.Test.Unit
                 userCacheAccess.AssertAccessCounts(0, 0);
             }
         }
-        private ClientCredentialWrapper GenerateClientAssertionCredential()
+        private ClientCredentialWrapper GenerateClientAssertionCredential(bool withSendX5C = false)
         {
             var cert = new X509Certificate2(
             ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
 
-            var credential = ClientCredentialWrapper.CreateWithCertificate(cert);
+            var credential = ClientCredentialWrapper.CreateWithCertificate(cert, withSendX5C:withSendX5C);
             return credential;
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/JsonHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/JsonHelperTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
             var certificate = new X509Certificate2(
                    ResourceHelper.GetTestResourceRelativePath("RSATestCertDotNet.pfx"));
 
-            var header = new JWTHeaderWithCertificate(ClientCredentialWrapper.CreateWithCertificate(certificate), true);
+            var header = new JWTHeaderWithCertificate(ClientCredentialWrapper.CreateWithCertificate(certificate, withSendX5C:true));
             string actualPayload = JsonHelper.SerializeToJson(payload);
             string actualHeader = JsonHelper.SerializeToJson(header);
 


### PR DESCRIPTION
Proposes a solution for #2804

**Changes proposed in this request**
Add WithSendX5C to ConfidentialClientApplicationBuilder. 
Makes the existing SendX5C channeled throughout confidential clients nullable, to be overwritten at request time by the default-null SendX5C within the ConfidentialClient. 
Marks the per-request SendX5C Builder methods as Obsolete, so that devs know to switch to per-app X5C. 


**Testing**
Inline updates to the existing unit tests, to switch away from the per-request model and into the per-app model.  This should validate that the claim is appearing as expected as a result of this change. 

**Performance impact**
No perf impact expected. 
