### PR TITLE
Add performance tests for user cache

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -18,23 +18,75 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public static long ValidExpiresIn = 28800;
         public static long ValidExtendedExpiresIn = 57600;
 
-        internal static MsalAccessTokenCacheItem CreateAccessTokenItem(string scopes = "")
+        internal static MsalAccessTokenCacheItem CreateAccessTokenItem(
+                    string scopes = TestConstants.ScopeStr,
+                    string tenant = TestConstants.Utid,
+                    string homeAccountId = TestConstants.HomeAccountId,
+                    bool isExpired = false)
         {
-            string clientInfo = MockHelpers.CreateClientInfo();
-            string homeAccId = ClientInfo.CreateFromJson(clientInfo).ToAccountIdentifier();
-
             MsalAccessTokenCacheItem atItem = new MsalAccessTokenCacheItem(
                TestConstants.ProductionPrefCacheEnvironment,
                TestConstants.ClientId,
-               string.IsNullOrEmpty(scopes) ? TestConstants.s_scope.AsSingleString() : scopes,
-               TestConstants.Utid,
-               "",
-               new DateTimeOffset(DateTime.UtcNow + TimeSpan.FromSeconds(ValidExpiresIn)),
-               new DateTimeOffset(DateTime.UtcNow + TimeSpan.FromSeconds(ValidExtendedExpiresIn)),
+               scopes,
+               tenantId: tenant,
+               secret: string.Empty,
+               accessTokenExpiresOn: isExpired ? new DateTimeOffset(DateTime.UtcNow) : new DateTimeOffset(DateTime.UtcNow + TimeSpan.FromSeconds(ValidExpiresIn)),
+               accessTokenExtendedExpiresOn: isExpired ? new DateTimeOffset(DateTime.UtcNow) : new DateTimeOffset(DateTime.UtcNow + TimeSpan.FromSeconds(ValidExtendedExpiresIn)),
                MockHelpers.CreateClientInfo(),
-               homeAccId);
+               homeAccountId);
 
             return atItem;
+        }
+
+        internal static MsalRefreshTokenCacheItem CreateRefreshTokenItem(
+            string userAssertionHash = TestConstants.UserAssertion,
+            string homeAccountId = TestConstants.HomeAccountId)
+        {
+            return new MsalRefreshTokenCacheItem()
+            {
+                ClientId = TestConstants.ClientId,
+                Environment = TestConstants.ProductionPrefCacheEnvironment,
+                HomeAccountId = homeAccountId,
+                UserAssertionHash = userAssertionHash,
+                Secret = string.Empty
+            };
+        }
+
+        internal static MsalIdTokenCacheItem CreateIdTokenCacheItem(
+            string tenant = TestConstants.Utid,
+            string homeAccountId = TestConstants.HomeAccountId,
+            string uid = TestConstants.Uid)
+        {
+            return new MsalIdTokenCacheItem()
+            {
+                ClientId = TestConstants.ClientId,
+                Environment = TestConstants.ProductionPrefCacheEnvironment,
+                HomeAccountId = homeAccountId,
+                TenantId = tenant,
+                Secret = MockHelpers.CreateIdToken(uid, TestConstants.DisplayableId, tenant)
+            };
+        }
+
+        internal static MsalAccountCacheItem CreateAccountItem(
+            string tenant = TestConstants.Utid,
+            string homeAccountId = TestConstants.HomeAccountId)
+        {
+            return new MsalAccountCacheItem()
+            {
+                Environment = TestConstants.ProductionPrefCacheEnvironment,
+                HomeAccountId = homeAccountId,
+                TenantId = tenant,
+                PreferredUsername = TestConstants.DisplayableId,
+            };
+        }
+
+        internal static MsalAppMetadataCacheItem CreateAppMetadataItem(
+            string clientId = TestConstants.ClientId)
+        {
+            return new MsalAppMetadataCacheItem(
+                clientId,
+                TestConstants.ProductionPrefCacheEnvironment,
+                null);
         }
 
         internal static void PopulateCache(

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForOboCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForOboCacheTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Unit;
+
+namespace Microsoft.Identity.Test.Performance
+{
+    /// <summary>
+    /// Used to test the performance of token cache with large amount of items.
+    /// </summary>
+    /// <remarks>
+    /// For OBO user cache, the partition key is
+    /// AT, RT: user assertion hash.
+    /// IDT, Accounts: home account ID.
+    /// 
+    /// Testing combinations
+    /// Users - Tokens - Total tokens
+    /// 1 - 10,000 - 10,000
+    /// 1 - 100,000 - 100,000
+    /// 100 - 10,000 - 1,000,000
+    /// 1,000 - 1,000 - 1,000,000
+    /// 10,000 - 100 - 1,000,000
+    /// </remarks>
+    [MeanColumn, StdDevColumn, MedianColumn, MinColumn, MaxColumn]
+    public class AcquireTokenForOboCacheTests
+    {
+        readonly string _scopePrefix = "scope";
+        readonly string _tenantPrefix = TestConstants.Utid;
+        ConfidentialClientApplication _cca;
+        string _scope;
+        string _authority;
+        UserAssertion _userAssertion;
+
+        [ParamsSource(nameof(CacheSizeSource), Priority = 0)]
+        public (int Users, int TokensPerUser) CacheSize { get; set; } = (3, 4);
+
+        // By default, benchmarks are run for all combinations of params.
+        // This is a workaround to specify the exact param combinations to be used.
+        public IEnumerable<(int, int)> CacheSizeSource => new[] {
+            (1, 10000),
+            (1, 100000),
+            (100, 10000),
+            (1000, 1000),
+            (10000, 100), };
+
+        // If the tokens are saved with different tenants.
+        // This results in ID tokens and accounts having multiple tenant profiles.
+        [Params(Priority = 1)]
+        public bool IsMultiTenant { get; set; } = true;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _cca = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithRedirectUri(TestConstants.RedirectUri)
+                .WithClientSecret(TestConstants.ClientSecret)
+                .BuildConcrete();
+
+            PopulateUserCache(CacheSize.Users, CacheSize.TokensPerUser);
+        }
+
+        [IterationSetup]
+        public void IterationSetup_AcquireTokenOnBehalfOf()
+        {
+            Random random = new Random();
+            _userAssertion = new UserAssertion($"{TestConstants.DefaultAccessToken}{random.Next(0, CacheSize.Users)}");
+            string id = random.Next(0, CacheSize.TokensPerUser).ToString();
+            _scope = $"{_scopePrefix}{id}";
+            _authority = IsMultiTenant ?
+                $"https://{TestConstants.ProductionPrefNetworkEnvironment}/{_tenantPrefix}{id}" :
+                $"https://{TestConstants.ProductionPrefNetworkEnvironment}/{_tenantPrefix}";
+        }
+
+        [Benchmark]
+        public async Task<AuthenticationResult> AcquireTokenOnBehalfOf_TestAsync()
+        {
+            return await _cca.AcquireTokenOnBehalfOf(new[] { _scope }, _userAssertion)
+                .WithAuthority(_authority)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+        }
+
+        private void PopulateUserCache(int usersNumber, int tokensNumber)
+        {
+            for (int user = 0; user < usersNumber; user++)
+            {
+                for (int token = 0; token < tokensNumber; token++)
+                {
+                    string userAssertionHash = new UserAssertion($"{TestConstants.DefaultAccessToken}{user}").AssertionHash;
+                    string homeAccountId = $"{user}.{TestConstants.Utid}";
+                    string tenant = IsMultiTenant ? $"{_tenantPrefix}{token}" : _tenantPrefix;
+                    string scope = $"{_scopePrefix}{token}";
+
+                    MsalAccessTokenCacheItem atItem = TokenCacheHelper.CreateAccessTokenItem(scope, tenant, homeAccountId);
+                    atItem.UserAssertionHash = userAssertionHash;
+                    _cca.UserTokenCacheInternal.Accessor.SaveAccessToken(atItem);
+
+                    MsalRefreshTokenCacheItem rtItem = TokenCacheHelper.CreateRefreshTokenItem(userAssertionHash, homeAccountId);
+                    _cca.UserTokenCacheInternal.Accessor.SaveRefreshToken(rtItem);
+
+                    MsalIdTokenCacheItem idtItem = TokenCacheHelper.CreateIdTokenCacheItem(tenant, homeAccountId, user.ToString());
+                    _cca.UserTokenCacheInternal.Accessor.SaveIdToken(idtItem);
+
+                    MsalAccountCacheItem accItem = TokenCacheHelper.CreateAccountItem(tenant, homeAccountId);
+                    _cca.UserTokenCacheInternal.Accessor.SaveAccount(accItem);
+                }
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForOboCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForOboCacheTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Test.Performance
         UserAssertion _userAssertion;
 
         [ParamsSource(nameof(CacheSizeSource), Priority = 0)]
-        public (int Users, int TokensPerUser) CacheSize { get; set; };
+        public (int Users, int TokensPerUser) CacheSize { get; set; }
 
         // By default, benchmarks are run for all combinations of params.
         // This is a workaround to specify the exact param combinations to be used.
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Test.Performance
         // If the tokens are saved with different tenants.
         // This results in ID tokens and accounts having multiple tenant profiles.
         [Params(Priority = 1)]
-        public bool IsMultiTenant { get; set; };
+        public bool IsMultiTenant { get; set; }
 
         [GlobalSetup]
         public void GlobalSetup()

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForOboCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForOboCacheTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Test.Performance
         UserAssertion _userAssertion;
 
         [ParamsSource(nameof(CacheSizeSource), Priority = 0)]
-        public (int Users, int TokensPerUser) CacheSize { get; set; } = (3, 4);
+        public (int Users, int TokensPerUser) CacheSize { get; set; };
 
         // By default, benchmarks are run for all combinations of params.
         // This is a workaround to specify the exact param combinations to be used.
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Test.Performance
         // If the tokens are saved with different tenants.
         // This results in ID tokens and accounts having multiple tenant profiles.
         [Params(Priority = 1)]
-        public bool IsMultiTenant { get; set; } = true;
+        public bool IsMultiTenant { get; set; };
 
         [GlobalSetup]
         public void GlobalSetup()

--- a/tests/Microsoft.Identity.Test.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Test.Performance/Program.cs
@@ -13,14 +13,13 @@ namespace Microsoft.Identity.Test.Performance
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<Base64Encode>(
+            BenchmarkRunner.Run<AcquireTokenForOboCacheTests>(
                 DefaultConfig.Instance
                     .WithOptions(ConfigOptions.DontOverwriteResults)
                     .AddDiagnoser(MemoryDiagnoser.Default)
                     .AddJob(
                         Job.Default
                             .WithId("Job-PerfTests")));
-
 
             Console.ReadKey();
         }

--- a/tests/Microsoft.Identity.Test.Performance/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/TokenCacheTests.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Unit;
+
+namespace Microsoft.Identity.Test.Performance
+{
+    /// <summary>
+    /// Used to test the performance of token cache with large amount of items.
+    /// </summary>
+    /// <remarks>
+    /// For non-OBO user cache, the partition key is home account ID.
+    /// 
+    /// Testing combinations
+    /// Partitions - Tokens per partition - Total tokens
+    /// 1 - 10,000 - 10,000
+    /// 1 - 100,000 - 100,000
+    /// 100 - 10,000 - 1,000,000
+    /// 1,000 - 1,000 - 1,000,000
+    /// 10,000 - 100 - 1,000,000
+    /// </remarks>
+    [MeanColumn, StdDevColumn, MedianColumn, MinColumn, MaxColumn]
+    public class TokenCacheTests
+    {
+        readonly string _scopePrefix = "scope";
+        readonly string _tenantPrefix = TestConstants.Utid;
+        ConfidentialClientApplication _cca;
+        string _scope;
+        string _authority;
+        IAccount _account;
+        string _tokenId;
+        string _userId;
+
+        [ParamsSource(nameof(CacheSizeSource), Priority = 0)]
+        public (int Users, int TokensPerUser) CacheSize { get; set; }
+
+        // By default, benchmarks are run for all combinations of params.
+        // This is a workaround to specify the exact param combinations to be used.
+        public IEnumerable<(int, int)> CacheSizeSource => new[] {
+            (1, 10000),
+            (1, 100000),
+            (100, 10000),
+            (1000, 1000),
+            (10000, 100), };
+
+        // If the tokens are saved with different tenants.
+        // This results in ID tokens and accounts having multiple tenant profiles.
+        [ParamsAllValues(Priority = 1)]
+        public bool IsMultiTenant { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _cca = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithRedirectUri(TestConstants.RedirectUri)
+                .WithClientSecret(TestConstants.ClientSecret)
+                .BuildConcrete();
+
+            PopulateUserCache(CacheSize.Users, CacheSize.TokensPerUser);
+        }
+
+        [IterationSetup]
+        public void IterationSetup_AcquireTokenSilent()
+        {
+            Random random = new Random();
+            _userId = random.Next(0, CacheSize.Users).ToString();
+            _account = new Account($"{_userId}.{TestConstants.Utid}", TestConstants.DisplayableId, TestConstants.ProductionPrefCacheEnvironment);
+            _tokenId = random.Next(0, CacheSize.TokensPerUser).ToString();
+            _scope = $"{_scopePrefix}{_tokenId}";
+            _authority = IsMultiTenant ?
+                $"https://{TestConstants.ProductionPrefNetworkEnvironment}/{_tenantPrefix}{_tokenId}" :
+                $"https://{TestConstants.ProductionPrefNetworkEnvironment}/{_tenantPrefix}";
+        }
+
+        [Benchmark]
+        public async Task<AuthenticationResult> AcquireTokenSilent_TestAsync()
+        {
+            return await _cca.AcquireTokenSilent(new string[] { _scope }, _account)
+                .WithAuthority(_authority)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+        }
+
+        [Benchmark]
+        public async Task<IAccount> GetAccountAsync_TestAsync()
+        {
+            return await _cca.GetAccountAsync(_account.HomeAccountId.Identifier)
+                .ConfigureAwait(false);
+        }
+
+        [Benchmark]
+        public async Task<IAccount> GetAccountsAsync_TestAsync()
+        {
+            var result = await _cca.GetAccountsAsync()
+                .ConfigureAwait(false);
+            return result.FirstOrDefault();
+        }
+
+        [Benchmark]
+        public async Task RemoveAccountAsync_TestAsync()
+        {
+            await _cca.RemoveAsync(_account)
+                .ConfigureAwait(false);
+        }
+
+        [IterationCleanup(Target = nameof(RemoveAccountAsync_TestAsync))]
+        public void IterationCleanup_RemoveAccount()
+        {
+            PopulationPartition(_userId, CacheSize.TokensPerUser.ToString());
+        }
+
+        private void PopulateUserCache(int usersNumber, int tokensNumber)
+        {
+            for (int userId = 0; userId < usersNumber; userId++)
+            {
+                for (int tokenId = 0; tokenId < tokensNumber; tokenId++)
+                {
+                    InsertCacheItem(userId.ToString(), tokenId.ToString());
+                }
+            }
+        }
+
+        // Inserts cache items into a partition
+        private void PopulationPartition(string userId, string tokensNumber)
+        {
+            for (int tokenId = 0; tokenId < int.Parse(tokensNumber); tokenId++)
+            {
+                InsertCacheItem(userId.ToString(), tokenId.ToString());
+            }
+        }
+
+        // Inserts a single AT, RT, IDT, Acc cache item
+        private void InsertCacheItem(string userId, string tokenId)
+        {
+            string userAssertionHash = null;
+            string homeAccountId = $"{userId}.{TestConstants.Utid}";
+            string tenant = IsMultiTenant ? $"{_tenantPrefix}{tokenId}" : _tenantPrefix;
+            string scope = $"{_scopePrefix}{tokenId}";
+
+            MsalAccessTokenCacheItem atItem = TokenCacheHelper.CreateAccessTokenItem(scope, tenant, homeAccountId);
+            atItem.UserAssertionHash = userAssertionHash;
+            _cca.UserTokenCacheInternal.Accessor.SaveAccessToken(atItem);
+
+            MsalRefreshTokenCacheItem rtItem = TokenCacheHelper.CreateRefreshTokenItem(userAssertionHash, homeAccountId);
+            _cca.UserTokenCacheInternal.Accessor.SaveRefreshToken(rtItem);
+
+            MsalIdTokenCacheItem idtItem = TokenCacheHelper.CreateIdTokenCacheItem(tenant, homeAccountId, userId);
+            _cca.UserTokenCacheInternal.Accessor.SaveIdToken(idtItem);
+
+            MsalAccountCacheItem accItem = TokenCacheHelper.CreateAccountItem(tenant, homeAccountId);
+            _cca.UserTokenCacheInternal.Accessor.SaveAccount(accItem);
+        }
+    }
+}


### PR DESCRIPTION
Fixes # .

**Changes proposed in this request**
Related to #2881, which also has the test results.. Just adding perf tests as a separate PR.
Tests for `AcquireTokenForOBO`, `GetAccount`, `GetAccounts`, `AcquireTokenSilent`, `RemoveAccount`. Also adds some helper methods.

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->
