### PR TITLE
Removing regional env variable (REGION_NAME)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Region/RegionAutodetectionSource.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/RegionAutodetectionSource.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Client.Region
         /// <summary>
         /// Auto-detected from IMDS
         /// </summary>
-        Imds = 3,
+        Imds = 4,
 
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Region/RegionAutodetectionSource.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/RegionAutodetectionSource.cs
@@ -26,14 +26,9 @@ namespace Microsoft.Identity.Client.Region
         Cache = 2,
 
         /// <summary>
-        /// Auto-detected from Env Variable
-        /// </summary>
-        EnvVariable = 3,
-
-        /// <summary>
         /// Auto-detected from IMDS
         /// </summary>
-        Imds = 4,
+        Imds = 3,
 
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Region/RegionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/RegionManager.cs
@@ -160,14 +160,6 @@ namespace Microsoft.Identity.Client.Region
 
         private async Task<RegionInfo> DiscoverAsync(ICoreLogger logger, CancellationToken requestCancellationToken)
         {
-            string region = Environment.GetEnvironmentVariable("REGION_NAME");
-
-            if (ValidateRegion(region, "REGION_NAME env variable", logger)) // this is just to validate the region string
-            {
-                logger.Info($"[Region discovery] Region found in environment variable: {region}.");
-                return new RegionInfo(region, RegionAutodetectionSource.EnvVariable);
-            }
-
             try
             {
                 var headers = new Dictionary<string, string>
@@ -191,7 +183,7 @@ namespace Microsoft.Identity.Client.Region
 
                 if (response.StatusCode == HttpStatusCode.OK && !response.Body.IsNullOrEmpty())
                 {
-                    region = response.Body;
+                    string region = response.Body;
 
                     if (ValidateRegion(region, $"IMDS call to {imdsUri.AbsoluteUri}", logger))
                     {

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -142,7 +142,6 @@ namespace Microsoft.Identity.Test.Unit
         public const string Username = "joe@localhost.com";
         public const string PKeyAuthResponse = "PKeyAuth Context=\"context\",Version=\"1.0\"";
 
-        public const string RegionName = "REGION_NAME";
         public const string Region = "centralus";
         public const string InvalidRegion = "invalidregion";
         public const int TimeoutInMs = 2000;

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -52,12 +52,12 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // Arrange
             var factory = new HttpSnifferClientFactory();
             var settings = ConfidentialAppSettings.GetSettings(Cloud.Public);
-            _confidentialClientApplication = BuildCCA(settings, factory);
+            _confidentialClientApplication = BuildCCA(settings, factory, false, TestConstants.Region);
 
             AuthenticationResult result = await GetAuthenticationResultAsync(settings.AppScopes).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             AssertValidHost(true, factory);
-            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,3,4|0,1");
+            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,1,2|0,1");
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await GetAuthenticationResultAsync(settings.AppScopes).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             AssertValidHost(true, factory);
-            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,1,2|0,1");
+            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,1,2|0,1", 1);
         }
 
         [TestMethod]
@@ -86,6 +86,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private void AssertTelemetry(HttpSnifferClientFactory factory, string currentTelemetryHeader, int placement = 0)
         {
+            Console.WriteLine($"Total requests for regional: {factory.RequestsAndResponses.Count}");
             var (req, res) = factory.RequestsAndResponses.Skip(placement).Single();
             Assert.AreEqual(currentTelemetryHeader, req.Headers.GetValues("x-client-current-telemetry").First());
         }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await GetAuthenticationResultAsync(settings.AppScopes).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             AssertValidHost(true, factory);
-            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,3,3|0,1", 1);
+            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,4,3|0,1", 1);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -46,12 +46,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             }
         }
 
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, null);
-        }
-
         [TestMethod]
         public async Task AcquireTokenToRegionalEndpointAsync()
         {
@@ -60,7 +54,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var settings = ConfidentialAppSettings.GetSettings(Cloud.Public);
             _confidentialClientApplication = BuildCCA(settings, factory);
 
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
             AuthenticationResult result = await GetAuthenticationResultAsync(settings.AppScopes).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             AssertValidHost(true, factory);
@@ -76,7 +69,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var settings = ConfidentialAppSettings.GetSettings(Cloud.Public);
             _confidentialClientApplication = BuildCCA(settings, factory, true, "invalid");
 
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
             AuthenticationResult result = await GetAuthenticationResultAsync(settings.AppScopes).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             Assert.AreEqual(

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -49,6 +49,11 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         [TestMethod]
         public async Task AcquireTokenToRegionalEndpointAsync()
         {
+            if (Environment.GetEnvironmentVariable("TF_BUILD") == null)
+            {
+                Assert.Inconclusive("This test needs to run on Azure DevOps hosted agent located on an Azure VM.");
+            }
+
             // Arrange
             var factory = new HttpSnifferClientFactory();
             var settings = ConfidentialAppSettings.GetSettings(Cloud.Public);
@@ -57,7 +62,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult result = await GetAuthenticationResultAsync(settings.AppScopes).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             AssertValidHost(true, factory);
-            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,1,2|0,1", 1);
+            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},centralus,3,3|0,1", 1);
         }
 
         [TestMethod]
@@ -86,7 +91,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private void AssertTelemetry(HttpSnifferClientFactory factory, string currentTelemetryHeader, int placement = 0)
         {
-            Console.WriteLine($"Total requests for regional: {factory.RequestsAndResponses.Count}");
             var (req, res) = factory.RequestsAndResponses.Skip(placement).Single();
             Assert.AreEqual(currentTelemetryHeader, req.Headers.GetValues("x-client-current-telemetry").First());
         }

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/RegionalTelemetryTests.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         [TestCleanup]
         public override void TestCleanup()
         {
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, null);
             _harness?.Dispose();
             base.TestCleanup();
         }
@@ -60,12 +59,12 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         [TestMethod]
         public async Task TelemetryAcceptanceTestAsync()
         {
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
+            _harness.HttpManager.AddRegionDiscoveryMockHandler(TestConstants.Region);
 
             Trace.WriteLine("Step 1. Acquire Token For Client with region successful");
             var result = await RunAcquireTokenForClientAsync(AcquireTokenForClientOutcome.Success).ConfigureAwait(false);
             AssertCurrentTelemetry(result.HttpRequest, ApiIds.AcquireTokenForClient, 
-                ((int)RegionAutodetectionSource.EnvVariable).ToString(), 
+                ((int)RegionAutodetectionSource.Imds).ToString(), 
                 ((int)RegionOutcome.AutodetectSuccess).ToString());
             AssertPreviousTelemetry(result.HttpRequest, expectedSilentCount: 0);
 
@@ -101,14 +100,14 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         [TestMethod]
         public async Task TelemetrySerializedTokenCacheTestAsync()
         {
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
+            _harness.HttpManager.AddRegionDiscoveryMockHandler(TestConstants.Region);
 
             Trace.WriteLine("Acquire token for client with token serialization.");
             var result = await RunAcquireTokenForClientAsync(AcquireTokenForClientOutcome.Success, serializeCache: true)
                 .ConfigureAwait(false);
             AssertCurrentTelemetry(result.HttpRequest,
                 ApiIds.AcquireTokenForClient,
-                ((int)RegionAutodetectionSource.EnvVariable).ToString(),
+                ((int)RegionAutodetectionSource.Imds).ToString(),
                 ((int)RegionOutcome.AutodetectSuccess).ToString(),
                 isCacheSerialized: true);
             AssertPreviousTelemetry(result.HttpRequest, expectedSilentCount: 0);
@@ -154,13 +153,13 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         [TestMethod]
         public async Task TelemetryUserProvidedRegionAutoDiscoverRegionSameTestsAsync()
         {
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
+            _harness.HttpManager.AddRegionDiscoveryMockHandler(TestConstants.Region);
 
             Trace.WriteLine("Acquire token for client with region provided by user and region detected is same as regionToUse.");
             var result = await RunAcquireTokenForClientAsync(AcquireTokenForClientOutcome.UserProvidedRegion).ConfigureAwait(false);
             AssertCurrentTelemetry(result.HttpRequest,
                 ApiIds.AcquireTokenForClient,
-                ((int)RegionAutodetectionSource.EnvVariable).ToString(),
+                ((int)RegionAutodetectionSource.Imds).ToString(),
                 ((int)RegionOutcome.UserProvidedValid).ToString(),
                 isCacheSerialized: false,
                 region: TestConstants.Region);
@@ -175,13 +174,13 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         [TestMethod]
         public async Task TelemetryUserProvidedRegionAutoDiscoverRegionMismatchTestsAsync()
         {
-            Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
+            _harness.HttpManager.AddRegionDiscoveryMockHandler(TestConstants.Region);
 
             Trace.WriteLine("Acquire token for client with region provided by user and region detected mismatches regionToUse.");
             var result = await RunAcquireTokenForClientAsync(AcquireTokenForClientOutcome.UserProvidedInvalidRegion).ConfigureAwait(false);
             AssertCurrentTelemetry(result.HttpRequest,
                 ApiIds.AcquireTokenForClient,
-                ((int)RegionAutodetectionSource.EnvVariable).ToString(),
+                ((int)RegionAutodetectionSource.Imds).ToString(),
                 ((int)RegionOutcome.UserProvidedInvalid).ToString(),
                 isCacheSerialized: false,
                 region: TestConstants.InvalidRegion);

--- a/tests/devapps/RegionalTestApp/Program.cs
+++ b/tests/devapps/RegionalTestApp/Program.cs
@@ -80,7 +80,6 @@ namespace TestApp
 {
     public class Program
     {
-        private const string s_environmentVarName = "REGION_NAME";
         private const string s_region = "centralus";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("AsyncUsage.CSharp.Naming", "UseAsyncSuffix:Use Async suffix", Justification = "Main method")]
@@ -92,13 +91,12 @@ namespace TestApp
 
                 Console.WriteLine(@"
     1: Regional with a valid user-specified region
-    2: Regional with environment variable
-    3: Regional with IMDS call (without environment variable, test in Azure VM)
-    4: Acquire token with global, then regional
-    5: Acquire token with regional, then global
-    6: Acquire token twice in a row with regional (tests for double region appending regression)
-    7: Acquire token twice in a row with global
-    8: Regional with an invalid user-specified region
+    2: Regional with IMDS call (test in Azure VM)
+    3: Acquire token with global, then regional
+    4: Acquire token with regional, then global
+    5: Acquire token twice in a row with regional (tests for double region appending regression)
+    6: Acquire token twice in a row with global
+    7: Regional with an invalid user-specified region
     0. Exit app
     Enter your selection: ");
                 int.TryParse(Console.ReadLine(), out var menuSelection);
@@ -113,35 +111,31 @@ namespace TestApp
                             await AcquireTokenAsync(certificate, region: "westus").ConfigureAwait(false);
                             break;
 
-                        case 2: // Regional auto-detect with environment variable
-                            await AcquireTokenAsync(certificate, region: ConfidentialClientApplication.AttemptRegionDiscovery).ConfigureAwait(false);
-                            break;
-
-                        case 3: // Regional auto-detect with IMDS call (without environment variable, test in Azure VM)
+                        case 2: // Regional auto-detect with IMDS call
                             await AcquireTokenAsync(certificate, region: ConfidentialClientApplication.AttemptRegionDiscovery, setEnvVariable: false).ConfigureAwait(false);
                             break;
 
-                        case 4: // Acquire token with global, then regional
+                        case 3: // Acquire token with global, then regional
                             await AcquireTokenAsync(certificate, region: string.Empty).ConfigureAwait(false);
                             await AcquireTokenAsync(certificate, region: ConfidentialClientApplication.AttemptRegionDiscovery).ConfigureAwait(false);
                             break;
 
-                        case 5: // Acquire token with regional, then global
+                        case 4: // Acquire token with regional, then global
                             await AcquireTokenAsync(certificate, region: ConfidentialClientApplication.AttemptRegionDiscovery).ConfigureAwait(false);
                             await AcquireTokenAsync(certificate, region: string.Empty).ConfigureAwait(false);
                             break;
 
-                        case 6: // Acquire token twice in a row with regional (tests for double region appending regression)
+                        case 5: // Acquire token twice in a row with regional (tests for double region appending regression)
                             await AcquireTokenAsync(certificate, region: ConfidentialClientApplication.AttemptRegionDiscovery).ConfigureAwait(false);
                             await AcquireTokenAsync(certificate, region: ConfidentialClientApplication.AttemptRegionDiscovery).ConfigureAwait(false);
                             break;
 
-                        case 7: // Acquire token twice in a row with global
+                        case 6: // Acquire token twice in a row with global
                             await AcquireTokenAsync(certificate, region: string.Empty).ConfigureAwait(false);
                             await AcquireTokenAsync(certificate, region: string.Empty).ConfigureAwait(false);
                             break;
 
-                        case 8: // Regional with an invalid user-specified region
+                        case 7: // Regional with an invalid user-specified region
                             await AcquireTokenAsync(certificate, region: "invalidRegion").ConfigureAwait(false);
                             break;
 
@@ -166,11 +160,6 @@ namespace TestApp
         private static async Task AcquireTokenAsync(X509Certificate2 certificate, string region, bool setEnvVariable = true)
         {
             string clientId = "16dab2ba-145d-4b1b-8569-bf4b9aed4dc8";
-
-            if (!string.IsNullOrEmpty(region) && setEnvVariable)
-            {
-                Environment.SetEnvironmentVariable(s_environmentVarName, s_region);
-            }
 
             string[] scopes = new string[] { $"{clientId}/.default", };
             Dictionary<string, string> dict = new Dictionary<string, string>
@@ -199,11 +188,6 @@ namespace TestApp
                 .ConfigureAwait(false);
 
             Console.WriteLine("Access token:" + result.AccessToken);
-
-            if (!string.IsNullOrEmpty(region) && setEnvVariable)
-            {
-                Environment.SetEnvironmentVariable(s_environmentVarName, null);
-            }
         }
 
         private static void Log(LogLevel level, string message, bool containsPii)


### PR DESCRIPTION
Fixes # .
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2803

**Changes proposed in this request**
Removing regional env variable (REGION_NAME)

**Testing**
Automated testing

**Performance impact**

