### PR TITLE
Discovery fails throws ex including HttpResponse

### DIFF
--- a/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -142,9 +142,19 @@ namespace Microsoft.Identity.Client.WsTrust
                 msalIdParams,
                 requestContext.Logger).ConfigureAwait(false);
 
-            return httpResponse.StatusCode == System.Net.HttpStatusCode.OK
-                ? JsonHelper.DeserializeFromJson<UserRealmDiscoveryResponse>(httpResponse.Body)
-                : null;
+            if (httpResponse.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                return JsonHelper.DeserializeFromJson<UserRealmDiscoveryResponse>(httpResponse.Body);
+            }
+
+            string message = string.Format(CultureInfo.CurrentCulture,
+                    MsalErrorMessage.HttpRequestUnsuccessful,
+                    (int)httpResponse.StatusCode, httpResponse.StatusCode);
+
+            throw MsalServiceExceptionFactory.FromHttpResponse(
+                MsalError.UserRealmDiscoveryFailed,
+                message,
+                httpResponse);
         }
     }
 }


### PR DESCRIPTION
Fixes #2835  .

**Changes proposed in this request**
When discover fails, it throws MsalServiceException with Http response message and status code.

**Testing**
Added unit test

**Performance impact**
None