### PR TITLE
Added Tenant ID to WwwAuthenticateParameters

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/HttpClientConfig.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpClientConfig.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Identity.Client.Http
     internal static class HttpClientConfig
     {
         public const long MaxResponseContentBufferSizeInBytes = 1024 * 1024;
-        public const int MaxConnections = 50; // default depends on rutnime but it is much smaller
+        public const int MaxConnections = 50; // default depends on runtime but it is much smaller
         public static readonly TimeSpan ConnectionLifeTime = TimeSpan.FromMinutes(1);
 
         public static void ConfigureRequestHeadersAndSize(HttpClient httpClient)

--- a/src/client/Microsoft.Identity.Client/Instance/Authority.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Authority.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Client.Internal;
 
 namespace Microsoft.Identity.Client.Instance
@@ -18,7 +17,7 @@ namespace Microsoft.Identity.Client.Instance
     {
         protected Authority(AuthorityInfo authorityInfo)
         {
-            if (authorityInfo == null)
+            if (authorityInfo is null)
             {
                 throw new ArgumentNullException(nameof(authorityInfo));
             }
@@ -43,9 +42,9 @@ namespace Microsoft.Identity.Client.Instance
         /// 2. If there is a request authority, try to use it.
         ///     2.1. If the request authority is not "common", then use it
         ///     2.2  If the request authority is "common", ignore it, and use 1.1
-        ///     
-        /// Special cases: 
-        /// 
+        ///
+        /// Special cases:
+        ///
         /// - if the authority is not defined at the application level and the request level is not AAD, use the request authority
         /// - if the authority is defined at app level, and the request level authority of is of different type, throw an exception
         ///
@@ -56,7 +55,7 @@ namespace Microsoft.Identity.Client.Instance
             string requestHomeAccountTenantId = null)
         {
             var configAuthorityInfo = requestContext.ServiceBundle.Config.AuthorityInfo;
-            if (configAuthorityInfo == null)
+            if (configAuthorityInfo is null)
             {
                 throw new ArgumentNullException(nameof(configAuthorityInfo));
             }
@@ -68,21 +67,22 @@ namespace Microsoft.Identity.Client.Instance
             {
                 // ADFS and B2C are tenant-less, no need to consider tenant
                 case AuthorityType.Adfs:
-                    return requestAuthorityInfo == null ?
-                        new AdfsAuthority(configAuthorityInfo) :
-                        new AdfsAuthority(requestAuthorityInfo);
-
+                {
+                    return requestAuthorityInfo is null ?
+                               new AdfsAuthority(configAuthorityInfo) :
+                               new AdfsAuthority(requestAuthorityInfo);
+                }
                 case AuthorityType.B2C:
-
-                    if (requestAuthorityInfo != null)
+                {
+                    if (requestAuthorityInfo is object)
                     {
                         return new B2CAuthority(requestAuthorityInfo);
                     }
                     return new B2CAuthority(configAuthorityInfo);
-
+                }
                 case AuthorityType.Aad:
-
-                    if (requestAuthorityInfo == null)
+                {
+                    if (requestAuthorityInfo is null)
                     {
                         return CreateAuthorityWithTenant(configAuthorityInfo, requestHomeAccountTenantId);
                     }
@@ -101,18 +101,20 @@ namespace Microsoft.Identity.Client.Instance
                     }
 
                     return CreateAuthorityWithTenant(configAuthorityInfo, requestHomeAccountTenantId);
-
+                }
                 default:
+                {
                     throw new MsalClientException(
                         MsalError.InvalidAuthorityType,
                         "Unsupported authority type");
+                }
             }
         }
 
         private static void ValidateTypeMismatch(AuthorityInfo configAuthorityInfo, AuthorityInfo requestAuthorityInfo)
         {
             if (!configAuthorityInfo.IsDefaultAuthority &&
-                            requestAuthorityInfo != null &&
+                            requestAuthorityInfo is object &&
                             configAuthorityInfo.AuthorityType != requestAuthorityInfo.AuthorityType)
             {
                 throw new MsalClientException(
@@ -122,6 +124,7 @@ namespace Microsoft.Identity.Client.Instance
                         requestAuthorityInfo.AuthorityType));
             }
         }
+
         public static Authority CreateAuthority(string authority, bool validateAuthority = false)
         {
             return CreateAuthority(AuthorityInfo.FromAuthorityUri(authority, validateAuthority));
@@ -132,18 +135,23 @@ namespace Microsoft.Identity.Client.Instance
             switch (authorityInfo.AuthorityType)
             {
                 case AuthorityType.Adfs:
+                {
                     return new AdfsAuthority(authorityInfo);
-
+                }
                 case AuthorityType.B2C:
+                {
                     return new B2CAuthority(authorityInfo);
-
+                }
                 case AuthorityType.Aad:
+                {
                     return new AadAuthority(authorityInfo);
-
+                }
                 default:
+                {
                     throw new MsalClientException(
                         MsalError.InvalidAuthorityType,
-                        "Unsupported authority type " + authorityInfo.AuthorityType);
+                        $"Unsupported authority type {authorityInfo.AuthorityType}");
+                }
             }
         }
 
@@ -183,7 +191,9 @@ namespace Microsoft.Identity.Client.Instance
         internal abstract string GetTenantedAuthority(string tenantId, bool forceTenantless = false);
 
         internal abstract string GetTokenEndpoint();
+
         internal abstract string GetAuthorizationEndpoint();
+
         internal abstract string GetDeviceCodeEndpoint();
         #endregion
 
@@ -191,13 +201,14 @@ namespace Microsoft.Identity.Client.Instance
         {
             var configAuthorityInfo = requestContext.ServiceBundle.Config.AuthorityInfo;
 
-            if (requestAuthorityInfo != null &&
+            if (requestAuthorityInfo is object &&
                 !string.Equals(requestAuthorityInfo.Host, configAuthorityInfo.Host, StringComparison.OrdinalIgnoreCase))
             {
                 if (requestAuthorityInfo.AuthorityType == AuthorityType.B2C)
                 {
                     throw new MsalClientException(MsalError.B2CAuthorityHostMismatch, MsalErrorMessage.B2CAuthorityHostMisMatch);
                 }
+
                 var authorityAliased = await IsAuthorityAliasedAsync(requestContext, requestAuthorityInfo).ConfigureAwait(false);
                 if (authorityAliased)
                 {
@@ -215,7 +226,7 @@ namespace Microsoft.Identity.Client.Instance
                 }
 
                 throw new MsalClientException(
-                    MsalError.AuthorityHostMismatch,                    
+                    MsalError.AuthorityHostMismatch,
                     $"\n\r The application is configured for cloud {configAuthorityInfo.Host} and the request for a different cloud - {requestAuthorityInfo.Host}. This is not supported - the app and the request must target the same cloud. " +
                     $"\n\rSee https://aka.ms/msal-net-authority-override for details");
             }
@@ -233,8 +244,5 @@ namespace Microsoft.Identity.Client.Instance
         {
             return new Uri(authority).Host;
         }
-
-
-    
     }
 }

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -163,11 +163,13 @@ namespace Microsoft.Identity.Client
                 scheme);
 
             // read the header and checks if it contains an error with insufficient_claims value.
-            if (string.Equals(parameters.Error, "insufficient_claims", StringComparison.OrdinalIgnoreCase &&
+            if (string.Equals(parameters.Error, "insufficient_claims", StringComparison.OrdinalIgnoreCase) &&
                 parameters.Claims is object)
             {
                 return parameters.Claims;
             }
+
+            return null;
         }
 
         internal static WwwAuthenticateParameters CreateWwwAuthenticateParameters(IDictionary<string, string> values)

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -141,8 +141,7 @@ namespace Microsoft.Identity.Client
         {
             // call this endpoint and see what the header says and return that
             HttpClient httpClient = new HttpClient();
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, resourceUri);
-            HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
+            HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(resourceUri, cancellationToken).ConfigureAwait(false);
             var wwwAuthParam = CreateFromResponseHeaders(httpResponseMessage.Headers);
             return wwwAuthParam;
         }

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -213,8 +213,10 @@ namespace Microsoft.Identity.Client
 
         internal static WwwAuthenticateParameters CreateWwwAuthenticateParameters(IDictionary<string, string> values)
         {
-            WwwAuthenticateParameters wwwAuthenticateParameters = new WwwAuthenticateParameters();
-            wwwAuthenticateParameters.RawParameters = values;
+            WwwAuthenticateParameters wwwAuthenticateParameters = new WwwAuthenticateParameters
+            {
+                RawParameters = values
+            };
 
             string value;
             if (values.TryGetValue("authorization_uri", out value))

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client.PlatformsCommon.Factories;
 
 namespace Microsoft.Identity.Client
 {
@@ -139,8 +140,8 @@ namespace Microsoft.Identity.Client
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
         public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri, CancellationToken cancellationToken = default)
         {
-            var httpClient = new HttpClient();
-            return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
+            var httpClientFactory = PlatformProxyFactory.CreatePlatformProxy(null).CreateDefaultHttpClientFactory();
+            return CreateFromResourceResponseAsync(httpClientFactory, resourceUri, cancellationToken);
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -134,6 +134,18 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
         /// </summary>
+        /// <param name="resourceUri">URI of the resource.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
+        public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri, CancellationToken cancellationToken = default)
+        {
+            var httpClient = new HttpClient();
+            return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
+        }
+
+        /// <summary>
+        /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
+        /// </summary>
         /// <param name="httpClientFactory">Factory to produce an instance of <see cref="HttpClient"/> to make the request with.</param>
         /// <param name="resourceUri">URI of the resource.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -134,13 +134,26 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
         /// </summary>
+        /// <param name="httpClientFactory">Factory to produce an instance of <see cref="HttpClient"/> to make the request with.</param>
         /// <param name="resourceUri">URI of the resource.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
-        public static async Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(string resourceUri, CancellationToken cancellationToken = default)
+        public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(IMsalHttpClientFactory httpClientFactory, string resourceUri, CancellationToken cancellationToken = default)
+        {
+            var httpClient = httpClientFactory.GetHttpClient();
+            return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
+        }
+
+        /// <summary>
+        /// Create the authenticate parameters by attempting to call the resource unauthenticated, and analyzing the response.
+        /// </summary>
+        /// <param name="httpClient">Instance of <see cref="HttpClient"/> to make the request with.</param>
+        /// <param name="resourceUri">URI of the resource.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
+        public static async Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(HttpClient httpClient, string resourceUri, CancellationToken cancellationToken = default)
         {
             // call this endpoint and see what the header says and return that
-            HttpClient httpClient = new HttpClient();
             HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(resourceUri, cancellationToken).ConfigureAwait(false);
             var wwwAuthParam = CreateFromResponseHeaders(httpResponseMessage.Headers);
             return wwwAuthParam;

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -153,6 +153,11 @@ namespace Microsoft.Identity.Client
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
         public static Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(IMsalHttpClientFactory httpClientFactory, string resourceUri, CancellationToken cancellationToken = default)
         {
+            if (httpClientFactory is null)
+            {
+                throw new ArgumentException($"'{nameof(httpClientFactory)}' cannot be null.", nameof(httpClientFactory));
+            }
+
             var httpClient = httpClientFactory.GetHttpClient();
             return CreateFromResourceResponseAsync(httpClient, resourceUri, cancellationToken);
         }
@@ -166,6 +171,15 @@ namespace Microsoft.Identity.Client
         /// <returns>WWW-Authenticate Parameters extracted from response to the un-authenticated call.</returns>
         public static async Task<WwwAuthenticateParameters> CreateFromResourceResponseAsync(HttpClient httpClient, string resourceUri, CancellationToken cancellationToken = default)
         {
+            if (httpClient is null)
+            {
+                throw new ArgumentException($"'{nameof(httpClient)}' cannot be null.", nameof(httpClient));
+            }
+            if (string.IsNullOrWhiteSpace(resourceUri))
+            {
+                throw new ArgumentException($"'{nameof(resourceUri)}' cannot be null or whitespace.", nameof(resourceUri));
+            }
+
             // call this endpoint and see what the header says and return that
             HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(resourceUri, cancellationToken).ConfigureAwait(false);
             var wwwAuthParam = CreateFromResponseHeaders(httpResponseMessage.Headers);

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -59,6 +59,13 @@ namespace Microsoft.Identity.Client
         /// Authority from which to request an access token.
         /// </summary>
         public string Authority { get; set; }
+
+        /// <summary>
+        /// AAD tenant ID to which the Azure subscription belongs to.
+        /// </summary>
+        public string TenantId => Instance.Authority
+                                          .CreateAuthority(Authority, validateAuthority: true)
+                                          .TenantId;
 
         /// <summary>
         /// Claims demanded by the web API.

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpMessageHandler.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -26,7 +25,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         public IList<string> UnexpectedRequestHeaders { get; set; }
 
         public HttpMethod ExpectedMethod { get; set; }
-        
+
         public Exception ExceptionToThrow { get; set; }
         public Action<HttpRequestMessage> AdditionalRequestValidation { get; set; }
 
@@ -51,11 +50,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             {
                 Assert.AreEqual(
                     ExpectedUrl,
-                    uri.AbsoluteUri.Split(
-                        new[]
-                        {
-                            '?'
-                        })[0]);
+                    uri.AbsoluteUri.Split('?')[0]);
             }
 
             Assert.AreEqual(ExpectedMethod, request.Method);
@@ -67,7 +62,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                     string.IsNullOrEmpty(uri.Query),
                     string.Format(
                         CultureInfo.InvariantCulture,
-                        "provided url ({0}) does not contain query parameters, as expected",
+                        "Provided url ({0}) does not contain query parameters, as expected",
                         uri.AbsolutePath));
                 IDictionary<string, string> inputQp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', false, null);
                 Assert.AreEqual(ExpectedQueryParams.Count, inputQp.Count, "Different number of query params`");
@@ -77,7 +72,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                         inputQp.ContainsKey(key),
                         string.Format(
                             CultureInfo.InvariantCulture,
-                            "expected QP ({0}) not found in the url ({1})",
+                            "Expected query parameter ({0}) not found in the url ({1})",
                             key,
                             uri.AbsolutePath));
                     Assert.AreEqual(ExpectedQueryParams[key], inputQp[key]);
@@ -104,8 +99,8 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                         Assert.AreEqual(ExpectedPostData[key], ActualRequestPostData[key]);
                     }
                 }
-            }       
-            
+            }
+
             if (ExpectedRequestHeaders != null )
             {
                 foreach (var kvp in ExpectedRequestHeaders)
@@ -131,14 +126,6 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             AdditionalRequestValidation?.Invoke(request);
 
             return new TaskFactory().StartNew(() => ResponseMessage, cancellationToken);
-        }
-
-        private string ReturnValueFromRequestHeader(string telemRequest)
-        {
-            IEnumerable<string> telemRequestValue = ActualRequestMessage.Headers.GetValues(telemRequest);
-            List<string> telemRequestValueAsList = telemRequestValue.ToList();
-            string value = telemRequestValueAsList[0];
-            return value;
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -16,16 +16,15 @@ namespace Microsoft.Identity.Test.Unit
 {
     internal static class TestConstants
     {
-
         public static HashSet<string> s_scope
         {
             get
             {
-                return new HashSet<string>(new[] { "r1/scope1", "r1/scope2" });
+                return new HashSet<string>(new[] { "r1/scope1", "r1/scope2" }, StringComparer.OrdinalIgnoreCase);
             }
         }
 
-        public static Dictionary<string, string> ExtraHttpHeader = new Dictionary<string, string>() { { "SomeExtraHeadderKey", "SomeExtraHeadderValue" } };
+        public static readonly Dictionary<string, string> ExtraHttpHeader = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "SomeExtraHeadderKey", "SomeExtraHeadderValue" } };
 
         public const string ScopeStr = "r1/scope1 r1/scope2";
         public const string ScopeStrFormat = "r{0}/scope1 r{0}/scope2";
@@ -35,8 +34,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string AutomationTestThumbprint = "378938210C976692D7F523B8C4FFBB645D17CE92";
         public const string RSATestCertThumbprint = "A7F68F87199F412451BF0FB364A3358A949D2CA8";
 
-        public static readonly SortedSet<string> s_scopeForAnotherResource = new SortedSet<string>(new[] { "r2/scope1", "r2/scope2" });
-        public static readonly SortedSet<string> s_cacheMissScope = new SortedSet<string>(new[] { "r3/scope1", "r3/scope2" });
+        public static readonly SortedSet<string> s_scopeForAnotherResource = new SortedSet<string>(new[] { "r2/scope1", "r2/scope2" }, StringComparer.OrdinalIgnoreCase);
+        public static readonly SortedSet<string> s_cacheMissScope = new SortedSet<string>(new[] { "r3/scope1", "r3/scope2" }, StringComparer.OrdinalIgnoreCase);
         public const string ScopeForAnotherResourceStr = "r2/scope1 r2/scope2";
         public const string Uid = "my-uid";
         public const string Utid = "my-utid";
@@ -47,7 +46,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string AadTenantId = "751a212b-4003-416e-b600-e1f48e40db9f";
         public const string MsaTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
         public const string AadAuthorityWithTestTenantId = "https://login.microsoftonline.com/751a212b-4003-416e-b600-e1f48e40db9f/";
-        public static readonly IDictionary<string, string> s_clientAssertionClaims = new Dictionary<string, string> { { "client_ip", "some_ip" }, { "aud", "some_audience" } };
+        public static readonly IDictionary<string, string> s_clientAssertionClaims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "client_ip", "some_ip" }, { "aud", "some_audience" }};
         public const string RTSecret = "someRT";
         public const string ATSecret = "some-access-token";
 
@@ -59,7 +58,6 @@ namespace Microsoft.Identity.Test.Unit
         public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.r.login.microsoftonline.com";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
         public const string PpeEnvironment = "login.windows-ppe.net";
-
 
         public const string AuthorityNotKnownCommon = "https://sts.access.edu/common/";
         public const string AuthorityNotKnownTenanted = "https://sts.access.edu/" + Utid + "/";
@@ -110,13 +108,12 @@ namespace Microsoft.Identity.Test.Unit
         public const string UniqueId = "unique_id";
         public const string IdentityProvider = "my-idp";
         public const string Name = "First Last";
-        
+
         public const string Claims = @"{""userinfo"":{""given_name"":{""essential"":true},""nickname"":null,""email"":{""essential"":true},""email_verified"":{""essential"":true},""picture"":null,""http://example.info/claims/groups"":null},""id_token"":{""auth_time"":{""essential"":true},""acr"":{""values"":[""urn:mace:incommon:iap:silver""]}}}";
         public static readonly string[] ClientCapabilities = new[] { "cp1", "cp2" };
         public const string ClientCapabilitiesJson = @"{""access_token"":{""xms_cc"":{""values"":[""cp1"",""cp2""]}}}";
         // this a JSON merge from Claims and ClientCapabilitiesJson
         public const string ClientCapabilitiesAndClaimsJson = @"{""access_token"":{""xms_cc"":{""values"":[""cp1"",""cp2""]}},""userinfo"":{""given_name"":{""essential"":true},""nickname"":null,""email"":{""essential"":true},""email_verified"":{""essential"":true},""picture"":null,""http://example.info/claims/groups"":null},""id_token"":{""auth_time"":{""essential"":true},""acr"":{""values"":[""urn:mace:incommon:iap:silver""]}}}";
-            
 
         public const string DisplayableId = "displayable@id.com";
         public const string RedirectUri = "urn:ietf:wg:oauth:2.0:oob";
@@ -176,11 +173,11 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         {
             get
             {
-                return new Dictionary<string, string>()
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    {"extra", "qp" },
-                    {"key1", "value1%20with%20encoded%20space"},
-                    {"key2", "value2"}
+                    { "extra", "qp" },
+                    { "key1", "value1%20with%20encoded%20space" },
+                    { "key2", "value2" }
                 };
             }
         }
@@ -193,15 +190,13 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         public const string MsalArlingtonCCAKeyVaultUri = "https://msidlabs.vault.azure.net:443/secrets/ARLMSIDLAB1-IDLASBS-App-CC-Secret";
 
         public enum AuthorityType { B2C };
-        public static string[] s_prodEnvAliases = new string[] {
+        public static string[] s_prodEnvAliases = new[] {
                                 "login.microsoftonline.com",
                                 "login.windows.net",
                                 "login.microsoft.com",
                                 "sts.windows.net"};
 
         public static readonly string s_userIdentifier = CreateUserIdentifier();
-
-
 
         public static string CreateUserIdentifier()
         {
@@ -277,7 +272,7 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
                             ""preferred_network"":""login.microsoftonline.com"",
                             ""preferred_cache"":""login.windows.net"",
                             ""aliases"":[
-                                ""login.microsoftonline.com"", 
+                                ""login.microsoftonline.com"",
                                 ""login.windows.net"",
                                 ""login.microsoft.com"",
                                 ""sts.windows.net""]},
@@ -314,7 +309,6 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
                ""trace_id"":""82e709b9-f0b3-431d-99cd-f3c2ca3d4b00"",
                ""correlation_id"":""e7619cf4-53ea-443c-b76a-194c032e9840"",
                ""error_uri"":""https://login.microsoftonline.com/error?code=50049""}";
-        
 
         public const string TokenResponseJson = @"{
                                                    ""token_type"": ""Bearer"",
@@ -346,7 +340,7 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
       ""local_account_id"":""ae821e4d-f408-451a-af82-882691148603"",
       ""scopes"":""User.Read openid offline_access profile"",
       ""success"":true,
-      ""tenant_id"":""49f548d0-12b7-4169-a390-bb5304d24462"",     
+      ""tenant_id"":""49f548d0-12b7-4169-a390-bb5304d24462"",
       ""token_type"":""Bearer"",
       ""username"":""some_user@contoso.com""
    }";
@@ -358,7 +352,6 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         public const string AzureADKerberosRealmName = "KERBEROS.MICROSOFTONLINE.COM";
         public const int KerberosMinMessageBufferLength = 256;
 
-
         // do not change these constants!
         public const string AadRawClientInfo = "eyJ1aWQiOiI5ZjQ4ODBkOC04MGJhLTRjNDAtOTdiYy1mN2EyM2M3MDMwODQiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0";
         public const string MsaRawClientInfo = "eyJ2ZXIiOiIxLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFNTmVBRnBTTGdsSGlPVHI5SVpISkVBIiwibmFtZSI6Ik9sZ2EgRGFsdG9tIiwicHJlZmVycmVkX3VzZXJuYW1lIjoibXNhbHNka3Rlc3RAb3V0bG9vay5jb20iLCJvaWQiOiIwMDAwMDAwMC0wMDAwLTAwMDAtNDBjMC0zYmFjMTg4ZDAxZDEiLCJ0aWQiOiI5MTg4MDQwZC02YzY3LTRjNWItYjExMi0zNmEzMDRiNjZkYWQiLCJob21lX29pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC00MGMwLTNiYWMxODhkMDFkMSIsInVpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC00MGMwLTNiYWMxODhkMDFkMSIsInV0aWQiOiI5MTg4MDQwZC02YzY3LTRjNWItYjExMi0zNmEzMDRiNjZkYWQifQ";
@@ -366,40 +359,39 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
 
         public static MsalTokenResponse CreateAadTestTokenResponse()
         {
-            string jsonResponse = "{\"token_type\":\"Bearer\",\"scope\":\"Calendars.Read openid profile Tasks.Read User.Read email\",\"expires_in\":3600,\"ext_expires_in\":262800,\"access_token\":\"<removed_at>\",\"refresh_token\":\"<removed_rt>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJiNmM2OWEzNy1kZjk2LTRkYjAtOTA4OC0yYWI5NmUxZDgyMTUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhL3YyLjAiLCJpYXQiOjE1Mzg1Mzg0MjIsIm5iZiI6MTUzODUzODQyMiwiZXhwIjoxNTM4NTQyMzIyLCJuYW1lIjoiQ2xvdWQgSURMQUIgQmFzaWMgVXNlciIsIm9pZCI6IjlmNDg4MGQ4LTgwYmEtNGM0MC05N2JjLWY3YTIzYzcwMzA4NCIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkbGFiQG1zaWRsYWI0Lm9ubWljcm9zb2Z0LmNvbSIsInN1YiI6Ilk2WWtCZEhOTkxITm1US2VsOUtoUno4d3Jhc3hkTFJGaVAxNEJSUFdybjQiLCJ0aWQiOiJmNjQ1YWQ5Mi1lMzhkLTRkMWEtYjUxMC1kMWIwOWE3NGE4Y2EiLCJ1dGkiOiI2bmNpWDAyU01raTlrNzMtRjFzWkFBIiwidmVyIjoiMi4wIn0.\",\"client_info\":\"" + AadRawClientInfo + "\"}";
+            const string jsonResponse = "{\"token_type\":\"Bearer\",\"scope\":\"Calendars.Read openid profile Tasks.Read User.Read email\",\"expires_in\":3600,\"ext_expires_in\":262800,\"access_token\":\"<removed_at>\",\"refresh_token\":\"<removed_rt>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJiNmM2OWEzNy1kZjk2LTRkYjAtOTA4OC0yYWI5NmUxZDgyMTUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhL3YyLjAiLCJpYXQiOjE1Mzg1Mzg0MjIsIm5iZiI6MTUzODUzODQyMiwiZXhwIjoxNTM4NTQyMzIyLCJuYW1lIjoiQ2xvdWQgSURMQUIgQmFzaWMgVXNlciIsIm9pZCI6IjlmNDg4MGQ4LTgwYmEtNGM0MC05N2JjLWY3YTIzYzcwMzA4NCIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkbGFiQG1zaWRsYWI0Lm9ubWljcm9zb2Z0LmNvbSIsInN1YiI6Ilk2WWtCZEhOTkxITm1US2VsOUtoUno4d3Jhc3hkTFJGaVAxNEJSUFdybjQiLCJ0aWQiOiJmNjQ1YWQ5Mi1lMzhkLTRkMWEtYjUxMC1kMWIwOWE3NGE4Y2EiLCJ1dGkiOiI2bmNpWDAyU01raTlrNzMtRjFzWkFBIiwidmVyIjoiMi4wIn0.\",\"client_info\":\"" + AadRawClientInfo + "\"}";
             var msalTokenResponse = JsonHelper.DeserializeFromJson<MsalTokenResponse>(jsonResponse);
             return msalTokenResponse;
         }
 
         public static MsalTokenResponse CreateMsaTestTokenResponse()
         {
-            string jsonResponse = "{\"token_type\":\"Bearer\",\"scope\":\"Tasks.Read User.Read openid profile\",\"expires_in\":3600,\"ext_expires_in\":262800,\"access_token\":\"<removed_at>\",\"refresh_token\":\"<removed_rt>\",\"id_token\":\"eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFNTmVBRnBTTGdsSGlPVHI5SVpISkVBIiwiYXVkIjoiYjZjNjlhMzctZGY5Ni00ZGIwLTkwODgtMmFiOTZlMWQ4MjE1IiwiZXhwIjoxNTM4ODg1MjU0LCJpYXQiOjE1Mzg3OTg1NTQsIm5iZiI6MTUzODc5ODU1NCwibmFtZSI6IlRlc3QgVXNlcm5hbWUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJtc2Fsc2RrdGVzdEBvdXRsb29rLmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC00MGMwLTNiYWMxODhkMDFkMSIsInRpZCI6IjkxODgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsImFpbyI6IkRXZ0tubCFFc2ZWa1NVOGpGVmJ4TTZQaFphUjJFeVhzTUJ5bVJHU1h2UkV1NGkqRm1CVTFSQmw1aEh2TnZvR1NHbHFkQkpGeG5kQXNBNipaM3FaQnIwYzl2YUlSd1VwZUlDVipTWFpqdzghQiIsImFsZyI6IkhTMjU2In0.\",\"client_info\":\"" + MsaRawClientInfo + "\"}";
+            const string jsonResponse = "{\"token_type\":\"Bearer\",\"scope\":\"Tasks.Read User.Read openid profile\",\"expires_in\":3600,\"ext_expires_in\":262800,\"access_token\":\"<removed_at>\",\"refresh_token\":\"<removed_rt>\",\"id_token\":\"eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFNTmVBRnBTTGdsSGlPVHI5SVpISkVBIiwiYXVkIjoiYjZjNjlhMzctZGY5Ni00ZGIwLTkwODgtMmFiOTZlMWQ4MjE1IiwiZXhwIjoxNTM4ODg1MjU0LCJpYXQiOjE1Mzg3OTg1NTQsIm5iZiI6MTUzODc5ODU1NCwibmFtZSI6IlRlc3QgVXNlcm5hbWUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJtc2Fsc2RrdGVzdEBvdXRsb29rLmNvbSIsIm9pZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC00MGMwLTNiYWMxODhkMDFkMSIsInRpZCI6IjkxODgwNDBkLTZjNjctNGM1Yi1iMTEyLTM2YTMwNGI2NmRhZCIsImFpbyI6IkRXZ0tubCFFc2ZWa1NVOGpGVmJ4TTZQaFphUjJFeVhzTUJ5bVJHU1h2UkV1NGkqRm1CVTFSQmw1aEh2TnZvR1NHbHFkQkpGeG5kQXNBNipaM3FaQnIwYzl2YUlSd1VwZUlDVipTWFpqdzghQiIsImFsZyI6IkhTMjU2In0.\",\"client_info\":\"" + MsaRawClientInfo + "\"}";
             var msalTokenResponse = JsonHelper.DeserializeFromJson<MsalTokenResponse>(jsonResponse);
             return msalTokenResponse;
         }
 
         public static MsalTokenResponse CreateB2CTestTokenResponse()
         {
-            string jsonResponse = "{\"access_token\":\"<removed_at>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Mzg4MDQ4NjAsIm5iZiI6MTUzODgwMTI2MCwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2JhNmMwZDk0LWE4ZGEtNDViMi04M2FlLTMzODcxZjljMmRkOC92Mi4wLyIsInN1YiI6ImFkMDIwZjhlLWIxYmEtNDRiMi1iZDY5LWMyMmJlODY3MzdmNSIsImF1ZCI6IjBhN2Y1MmRkLTI2MGUtNDMyZi05NGRlLWI0NzgyOGMzZjM3MiIsImlhdCI6MTUzODgwMTI2MCwiYXV0aF90aW1lIjoxNTM4ODAxMjYwLCJpZHAiOiJsaXZlLmNvbSIsIm5hbWUiOiJNU0FMIFNESyBUZXN0Iiwib2lkIjoiYWQwMjBmOGUtYjFiYS00NGIyLWJkNjktYzIyYmU4NjczN2Y1IiwiZmFtaWx5X25hbWUiOiJTREsgVGVzdCIsImdpdmVuX25hbWUiOiJNU0FMIiwiZW1haWxzIjpbIm1zYWxzZGt0ZXN0QG91dGxvb2suY29tIl0sInRmcCI6IkIyQ18xX1NpZ25pbiIsImF0X2hhc2giOiJRNE8zSERDbGNhTGw3eTB1VS1iSkFnIn0.\",\"token_type\":\"Bearer\",\"not_before\":1538801260,\"expires_in\":3600,\"ext_expires_in\":262800,\"expires_on\":1538804860,\"resource\":\"14df2240-96cc-4f42-a133-ef0807492869\",\"client_info\":\"" + B2CRawClientInfo + "\",\"scope\":\"https://iosmsalb2c.onmicrosoft.com/webapitest/user.read\",\"refresh_token\":\"<removed_rt>\",\"refresh_token_expires_in\":1209600}";
+            const string jsonResponse = "{\"access_token\":\"<removed_at>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Mzg4MDQ4NjAsIm5iZiI6MTUzODgwMTI2MCwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2JhNmMwZDk0LWE4ZGEtNDViMi04M2FlLTMzODcxZjljMmRkOC92Mi4wLyIsInN1YiI6ImFkMDIwZjhlLWIxYmEtNDRiMi1iZDY5LWMyMmJlODY3MzdmNSIsImF1ZCI6IjBhN2Y1MmRkLTI2MGUtNDMyZi05NGRlLWI0NzgyOGMzZjM3MiIsImlhdCI6MTUzODgwMTI2MCwiYXV0aF90aW1lIjoxNTM4ODAxMjYwLCJpZHAiOiJsaXZlLmNvbSIsIm5hbWUiOiJNU0FMIFNESyBUZXN0Iiwib2lkIjoiYWQwMjBmOGUtYjFiYS00NGIyLWJkNjktYzIyYmU4NjczN2Y1IiwiZmFtaWx5X25hbWUiOiJTREsgVGVzdCIsImdpdmVuX25hbWUiOiJNU0FMIiwiZW1haWxzIjpbIm1zYWxzZGt0ZXN0QG91dGxvb2suY29tIl0sInRmcCI6IkIyQ18xX1NpZ25pbiIsImF0X2hhc2giOiJRNE8zSERDbGNhTGw3eTB1VS1iSkFnIn0.\",\"token_type\":\"Bearer\",\"not_before\":1538801260,\"expires_in\":3600,\"ext_expires_in\":262800,\"expires_on\":1538804860,\"resource\":\"14df2240-96cc-4f42-a133-ef0807492869\",\"client_info\":\"" + B2CRawClientInfo + "\",\"scope\":\"https://iosmsalb2c.onmicrosoft.com/webapitest/user.read\",\"refresh_token\":\"<removed_rt>\",\"refresh_token_expires_in\":1209600}";
             var msalTokenResponse = JsonHelper.DeserializeFromJson<MsalTokenResponse>(jsonResponse);
             return msalTokenResponse;
         }
 
         public static MsalTokenResponse CreateB2CTestTokenResponseWithTenantId()
         {
-            string jsonResponse = "{\"access_token\":\"<removed_at>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Mzg4MDQ4NjAsIm5iZiI6MTUzODgwMTI2MCwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2JhNmMwZDk0LWE4ZGEtNDViMi04M2FlLTMzODcxZjljMmRkOC92Mi4wLyIsInN1YiI6ImFkMDIwZjhlLWIxYmEtNDRiMi1iZDY5LWMyMmJlODY3MzdmNSIsImF1ZCI6IjBhN2Y1MmRkLTI2MGUtNDMyZi05NGRlLWI0NzgyOGMzZjM3MiIsImlhdCI6MTUzODgwMTI2MCwiYXV0aF90aW1lIjoxNTM4ODAxMjYwLCJpZHAiOiJsaXZlLmNvbSIsIm5hbWUiOiJNU0FMIFNESyBUZXN0Iiwib2lkIjoiYWQwMjBmOGUtYjFiYS00NGIyLWJkNjktYzIyYmU4NjczN2Y1IiwiZmFtaWx5X25hbWUiOiJTREsgVGVzdCIsImdpdmVuX25hbWUiOiJNU0FMIiwiZW1haWxzIjpbIm1zYWxzZGt0ZXN0QG91dGxvb2suY29tIl0sInRmcCI6IkIyQ18xX1NpZ25pbiIsImF0X2hhc2giOiJRNE8zSERDbGNhTGw3eTB1VS1iSkFnIiwidGlkIjoiYmE2YzBkOTQtYThkYS00NWIyLTgzYWUtMzM4NzFmOWMyZGQ4IiwicHJlZmVycmVkX3VzZXJuYW1lIjoibXNhbHNka3Rlc3RAb3V0bG9vay5jb20ifQ.\",\"token_type\":\"Bearer\",\"not_before\":1538801260,\"expires_in\":3600,\"ext_expires_in\":262800,\"expires_on\":1538804860,\"resource\":\"14df2240-96cc-4f42-a133-ef0807492869\",\"client_info\":\"" + B2CRawClientInfo + "\",\"scope\":\"https://iosmsalb2c.onmicrosoft.com/webapitest/user.read\",\"refresh_token\":\"<removed_rt>\",\"refresh_token_expires_in\":1209600}";
+            const string jsonResponse = "{\"access_token\":\"<removed_at>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Mzg4MDQ4NjAsIm5iZiI6MTUzODgwMTI2MCwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2JhNmMwZDk0LWE4ZGEtNDViMi04M2FlLTMzODcxZjljMmRkOC92Mi4wLyIsInN1YiI6ImFkMDIwZjhlLWIxYmEtNDRiMi1iZDY5LWMyMmJlODY3MzdmNSIsImF1ZCI6IjBhN2Y1MmRkLTI2MGUtNDMyZi05NGRlLWI0NzgyOGMzZjM3MiIsImlhdCI6MTUzODgwMTI2MCwiYXV0aF90aW1lIjoxNTM4ODAxMjYwLCJpZHAiOiJsaXZlLmNvbSIsIm5hbWUiOiJNU0FMIFNESyBUZXN0Iiwib2lkIjoiYWQwMjBmOGUtYjFiYS00NGIyLWJkNjktYzIyYmU4NjczN2Y1IiwiZmFtaWx5X25hbWUiOiJTREsgVGVzdCIsImdpdmVuX25hbWUiOiJNU0FMIiwiZW1haWxzIjpbIm1zYWxzZGt0ZXN0QG91dGxvb2suY29tIl0sInRmcCI6IkIyQ18xX1NpZ25pbiIsImF0X2hhc2giOiJRNE8zSERDbGNhTGw3eTB1VS1iSkFnIiwidGlkIjoiYmE2YzBkOTQtYThkYS00NWIyLTgzYWUtMzM4NzFmOWMyZGQ4IiwicHJlZmVycmVkX3VzZXJuYW1lIjoibXNhbHNka3Rlc3RAb3V0bG9vay5jb20ifQ.\",\"token_type\":\"Bearer\",\"not_before\":1538801260,\"expires_in\":3600,\"ext_expires_in\":262800,\"expires_on\":1538804860,\"resource\":\"14df2240-96cc-4f42-a133-ef0807492869\",\"client_info\":\"" + B2CRawClientInfo + "\",\"scope\":\"https://iosmsalb2c.onmicrosoft.com/webapitest/user.read\",\"refresh_token\":\"<removed_rt>\",\"refresh_token_expires_in\":1209600}";
             var msalTokenResponse = JsonHelper.DeserializeFromJson<MsalTokenResponse>(jsonResponse);
             return msalTokenResponse;
         }
 
         public static MsalTokenResponse CreateAadTestTokenResponseWithFoci()
         {
-            string jsonResponse = "{\"token_type\":\"Bearer\",\"scope\":\"Calendars.Read openid profile Tasks.Read User.Read email\",\"expires_in\":3600,\"ext_expires_in\":262800,\"access_token\":\"<removed_at>\",\"refresh_token\":\"<removed_rt>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJiNmM2OWEzNy1kZjk2LTRkYjAtOTA4OC0yYWI5NmUxZDgyMTUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhL3YyLjAiLCJpYXQiOjE1Mzg1Mzg0MjIsIm5iZiI6MTUzODUzODQyMiwiZXhwIjoxNTM4NTQyMzIyLCJuYW1lIjoiQ2xvdWQgSURMQUIgQmFzaWMgVXNlciIsIm9pZCI6IjlmNDg4MGQ4LTgwYmEtNGM0MC05N2JjLWY3YTIzYzcwMzA4NCIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkbGFiQG1zaWRsYWI0Lm9ubWljcm9zb2Z0LmNvbSIsInN1YiI6Ilk2WWtCZEhOTkxITm1US2VsOUtoUno4d3Jhc3hkTFJGaVAxNEJSUFdybjQiLCJ0aWQiOiJmNjQ1YWQ5Mi1lMzhkLTRkMWEtYjUxMC1kMWIwOWE3NGE4Y2EiLCJ1dGkiOiI2bmNpWDAyU01raTlrNzMtRjFzWkFBIiwidmVyIjoiMi4wIn0.\",\"client_info\":\"" + AadRawClientInfo + "\",\"foci\":\"1\"}";
+            const string jsonResponse = "{\"token_type\":\"Bearer\",\"scope\":\"Calendars.Read openid profile Tasks.Read User.Read email\",\"expires_in\":3600,\"ext_expires_in\":262800,\"access_token\":\"<removed_at>\",\"refresh_token\":\"<removed_rt>\",\"id_token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJiNmM2OWEzNy1kZjk2LTRkYjAtOTA4OC0yYWI5NmUxZDgyMTUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhL3YyLjAiLCJpYXQiOjE1Mzg1Mzg0MjIsIm5iZiI6MTUzODUzODQyMiwiZXhwIjoxNTM4NTQyMzIyLCJuYW1lIjoiQ2xvdWQgSURMQUIgQmFzaWMgVXNlciIsIm9pZCI6IjlmNDg4MGQ4LTgwYmEtNGM0MC05N2JjLWY3YTIzYzcwMzA4NCIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkbGFiQG1zaWRsYWI0Lm9ubWljcm9zb2Z0LmNvbSIsInN1YiI6Ilk2WWtCZEhOTkxITm1US2VsOUtoUno4d3Jhc3hkTFJGaVAxNEJSUFdybjQiLCJ0aWQiOiJmNjQ1YWQ5Mi1lMzhkLTRkMWEtYjUxMC1kMWIwOWE3NGE4Y2EiLCJ1dGkiOiI2bmNpWDAyU01raTlrNzMtRjFzWkFBIiwidmVyIjoiMi4wIn0.\",\"client_info\":\"" + AadRawClientInfo + "\",\"foci\":\"1\"}";
             var msalTokenResponse = JsonHelper.DeserializeFromJson<MsalTokenResponse>(jsonResponse);
             return msalTokenResponse;
         }
     }
-
 
     internal static class Adfs2019LabConstants
     {
@@ -408,7 +400,7 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         public const string PublicClientId = "PublicClientId";
         public const string ConfidentialClientId = "ConfidentialClientId";
         public const string ClientRedirectUri = "http://localhost:8080";
-        public static readonly SortedSet<string> s_supportedScopes = new SortedSet<string>(new[] { "openid", "email", "profile" });
+        public static readonly SortedSet<string> s_supportedScopes = new SortedSet<string>(new[] { "openid", "email", "profile" }, StringComparer.OrdinalIgnoreCase);
         public const string ADFS2019ClientSecretURL = "https://buildautomation.vault.azure.net/secrets/ADFS2019ClientCredSecret/";
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/AuthorityTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -8,13 +9,11 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Integration.net45.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
-using Microsoft.Identity.Test.Unit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
@@ -25,6 +24,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private static readonly string[] s_scopes = { "User.Read" };
 
         public TestContext TestContext { get; set; }
+
 #if NET_CORE
 
         [TestMethod]
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 user.Upn,
                 new NetworkCredential("", user.GetOrFetchPassword()).SecurePassword)
                 // BugBug https://identitydivision.visualstudio.com/Engineering/_workitems/edit/776308/
-                // sts.windows.net fails when doing instance discovery, e.g.: 
+                // sts.windows.net fails when doing instance discovery, e.g.:
                 // https://sts.windows.net/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Fsts.windows.net%2Ff645ad92-e38d-4d1a-b510-d1b09a74a8ca%2Foauth2%2Fv2.0%2Fauthorize
                 .WithAuthority("https://login.windows.net/" + labResponse.Lab.TenantId + "/")
                 .ExecuteAsync()
@@ -115,13 +115,13 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
 
         /// <summary>
-        /// If this test fails, please update the <see cref="KnownMetadataProvider"/> to 
+        /// If this test fails, please update the <see cref="KnownMetadataProvider"/> to
         /// use whatever Evo uses (i.e. the aliases, preferred network / metadata from the url below).
         /// </summary>
         [TestMethod]
         public async Task KnownInstanceMetadataIsUpToDateAsync()
         {
-            string validDiscoveryUri = @"https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize";
+            const string validDiscoveryUri = @"https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize";
             HttpClient httpClient = new HttpClient();
             HttpResponseMessage discoveryResponse = await httpClient.SendAsync(
                 new HttpRequestMessage(
@@ -149,17 +149,17 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         #endif
-
     }
 
     internal class InstanceDiscoveryMetadataEntryComparer : IEqualityComparer<InstanceDiscoveryMetadataEntry>
     {
         public bool Equals(InstanceDiscoveryMetadataEntry x, InstanceDiscoveryMetadataEntry y)
         {
-            return
-                 string.Equals(x.PreferredCache, y.PreferredCache, System.StringComparison.OrdinalIgnoreCase) &&
-                 string.Equals(x.PreferredNetwork, y.PreferredNetwork, System.StringComparison.OrdinalIgnoreCase) &&
-                 Enumerable.SequenceEqual(x.Aliases, y.Aliases);
+            return x is object &&
+                   y is object &&
+                   string.Equals(x.PreferredCache, y.PreferredCache, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(x.PreferredNetwork, y.PreferredNetwork, StringComparison.OrdinalIgnoreCase) &&
+                   Enumerable.SequenceEqual(x.Aliases, y.Aliases, StringComparer.OrdinalIgnoreCase);
         }
 
         public int GetHashCode(InstanceDiscoveryMetadataEntry obj)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -38,17 +38,26 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
             Assert.IsNull(authParams.Error);
         }
 
+        /// <summary>
+        /// Makes unauthorized call to Azure Resource Manager REST API https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/get.
+        /// Expects response 401 Unauthorized. Analyzes the WWW-Authenticate header values.
+        /// </summary>
+        /// <param name="hostName">ARM endpoint, e.g. Production or Dogfood</param>
+        /// <param name="subscriptionId">Well-known subscription ID</param>
+        /// <param name="authority">AAD endpoint, e.g. Production or PPE</param>
+        /// <param name="tenantId">Expected Tenant ID</param>
         [DataRow("management.azure.com", "c1686c51-b717-4fe0-9af3-24a20a41fb0c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
         [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
         [DataTestMethod]
         public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
         {
-            const string apiVersion = "2020-08-01";
+            const string apiVersion = "2020-08-01"; // current latest API version for /subscriptions/get
             var url = $"https://{hostName}/subscriptions/{subscriptionId}?api-version={apiVersion}";
+
             var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(url).ConfigureAwait(false);
 
             Assert.IsNull(authParams.Resource);
-            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority);
+            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority); // authority consists of AAD endpoint and tenant ID
             Assert.IsNull(authParams.Scopes);
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -37,5 +37,22 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
         }
+
+        [DataRow("management.azure.com", "a645d3be-5a4a-40ef-82a1-d5f5358a424c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
+        [DataRow("api-dogfood.resources.windows-int.net", "5d04a672-05ce-492b-958f-d225b6a67926", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
+        [DataTestMethod]
+        public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
+        {
+            const string apiVersion = "2020-08-01";
+            var url = $"https://{hostName}/subscriptions/{subscriptionId}?api-version={apiVersion}";
+            var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(url).ConfigureAwait(false);
+
+            Assert.IsNull(authParams.Resource);
+            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority);
+            Assert.IsNull(authParams.Scopes);
+            Assert.AreEqual(3, authParams.RawParameters.Count);
+            Assert.IsNull(authParams.Claims);
+            Assert.AreEqual("invalid_token", authParams.Error);
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
         /// <param name="subscriptionId">Well-known subscription ID</param>
         /// <param name="authority">AAD endpoint, e.g. Production or PPE</param>
         /// <param name="tenantId">Expected Tenant ID</param>
+        [TestMethod]
         [DataRow("management.azure.com", "c1686c51-b717-4fe0-9af3-24a20a41fb0c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
         [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
-        [DataTestMethod]
         public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
         {
             const string apiVersion = "2020-08-01"; // current latest API version for /subscriptions/get

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
             Assert.IsNull(authParams.Error);
         }
 
-        [DataRow("management.azure.com", "a645d3be-5a4a-40ef-82a1-d5f5358a424c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
-        [DataRow("api-dogfood.resources.windows-int.net", "5d04a672-05ce-492b-958f-d225b6a67926", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
+        [DataRow("management.azure.com", "c1686c51-b717-4fe0-9af3-24a20a41fb0c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
+        [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
         [DataTestMethod]
         public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
         {

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
 
             Assert.AreEqual("https://vault.azure.net", authParams.Resource);
             Assert.AreEqual("login.windows.net", new Uri(authParams.Authority).Host);
+            Assert.IsNull(authParams.TenantId);
             Assert.AreEqual("https://vault.azure.net/.default", authParams.Scopes.FirstOrDefault());
             Assert.AreEqual(2, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
@@ -32,6 +33,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
 
             Assert.AreEqual("00000003-0000-0000-c000-000000000000", authParams.Resource);
             Assert.AreEqual("https://login.microsoftonline.com/common", authParams.Authority);
+            Assert.IsNull(authParams.TenantId);
             Assert.AreEqual("00000003-0000-0000-c000-000000000000/.default", authParams.Scopes.FirstOrDefault());
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
@@ -57,7 +59,8 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
             var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(url).ConfigureAwait(false);
 
             Assert.IsNull(authParams.Resource);
-            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority); // authority consists of AAD endpoint and tenant ID
+            Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority); // authority URI consists of AAD endpoint and tenant ID
+            Assert.AreEqual(tenantId, authParams.TenantId); // tenant ID is extracted out of authority URI
             Assert.IsNull(authParams.Scopes);
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
 
             Assert.AreEqual("https://vault.azure.net", authParams.Resource);
             Assert.AreEqual("login.windows.net", new Uri(authParams.Authority).Host);
-            Assert.IsNull(authParams.TenantId);
+            Assert.AreEqual("72f988bf-86f1-41af-91ab-2d7cd011db47", authParams.TenantId); // because the Key Vault resource belong to Microsoft Corp tenant
             Assert.AreEqual("https://vault.azure.net/.default", authParams.Scopes.FirstOrDefault());
             Assert.AreEqual(2, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.HeadlessTests
 
             Assert.AreEqual("00000003-0000-0000-c000-000000000000", authParams.Resource);
             Assert.AreEqual("https://login.microsoftonline.com/common", authParams.Authority);
-            Assert.IsNull(authParams.TenantId);
+            Assert.AreEqual("common", authParams.TenantId);
             Assert.AreEqual("00000003-0000-0000-c000-000000000000/.default", authParams.Scopes.FirstOrDefault());
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
     {
         private static readonly AuthorityInfo s_commonAuthority =
             AuthorityInfo.FromAuthorityUri(TestConstants.AuthorityCommonTenant, true);
-        static string s_ppeCommonUri = $@"https://{TestConstants.PpeEnvironment}/{TestConstants.TenantId}";
+        private static readonly string s_ppeCommonUri = $@"https://{TestConstants.PpeEnvironment}/{TestConstants.TenantId}";
         private static readonly AuthorityInfo s_ppeAuthority =
           AuthorityInfo.FromAuthorityUri(s_ppeCommonUri, true);
         private static readonly AuthorityInfo s_utidAuthority =
@@ -54,8 +54,8 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         [TestMethod]
         public void VerifyAuthorityTest()
         {
-            var utid = TestConstants.Utid;
-            var utid2 = TestConstants.Utid2;
+            const string utid = TestConstants.Utid;
+            const string utid2 = TestConstants.Utid2;
 
             VerifyAuthority(
                 config: s_commonAuthority,

--- a/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.UI;
-using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Test.Common.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,123 +30,146 @@ namespace Microsoft.Identity.Test.Unit
             // (it is taken from metadata in instance discovery response),
             // except very first network call - instance discovery
 
-            using (var harness = base.CreateTestHarness())
+            using var harness = base.CreateTestHarness();
+
+            var httpManager = harness.HttpManager;
+            var authorityUri = new Uri(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "https://{0}/common",
+                    TestConstants.ProductionNotPrefEnvironmentAlias));
+
+            httpManager.AddInstanceDiscoveryMockHandler(authorityUri.AbsoluteUri);
+
+            PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                        .WithAuthority(authorityUri, validateAuthority: true)
+                                                                        .WithHttpManager(httpManager)
+                                                                        .WithTelemetry(new TraceTelemetryConfig())
+                                                                        .WithDebugLoggingCallback()
+                                                                        .BuildConcrete();
+
+            InMemoryTokenCache cache = new InMemoryTokenCache();
+            cache.Bind(app.UserTokenCache);
+
+            app.ServiceBundle.ConfigureMockWebUI(
+                AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"),
+                null,
+                TestConstants.ProductionPrefNetworkEnvironment);
+
+            // mock token request
+            httpManager.AddMockHandler(new MockHttpMessageHandler
             {
-                var httpManager = harness.HttpManager;
-                var authorityUri = new Uri(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        "https://{0}/common",
-                        TestConstants.ProductionNotPrefEnvironmentAlias));
+                ExpectedUrl = string.Format(CultureInfo.InvariantCulture, "https://{0}/common/oauth2/v2.0/token",
+                    TestConstants.ProductionPrefNetworkEnvironment),
+                ExpectedMethod = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+            });
 
-                httpManager.AddInstanceDiscoveryMockHandler(authorityUri.AbsoluteUri);
+            AuthenticationResult result = await app.AcquireTokenInteractive(TestConstants.s_scope).ExecuteAsync().ConfigureAwait(false);
 
-                PublicClientApplication app = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                          .WithAuthority(authorityUri, true)
-                          .WithHttpManager(httpManager)
-                          //.WithUserTokenLegacyCachePersistenceForTest(new TestLegacyCachePersistance())
-                          .WithTelemetry(new TraceTelemetryConfig())
-                          .WithDebugLoggingCallback()
-                          .BuildConcrete();
+            // make sure that all cache entities are stored with "preferred_cache" environment
+            // (it is taken from metadata in instance discovery response)
+            ValidateCacheEntitiesEnvironment(app.UserTokenCacheInternal, TestConstants.ProductionPrefCacheEnvironment);
 
-                InMemoryTokenCache cache = new InMemoryTokenCache();
-                cache.Bind(app.UserTokenCache);
+            // silent request targeting at, should return at from cache for any environment alias
+            foreach (var envAlias in TestConstants.s_prodEnvAliases)
+            {
+                var app2 = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                         .WithAuthority($"https://{envAlias}/common", validateAuthority: true)
+                                                         .WithHttpManager(httpManager)
+                                                         .WithTelemetry(new TraceTelemetryConfig())
+                                                         .WithDebugLoggingCallback()
+                                                         .BuildConcrete();
 
-                app.ServiceBundle.ConfigureMockWebUI(
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"),
-                    null, 
-                    TestConstants.ProductionPrefNetworkEnvironment);
+                cache.Bind(app2.UserTokenCache);
 
-                // mock token request
-                httpManager.AddMockHandler(new MockHttpMessageHandler
-                {
-                    ExpectedUrl = string.Format(CultureInfo.InvariantCulture, "https://{0}/common/oauth2/v2.0/token",
-                        TestConstants.ProductionPrefNetworkEnvironment),
-                    ExpectedMethod = HttpMethod.Post,
-                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
-                });
+                IEnumerable<IAccount> accounts = await app.GetAccountsAsync().ConfigureAwait(false);
+                result = await app2.AcquireTokenSilent(TestConstants.s_scope, accounts.First())
+                                   .WithAuthority(string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/", envAlias, TestConstants.Utid))
+                                   .WithForceRefresh(false)
+                                   .ExecuteAsync(CancellationToken.None)
+                                   .ConfigureAwait(false);
 
-                AuthenticationResult result = await app.AcquireTokenInteractive(TestConstants.s_scope).ExecuteAsync().ConfigureAwait(false);
+                Assert.IsNotNull(result);
+            }
 
-                // make sure that all cache entities are stored with "preferred_cache" environment
-                // (it is taken from metadata in instance discovery response)
-                ValidateCacheEntitiesEnvironment(app.UserTokenCacheInternal, TestConstants.ProductionPrefCacheEnvironment);
+            // silent request targeting rt should find rt in cache for authority with any environment alias
+            foreach (var envAlias in TestConstants.s_prodEnvAliases)
+            {
+                result = null;
 
-                // silent request targeting at, should return at from cache for any environment alias
-                foreach (var envAlias in TestConstants.s_prodEnvAliases)
-                {
-                    var app2 = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                          .WithAuthority($"https://{envAlias}/common", true)
-                          .WithHttpManager(httpManager)
-                          .WithTelemetry(new TraceTelemetryConfig())
-                          .WithDebugLoggingCallback()
-                          .BuildConcrete();
-
-                    cache.Bind(app2.UserTokenCache);
-
-                    result = await app2
-                        .AcquireTokenSilent(
-                            TestConstants.s_scope,
-                            app.GetAccountsAsync().Result.First())
-                        .WithAuthority(string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/", envAlias, TestConstants.Utid))
-                        .WithForceRefresh(false)
-                        .ExecuteAsync(CancellationToken.None)
-                        .ConfigureAwait(false);
-
-                    Assert.IsNotNull(result);
-                }
-
-                // silent request targeting rt should find rt in cache for authority with any environment alias
-                foreach (var envAlias in TestConstants.s_prodEnvAliases)
-                {
-                    result = null;
-
-                    httpManager.AddMockHandler(new MockHttpMessageHandler()
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
                     {
                         ExpectedUrl = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/oauth2/v2.0/token",
                             TestConstants.ProductionPrefNetworkEnvironment, TestConstants.Utid),
                         ExpectedMethod = HttpMethod.Post,
-                        ExpectedPostData = new Dictionary<string, string>()
-                    {
-                        {"grant_type", "refresh_token"}
-                    },
+                        ExpectedPostData = new Dictionary<string, string>
+                        {
+                            { "grant_type", "refresh_token" }
+                        },
                         // return not retriable status code
                         ResponseMessage = MockHelpers.CreateInvalidGrantTokenResponseMessage()
                     });
 
-                    try
-                    {
-                        var app3 = PublicClientApplicationBuilder
-                               .Create(TestConstants.ClientId)
-                                     .WithAuthority($"https://{envAlias}/common", true)
-                                     .WithHttpManager(httpManager)
-                                     .WithTelemetry(new TraceTelemetryConfig())
-                                     .WithDebugLoggingCallback()
-                                     .BuildConcrete();
+                try
+                {
+                    var app3 = PublicClientApplicationBuilder
+                           .Create(TestConstants.ClientId)
+                                 .WithAuthority($"https://{envAlias}/common", true)
+                                 .WithHttpManager(httpManager)
+                                 .WithTelemetry(new TraceTelemetryConfig())
+                                 .WithDebugLoggingCallback()
+                                 .BuildConcrete();
 
-                        cache.Bind(app3.UserTokenCache);
+                    cache.Bind(app3.UserTokenCache);
 
-                        result = await app3
-                            .AcquireTokenSilent(
-                                TestConstants.s_scopeForAnotherResource,
-                                (await app.GetAccountsAsync().ConfigureAwait(false)).First())
-                            .WithAuthority(string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/", envAlias, TestConstants.Utid))
-                            .WithForceRefresh(false)
-                            .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
-                    }
-                    catch (MsalUiRequiredException)
-                    {
-                    }
-                  
-
-                    Assert.IsNull(result);
+                    result = await app3
+                        .AcquireTokenSilent(
+                            TestConstants.s_scopeForAnotherResource,
+                            (await app.GetAccountsAsync().ConfigureAwait(false)).First())
+                        .WithAuthority(string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/", envAlias, TestConstants.Utid))
+                        .WithForceRefresh(false)
+                        .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
                 }
+                catch (MsalUiRequiredException)
+                {
+                }
+
+
+                Assert.IsNull(result);
             }
         }
 
-        private void ValidateCacheEntitiesEnvironment(ITokenCacheInternal cache, string expectedEnvironment)
+        [TestMethod]
+        public void AuthorityNotIncludedInAliasesTestAsync()
+        {
+            //Make sure MSAL is able to create an entry for instance discovery when the configured environment is not present in the
+            //instance discovery metadata. This is for non-public cloud scenarios. See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2701
+
+            using var harness = base.CreateTestHarness();
+
+            PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                        .WithAuthority(new Uri(TestConstants.AuthorityCommonPpeAuthority), true)
+                                                                        .WithHttpManager(harness.HttpManager)
+                                                                        .WithTelemetry(new TraceTelemetryConfig())
+                                                                        .BuildConcrete();
+            app.ServiceBundle.ConfigureMockWebUI();
+
+            //Adding one instance discovery response to ensure the cache is hit for the subsiquent requests.
+            //If MSAL tries to do an additional request this test will fail.
+            harness.HttpManager.AddInstanceDiscoveryMockHandler();
+            harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonPpeAuthority);
+
+            AuthenticationResult result = app
+                .AcquireTokenInteractive(TestConstants.s_scope)
+                .ExecuteAsync(CancellationToken.None)
+                .Result;
+
+            Assert.IsNotNull(result);
+        }
+
+        private static void ValidateCacheEntitiesEnvironment(ITokenCacheInternal cache, string expectedEnvironment)
         {
             ICoreLogger logger = Substitute.For<ICoreLogger>();
             IEnumerable<Client.Cache.Items.MsalAccessTokenCacheItem> accessTokens = cache.Accessor.GetAllAccessTokens();
@@ -180,35 +202,6 @@ namespace Microsoft.Identity.Test.Unit
             foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> kvp in adalCache)
             {
                 Assert.AreEqual(expectedEnvironment, new Uri(kvp.Key.Authority).Host);
-            }
-        }
-
-        [TestMethod]
-        public void AuthorityNotIncludedInAliasesTestAsync()
-        {
-            //Make sure MSAL is able to create an entry for instance discovery when the configured environment is not present in the 
-            //instance discovery metadata. This is for non-public cloud scenarios. See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2701
-
-            using (var harness = base.CreateTestHarness())
-            {
-                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                                            .WithAuthority(new Uri(TestConstants.AuthorityCommonPpeAuthority), true)
-                                                                            .WithHttpManager(harness.HttpManager)
-                                                                            .WithTelemetry(new TraceTelemetryConfig())
-                                                                            .BuildConcrete();
-                app.ServiceBundle.ConfigureMockWebUI();
-
-                //Adding one instance discovery response to ensure the cache is hit for the subsiquent requests.
-                //If MSAL tries to do an additional request this test will fail.
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
-                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonPpeAuthority);
-
-                AuthenticationResult result = app
-                    .AcquireTokenInteractive(TestConstants.s_scope)
-                    .ExecuteAsync(CancellationToken.None)
-                    .Result;
-
-                Assert.IsNotNull(result);
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -3,21 +3,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Test.Common;
-using Microsoft.Identity.Test.Common.Core.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Identity.Test.Common.Core.Helpers;
-using Microsoft.Identity.Test.Common.Mocks;
-using Microsoft.Identity.Client.UI;
-using System.Threading;
-using System.Web;
 using Microsoft.Identity.Client.Internal;
-using System.Threading.Tasks;
+using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Common.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 {
@@ -27,7 +25,6 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
     [DeploymentItem("Resources\\OpenidConfigurationCommon.json")]
     public class AadAuthorityTests : TestBase
     {
-
         [TestMethod]
         public void ImmutableTest()
         {
@@ -39,66 +36,62 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestMethod]
         public void CreateEndpointsWithCommonTenantTest()
         {
-            using (var harness = CreateTestHarness())
-            {
-                Authority instance = Authority.CreateAuthority("https://login.microsoftonline.com/common");
-                Assert.IsNotNull(instance);
-                Assert.AreEqual(instance.AuthorityInfo.AuthorityType, AuthorityType.Aad);
+            using var harness = CreateTestHarness();
 
-                Assert.AreEqual("https://login.microsoftonline.com/common/oauth2/v2.0/authorize", instance.GetAuthorizationEndpoint());
-                Assert.AreEqual("https://login.microsoftonline.com/common/oauth2/v2.0/token", instance.GetTokenEndpoint());
-            }
+            Authority instance = Authority.CreateAuthority("https://login.microsoftonline.com/common");
+            Assert.IsNotNull(instance);
+            Assert.AreEqual(instance.AuthorityInfo.AuthorityType, AuthorityType.Aad);
+
+            Assert.AreEqual("https://login.microsoftonline.com/common/oauth2/v2.0/authorize", instance.GetAuthorizationEndpoint());
+            Assert.AreEqual("https://login.microsoftonline.com/common/oauth2/v2.0/token", instance.GetTokenEndpoint());
         }
-
 
         [TestMethod]
         public async Task FailedValidationTestAsync()
         {
-            using (var harness = CreateTestHarness())
-            {
-                // add mock response for instance validation
-                harness.HttpManager.AddMockHandler(
-                    new MockHttpMessageHandler
+            using var harness = CreateTestHarness();
+
+            // add mock response for instance validation
+            harness.HttpManager.AddMockHandler(
+                new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedUrl = "https://login.microsoftonline.com/common/discovery/instance",
+                    ExpectedQueryParams = new Dictionary<string, string>
                     {
-                        ExpectedMethod = HttpMethod.Get,
-                        ExpectedUrl = "https://login.microsoftonline.com/common/discovery/instance",
-                        ExpectedQueryParams = new Dictionary<string, string>
+                        {"api-version", "1.1"},
                         {
-                            {"api-version", "1.1"},
-                            {
-                                "authorization_endpoint",
-                                "https%3A%2F%2Flogin.microsoft0nline.com%2Fmytenant.com%2Foauth2%2Fv2.0%2Fauthorize"
-                            },
+                            "authorization_endpoint",
+                            "https%3A%2F%2Flogin.microsoft0nline.com%2Fmytenant.com%2Foauth2%2Fv2.0%2Fauthorize"
                         },
-                        ResponseMessage = MockHelpers.CreateFailureMessage(
-                            HttpStatusCode.BadRequest,
-                            "{\"error\":\"invalid_instance\"," + "\"error_description\":\"AADSTS50049: " +
-                            "Unknown or invalid instance. Trace " + "ID: b9d0894d-a9a4-4dba-b38e-8fb6a009bc00 " +
-                            "Correlation ID: 34f7b4cf-4fa2-4f35-a59b" + "-54b6f91a9c94 Timestamp: 2016-08-23 " +
-                            "20:45:49Z\",\"error_codes\":[50049]," + "\"timestamp\":\"2016-08-23 20:45:49Z\"," +
-                            "\"trace_id\":\"b9d0894d-a9a4-4dba-b38e-8f" + "b6a009bc00\",\"correlation_id\":\"34f7b4cf-" +
-                            "4fa2-4f35-a59b-54b6f91a9c94\"}")
-                    });
+                    },
+                    ResponseMessage = MockHelpers.CreateFailureMessage(
+                        HttpStatusCode.BadRequest,
+                        "{\"error\":\"invalid_instance\"," + "\"error_description\":\"AADSTS50049: " +
+                        "Unknown or invalid instance. Trace " + "ID: b9d0894d-a9a4-4dba-b38e-8fb6a009bc00 " +
+                        "Correlation ID: 34f7b4cf-4fa2-4f35-a59b" + "-54b6f91a9c94 Timestamp: 2016-08-23 " +
+                        "20:45:49Z\",\"error_codes\":[50049]," + "\"timestamp\":\"2016-08-23 20:45:49Z\"," +
+                        "\"trace_id\":\"b9d0894d-a9a4-4dba-b38e-8f" + "b6a009bc00\",\"correlation_id\":\"34f7b4cf-" +
+                        "4fa2-4f35-a59b-54b6f91a9c94\"}")
+                });
 
-                Authority instance = Authority.CreateAuthority("https://login.microsoft0nline.com/mytenant.com", true);
-                Assert.IsNotNull(instance);
-                Assert.AreEqual(instance.AuthorityInfo.AuthorityType, AuthorityType.Aad);
+            Authority instance = Authority.CreateAuthority("https://login.microsoft0nline.com/mytenant.com", true);
+            Assert.IsNotNull(instance);
+            Assert.AreEqual(instance.AuthorityInfo.AuthorityType, AuthorityType.Aad);
 
-                TestCommon.CreateServiceBundleWithCustomHttpManager(harness.HttpManager, authority: instance.AuthorityInfo.CanonicalAuthority, validateAuthority: true);
-                try
-                {
-                    AuthorityManager am = new AuthorityManager(new RequestContext(harness.ServiceBundle, Guid.NewGuid()), instance);
-                    await am.RunInstanceDiscoveryAndValidationAsync().ConfigureAwait(false);
-                    Assert.Fail("validation should have failed here");
-                }
-                catch (Exception exc)
-                {
-                    Assert.IsTrue(exc is MsalServiceException);
-                    Assert.AreEqual(((MsalServiceException)exc).ErrorCode, "invalid_instance");
-                }
+            TestCommon.CreateServiceBundleWithCustomHttpManager(harness.HttpManager, authority: instance.AuthorityInfo.CanonicalAuthority, validateAuthority: true);
+            try
+            {
+                AuthorityManager am = new AuthorityManager(new RequestContext(harness.ServiceBundle, Guid.NewGuid()), instance);
+                await am.RunInstanceDiscoveryAndValidationAsync().ConfigureAwait(false);
+                Assert.Fail("validation should have failed here");
+            }
+            catch (Exception exc)
+            {
+                Assert.IsTrue(exc is MsalServiceException);
+                Assert.AreEqual(((MsalServiceException)exc).ErrorCode, "invalid_instance");
             }
         }
-
 
         [TestMethod]
         public void CanonicalAuthorityInitTest()
@@ -197,26 +190,28 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         private static void ValidateAuthorityType(string inputAuthority, AuthorityType expectedAuthorityType)
         {
             var pca1 = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                     .WithAuthority(new Uri(inputAuthority)).BuildConcrete();
+                                                     .WithAuthority(new Uri(inputAuthority))
+                                                     .BuildConcrete();
             var pca2 = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                   .WithAuthority(inputAuthority).BuildConcrete();
+                                                     .WithAuthority(inputAuthority)
+                                                     .BuildConcrete();
 
             Assert.AreEqual(
                 expectedAuthorityType,
-                (pca1.AppConfig as ApplicationConfiguration).AuthorityInfo.AuthorityType);
+                ((ApplicationConfiguration)pca1.AppConfig).AuthorityInfo.AuthorityType);
             Assert.AreEqual(
                 expectedAuthorityType,
-                (pca2.AppConfig as ApplicationConfiguration).AuthorityInfo.AuthorityType);
+                ((ApplicationConfiguration)pca2.AppConfig).AuthorityInfo.AuthorityType);
         }
-      
+
         [TestMethod]
         public void CreateAuthorityFromTenantedWithTenantTest()
         {
             Authority authority = AuthorityTestHelper.CreateAuthorityFromUrl("https://login.microsoft.com/tid");
 
             string updatedAuthority = authority.GetTenantedAuthority("other_tenant_id");
-            Assert.AreEqual("https://login.microsoft.com/tid/", updatedAuthority, "Not changed, original authority aleady has tenant id");
-            
+            Assert.AreEqual("https://login.microsoft.com/tid/", updatedAuthority, "Not changed, original authority already has tenant id");
+
             string updatedAuthority2 = authority.GetTenantedAuthority("other_tenant_id", true);
             Assert.AreEqual("https://login.microsoft.com/other_tenant_id/", updatedAuthority2, "Changed with forced flag");
         }
@@ -256,34 +251,31 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         //Test for bug #1292 (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1292)
         public void AuthorityCustomPortTest()
         {
-            var customPortAuthority = "https://localhost:5215/common/";
+            const string customPortAuthority = "https://localhost:5215/common/";
 
-            using (var harness = CreateTestHarness())
-            {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler(customPortAuthority);
+            using var harness = CreateTestHarness();
+            harness.HttpManager.AddInstanceDiscoveryMockHandler(customPortAuthority);
 
-                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                                            .WithAuthority(new Uri(customPortAuthority), false)
-                                                                            .WithHttpManager(harness.HttpManager)
-                                                                            .BuildConcrete();
+            PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                                        .WithAuthority(new Uri(customPortAuthority), false)
+                                                                        .WithHttpManager(harness.HttpManager)
+                                                                        .BuildConcrete();
 
-                //Ensure that the PublicClientApplication init does not remove the port from the authority
-                Assert.AreEqual(customPortAuthority, app.Authority);
+            //Ensure that the PublicClientApplication init does not remove the port from the authority
+            Assert.AreEqual(customPortAuthority, app.Authority);
 
 
-                app.ServiceBundle.ConfigureMockWebUI(
-                    AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
+            app.ServiceBundle.ConfigureMockWebUI(
+                AuthorizationResult.FromUri(app.AppConfig.RedirectUri + "?code=some-code"));
 
-                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(customPortAuthority);
+            harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(customPortAuthority);
 
-                AuthenticationResult result = app
-                    .AcquireTokenInteractive(TestConstants.s_scope)
-                    .ExecuteAsync(CancellationToken.None)
-                    .Result;
+            AuthenticationResult result = app.AcquireTokenInteractive(TestConstants.s_scope)
+                                             .ExecuteAsync(CancellationToken.None)
+                                             .Result;
 
-                //Ensure that acquiring a token does not remove the port from the authority
-                Assert.AreEqual(customPortAuthority, app.Authority);
-            }
+            //Ensure that acquiring a token does not remove the port from the authority
+            Assert.AreEqual(customPortAuthority, app.Authority);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/B2cAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/B2cAuthorityTests.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
-using System.Net.Http;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -56,28 +53,17 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         [TestMethod]
         public void B2CLoginAuthorityEndpoints()
         {
-            using (var httpManager = new MockHttpManager())
-            {
-                var appConfig = new ApplicationConfiguration()
-                {
-                    HttpManager = httpManager,
-                    AuthorityInfo = AuthorityInfo.FromAuthorityUri(
-                        "https://sometenantid.b2clogin.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/b2c_1_susi/", true)
-                };
+            Authority instance = Authority.CreateAuthority(
+                "https://sometenantid.b2clogin.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/b2c_1_susi/");
 
-                Authority instance = Authority.CreateAuthority(
-                    "https://sometenantid.b2clogin.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/b2c_1_susi/");
-                Assert.IsNotNull(instance);
-                Assert.AreEqual(instance.AuthorityInfo.AuthorityType, AuthorityType.B2C);
-                    
-
-                Assert.AreEqual(
-                    "https://sometenantid.b2clogin.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/b2c_1_susi/oauth2/v2.0/authorize",
-                    instance.GetAuthorizationEndpoint());
-                Assert.AreEqual(
-                    "https://sometenantid.b2clogin.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/b2c_1_susi/oauth2/v2.0/token",
-                    instance.GetTokenEndpoint());                
-            }
+            Assert.IsNotNull(instance);
+            Assert.AreEqual(instance.AuthorityInfo.AuthorityType, AuthorityType.B2C);
+            Assert.AreEqual(
+                "https://sometenantid.b2clogin.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/b2c_1_susi/oauth2/v2.0/authorize",
+                instance.GetAuthorizationEndpoint());
+            Assert.AreEqual(
+                "https://sometenantid.b2clogin.com/tfp/6babcaad-604b-40ac-a9d7-9fd97c0b779f/b2c_1_susi/oauth2/v2.0/token",
+                instance.GetTokenEndpoint());
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworkNetDesktop461>net472</TargetFrameworkNetDesktop461>
     <TargetFrameworkNetCore>netcoreapp3.1</TargetFrameworkNetCore>
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
-      
+
     <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetCore);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -7,6 +7,8 @@
 
     <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetCore);$(TargetFrameworkNet5Win)</TargetFrameworks>
     <IsPackable>false</IsPackable>
+
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Identity.Test.Unit/TestBase.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Identity.Test.Unit
             Trace.WriteLine("Test run started");
         }
 
-        [AssemblyCleanup()]
+        [AssemblyCleanup]
         public static void AssemblyCleanup()
         {
             Trace.WriteLine("Test run finished");
@@ -60,7 +60,6 @@ namespace Microsoft.Identity.Test.Unit
                 isExtendedTokenLifetimeEnabled,
                 testContext: TestContext);
         }
-
 
         private static void EnableFileTracingOnEnvVar()
         {

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -5,8 +5,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
 
 namespace Microsoft.Identity.Test.Unit
 {
@@ -138,6 +141,27 @@ namespace Microsoft.Identity.Test.Unit
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
+        }
+
+        [TestMethod]
+        public async Task CreateFromResourceResponseAsync_HttpClientFactoryAsync()
+        {
+            const string resourceUri = "https://example.com/";
+
+            var handler = new MockHttpMessageHandler
+            {
+                ExpectedMethod = HttpMethod.Get,
+                ExpectedUrl = resourceUri,
+                ResponseMessage = new HttpResponseMessage()
+            };
+            var httpClient = new HttpClient(handler);
+
+            var httpClientFactory = Substitute.For<IMsalHttpClientFactory>();
+            httpClientFactory.GetHttpClient().Returns(httpClient);
+
+            var _ = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(httpClientFactory, resourceUri).ConfigureAwait(false);
+
+            httpClientFactory.Received().GetHttpClient();
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -1,33 +1,33 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Identity.Client;
-using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit
 {
     [TestClass]
     public class WwwAuthenticateParametersTests
     {
-        const string ClientIdKey = "client_id";
-        const string ResourceIdKey = "resource_id";
-        const string ResourceKey = "resource";
-        const string GraphGuid = "00000003-0000-0000-c000-000000000000";
-        const string AuthorizationUriKey = "authorization_uri";
-        const string AuthorizationKey = "authorization";
-        const string AuthorityKey = "authority";
-        const string AuthorizationValue = "https://login.microsoftonline.com/common/oauth2/authorize";
-        const string Realm = "realm";
-        const string EncodedClaims = "eyJpZF90b2tlbiI6eyJhdXRoX3RpbWUiOnsiZXNzZW50aWFsIjp0cnVlfSwiYWNyIjp7InZhbHVlcyI6WyJ1cm46bWFjZTppbmNvbW1vbjppYXA6c2lsdmVyIl19fX0=";
-        const string DecodedClaims = "{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}";
-        const string DecodedClaimsHeader = "{\\\"id_token\\\":{\\\"auth_time\\\":{\\\"essential\\\":true},\\\"acr\\\":{\\\"values\\\":[\\\"urn:mace:incommon:iap:silver\\\"]}}}";
-        const string SomeClaims = "some_claims";
-        const string ClaimsKey = "claims";
-        const string ErrorKey = "error";
+        private const string ClientIdKey = "client_id";
+        private const string ResourceIdKey = "resource_id";
+        private const string ResourceKey = "resource";
+        private const string GraphGuid = "00000003-0000-0000-c000-000000000000";
+        private const string AuthorizationUriKey = "authorization_uri";
+        private const string AuthorizationKey = "authorization";
+        private const string AuthorityKey = "authority";
+        private const string AuthorizationValue = "https://login.microsoftonline.com/common/oauth2/authorize";
+        private const string Realm = "realm";
+        private const string EncodedClaims = "eyJpZF90b2tlbiI6eyJhdXRoX3RpbWUiOnsiZXNzZW50aWFsIjp0cnVlfSwiYWNyIjp7InZhbHVlcyI6WyJ1cm46bWFjZTppbmNvbW1vbjppYXA6c2lsdmVyIl19fX0=";
+        private const string DecodedClaims = "{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}";
+        private const string DecodedClaimsHeader = "{\\\"id_token\\\":{\\\"auth_time\\\":{\\\"essential\\\":true},\\\"acr\\\":{\\\"values\\\":[\\\"urn:mace:incommon:iap:silver\\\"]}}}";
+        private const string SomeClaims = "some_claims";
+        private const string ClaimsKey = "claims";
+        private const string ErrorKey = "error";
 
         [TestMethod]
         [DataRow("client_id=00000003-0000-0000-c000-000000000000", "authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\"")]
@@ -39,9 +39,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateResponse(string resource, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {resource}, {authorizationUri}");
 
             // Act
@@ -99,7 +97,7 @@ namespace Microsoft.Identity.Test.Unit
             var authParams = WwwAuthenticateParameters.CreateFromResponseHeaders(httpResponse.Headers);
 
             // Assert
-            string errorValue = "insufficient_claims";
+            const string errorValue = "insufficient_claims";
             Assert.IsTrue(authParams.RawParameters.TryGetValue(AuthorizationUriKey, out string authorizationUri));
             Assert.AreEqual(AuthorizationValue, authorizationUri);
             Assert.AreEqual(AuthorizationValue, authParams[AuthorizationUriKey]);
@@ -125,20 +123,18 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateParamsFromWwwAuthenticateHeader(string clientId, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {clientId}, {authorizationUri}");
 
-            var wwwAuthenticateResponse = httpResponse.Headers.WwwAuthenticate.FirstOrDefault().Parameter;
+            var wwwAuthenticateResponse = httpResponse.Headers.WwwAuthenticate.First().Parameter;
 
             // Act
             var authParams = WwwAuthenticateParameters.CreateFromWwwAuthenticateHeaderValue(wwwAuthenticateResponse);
-            
+
             // Assert
             Assert.AreEqual(GraphGuid, authParams.Resource);
             Assert.AreEqual(TestConstants.AuthorityCommonTenant.TrimEnd('/'), authParams.Authority);
-            Assert.AreEqual($"{GraphGuid}/.default", authParams.Scopes.FirstOrDefault());
+            Assert.AreEqual($"{GraphGuid}/.default", authParams.Scopes.First());
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
@@ -183,26 +179,20 @@ namespace Microsoft.Identity.Test.Unit
         private static HttpResponseMessage CreateClaimsHttpResponse(string claims)
         {
             HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
-            {
-            };
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", client_id=\"00000003-0000-0000-c000-000000000000\", authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\", error=\"insufficient_claims\", claims=\"{claims}\"");
             return httpResponse;
         }
 
         private static HttpResponseMessage CreateErrorHttpResponse()
         {
-            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", client_id=\"00000003-0000-0000-c000-000000000000\", authorization_uri=\"https://login.microsoftonline.com/common/oauth2/authorize\", error=\"some_error\", claims=\"{DecodedClaimsHeader}\"");
             return httpResponse;
         }
 
         private static HttpResponseMessage CreateHttpResponseHeaders(string resourceHeaderKey, string authorizationUriHeaderKey)
         {
-            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized)
-            {
-            };
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {resourceHeaderKey}=\"{GraphGuid}\", {authorizationUriHeaderKey}=\"{AuthorizationValue}\"");
             return httpResponse;
         }

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateResponse(string resource, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {resource}, {authorizationUri}");
 
             // Act
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CreateWwwAuthenticateParamsFromWwwAuthenticateHeader(string clientId, string authorizationUri)
         {
             // Arrange
-            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)401);
+            HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             httpResponse.Headers.Add("WWW-Authenticate", $"Bearer realm=\"\", {clientId}, {authorizationUri}");
 
             var wwwAuthenticateResponse = httpResponse.Headers.WwwAuthenticate.First().Parameter;


### PR DESCRIPTION
**Changes proposed in this request**

- Added property `TenantID` to `WwwAuthenticateParameters`
- Which underneath calls internal class `Authority` to parse `authority uri`

**Testing**

- Updated unit and integration tests

**Performance impact**

- There should be no impact as a new property has been added
