### PR TITLE
Correct XML summary element casing

### DIFF
--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -19,16 +19,16 @@ using System.Threading;
 
 namespace Microsoft.Identity.Client
 {
-    /// <Summary>
+    /// <summary>
     /// Abstract class containing common API methods and properties. Both <see cref="Microsoft.Identity.Client.PublicClientApplication"/> and 
     /// ConfidentialClientApplication
     /// extend this class. For details see https://aka.ms/msal-net-client-applications
-    /// </Summary>
+    /// </summary>
     public abstract partial class ClientApplicationBase : IClientApplicationBase
     {
-        /// <Summary>
+        /// <summary>
         /// Default Authority used for interactive calls.
-        /// </Summary>
+        /// </summary>
         internal const string DefaultAuthority = "https://login.microsoftonline.com/common/";
 
         internal IServiceBundle ServiceBundle { get; }
@@ -38,24 +38,25 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public IAppConfig AppConfig => ServiceBundle.Config;        
 
-        /// <Summary>
+        /// <summary>
         /// Gets the URL of the authority, or security token service (STS) from which MSAL.NET will acquire security tokens
         /// The return value of this property is either the value provided by the developer in the constructor of the application, or otherwise
         /// the value of the <see cref="DefaultAuthority"/> static member (that is <c>https://login.microsoftonline.com/common/</c>)
-        /// </Summary>
+        /// </summary>
         public string Authority => ServiceBundle.Config.AuthorityInfo.CanonicalAuthority; // Do not use in MSAL, use AuthorityInfo instead to avoid re-parsing
 
         internal AuthorityInfo AuthorityInfo => ServiceBundle.Config.AuthorityInfo;
 
-        /// <Summary>
-        /// User token cache. This case holds id tokens, access tokens and refresh tokens for accounts. It's used
+        /// <summary>
+        /// User token cache. It holds access tokens, id tokens and refresh tokens for accounts. It's used
         /// and updated silently if needed when calling <see cref="AcquireTokenSilent(IEnumerable{string}, IAccount)"/>
         /// or one of the overrides of <see cref="AcquireTokenSilent(IEnumerable{string}, IAccount)"/>.
         /// It is updated by each AcquireTokenXXX method, with the exception of <c>AcquireTokenForClient</c> which only uses the application
         /// cache (see <c>IConfidentialClientApplication</c>).
-        /// </Summary>
+        /// </summary>
         /// <remarks>On .NET Framework and .NET Core you can also customize the token cache serialization.
-        /// See https://aka.ms/msal-net-token-cache-serialization. This is taken care of by MSAL.NET on other platforms.
+        /// See https://aka.ms/msal-net-token-cache-serialization. This is taken care of by MSAL.NET on mobile platforms and on UWP.
+        /// It is recommended to use token cache serialization for web site and web api scenarios.
         /// </remarks>
         public ITokenCache UserTokenCache => UserTokenCacheInternal;
 

--- a/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -160,10 +160,10 @@ namespace Microsoft.Identity.Client
 
         internal ClientCredentialWrapper ClientCredential => ServiceBundle.Config.ClientCredential;
 
-        /// <Summary>
+        /// <summary>
         /// Application token cache. This case holds access tokens and refresh tokens for the application. It's maintained
         /// and updated silently if needed when calling <see cref="AcquireTokenForClient(IEnumerable{string})"/>
-        /// </Summary>
+        /// </summary>
         /// <remarks>On .NET Framework and .NET Core you can also customize the token cache serialization.
         /// See https://aka.ms/msal-net-token-cache-serialization. This is taken care of by MSAL.NET on other platforms
         /// </remarks>

--- a/src/client/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -7,10 +7,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client
 {
-    /// <Summary>
+    /// <summary>
     /// Abstract class containing common API methods and properties. Both <see cref="T:PublicClientApplication"/> and <see cref="T:ConfidentialClientApplication"/>
     /// extend this class. For details see https://aka.ms/msal-net-client-applications.
-    /// </Summary>
+    /// </summary>
     public partial interface IClientApplicationBase
     {
         /// <summary>
@@ -18,22 +18,22 @@ namespace Microsoft.Identity.Client
         /// </summary>
         IAppConfig AppConfig { get; }
 
-        /// <Summary>
+        /// <summary>
         /// User token cache. This case holds id tokens, access tokens and refresh tokens for accounts. It's used
         /// and updated silently if needed when calling <see cref="AcquireTokenSilent(IEnumerable{string}, IAccount)"/>
         /// It is updated by each AcquireTokenXXX method, with the exception of <c>AcquireTokenForClient</c> which only uses the application
         /// cache (see <c>IConfidentialClientApplication</c>).
-        /// </Summary>
+        /// </summary>
         /// <remarks>On .NET Framework and .NET Core you can also customize the token cache serialization.
         /// See https://aka.ms/msal-net-token-cache-serialization. This is taken care of by MSAL.NET on other platforms.
         /// </remarks>
         ITokenCache UserTokenCache { get; }
 
-        /// <Summary>
+        /// <summary>
         /// Gets the URL of the authority, or the security token service (STS) from which MSAL.NET will acquire security tokens.
         /// The return value of this property is either the value provided by the developer in the constructor of the application, or otherwise
         /// the value of the <see cref="ClientApplicationBase.Authority"/> static member (that is <c>https://login.microsoftonline.com/common/</c>)
-        /// </Summary>
+        /// </summary>
         // TODO: move to IAppConfig like ClientId?
         string Authority { get; }
 

--- a/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Identity.Client
 #endif
     public partial interface IConfidentialClientApplication : IClientApplicationBase
     {
-        /// <Summary>
+        /// <summary>
         /// Application token cache. This case holds access tokens and refresh tokens for the application. It's maintained
         /// and updated silently if needed when calling <see cref="AcquireTokenForClient(IEnumerable{string})"/>
-        /// </Summary>
+        /// </summary>
         /// <remarks>On .NET Framework and .NET Core you can also customize the token cache serialization.
         /// See https://aka.ms/msal-net-token-cache-serialization. This is taken care of by MSAL.NET on other platforms.
         /// </remarks>

--- a/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -76,10 +76,10 @@ namespace Microsoft.Identity.Client
         string Identifier { get; }
     }
 
-    /// <Summary>
+    /// <summary>
     /// Interface defining common API methods and properties. Both <see cref="T:PublicClientApplication"/> and <see cref="T:ConfidentialClientApplication"/>
     /// extend this class. For details see https://aka.ms/msal-net-client-applications
-    /// </Summary>    
+    /// </summary>    
     public partial interface IClientApplicationBase
     {
         /// <summary>
@@ -216,10 +216,10 @@ namespace Microsoft.Identity.Client
         #endregion MSAL3X deprecations
     }
 
-    /// <Summary>
+    /// <summary>
     /// Abstract class containing common API methods and properties. Both <see cref="T:PublicClientApplication"/> and <see cref="T:ConfidentialClientApplication"/>
     /// extend this class. For details see https://aka.ms/msal-net-client-applications
-    /// </Summary>
+    /// </summary>
     public partial class ClientApplicationBase
     {
         /// <summary>
@@ -800,10 +800,10 @@ namespace Microsoft.Identity.Client
         #endregion MSAL3X deprecations
     }
 
-    /// <Summary>
+    /// <summary>
     /// Abstract class containing common API methods and properties.
     /// For details see https://aka.ms/msal-net-client-applications
-    /// </Summary>
+    /// </summary>
     public partial class PublicClientApplication
     {
 #if WINDOWS_APP
@@ -1396,10 +1396,10 @@ namespace Microsoft.Identity.Client
         #endregion MSAL3X deprecations
     }
 
-    /// <Summary>
+    /// <summary>
     /// Interface defining common API methods and properties.
     /// For details see https://aka.ms/msal-net-client-applications
-    /// </Summary>
+    /// </summary>
     public partial interface IPublicClientApplication
     {
 #if iOS

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -123,13 +123,13 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        /// <Summary>
+        /// <summary>
         /// Suggested value of the expiry, to help determining the cache eviction time. 
         /// This value is <b>only</b> set on the <code>OnAfterAccess</code> delegate, on a cache write
         /// operation (that is when <code>args.HasStateChanged</code> is <code>true</code>) and when the cache write 
         /// is triggered from the <code>AcquireTokenForClient</code> method. In all other cases it's <code>null</code>, as there is a refresh token, and therefore the
         /// access tokens are refreshable.
-        /// </Summary> 
+        /// </summary> 
         public DateTimeOffset? SuggestedCacheExpiry { get; private set; }
     }
 }


### PR DESCRIPTION
Fixes #2872
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
Summary vs summary. Looks like docs.microsoft.com is case sensitive
