### PR TITLE
Optimization of Base64UrlEncode operations based (copy from Wilson)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,5 @@
 <Project>
   <PropertyGroup>
-
-    <LangVersion>7.2</LangVersion>
     <!-- This is strong naming, not signing-->
     <SignAssembly>true</SignAssembly>
     <!-- The MSAL.snk has both private and public keys -->

--- a/src/client/Microsoft.Identity.Client/Internal/ClientInfo.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientInfo.cs
@@ -8,6 +8,8 @@ using Microsoft.Identity.Json;
 
 namespace Microsoft.Identity.Client.Internal
 {
+
+
     [JsonObject]
     [Preserve(AllMembers = true)]
     internal class ClientInfo

--- a/src/client/Microsoft.Identity.Client/Internal/ClientInfo.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client.Internal
 
             try
             {
-                return JsonHelper.DeserializeFromJson<ClientInfo>(Base64UrlHelpers.DecodeToBytes(clientInfo));
+                return JsonHelper.DeserializeFromJson<ClientInfo>(Base64UrlHelpers.DecodeBytes(clientInfo));
             }
             catch (Exception exc)
             {

--- a/src/client/Microsoft.Identity.Client/Internal/IdToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/IdToken.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client.Internal
 
             try
             {
-                string payload = Base64UrlHelpers.DecodeToString(idTokenSegments[1]);
+                string payload = Base64UrlHelpers.Decode(idTokenSegments[1]);
                 var idTokenClaims = JsonConvert.DeserializeObject<Dictionary<string, object>>(payload);                
 
                 IdToken parsedIdToken = new IdToken();

--- a/src/client/Microsoft.Identity.Client/Kerberos/KerberosSupplementalTicketManager.cs
+++ b/src/client/Microsoft.Identity.Client/Kerberos/KerberosSupplementalTicketManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Client.Kerberos
             }
 
             // decodes the second section containing the Kerberos Ticket claim if exists.
-            byte[] payloadBytes = Base64UrlHelpers.DecodeToBytes(sections[1]);
+            byte[] payloadBytes = Base64UrlHelpers.DecodeBytes(sections[1]);
             string payload = Encoding.UTF8.GetString(payloadBytes);
             if (string.IsNullOrEmpty(payload))
             {

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -17,6 +17,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Linux')) Or '$(NetCoreOnly)' !='' ">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);</TargetFrameworks>
     
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet and AssemblyInfo metadata">

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -64,8 +64,6 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NoWarn>$(NoWarn);CS8002;NU5131;</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- VS 2019 uses C# 10. Not all C# 10 language features are available. See https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
-    <LangVersion>latestMajor</LangVersion> 
   </PropertyGroup>
 
   <Import Project="../../../build/platform_and_feature_flags.props" />

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -16,8 +16,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkMac)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Linux')) Or '$(NetCoreOnly)' !='' ">$(TargetFrameworkNetStandard);$(TargetFrameworkNetCore);</TargetFrameworks>
     
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>latest</LangVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>   
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet and AssemblyInfo metadata">

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -64,6 +64,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NoWarn>$(NoWarn);CS8002;NU5131;</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latestMajor</LangVersion>
   </PropertyGroup>
 
   <Import Project="../../../build/platform_and_feature_flags.props" />

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -54,7 +54,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup  Label="For CI build" Condition="'$(TF_BUILD)' == 'true'">
+  <PropertyGroup Label="For CI build" Condition="'$(TF_BUILD)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
@@ -64,7 +64,8 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NoWarn>$(NoWarn);CS8002;NU5131;</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latestMajor</LangVersion>
+    <!-- VS 2019 uses C# 10. Not all C# 10 language features are available. See https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
+    <LangVersion>latestMajor</LangVersion> 
   </PropertyGroup>
 
   <Import Project="../../../build/platform_and_feature_flags.props" />

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/BrokerKeyHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/BrokerKeyHelper.cs
@@ -107,8 +107,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
         internal static string DecryptBrokerResponse(string encryptedBrokerResponse, ICoreLogger logger)
         {
-            byte[] outputBytes = Base64UrlHelpers.DecodeToBytes(encryptedBrokerResponse);
-            string plaintext = string.Empty;
+            byte[] outputBytes = Base64UrlHelpers.DecodeBytes(encryptedBrokerResponse);
 
             if (TryGetBrokerKey(out byte[] key))
             {
@@ -125,7 +124,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
                         CryptoStreamMode.Read);
                     using (StreamReader srDecrypt = new StreamReader(cryptoStream))
                     {
-                        plaintext = srDecrypt.ReadToEnd();
+                        string plaintext = srDecrypt.ReadToEnd();
                         return plaintext;
                     }
                 }

--- a/src/client/Microsoft.Identity.Client/Utils/Base64UrlHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/Base64UrlHelpers.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Identity.Client.Utils
                     //default or case 0: no further operations are needed.
             }
 
-            return new(output, 0, j);
+            return new string(output, 0, j);
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Utils/Base64UrlHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/Base64UrlHelpers.cs
@@ -2,79 +2,267 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 
 namespace Microsoft.Identity.Client.Utils
 {
+    // Based on https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/1698/files
     internal static class Base64UrlHelpers
     {
-        private const char Base64PadCharacter = '=';
-        private const char Base64Character62 = '+';
-        private const char Base64Character63 = '/';
-        private const char Base64UrlCharacter62 = '-';
-        private const char Base64UrlCharacter63 = '_';
-        private static readonly Encoding s_textEncoding = Encoding.UTF8;
+        private const char base64PadCharacter = '=';
+#if NET45
+        private const string doubleBase64PadCharacter = "==";
+#endif
+        private const char base64Character62 = '+';
+        private const char base64Character63 = '/';
+        private const char base64UrlCharacter62 = '-';
+        private const char base64UrlCharacter63 = '_';
 
-        private static readonly string s_doubleBase64PadCharacter = new string(Base64PadCharacter, 2);
+        /// <summary>
+        /// Encoding table
+        /// </summary>
+        internal static readonly char[] s_base64Table =
+        {
+            'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+            'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
+            '0','1','2','3','4','5','6','7','8','9',
+            base64UrlCharacter62,
+            base64UrlCharacter63
+        };
 
-        // The following functions perform base64url encoding which differs from regular base64 encoding as follows
-        // * padding is skipped so the pad character '=' doesn't have to be percent encoded
-        // * the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
-        // The changes make the encoding alphabet file and URL safe
-        // See RFC4648, section 5 for more info
+        /// <summary>
+        /// The following functions perform base64url encoding which differs from regular base64 encoding as follows
+        /// * padding is skipped so the pad character '=' doesn't have to be percent encoded
+        /// * the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
+        /// The changes make the encoding alphabet file and URL safe.
+        /// </summary>
+        /// <param name="arg">string to encode.</param>
+        /// <returns>Base64Url encoding of the UTF8 bytes.</returns>
         public static string Encode(string arg)
         {
             if (arg == null)
-            {
                 return null;
+
+            return Encode(Encoding.UTF8.GetBytes(arg));
+        }
+
+        /// <summary>
+        /// Converts a subset of an array of 8-bit unsigned integers to its equivalent string representation that is encoded with base-64-url digits. Parameters specify
+        /// the subset as an offset in the input array, and the number of elements in the array to convert.
+        /// </summary>
+        /// <param name="inArray">An array of 8-bit unsigned integers.</param>
+        /// <param name="length">An offset in inArray.</param>
+        /// <param name="offset">The number of elements of inArray to convert.</param>
+        /// <returns>The string representation in base 64 url encoding of length elements of inArray, starting at position offset.</returns>
+        /// <exception cref="ArgumentNullException">'inArray' is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">offset or length is negative OR offset plus length is greater than the length of inArray.</exception>
+        private static string Encode(byte[] inArray, int offset, int length)
+        {
+            _ = inArray ?? throw new ArgumentNullException(nameof(inArray));
+
+            if (length == 0)
+                return string.Empty;
+
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            if (offset < 0 || inArray.Length < offset)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            if (inArray.Length < offset + length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            int lengthmod3 = length % 3;
+            int limit = offset + (length - lengthmod3);
+            char[] output = new char[(length + 2) / 3 * 4];
+            char[] table = s_base64Table;
+            int i, j = 0;
+
+            // takes 3 bytes from inArray and insert 4 bytes into output
+            for (i = offset; i < limit; i += 3)
+            {
+                byte d0 = inArray[i];
+                byte d1 = inArray[i + 1];
+                byte d2 = inArray[i + 2];
+
+                output[j + 0] = table[d0 >> 2];
+                output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
+                output[j + 2] = table[((d1 & 0x0f) << 2) | (d2 >> 6)];
+                output[j + 3] = table[d2 & 0x3f];
+                j += 4;
             }
 
-            return Encode(s_textEncoding.GetBytes(arg));
-        }
+            //Where we left off before
+            i = limit;
 
-        public static string DecodeToString(string arg)
-        {
-            byte[] decoded = DecodeToBytes(arg);
-            return CoreHelpers.CreateString(decoded);
-        }
-
-        public static byte[] DecodeToBytes(string arg)
-        {
-            string s = arg;
-            s = s.Replace(Base64UrlCharacter62, Base64Character62); // 62nd char of encoding
-            s = s.Replace(Base64UrlCharacter63, Base64Character63); // 63rd char of encoding
-
-            switch (s.Length%4)
+            switch (lengthmod3)
             {
-                // Pad
-                case 0:
-                    break; // No pad chars in this case
                 case 2:
-                    s += s_doubleBase64PadCharacter;
-                    break; // Two pad chars
-                case 3:
-                    s += Base64PadCharacter;
-                    break; // One pad char
-                default:
-                    throw new ArgumentException("Illegal base64url string!", nameof(arg));
+                    {
+                        byte d0 = inArray[i];
+                        byte d1 = inArray[i + 1];
+
+                        output[j + 0] = table[d0 >> 2];
+                        output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
+                        output[j + 2] = table[(d1 & 0x0f) << 2];
+                        j += 3;
+                    }
+                    break;
+
+                case 1:
+                    {
+                        byte d0 = inArray[i];
+
+                        output[j + 0] = table[d0 >> 2];
+                        output[j + 1] = table[(d0 & 0x03) << 4];
+                        j += 2;
+                    }
+                    break;
+
+                    //default or case 0: no further operations are needed.
             }
 
-            return Convert.FromBase64String(s); // Standard base64 decoder
+            return new(output, 0, j);
         }
 
-        internal static string Encode(byte[] arg)
+        /// <summary>
+        /// Converts a subset of an array of 8-bit unsigned integers to its equivalent string representation that is encoded with base-64-url digits. Parameters specify
+        /// the subset as an offset in the input array, and the number of elements in the array to convert.
+        /// </summary>
+        /// <param name="inArray">An array of 8-bit unsigned integers.</param>
+        /// <returns>The string representation in base 64 url encoding of length elements of inArray, starting at position offset.</returns>
+        /// <exception cref="ArgumentNullException">'inArray' is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">offset or length is negative OR offset plus length is greater than the length of inArray.</exception>
+        public static string Encode(byte[] inArray)
         {
-            if (arg == null)
-            {
+            if (inArray == null)
                 return null;
+
+            return Encode(inArray, 0, inArray.Length);
+        }
+
+        internal static string EncodeString(string str)
+        {
+            if (str == null)
+                return null;
+
+            return Encode(Encoding.UTF8.GetBytes(str));
+        }
+
+        /// <summary>
+        ///  Converts the specified string, which encodes binary data as base-64-url digits, to an equivalent 8-bit unsigned integer array.</summary>
+        /// <param name="str">base64Url encoded string.</param>
+        /// <returns>UTF8 bytes.</returns>
+        public static byte[] DecodeBytes(string str)
+        {
+            if (str == null)
+                return null;
+#if NET45
+            // 62nd char of encoding
+            str = str.Replace(base64UrlCharacter62, base64Character62);
+
+            // 63rd char of encoding
+            str = str.Replace(base64UrlCharacter63, base64Character63);
+
+            // check for padding
+            switch (str.Length % 4)
+            {
+                case 0:
+                    // No pad chars in this case
+                    break;
+                case 2:
+                    // Two pad chars
+                    str += doubleBase64PadCharacter;
+                    break;
+                case 3:
+                    // One pad char
+                    str += base64PadCharacter;
+                    break;
+                default:
+                    throw new FormatException($"Unable to decode: {str} as Base64url encoded string.");
             }
 
-            string s = Convert.ToBase64String(arg);
-            s = s.Split(Base64PadCharacter)[0]; // RemoveAccount any trailing padding
-            s = s.Replace(Base64Character62, Base64UrlCharacter62); // 62nd char of encoding
-            s = s.Replace(Base64Character63, Base64UrlCharacter63); // 63rd char of encoding
-
-            return s;
+            return Convert.FromBase64String(str);
+#else
+            return UnsafeDecode(str);
+#endif
         }
-    }
+
+#if !NET45
+        private unsafe static byte[] UnsafeDecode(string str)
+        {
+            int mod = str.Length % 4;
+            if (mod == 1)
+                throw new FormatException($"Unable to decode: {str} as Base64url encoded string.");
+
+            bool needReplace = false;
+            int decodedLength = str.Length + (4 - mod) % 4;
+
+            for (int i = 0; i < str.Length; i++)
+            {
+                if (str[i] == base64UrlCharacter62 || str[i] == base64UrlCharacter63)
+                {
+                    needReplace = true;
+                    break;
+                }
+            }
+
+            if (needReplace)
+            {
+                string decodedString = new string(char.MinValue, decodedLength);
+                fixed (char* dest = decodedString)
+                {
+                    int i = 0;
+                    for (; i < str.Length; i++)
+                    {
+                        if (str[i] == base64UrlCharacter62)
+                            dest[i] = base64Character62;
+                        else if (str[i] == base64UrlCharacter63)
+                            dest[i] = base64Character63;
+                        else
+                            dest[i] = str[i];
+                    }
+
+                    for (; i < decodedLength; i++)
+                        dest[i] = base64PadCharacter;
+                }
+
+                return Convert.FromBase64String(decodedString);
+            }
+            else
+            {
+                if (decodedLength == str.Length)
+                {
+                    return Convert.FromBase64String(str);
+                }
+                else
+                {
+                    string decodedString = new string(char.MinValue, decodedLength);
+                    fixed (char* src = str)
+                    fixed (char* dest = decodedString)
+                    {
+                        Buffer.MemoryCopy(src, dest, str.Length * 2, str.Length * 2);
+                        dest[str.Length] = base64PadCharacter;
+                        if (str.Length + 2 == decodedLength)
+                            dest[str.Length + 1] = base64PadCharacter;
+                    }
+
+                    return Convert.FromBase64String(decodedString);
+                }
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Decodes the string from Base64UrlEncoded to UTF8.
+        /// </summary>
+        /// <param name="arg">string to decode.</param>
+        /// <returns>UTF8 string.</returns>
+        public static string Decode(string arg)
+        {
+            return Encoding.UTF8.GetString(DecodeBytes(arg));
+        }
+    }   
 }

--- a/tests/Microsoft.Identity.Test.Performance/Base64Encode.cs
+++ b/tests/Microsoft.Identity.Test.Performance/Base64Encode.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Test.Performance
+{
+    [SimpleJob(RuntimeMoniker.Net472)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    public class Base64Encode
+    {
+        const string s1 = "The quick brown fox jumps over the lazy dog";
+        const string s2 = "The quick brown fox jumps over the lazy dog==";
+        const string s3 = "The quick +brown fox jumps //over the lazy dog=";
+
+        static readonly byte[] d1 = Encoding.UTF8.GetBytes(s1);
+        static readonly byte[] d2 = Encoding.UTF8.GetBytes(s2);
+        static readonly byte[] d3 = Encoding.UTF8.GetBytes(s3);
+
+        static string s4 = Base64UrlHelpers.Encode(s1);
+        static string s5 = Base64UrlHelpers.Encode(s2);
+        static string s6 = Base64UrlHelpers.Encode(s3);
+
+        static readonly byte[] d4 = Encoding.UTF8.GetBytes(s4);
+        static readonly byte[] d5 = Encoding.UTF8.GetBytes(s5);
+        static readonly byte[] d6 = Encoding.UTF8.GetBytes(s6);
+        #region Encode
+
+        //[Benchmark]
+        //public void Encoding_String_Old()
+        //{
+        //    OldBase64UrlHelpers.Encode(s1);
+        //    OldBase64UrlHelpers.Encode(s2);
+        //    OldBase64UrlHelpers.Encode(s3);
+        //}
+
+        [Benchmark]
+        public void Encode_String_New()
+        {
+            Base64UrlHelpers.Encode(s1);
+            Base64UrlHelpers.Encode(s2);
+            Base64UrlHelpers.Encode(s3);
+        }
+
+        //[Benchmark]
+        //public void Encode_Byte_Old()
+        //{
+        //    OldBase64UrlHelpers.Encode(d1);
+        //    OldBase64UrlHelpers.Encode(d2);
+        //    OldBase64UrlHelpers.Encode(d3);
+        //}
+
+        [Benchmark]
+        public void Encode_Byte_New()
+        {
+            Base64UrlHelpers.Encode(d1);
+            Base64UrlHelpers.Encode(d2);
+            Base64UrlHelpers.Encode(d3);
+        }
+        #endregion
+
+        #region Decode
+        //[Benchmark]
+        //public void Decode_Bytes_Old()
+        //{
+        //    OldBase64UrlHelpers.DecodeToBytes(s4);
+        //    OldBase64UrlHelpers.DecodeToBytes(s5);
+        //    OldBase64UrlHelpers.DecodeToBytes(s6);
+        //}
+
+        [Benchmark]
+        public void Decode_Bytes_New()
+        {
+            Base64UrlHelpers.DecodeBytes(s4);
+            Base64UrlHelpers.DecodeBytes(s5);
+            Base64UrlHelpers.DecodeBytes(s6);
+        }
+
+        //[Benchmark]
+        //public void Decode_String_Old()
+        //{
+        //    OldBase64UrlHelpers.DecodeToString(s4);
+        //    OldBase64UrlHelpers.DecodeToString(s5);
+        //    OldBase64UrlHelpers.DecodeToString(s6);
+        //}
+
+        [Benchmark]
+        public void Decode_String_New()
+        {
+            Base64UrlHelpers.Decode(s4);
+            Base64UrlHelpers.Decode(s5);
+            Base64UrlHelpers.Decode(s6);
+        }
+        #endregion
+    }
+}

--- a/tests/Microsoft.Identity.Test.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Test.Performance/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 
@@ -12,14 +13,17 @@ namespace Microsoft.Identity.Test.Performance
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<AcquireTokenForClientLargeCacheTests>(
+            BenchmarkRunner.Run<Base64Encode>(
                 DefaultConfig.Instance
                     .WithOptions(ConfigOptions.DontOverwriteResults)
-                    
+                    .AddDiagnoser(MemoryDiagnoser.Default)
                     .AddJob(
                         Job.Default
-                            .WithId("Job-PerfTests")                            
-                            ));
+                            .WithId("Job-PerfTests")
+                    //        .WithGcMode(new GcMode() { Server = true })
+
+));
+
 
             Console.ReadKey();
         }


### PR DESCRIPTION
Fixes # .
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
Copy UrlEncoders from Wilson
Add     `<LangVersion>latest</LangVersion>` - this will allow us to use newer language features, but we are still bound to c# 7.3 due to net45 and netstandard1.3 ... Once we stop supporting those, we can move to C# 8 or 9 consistently. 

**Testing**
perf test. existing ut cover functionality

**Performance impact**
Encode operations are 2x+ faster and consume 1/2 memory. Decode operations are more or less the same.


|              Method |           Job |       Runtime | Server |    StdDev |     Median | Allocated |
|-------------------- |-------------- |-------------- |------- |----------:|-----------:|----------:|
| Encoding_String_Old |    .NET 4.7.2 |    .NET 4.7.2 |  False |  10.17 ns | 1,080.9 ns |    2006 B |
|   Encode_String_New |    .NET 4.7.2 |    .NET 4.7.2 |  False |   7.83 ns |   487.5 ns |    1107 B |
|     Encode_Byte_Old |    .NET 4.7.2 |    .NET 4.7.2 |  False |  71.60 ns |   970.7 ns |    1789 B |
|     Encode_Byte_New |    .NET 4.7.2 |    .NET 4.7.2 |  False |   8.97 ns |   350.5 ns |     891 B |
|    Decode_Bytes_Old |    .NET 4.7.2 |    .NET 4.7.2 |  False |   8.72 ns |   851.9 ns |     530 B |
|    Decode_Bytes_New |    .NET 4.7.2 |    .NET 4.7.2 |  False |   9.58 ns |   782.6 ns |     530 B |
|   Decode_String_Old |    .NET 4.7.2 |    .NET 4.7.2 |  False |  86.36 ns | 1,135.5 ns |     883 B |
|   Decode_String_New |    .NET 4.7.2 |    .NET 4.7.2 |  False |  12.93 ns | 1,054.3 ns |     883 B |
| Encoding_String_Old | .NET Core 3.1 | .NET Core 3.1 |  False |  24.56 ns |   985.7 ns |    1072 B |
|   Encode_String_New | .NET Core 3.1 | .NET Core 3.1 |  False |  17.43 ns |   492.4 ns |    1096 B |
|     Encode_Byte_Old | .NET Core 3.1 | .NET Core 3.1 |  False | 376.60 ns | 1,114.4 ns |     856 B |
|     Encode_Byte_New | .NET Core 3.1 | .NET Core 3.1 |  False |  52.15 ns |   450.8 ns |     880 B |
|    Decode_Bytes_Old | .NET Core 3.1 | .NET Core 3.1 |  False |  11.78 ns |   739.5 ns |     512 B |
|    Decode_Bytes_New | .NET Core 3.1 | .NET Core 3.1 |  False | 152.94 ns |   697.7 ns |     512 B |
|   Decode_String_Old | .NET Core 3.1 | .NET Core 3.1 |  False | 175.25 ns |   996.4 ns |     856 B |
|   Decode_String_New | .NET Core 3.1 | .NET Core 3.1 |  False | 153.59 ns |   894.4 ns |     856 B |
| Encoding_String_Old | Job-PerfTests | .NET Core 3.1 |   True |  44.78 ns | 1,012.5 ns |    1072 B |
|   Encode_String_New | Job-PerfTests | .NET Core 3.1 |   True |  13.91 ns |   526.5 ns |    1096 B |
|     Encode_Byte_Old | Job-PerfTests | .NET Core 3.1 |   True |   9.36 ns |   736.1 ns |     856 B |
|     Encode_Byte_New | Job-PerfTests | .NET Core 3.1 |   True |   6.22 ns |   370.5 ns |     880 B |
|    Decode_Bytes_Old | Job-PerfTests | .NET Core 3.1 |   True |  16.89 ns |   743.9 ns |     512 B |
|    Decode_Bytes_New | Job-PerfTests | .NET Core 3.1 |   True |   6.71 ns |   628.6 ns |     512 B |
|   Decode_String_Old | Job-PerfTests | .NET Core 3.1 |   True |  17.95 ns |   993.5 ns |     856 B |
|   Decode_String_New | Job-PerfTests | .NET Core 3.1 |   True |  17.39 ns |   932.0 ns |     856 B |

