### PR TITLE
Fixing regional test issue

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
-        public async Task RequestGoesToUserSpecifiedRegion_Async()
+        public async Task InvalidRegion_GoesToInvalidAuthority_Async()
         {
             // Arrange
             var factory = new HttpSnifferClientFactory();
@@ -82,13 +82,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
               "https://westus.r.login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token?allowestsrnonmsi=true",
               factory.RequestsAndResponses.Single().Item1.RequestUri.ToString());
 
-            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},westus,3,3|0,1");
-
             _confidentialClientApplication = BuildCCA(settings, factory, true, TestConstants.Region);
             result = await GetAuthenticationResultAsync(settings.AppScopes, withForceRefresh: true).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             AssertValidHost(true, factory, 1);
-            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.ForceRefresh:D},centralus,2,1|0,1", 1);
         }
 
         private void AssertTelemetry(HttpSnifferClientFactory factory, string currentTelemetryHeader, int placement = 0)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -68,22 +68,21 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
-        [Ignore] //See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2781
-        public async Task InvalidRegion_GoesToInvalidAuthority_Async()
+        public async Task RequestGoesToUserSpecifiedRegion_Async()
         {
             // Arrange
             var factory = new HttpSnifferClientFactory();
             var settings = ConfidentialAppSettings.GetSettings(Cloud.Public);
-            _confidentialClientApplication = BuildCCA(settings, factory, true, "invalid");
+            _confidentialClientApplication = BuildCCA(settings, factory, true, "westus");
 
             Environment.SetEnvironmentVariable(TestConstants.RegionName, TestConstants.Region);
             AuthenticationResult result = await GetAuthenticationResultAsync(settings.AppScopes).ConfigureAwait(false); // regional endpoint
             AssertTokenSourceIsIdp(result);
             Assert.AreEqual(
-              "https://invalid.login.microsoft.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token?allowestsrnonmsi=true",
+              "https://westus.r.login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token?allowestsrnonmsi=true",
               factory.RequestsAndResponses.Single().Item1.RequestUri.ToString());
 
-            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},invalid,3,3|0,1");
+            AssertTelemetry(factory, $"{TelemetryConstants.HttpTelemetrySchemaVersion}|1004,{CacheInfoTelemetry.NoCachedAT:D},westus,3,3|0,1");
 
             _confidentialClientApplication = BuildCCA(settings, factory, true, TestConstants.Region);
             result = await GetAuthenticationResultAsync(settings.AppScopes, withForceRefresh: true).ConfigureAwait(false); // regional endpoint


### PR DESCRIPTION
Fixes # .
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2781
[conversation here](https://teams.microsoft.com/l/message/19:52a29b76367e45dda20a02de7184b4f4@thread.skype/1628720389242?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=e8095862-5f1f-4095-b996-6b78e479e4b4&parentMessageId=1628709938977&teamName=Azure%20AD%20Client%20SDK%20Team&channelName=Dotnet%20SDK%20discussions&createdTime=1628720389242)

**Changes proposed in this request**
Fixing test to point valid region. 

**Testing**
Integration test

**Performance impact**
None
