### PR TITLE
Refactored WwwAuthenticateParameters

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/HttpClientConfig.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpClientConfig.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Client.Http
     internal static class HttpClientConfig
     {
         public const long MaxResponseContentBufferSizeInBytes = 1024 * 1024;
-        public const int MaxConnections = 50; // default depends on rutnime but it is much smaller
+        public const int MaxConnections = 50; // default depends on runtime but it is much smaller
         public static readonly TimeSpan ConnectionLifeTime = TimeSpan.FromMinutes(1);
 
         public static void ConfigureRequestHeadersAndSize(HttpClient httpClient)

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -163,11 +163,13 @@ namespace Microsoft.Identity.Client
                 scheme);
 
             // read the header and checks if it contains an error with insufficient_claims value.
-            if (string.Equals(parameters.Error, "insufficient_claims", StringComparison.OrdinalIgnoreCase &&
+            if (string.Equals(parameters.Error, "insufficient_claims", StringComparison.OrdinalIgnoreCase) &&
                 parameters.Claims is object)
             {
                 return parameters.Claims;
             }
+
+            return null;
         }
 
         internal static WwwAuthenticateParameters CreateWwwAuthenticateParameters(IDictionary<string, string> values)

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -141,8 +141,7 @@ namespace Microsoft.Identity.Client
         {
             // call this endpoint and see what the header says and return that
             HttpClient httpClient = new HttpClient();
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, resourceUri);
-            HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
+            HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(resourceUri, cancellationToken).ConfigureAwait(false);
             var wwwAuthParam = CreateFromResponseHeaders(httpResponseMessage.Headers);
             return wwwAuthParam;
         }

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -213,8 +213,10 @@ namespace Microsoft.Identity.Client
 
         internal static WwwAuthenticateParameters CreateWwwAuthenticateParameters(IDictionary<string, string> values)
         {
-            WwwAuthenticateParameters wwwAuthenticateParameters = new WwwAuthenticateParameters();
-            wwwAuthenticateParameters.RawParameters = values;
+            WwwAuthenticateParameters wwwAuthenticateParameters = new WwwAuthenticateParameters
+            {
+                RawParameters = values
+            };
 
             string value;
             if (values.TryGetValue("authorization_uri", out value))

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client.PlatformsCommon.Factories;
 
 namespace Microsoft.Identity.Client
 {
@@ -139,8 +140,8 @@ namespace Microsoft.Identity.Client
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
         public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri, CancellationToken cancellationToken = default)
         {
-            var httpClient = new HttpClient();
-            return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
+            var httpClientFactory = PlatformProxyFactory.CreatePlatformProxy(null).CreateDefaultHttpClientFactory();
+            return CreateFromResourceResponseAsync(httpClientFactory, resourceUri, cancellationToken);
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -134,6 +134,18 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
         /// </summary>
+        /// <param name="resourceUri">URI of the resource.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
+        public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri, CancellationToken cancellationToken = default)
+        {
+            var httpClient = new HttpClient();
+            return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
+        }
+
+        /// <summary>
+        /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
+        /// </summary>
         /// <param name="httpClientFactory">Factory to produce an instance of <see cref="HttpClient"/> to make the request with.</param>
         /// <param name="resourceUri">URI of the resource.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -134,13 +134,26 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
         /// </summary>
+        /// <param name="httpClientFactory">Factory to produce an instance of <see cref="HttpClient"/> to make the request with.</param>
         /// <param name="resourceUri">URI of the resource.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
-        public static async Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri, CancellationToken cancellationToken = default)
+        public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(IMsalHttpClientFactory httpClientFactory, string resourceUri, CancellationToken cancellationToken = default)
+        {
+            var httpClient = httpClientFactory.GetHttpClient();
+            return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
+        }
+
+        /// <summary>
+        /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
+        /// </summary>
+        /// <param name="httpClient">Instance of <see cref="HttpClient"/> to make the request with.</param>
+        /// <param name="resourceUri">URI of the resource.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
+        public static async Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(HttpClient httpClient, string resourceUri, CancellationToken cancellationToken = default)
         {
             // call this endpoint and see what the header says and return that
-            HttpClient httpClient = new HttpClient();
             HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(resourceUri, cancellationToken).ConfigureAwait(false);
             var wwwAuthParam = CreateFromResponseHeaders(httpResponseMessage.Headers);
             return wwwAuthParam;

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -153,6 +153,11 @@ namespace Microsoft.Identity.Client
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
         public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(IMsalHttpClientFactory httpClientFactory, string resourceUri, CancellationToken cancellationToken = default)
         {
+            if (httpClientFactory is null)
+            {
+                throw new ArgumentException($"'{nameof(httpClientFactory)}' cannot be null.", nameof(httpClientFactory));
+            }
+
             var httpClient = httpClientFactory.GetHttpClient();
             return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
         }
@@ -166,6 +171,15 @@ namespace Microsoft.Identity.Client
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
         public static async Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(HttpClient httpClient, string resourceUri, CancellationToken cancellationToken = default)
         {
+            if (httpClient is null)
+            {
+                throw new ArgumentException($"'{nameof(httpClient)}' cannot be null.", nameof(httpClient));
+            }
+            if (string.IsNullOrWhiteSpace(resourceUri))
+            {
+                throw new ArgumentException($"'{nameof(resourceUri)}' cannot be null or whitespace.", nameof(resourceUri));
+            }
+
             // call this endpoint and see what the header says and return that
             HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(resourceUri, cancellationToken).ConfigureAwait(false);
             var wwwAuthParam = CreateFromResponseHeaders(httpResponseMessage.Headers);

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -26,7 +25,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public IList<string> UnexpectedRequestHeaders { get; set; }
 
         public HttpMethod ExpectedMethod { get; set; }
-        
+
         public Exception ExceptionToThrow { get; set; }
         public Action<HttpRequestMessage> AdditionalRequestValidation { get; set; }
 
@@ -51,11 +50,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             {
                 Assert.AreEqual(
                     ExpectedUrl,
-                    uri.AbsoluteUri.Split(
-                        new[]
-                        {
-                            '?'
-                        })[0]);
+                    uri.AbsoluteUri.Split('?')[0]);
             }
 
             Assert.AreEqual(ExpectedMethod, request.Method);
@@ -67,7 +62,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                     string.IsNullOrEmpty(uri.Query),
                     string.Format(
                         CultureInfo.InvariantCulture,
-                        "provided url ({0}) does not contain query parameters, as expected",
+                        "Provided url ({0}) does not contain query parameters, as expected",
                         uri.AbsolutePath));
                 IDictionary<string, string> inputQp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', false, null);
                 Assert.AreEqual(ExpectedQueryParams.Count, inputQp.Count, "Different number of query params`");
@@ -77,7 +72,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                         inputQp.ContainsKey(key),
                         string.Format(
                             CultureInfo.InvariantCulture,
-                            "expected QP ({0}) not found in the url ({1})",
+                            "Expected query parameter ({0}) not found in the url ({1})",
                             key,
                             uri.AbsolutePath));
                     Assert.AreEqual(ExpectedQueryParams[key], inputQp[key]);
@@ -104,8 +99,8 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                         Assert.AreEqual(ExpectedPostData[key], ActualRequestPostData[key]);
                     }
                 }
-            }       
-            
+            }
+
             if (ExpectedRequestHeaders != null )
             {
                 foreach (var kvp in ExpectedRequestHeaders)
@@ -131,14 +126,6 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             AdditionalRequestValidation?.Invoke(request);
 
             return new TaskFactory().StartNew(() => ResponseMessage, cancellationToken);
-        }
-
-        private string ReturnValueFromRequestHeader(string telemRequest)
-        {
-            IEnumerable<string> telemRequestValue = ActualRequestMessage.Headers.GetValues(telemRequest);
-            List<string> telemRequestValueAsList = telemRequestValue.ToList();
-            string value = telemRequestValueAsList[0];
-            return value;
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -38,17 +38,26 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
             Assert.IsNull(authParams.Error);
         }
 
+        /// <summary>
+        /// Makes unauthorized call to Azure Resource Manager REST API https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/get.
+        /// Expects response 401 Unauthorized. Analyzes the WWW-Authenticate header values.
+        /// </summary>
+        /// <param name="hostName">ARM endpoint, e.g. Production or Dogfood</param>
+        /// <param name="subscriptionId">Well-known subscription ID</param>
+        /// <param name="authority">AAD endpoint, e.g. Production or PPE</param>
+        /// <param name="tenantId">Expected Tenant ID</param>
         [DataRow("management.azure.com", "c1686c51-b717-4fe0-9af3-24a20a41fb0c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
         [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
         [DataTestMethod]
         public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
         {
-            const string apiVersion = "2020-08-01";
+            const string apiVersion = "2020-08-01"; // current latest API version for /subscriptions/get
             var url = $"https://{hostName}/subscriptions/{subscriptionId}?api-version={apiVersion}";
+
             var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(url).ConfigureAwait(false);
 
             Assert.IsNull(authParams.Resource);
-            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority);
+            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority); // authority consists of AAD endpoint and tenant ID
             Assert.IsNull(authParams.Scopes);
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -37,5 +37,22 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
         }
+
+        [DataRow("management.azure.com", "a645d3be-5a4a-40ef-82a1-d5f5358a424c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
+        [DataRow("api-dogfood.resources.windows-int.net", "5d04a672-05ce-492b-958f-d225b6a67926", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
+        [DataTestMethod]
+        public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
+        {
+            const string apiVersion = "2020-08-01";
+            var url = $"https://{hostName}/subscriptions/{subscriptionId}?api-version={apiVersion}";
+            var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(url).ConfigureAwait(false);
+
+            Assert.IsNull(authParams.Resource);
+            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority);
+            Assert.IsNull(authParams.Scopes);
+            Assert.AreEqual(3, authParams.RawParameters.Count);
+            Assert.IsNull(authParams.Claims);
+            Assert.AreEqual("invalid_token", authParams.Error);
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
         /// <param name="subscriptionId">Well-known subscription ID</param>
         /// <param name="authority">AAD endpoint, e.g. Production or PPE</param>
         /// <param name="tenantId">Expected Tenant ID</param>
+        [TestMethod]
         [DataRow("management.azure.com", "c1686c51-b717-4fe0-9af3-24a20a41fb0c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
         [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
-        [DataTestMethod]
         public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
         {
             const string apiVersion = "2020-08-01"; // current latest API version for /subscriptions/get

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
             Assert.IsNull(authParams.Error);
         }
 
-        [DataRow("management.azure.com", "a645d3be-5a4a-40ef-82a1-d5f5358a424c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
-        [DataRow("api-dogfood.resources.windows-int.net", "5d04a672-05ce-492b-958f-d225b6a67926", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
+        [DataRow("management.azure.com", "c1686c51-b717-4fe0-9af3-24a20a41fb0c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
+        [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
         [DataTestMethod]
         public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
         {

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworkNetDesktop461>net472</TargetFrameworkNetDesktop461>
     <TargetFrameworkNetCore>netcoreapp3.1</TargetFrameworkNetCore>
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
-      
+
     <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetCore);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Microsoft.Identity.Test.Unit/TestBase.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Test.Unit
             Trace.WriteLine("Test run started");
         }
 
-        [AssemblyCleanup()]
+        [AssemblyCleanup]
         public static void AssemblyCleanup()
         {
             Trace.WriteLine("Test run finished");
@@ -60,7 +60,6 @@ namespace Microsoft.Identity.Test.Unit
                 isExtendedTokenLifetimeEnabled,
                 testContext: TestContext);
         }
-
 
         private static void EnableFileTracingOnEnvVar()
         {

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Test.Unit
 
             Func<Task> action = () => WwwAuthenticateParameters.CreateFromResourceResponseAsync(httpClientFactory, resourceUri);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(action).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(action).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -186,7 +186,7 @@ namespace Microsoft.Identity.Test.Unit
 
             Func<Task> action = () => WwwAuthenticateParameters.CreateFromResourceResponseAsync(httpClient, resourceUri);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(action).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(action).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Test.Unit
         {
             Func<Task> action = () => WwwAuthenticateParameters.CreateFromResourceResponseAsync(resourceUri);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(action).ConfigureAwait(false);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(action).ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -5,8 +5,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
 
 namespace Microsoft.Identity.Test.Unit
 {
@@ -138,6 +141,27 @@ namespace Microsoft.Identity.Test.Unit
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
+        }
+
+        [TestMethod]
+        public async Task CreateFromResourceResponseAsync_HttpClientFactoryAsync()
+        {
+            const string resourceUri = "https://example.com/";
+
+            var handler = new MockHttpMessageHandler
+            {
+                ExpectedMethod = HttpMethod.Get,
+                ExpectedUrl = resourceUri,
+                ResponseMessage = new HttpResponseMessage()
+            };
+            var httpClient = new HttpClient(handler);
+
+            var httpClientFactory = Substitute.For<IMsalHttpClientFactory>();
+            httpClientFactory.GetHttpClient().Returns(httpClient);
+
+            var _ = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(httpClientFactory, resourceUri).ConfigureAwait(false);
+
+            httpClientFactory.Received().GetHttpClient();
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -1,33 +1,33 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Identity.Client;
-using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit
 {
     [TestClass]
     public class WwwAuthenticateParametersTests
     {
-        const string ClientIdKey = "client_id";
-        const string ResourceIdKey = "resource_id";
-        const string ResourceKey = "resource";
-        const string GraphGuid = "00000003-0000-0000-c000-000000000000";
-        const string AuthorizationUriKey = "authorization_uri";
-        const string AuthorizationKey = "authorization";
-        const string AuthorityKey = "authority";
-        const string AuthorizationValue = "https://login.microsoftonline.com/common/oauth2/authorize";
-        const string Realm = "realm";
-        const string EncodedClaims = "eyJpZF90b2tlbiI6eyJhdXRoX3RpbWUiOnsiZXNzZW50aWFsIjp0cnVlfSwiYWNyIjp7InZhbHVlcyI6WyJ1cm46bWFjZTppbmNvbW1vbjppYXA6c2lsdmVyIl19fX0=";
-        const string DecodedClaims = "{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}";
-        const string DecodedClaimsHeader = "{\\\"id_token\\\":{\\\"auth_time\\\":{\\\"essential\\\":true},\\\"acr\\\":{\\\"values\\\":[\\\"urn:mace:incommon:iap:silver\\\"]}}}";
-        const string SomeClaims = "some_claims";
-        const string ClaimsKey = "claims";
-        const string ErrorKey = "error";
+        private const string ClientIdKey = "client_id";
+        private const string ResourceIdKey = "resource_id";
+        private const string ResourceKey = "resource";
+        private const string GraphGuid = "00000003-0000-0000-c000-000000000000";
+        private const string AuthorizationUriKey = "authorization_uri";
+        private const string AuthorizationKey = "authorization";
+        private const string AuthorityKey = "authority";
+        private const string AuthorizationValue = "https://login.microsoftonline.com/common/oauth2/authorize";
+        private const string Realm = "realm";
+        private const string EncodedClaims = "eyJpZF90b2tlbiI6eyJhdXRoX3RpbWUiOnsiZXNzZW50aWFsIjp0cnVlfSwiYWNyIjp7InZhbHVlcyI6WyJ1cm46bWFjZTppbmNvbW1vbjppYXA6c2lsdmVyIl19fX0=";
+        private const string DecodedClaims = "{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}";
+        private const string DecodedClaimsHeader = "{\\\"id_token\\\":{\\\"auth_time\\\":{\\\"essential\\\":true},\\\"acr\\\":{\\\"values\\\":[\\\"urn:mace:incommon:iap:silver\\\"]}}}";
+        private const string SomeClaims = "some_claims";
+        private const string ClaimsKey = "claims";
+        private const string ErrorKey = "error";
 
         [TestMethod]
         [DataRow("client_id=00000003-0000-0000-c000-000000000000", "authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\"")]
@@ -39,9 +39,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateResponse(string resource, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {resource}, {authorizationUri}");
 
             // Act
@@ -99,7 +97,7 @@ namespace Microsoft.Identity.Test.Unit
             var authParams = WwwAuthenticateParameters.CreateFromResponseHeaders(httpResponse.Headers);
 
             // Assert
-            string errorValue = "insufficient_claims";
+            const string errorValue = "insufficient_claims";
             Assert.IsTrue(authParams.RawParameters.TryGetValue(AuthorizationUriKey, out string authorizationUri));
             Assert.AreEqual(AuthorizationValue, authorizationUri);
             Assert.AreEqual(AuthorizationValue, authParams[AuthorizationUriKey]);
@@ -125,20 +123,18 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateParamsFromWwwAuthenticateHeader(string clientId, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {clientId}, {authorizationUri}");
 
-            var wwwAuthenticateResponse = httpResponse.Headers.WwwAuthenticate.FirstOrDefault().Parameter;
+            var wwwAuthenticateResponse = httpResponse.Headers.WwwAuthenticate.First().Parameter;
 
             // Act
             var authParams = WwwAuthenticateParameters.CreateFromWwwAuthenticateHeaderValue(wwwAuthenticateResponse);
-            
+
             // Assert
             Assert.AreEqual(GraphGuid, authParams.Resource);
             Assert.AreEqual(TestConstants.AuthorityCommonTenant.TrimEnd('/'), authParams.Authority);
-            Assert.AreEqual($"{GraphGuid}/.default", authParams.Scopes.FirstOrDefault());
+            Assert.AreEqual($"{GraphGuid}/.default", authParams.Scopes.First());
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
@@ -183,26 +179,20 @@ namespace Microsoft.Identity.Test.Unit
         private static HttpResponseMessage CreateClaimsHttpResponse(string claims)
         {
             HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
-            {
-            };
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", client_id=\"00000003-0000-0000-c000-000000000000\", authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\", error=\"insufficient_claims\", claims=\"{claims}\"");
             return httpResponse;
         }
 
         private static HttpResponseMessage CreateErrorHttpResponse()
         {
-            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", client_id=\"00000003-0000-0000-c000-000000000000\", authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\", error=\"some_error\", claims=\"{DecodedClaimsHeader}\"");
             return httpResponse;
         }
 
         private static HttpResponseMessage CreateHttpResponseHeaders(string resourceHeaderKey, string authorizationUriHeaderKey)
         {
-            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {resourceHeaderKey}=\"{GraphGuid}\", {authorizationUriHeaderKey}=\"{AuthorizationValue}\"");
             return httpResponse;
         }

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Identity.Test.Unit
             var httpClientFactory = Substitute.For<IMsalHttpClientFactory>();
             httpClientFactory.GetHttpClient().Returns(httpClient);
 
-            var _ = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(httpClientFactory, resourceUri).ConfigureAwait(false);
+            _ = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(httpClientFactory, resourceUri).ConfigureAwait(false);
 
             httpClientFactory.Received().GetHttpClient();
         }

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateResponse(string resource, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {resource}, {authorizationUri}");
 
             // Act
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateParamsFromWwwAuthenticateHeader(string clientId, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {clientId}, {authorizationUri}");
 
             var wwwAuthenticateResponse = httpResponse.Headers.WwwAuthenticate.First().Parameter;


### PR DESCRIPTION
**Changes proposed in this request**

- Added optional `cancellationToken` to `CreateFromResourceResponseAsync()`
- Used `is null`, `is object` for null checks
- Used `string.Equals()` with `StringComparison.OrdinalIgnoreCase` for string comparison
- Removed no-op `try/catch` that does nothing but erases the exception stack trace

**Testing**

- Refactored unit tests
- Added integration test to call [ARM](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/get)

**Performance impact**

Will slightly improve the performance of the helper methods.