### PR TITLE
Add async delegate for WithClientAssertion

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -184,7 +184,6 @@ namespace Microsoft.Identity.Client
             return (T)this;
         }
 
-
         internal T WithUserTokenCacheInternalForTest(ITokenCacheInternal tokenCacheInternal)
         {
             Config.UserTokenCacheInternalForTest = tokenCacheInternal;

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http;
@@ -89,7 +91,8 @@ namespace Microsoft.Identity.Client
         public ClientCredentialWrapper ClientCredential { get; internal set; }
         public string ClientSecret { get; internal set; }
         public string SignedClientAssertion { get; internal set; }
-        public Func<string> SignedClientAssertionDelegate { get; internal set; }
+        public Func<CancellationToken, Task<string>> SignedClientAssertionDelegate { get; internal set; }
+         
         public X509Certificate2 ClientCredentialCertificate { get; internal set; }
         public IDictionary<string, string> ClaimsToSign { get; internal set; }
         public bool MergeWithDefaultClaims { get; internal set; }

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Identity.Client.Internal;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client
 {
@@ -177,7 +179,33 @@ namespace Microsoft.Identity.Client
                 throw new ArgumentNullException(nameof(clientAssertionDelegate));
             }
 
-            Config.SignedClientAssertionDelegate = clientAssertionDelegate;
+            Func<CancellationToken, Task<string>> clientAssertionAsyncDelegate = (_) =>
+            {                
+                return Task.FromResult(clientAssertionDelegate());
+            };
+
+
+            Config.SignedClientAssertionDelegate = clientAssertionAsyncDelegate;
+            Config.ConfidentialClientCredentialCount++;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures an async delegate that creates a client assertion. See https://aka.ms/msal-net-client-assertion
+        /// </summary>
+        /// <param name="clientAssertionAsyncDelegate">An async delegate computing the client assertion used to prove the identity of the application to Azure AD.
+        /// This is a delegate that computes a Base-64 encoded JWT for each authentication call.</param>
+        /// <returns>The ConfidentialClientApplicationBuilder to chain more .With methods</returns>
+        /// <remarks> Callers can use this mechanism to cache their assertions </remarks>
+        public ConfidentialClientApplicationBuilder WithClientAssertion(Func<CancellationToken, Task<string>> clientAssertionAsyncDelegate)
+        {
+            
+            if (clientAssertionAsyncDelegate == null)
+            {
+                throw new ArgumentNullException(nameof(clientAssertionAsyncDelegate));
+            }
+
+            Config.SignedClientAssertionDelegate = clientAssertionAsyncDelegate;
             Config.ConfidentialClientCredentialCount++;
             return this;
         }


### PR DESCRIPTION
Fixes #2863 

**Changes proposed in this request**
Add async delegate. 

Note to self: always go for async + cancellation token. 


