### PR TITLE
Enabling App Id Uri to be used with web apps

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -470,12 +470,6 @@ namespace Microsoft.Identity.Client
                 throw new MsalClientException(MsalError.NoClientId, MsalErrorMessage.NoClientIdWasSpecified);
             }         
 
-            //ADFS does not require client id to be in the form of a GUID.
-            if (Config.AuthorityInfo?.AuthorityType != AuthorityType.Adfs && !Guid.TryParse(Config.ClientId, out _))
-            {
-                throw new MsalClientException(MsalError.ClientIdMustBeAGuid, MsalErrorMessage.ClientIdMustBeAGuid);
-            }
-
             if (Config.CustomInstanceDiscoveryMetadata != null && Config.CustomInstanceDiscoveryMetadataUri != null)
             {
                 throw new MsalClientException(

--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -353,6 +353,12 @@ namespace Microsoft.Identity.Client
         {
             base.Validate();
 
+            //ADFS does not require client id to be in the form of a GUID.
+            if (Config.AuthorityInfo?.AuthorityType != AuthorityType.Adfs && !Guid.TryParse(Config.ClientId, out _))
+            {
+                throw new MsalClientException(MsalError.ClientIdMustBeAGuid, MsalErrorMessage.ClientIdMustBeAGuid);
+            }
+
             if (string.IsNullOrWhiteSpace(Config.RedirectUri))
             {
                 Config.RedirectUri = PlatformProxyFactory.CreatePlatformProxy(null)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
@@ -56,11 +56,13 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         [DataRow(Cloud.Public, RunOn.NetFx | RunOn.NetCore)]
         [DataRow(Cloud.Adfs, RunOn.NetCore)]
         [DataRow(Cloud.PPE, RunOn.NetFx)]
-         //[DataRow(Cloud.Arlington)] - cert not setup
-        public async Task WithCertificate_TestAsync(Cloud cloud, RunOn runOn)
+        [DataRow(Cloud.PPE, new object[] { RunOn.NetFx, true })]
+        [DataRow(Cloud.Public, new object[] { RunOn.NetFx | RunOn.NetCore, true })]
+        //[DataRow(Cloud.Arlington)] - cert not setup
+        public async Task WithCertificate_TestAsync(Cloud cloud, RunOn runOn, bool useAppIdUri = false)
         {
             runOn.AssertFramework();
-            await RunClientCredsAsync(cloud, CredentialType.Cert).ConfigureAwait(false);
+            await RunClientCredsAsync(cloud, CredentialType.Cert, useAppIdUri).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -115,10 +117,12 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             await RunClientCredsAsync(cloud, CredentialType.ClientClaims_MergeClaims).ConfigureAwait(false);
         }
 
-        private async Task RunClientCredsAsync(Cloud cloud, CredentialType credentialType)
+        private async Task RunClientCredsAsync(Cloud cloud, CredentialType credentialType, bool UseAppIdUri = false)
         {
             Trace.WriteLine($"Running test with settings for cloud {cloud}, credential type {credentialType}");
             IConfidentialAppSettings settings = ConfidentialAppSettings.GetSettings(cloud);
+
+            settings.UseAppIdUri = UseAppIdUri;
 
             AuthenticationResult authResult;
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
@@ -30,13 +30,14 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
         string Authority { get; }
 
         Cloud Cloud { get; }
+        bool UseAppIdUri { get; set; }
     }    
 
     public class ConfidentialAppSettings
     {
         private class PublicCloudConfidentialAppSettings : IConfidentialAppSettings
         {
-            public string ClientId => "16dab2ba-145d-4b1b-8569-bf4b9aed4dc8";
+            public string ClientId => UseAppIdUri? "https://microsoft.onmicrosoft.com/aa3e634f-58b3-4eb7-b4ed-244c44c29c47" : "16dab2ba-145d-4b1b-8569-bf4b9aed4dc8";
 
             public string TenantId => "72f988bf-86f1-41af-91ab-2d7cd011db47";
 
@@ -47,6 +48,8 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
             public string Authority => $@"https://{Environment}/{TenantId}";
 
             public Cloud Cloud => Cloud.Public;
+
+            public bool UseAppIdUri { get; set; }
 
             public X509Certificate2 GetCertificate()
             {
@@ -92,11 +95,12 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
 
             public Cloud Cloud => Cloud.Adfs;
 
+            public bool UseAppIdUri { get; set; }
         }
 
         private class PpeConfidentialAppSettings : IConfidentialAppSettings
         {
-            public string ClientId => "9793041b-9078-4942-b1d2-babdc472cc0c";
+            public string ClientId => UseAppIdUri? "api://microsoft.identity.9793041b-9078-4942-b1d2-babdc472cc0c" : "9793041b-9078-4942-b1d2-babdc472cc0c";
 
             public string TenantId => "f686d426-8d16-42db-81b7-ab578e110ccd";
 
@@ -116,6 +120,8 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
             public string Authority => $@"https://{Environment}/{TenantId}";
 
             public Cloud Cloud => Cloud.PPE;
+
+            public bool UseAppIdUri { get; set; }
         }
 
         private class ArlingtonConfidentialAppSettings : IConfidentialAppSettings
@@ -142,6 +148,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
 
             public Cloud Cloud => Cloud.Arlington;
 
+            public bool UseAppIdUri { get; set; }
         }   
 
         private static Lazy<IConfidentialAppSettings> s_publicCloudSettings =
@@ -169,8 +176,6 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
                     throw new NotImplementedException();
             }
         }
-
-       
 
         private static Lazy<string> GetSecretLazy(string secretName) => new Lazy<string>(() =>
         {

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
@@ -169,8 +169,12 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestWithDifferentClientId()
         {
             const string ClientId = "9340c42a-f5de-4a80-aea0-874adc2ca325";
+            const string AppIdUri = "https://microsoft.onmicrosoft.com/aa3e634f-58b3-4eb7-b4ed-244c44c29c47";
             var cca = ConfidentialClientApplicationBuilder.Create(ClientId).WithClientSecret("cats").Build();
             Assert.AreEqual(ClientId, cca.AppConfig.ClientId);
+
+            cca = ConfidentialClientApplicationBuilder.Create(AppIdUri).WithClientSecret("cats").Build();
+            Assert.AreEqual(AppIdUri, cca.AppConfig.ClientId);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes # .
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2852

**Changes proposed in this request**
Enabling App Id Uri to be used with web apps

**Testing**
Unit/Integration

**Performance impact**
None
