### PR TITLE
Adding better message for retry after error for client credential request

### DIFF
--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -120,6 +120,12 @@ namespace Microsoft.Identity.Client
         public const string RequestTimeout = "request_timeout";
 
         /// <summary>
+        /// Service returned HTTP error code 429 which indicated that the request has been throttled.
+        /// For more details see https://aka.ms/msal-net-throttling
+        /// </summary>
+        public const string RequestThrottled = "request_throttled";
+
+        /// <summary>
         /// loginHint should be a UPN
         /// <para>What happens?</para> An override of a token acquisition operation was called in <see cref="T:IPublicClientApplication"/> which
         /// takes a <c>loginHint</c> as a parameters, but this login hint was not using the UserPrincipalName (UPN) format, e.g. <c>john.doe@contoso.com</c>

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Identity.Client
         public const string RequestTimeout = "request_timeout";
 
         /// <summary>
-        /// Service returned HTTP error code 429 which indicated that the request has been throttled.
+        /// Service returned HTTP error code 429 which indicates the request has been throttled.
         /// For more details see https://aka.ms/msal-net-throttling
         /// </summary>
         public const string RequestThrottled = "request_throttled";

--- a/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
@@ -92,10 +92,7 @@ namespace Microsoft.Identity.Client
                 ex = new MsalServiceException(errorCode, errorMessage);
             }
 
-            if (brokerHttpResponse != null)
-            {
-                SetHttpExceptionData(ex, brokerHttpResponse);
-            }
+            SetHttpExceptionData(ex, brokerHttpResponse);
 
             ex.CorrelationId = correlationId;
             ex.SubError = subErrorCode;
@@ -116,7 +113,7 @@ namespace Microsoft.Identity.Client
             return ex;
         }
 
-        internal static MsalThrottledServiceException FromThrottledCLientCredentialResponse(HttpResponse httpResponse)
+        internal static MsalThrottledServiceException FromThrottledAuthenticationResponse(HttpResponse httpResponse)
         {
             MsalServiceException ex = new MsalServiceException(MsalError.RequestThrottled, MsalErrorMessage.AadThrottledError);
             SetHttpExceptionData(ex, httpResponse);

--- a/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.OAuth2.Throttling;
 using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client
@@ -45,11 +46,18 @@ namespace Microsoft.Identity.Client
                     innerException);
             }
 
+            if (httpResponse.HeadersAsDictionary != null && httpResponse.HeadersAsDictionary.ContainsKey(ThrottleCommon.ThrottleRetryAfterHeaderResponseValue))
+            {
+                ex = new MsalServiceException(
+                    errorCode,
+                    MsalErrorMessage.AadThrottledError,
+                    innerException);
+            }
+
             if (ex == null)
             {
                 ex = new MsalServiceException(errorCode, errorMessage, innerException);
             }
-
 
             ex.ResponseBody = httpResponse?.Body;
             ex.StatusCode = httpResponse != null ? (int)httpResponse.StatusCode : 0;

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Identity.Client.OAuth2
                 //Throttled responses for client credential flows do not have a parsable response.
                 if ((int)response.StatusCode == 429)
                 {
-                    return MsalServiceExceptionFactory.FromThrottledCLientCredentialResponse(response);
+                    return MsalServiceExceptionFactory.FromThrottledAuthenticationResponse(response);
                 }
 
                 throw;

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -17,6 +17,7 @@ using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Microsoft.Identity.Json;
 using System.Collections.ObjectModel;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.OAuth2.Throttling;
 
 namespace Microsoft.Identity.Client.OAuth2
 {
@@ -273,6 +274,14 @@ namespace Microsoft.Identity.Client.OAuth2
             if (string.IsNullOrWhiteSpace(response.Body))
             {
                 return null;
+            }
+
+            if (response.HeadersAsDictionary != null && response.HeadersAsDictionary.ContainsKey(ThrottleCommon.ThrottleRetryAfterHeaderResponseValue))
+            {
+                return MsalServiceExceptionFactory.FromHttpResponse(
+                    response.StatusCode.ToString(),
+                    response.Body,
+                    response);
             }
 
             var msalTokenResponse = JsonHelper.DeserializeFromJson<MsalTokenResponse>(response.Body);

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
     {
         public const string ThrottleRetryAfterHeaderName = "x-ms-lib-capability";
         public const string ThrottleRetryAfterHeaderValue = "retry-after, h429";
-        public const string ThrottleRetryAfterHeaderResponseValue = "Retry-After";
 
         internal const string KeyDelimiter = ".";
 

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
     {
         public const string ThrottleRetryAfterHeaderName = "x-ms-lib-capability";
         public const string ThrottleRetryAfterHeaderValue = "retry-after, h429";
+        public const string ThrottleRetryAfterHeaderResponseValue = "Retry-After";
 
         internal const string KeyDelimiter = ".";
 

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -176,6 +176,20 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return handler;
         }
 
+        public static MockHttpMessageHandler AddMockHandlerForThrottledResponseMessage(
+            this MockHttpManager httpManager)
+        {
+            var handler = new MockHttpMessageHandler()
+            {
+                ExpectedMethod = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateTooManyRequestsNonJsonResponse()
+            };
+
+            httpManager.AddMockHandler(handler);
+
+            return handler;
+        }
+
         public static void AddFailingRequest(this MockHttpManager httpManager, Exception exceptionToThrow)
         {
             httpManager.AddMockHandler(

--- a/tests/Microsoft.Identity.Test.Unit/OAuthClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/OAuthClientTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.AreEqual(429, serverEx.StatusCode);
                     Assert.AreEqual(MockHelpers.TooManyRequestsContent, serverEx.ResponseBody);
                     Assert.AreEqual(MockHelpers.TestRetryAfterDuration, serverEx.Headers.RetryAfter.Delta);
-                    Assert.AreEqual(MsalError.NonParsableOAuthError, serverEx.ErrorCode);
+                    Assert.AreEqual(MsalError.RequestThrottled, serverEx.ErrorCode);
                 }).ConfigureAwait(false);
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/Throttling/ThrottlingAcceptanceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/Throttling/ThrottlingAcceptanceTests.cs
@@ -217,13 +217,14 @@ namespace Microsoft.Identity.Test.Unit.Throttling
                 httpManager.AddInstanceDiscoveryMockHandler();
                 var tokenResponse = httpManager.AddMockHandlerForThrottledResponseMessage();
 
-                var ex = await AssertException.TaskThrowsAsync<MsalServiceException>(
+                var serverEx = await AssertException.TaskThrowsAsync<MsalThrottledServiceException>(
                     () => app.AcquireTokenForClient(TestConstants.s_scope).ExecuteAsync())
                     .ConfigureAwait(false);
 
-                Assert.AreEqual(429, ex.StatusCode);
-                Assert.IsTrue(ex.Headers.Contains("Retry-After"));
-                Assert.AreEqual(ex.Message, MsalErrorMessage.AadThrottledError);
+                Assert.AreEqual(serverEx.StatusCode, 429);
+                Assert.AreEqual(serverEx.ErrorCode, MsalError.RequestThrottled);
+                Assert.AreEqual(serverEx.Message, MsalErrorMessage.AadThrottledError);
+                Assert.AreEqual(serverEx.ResponseBody, MockHelpers.TooManyRequestsContent);
             }
         }
         #endregion


### PR DESCRIPTION
Fixes # .
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2855

**Changes proposed in this request**
Adding better message for retry after error for client credential request

**Testing**
Unit test

**Performance impact**
none
