### PR TITLE
InjectAppToken prototype

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/SuggestedWebCacheKeyFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/SuggestedWebCacheKeyFactory.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Identity.Client.Cache
                 return true;
             }
 
-            if (requestParameters.ApiId == TelemetryCore.Internal.Events.ApiEvent.ApiIds.AcquireTokenForClient)
+            if (requestParameters.ApiId == TelemetryCore.Internal.Events.ApiEvent.ApiIds.AcquireTokenForClient ||
+                requestParameters.ApiId == TelemetryCore.Internal.Events.ApiEvent.ApiIds.InjectAppToken)
             {
                 string tenantId = requestParameters.Authority.TenantId ?? "";
                 key = GetClientCredentialKey(requestParameters.AppConfig.ClientId, tenantId);

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -189,7 +189,13 @@ namespace Microsoft.Identity.Client
         /// <param name="cancellationToken">Cancellation token</param>
         public async Task RemoveAsync(IAccount account, CancellationToken cancellationToken = default)
         {
-            RequestContext requestContext = CreateRequestContext(Guid.NewGuid(), cancellationToken);            
+            Guid correlationId = Guid.NewGuid();
+            RequestContext requestContext = CreateRequestContext(correlationId, cancellationToken);
+            requestContext.ApiEvent = new ApiEvent(
+               requestContext.Logger,
+               requestContext.ServiceBundle.PlatformProxy.CryptographyManager,
+               correlationId.ToString());
+            requestContext.ApiEvent.ApiId = ApiEvent.ApiIds.RemoveAccount;
 
             if (account != null && UserTokenCacheInternal != null)
             {
@@ -212,10 +218,13 @@ namespace Microsoft.Identity.Client
         {
             Guid correlationId = Guid.NewGuid();
             RequestContext requestContext = CreateRequestContext(correlationId, cancellationToken);
-            requestContext.ApiEvent = new ApiEvent(requestContext.Logger, requestContext.ServiceBundle.PlatformProxy.CryptographyManager, correlationId.ToString());
+            requestContext.ApiEvent = new ApiEvent(
+                requestContext.Logger, 
+                requestContext.ServiceBundle.PlatformProxy.CryptographyManager, 
+                correlationId.ToString());
             requestContext.ApiEvent.ApiId = apiId;
 
-            var authority = await Microsoft.Identity.Client.Instance.Authority.CreateAuthorityForRequestAsync(
+            var authority = await Instance.Authority.CreateAuthorityForRequestAsync(
               requestContext,
               null).ConfigureAwait(false);
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -146,7 +146,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public IDictionary<string, string> ExtraHttpHeaders => _commonParameters.ExtraHttpHeaders;
 
-        public bool IsClientCredentialRequest => ApiId == ApiEvent.ApiIds.AcquireTokenForClient;
+        public bool IsClientCredentialRequest =>
+            ApiId == ApiEvent.ApiIds.AcquireTokenForClient ||
+            ApiId == ApiEvent.ApiIds.InjectAppToken;
 
         public bool IsConfidentialClient
         {

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Identity.Client.OAuth2
         private long _extendedExpiresIn;
         private long _refreshIn;
 
+        public MsalTokenResponse()
+        {
+
+        }
+
         [JsonProperty(PropertyName = TokenResponseClaim.TokenType)]
         public string TokenType { get; set; }
 

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Events/ApiEvent.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/Internal/Events/ApiEvent.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Identity.Client.TelemetryCore.Internal.Events
             GetAccounts = 1010,
             GetAccountById = 1011,
             GetAccountsByUserFlow = 1012,
-            RemoveAccount = 1013
+            RemoveAccount = 1013,
+            InjectAppToken = 1014
         }
 
         private readonly ICryptographyManager _cryptographyManager;

--- a/tests/devapps/Net5TestApp/Program.cs
+++ b/tests/devapps/Net5TestApp/Program.cs
@@ -4,44 +4,48 @@ using Microsoft.Identity.Client;
 
 namespace Net5TestApp
 {
+  
     class Program
     {
-        static void Main(string[] args)
-        {
-            try
-            {
-                var result = TryAuthAsync().Result;
-                Console.BackgroundColor = ConsoleColor.DarkGreen;
-                Console.WriteLine("Access Token = " + result?.AccessToken);
-                Console.ResetColor();
-            }
-            catch (MsalException e)
-            {
-                Console.BackgroundColor = ConsoleColor.DarkRed;
-                Console.WriteLine("Error: ErrorCode=" + e.ErrorCode + "ErrorMessage=" + e.Message);
-                Console.ResetColor();
-            }
+#pragma warning disable UseAsyncSuffix // Use Async suffix
+        static async Task Main(string[] args)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
+        {            
+            string clientId = Environment.GetEnvironmentVariable("LAB_APP_CLIENT_ID");
+            string clientSecret = Environment.GetEnvironmentVariable("LAB_APP_CLIENT_SECRET");
+            string[] scopes = new string[] { "https://graph.microsoft.com/.default" };
 
-            Console.Read();
+            // the tenant id is important, especially for multi-tenant apps
+            // single tenant apps could get away with setting "common", but this is strongly discouraged
+            // because "common" + multi-tenant S2S app = non defined behavior
+            string authority = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47"; 
+
+            IConfidentialClientApplication cca = ConfidentialClientApplicationBuilder
+                   .Create(clientId)
+                   .WithAuthority(authority)
+                   .WithClientSecret(clientSecret) // today, a secret or a cert MUST be configured. Maybe we should relax this if MSI is to be used?
+                   .Build();
+            
+            await (cca as ConfidentialClientApplication).InjectAppTokenAsync(scopes, 3600, "secret_at")
+                .ConfigureAwait(false);
+
+            AuthenticationResult result_msi = await cca.AcquireTokenForClient(scopes)                                    
+                                    .ExecuteAsync()
+                                    .ConfigureAwait(false);
+
+            Console.WriteLine($"Token {result_msi.AccessToken} from {result_msi.AuthenticationResultMetadata.TokenSource}");
+
+            AuthenticationResult result_ests = await cca.AcquireTokenForClient(scopes)
+                                    .WithForceRefresh(true)
+                                   .ExecuteAsync()
+                                   .ConfigureAwait(false);
+           
+            Console.WriteLine($"Token {result_ests.AccessToken} from {result_ests.AuthenticationResultMetadata.TokenSource}");
+
+
         }
 
-        private static async Task<AuthenticationResult> TryAuthAsync()
-        {
-            var pca = PublicClientApplicationBuilder.Create("16dab2ba-145d-4b1b-8569-bf4b9aed4dc8")
-                .WithLogging(MyLoggingMethod, LogLevel.Info,
-                             enablePiiLogging: true,
-                             enableDefaultPlatformLogging: true)
-                .WithDefaultRedirectUri()
-                .Build();
 
-            return await pca.AcquireTokenInteractive(new[] { "user.read" })
-               .WithUseEmbeddedWebView(true)
-               .ExecuteAsync().ConfigureAwait(false);
-        }
 
-        static void MyLoggingMethod(LogLevel level, string message, bool containsPii)
-        {
-            Console.WriteLine($"MSALTest {level} {containsPii} {message}");
-        }
     }
 }


### PR DESCRIPTION
Fixes #2806 

This a prototype to see MSAL could cache IMDS tokens.

We could tackle this in 2 ways: 

a) `cca.InjectAppTokenAsync(string[] scopes, long expiresInSeconds, string rawAccessToken)` (this is implemented in the prototype)

b) `cca.AcquireTokenFromAzureImds(string[] scopes)` - i.e. we move the IMDS code from Azure SDK to MSAL. We still need to figure out how to cache the token though.


