### PR TITLE
Log error when common or organizations were used for client credential flow

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/AadAuthority.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AadAuthority.cs
@@ -57,6 +57,18 @@ namespace Microsoft.Identity.Client.Instance
                 s_tenantlessTenantNames.Contains(tenantId);
         }
 
+        internal bool IsCommonOrOrganizationsTenant()
+        {
+            return IsCommonOrOrganizationsTenant(TenantId);
+        }
+
+        internal static bool IsCommonOrOrganizationsTenant(string tenantId)
+        {
+            return !string.IsNullOrEmpty(tenantId) && 
+                tenantId != Constants.ConsumerTenant &&
+                s_tenantlessTenantNames.Contains(tenantId);
+        }
+
         internal override string GetTenantedAuthority(string tenantId, bool forceSpecifiedTenant = false)
         {
             if (!string.IsNullOrEmpty(tenantId) &&

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -44,8 +44,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             AuthenticationResult authResult = null;
 
             if (AuthenticationRequestParameters.Authority is AadAuthority aadAuthority &&
-                aadAuthority.TenantId != Constants.ConsumerTenant &&
-                aadAuthority.IsCommonOrganizationsOrConsumersTenant())
+                aadAuthority.IsCommonOrOrganizationsTenant())
             {
                 logger.Error(MsalErrorMessage.ClientCredentialWrongAuthority);
             }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             AuthenticationResult authResult = null;
 
+            if(AuthenticationRequestParameters.Authority.TenantId.Contains("common") ||
+               AuthenticationRequestParameters.Authority.TenantId.Contains("organizations"))
+            {
+                logger.Error(MsalErrorMessage.ClientCredentialWrongAuthority);
+            }
+
             if (!_clientParameters.ForceRefresh && 
                 string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -11,6 +11,7 @@ using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.Utils;
 using System;
+using Microsoft.Identity.Client.Instance;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {
@@ -42,10 +43,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             AuthenticationResult authResult = null;
 
-            if(AuthenticationRequestParameters.Authority.TenantId.Contains("common") ||
-               AuthenticationRequestParameters.Authority.TenantId.Contains("organizations"))
+            if (AuthenticationRequestParameters.Authority is AadAuthority aadAuthority)
             {
-                logger.Error(MsalErrorMessage.ClientCredentialWrongAuthority);
+                if (aadAuthority.IsCommonOrganizationsOrConsumersTenant())
+                {
+                    logger.Error(MsalErrorMessage.ClientCredentialWrongAuthority);
+                }
             }
 
             if (!_clientParameters.ForceRefresh && 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -43,12 +43,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             AuthenticationResult authResult = null;
 
-            if (AuthenticationRequestParameters.Authority is AadAuthority aadAuthority)
+            if (AuthenticationRequestParameters.Authority is AadAuthority aadAuthority &&
+                aadAuthority.TenantId != Constants.ConsumerTenant &&
+                aadAuthority.IsCommonOrganizationsOrConsumersTenant())
             {
-                if (aadAuthority.IsCommonOrganizationsOrConsumersTenant())
-                {
-                    logger.Error(MsalErrorMessage.ClientCredentialWrongAuthority);
-                }
+                logger.Error(MsalErrorMessage.ClientCredentialWrongAuthority);
             }
 
             if (!_clientParameters.ForceRefresh && 

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -394,6 +394,7 @@ namespace Microsoft.Identity.Client
                 errorCode);
 
         public static string CcsRoutingHintMissing = "Either the userObjectIdentifier or tenantIdenifier are missing. Both are needed to create the ccs routing hint. See https://aka.ms/msal-net/ccsRouting. ";
-        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common or /organizations endpoint which is not reccomended. See https://aka.ms/msal-net-client-credentials for more details.";
+        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common or /organizations endpoint which is not recommended. See https://aka.ms/msal-net-client-credentials for more details.";
+
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -394,6 +394,7 @@ namespace Microsoft.Identity.Client
                 errorCode);
 
         public static string CcsRoutingHintMissing = "Either the userObjectIdentifier or tenantIdenifier are missing. Both are needed to create the ccs routing hint. See https://aka.ms/msal-net/ccsRouting. ";
-        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common, /consumers or /organizations endpoint which is not reccomended. See https://aka.ms/msal-net-client-credentials for more details.";
+        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common, /consumers or /organizations endpoint which is not recommended. See https://aka.ms/msal-net-client-credentials for more details.";
+
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -394,7 +394,6 @@ namespace Microsoft.Identity.Client
                 errorCode);
 
         public static string CcsRoutingHintMissing = "Either the userObjectIdentifier or tenantIdenifier are missing. Both are needed to create the ccs routing hint. See https://aka.ms/msal-net/ccsRouting. ";
-        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common, /consumers or /organizations endpoint which is not recommended. See https://aka.ms/msal-net-client-credentials for more details.";
-
+        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common or /organizations endpoint which is not reccomended. See https://aka.ms/msal-net-client-credentials for more details.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -394,7 +394,6 @@ namespace Microsoft.Identity.Client
                 errorCode);
 
         public static string CcsRoutingHintMissing = "Either the userObjectIdentifier or tenantIdenifier are missing. Both are needed to create the ccs routing hint. See https://aka.ms/msal-net/ccsRouting. ";
-        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common or /organizations endpoint which is not recommended. See https://aka.ms/msal-net-client-credentials for more details.";
-
+        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common, /consumers or /organizations endpoint which is not reccomended. See https://aka.ms/msal-net-client-credentials for more details.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -394,5 +394,6 @@ namespace Microsoft.Identity.Client
                 errorCode);
 
         public static string CcsRoutingHintMissing = "Either the userObjectIdentifier or tenantIdenifier are missing. Both are needed to create the ccs routing hint. See https://aka.ms/msal-net/ccsRouting. ";
+        public static string ClientCredentialWrongAuthority = "The current authority is targeting the /common or /organizations endpoint which is not reccomended. See https://aka.ms/msal-net-client-credentials for more details.";
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1370,6 +1370,15 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .ConfigureAwait(false);
 
                 Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
+
+                log = string.Empty;
+                result = await app
+                    .AcquireTokenForClient(TestConstants.s_scope)
+                    .WithAuthority(TestConstants.AuthorityConsumersTenant, true)
+                    .ExecuteAsync(CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1370,15 +1370,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .ConfigureAwait(false);
 
                 Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
-
-                log = string.Empty;
-                result = await app
-                    .AcquireTokenForClient(TestConstants.s_scope)
-                    .WithAuthority(TestConstants.AuthorityConsumersTenant, true)
-                    .ExecuteAsync(CancellationToken.None)
-                    .ConfigureAwait(false);
-
-                Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1336,6 +1336,42 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             _serializedCache = args.TokenCache.SerializeMsalV3();
         }
+
+        [TestMethod]
+        public async Task AcquireTokenForClientAuthorityCheckTestAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                string log = string.Empty;
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithLogging((LogLevel level, string message, bool containsPii) => log = log + message)
+                    .BuildConcrete();
+
+                var result = await app
+                    .AcquireTokenForClient(TestConstants.s_scope)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant, true)
+                    .ExecuteAsync(CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
+
+                log = string.Empty;
+                result = await app
+                    .AcquireTokenForClient(TestConstants.s_scope)
+                    .WithAuthority(TestConstants.AuthorityOrganizationsTenant, true)
+                    .ExecuteAsync(CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes # .
fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2887

**Changes proposed in this request**
Log error when common or organizations were used for client credential flow

**Testing**
unit test

**Performance impact**
negligable
