### PR TITLE
Adding "always: true" to ensure scheduled builds run continuously.

### DIFF
--- a/LibsAndSamples.sln
+++ b/LibsAndSamples.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31512.422
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31424.327
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9B0B5396-4D95-4C15-82ED-DC22B5A3123F}"
 EndProject
@@ -109,7 +109,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pipelines", "pipelines", "{
 		build\template-build-and-run-cachecompat-tests.yaml = build\template-build-and-run-cachecompat-tests.yaml
 		build\template-build-android-automation.yaml = build\template-build-android-automation.yaml
 		build\template-build-ios-automation.yaml = build\template-build-ios-automation.yaml
-		build\template-ci-and-pr.yaml = build\template-ci-and-pr.yaml
 		build\template-desktop-unit-and-automation.yaml = build\template-desktop-unit-and-automation.yaml
 		build\template-install-dotnet-core.yaml = build\template-install-dotnet-core.yaml
 		build\template-install-keyvault-secrets.yaml = build\template-install-keyvault-secrets.yaml

--- a/build/pipeline-ci.yaml
+++ b/build/pipeline-ci.yaml
@@ -11,6 +11,7 @@ schedules:
   branches:
     include:
     - master
+  always: true
 
 pr: none
 

--- a/build/pipeline-ci.yaml
+++ b/build/pipeline-ci.yaml
@@ -4,15 +4,6 @@ trigger:
     include:
     - 'master'
 
-# Create a daily midnight build for CI builds on master to ensure our build functions
-schedules:
-- cron: "0 0 * * *"
-  displayName: Daily midnight build
-  branches:
-    include:
-    - master
-  always: true
-
 pr: none
 
 variables:

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -10,6 +10,7 @@ schedules:
   branches:
     include:
     - master
+  always: true
 
 variables:
   BuildPlatform: 'any cpu'


### PR DESCRIPTION
Fixes # .
Fixing scheduled builds not running nightly

**Changes proposed in this request**
Adding "always: true" to ensure scheduled builds run always.
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#running-even-when-there-are-no-code-changes
