### PR TITLE
updating CCS naming

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -111,8 +111,8 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// To help with resiliency, AAD Cached Credential Service (CCS) operates as an AAD backup.
-        /// This will provide CCS with a routing hint to help improve performance during authentication.
+        /// To help with resiliency, the AAD backup authentication system operates as an AAD backup.
+        /// This will provide backup authentication system with a routing hint to help improve performance during authentication.
         /// </summary>
         /// <param name="userObjectIdentifier">GUID which is unique to the user, parsed from the client_info.</param>
         /// <param name="tenantIdentifier">GUID format of the tenant ID, parsed from the client_info.</param>
@@ -134,8 +134,8 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// To help with resiliency, AAD Cached Credential Service (CCS) operates as an AAD backup.
-        /// This will provide CCS with a routing hint to help improve performance during authentication.
+        /// To help with resiliency, the AAD backup authentication system operates as an AAD backup.
+        /// This will provide backup authentication system with a routing hint to help improve performance during authentication.
         /// </summary>
         /// <param name="userName">Identifier of the user. Generally in UserPrincipalName (UPN) format, e.g. <c>john.doe@contoso.com</c></param>
         /// <returns>The builder to chain the .With methods</returns>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -90,8 +90,8 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// To help with resiliency, AAD Cached Credential Service (CCS) operates as an AAD backup.
-        /// This will provide CCS with a routing hint to help improve performance during authentication.
+        /// To help with resiliency, the AAD backup authentication system operates as an AAD backup.
+        /// This will provide the AAD backup authentication system with a routing hint to help improve performance during authentication.
         /// </summary>
         /// <param name="userObjectIdentifier">GUID which is unique to the user, parsed from the client_info.</param>
         /// <param name="tenantIdentifier">GUID format of the tenant ID, parsed from the client_info.</param>
@@ -113,8 +113,8 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// To help with resiliency, AAD Cached Credential Service (CCS) operates as an AAD backup.
-        /// This will provide CCS with a routing hint to help improve performance during authentication.
+        /// To help with resiliency, the AAD backup authentication system operates as an AAD backup.
+        /// This will provide the AAD backup authentication system with a routing hint to help improve performance during authentication.
         /// </summary>
         /// <param name="userName">Identifier of the user. Generally in UserPrincipalName (UPN) format, e.g. <c>john.doe@contoso.com</c></param>
         /// <returns>The builder to chain the .With methods</returns>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/GetAuthorizationRequestUrlParameterBuilder.cs
@@ -102,8 +102,8 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// To help with resiliency, AAD Cached Credential Service (CCS) operates as an AAD backup.
-        /// This will provide CCS with a routing hint to help improve performance during authentication.
+        /// To help with resiliency, the AAD backup authentication system operates as an AAD backup.
+        /// This will provide the AAD backup authentication system with a routing hint to help improve performance during authentication.
         /// The hint created with this api will take precedence over the one created with <see cref="WithLoginHint"/>
         /// </summary>
         /// <param name="userObjectIdentifier">GUID which is unique to the user, parsed from the client_info.</param>

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Identity.Client.Internal
                 authorizationRequestParameters[OAuth2Parameter.Claims] = _requestParams.ClaimsAndClientCapabilities;
             }
 
-            //CcsRoutingHint passed in from WithCcsRoutingHint() will override the CCS Hint created from the login hint
+            //CcsRoutingHint passed in from WithCcsRoutingHint() will override the AAD backup authentication system Hint created from the login hint
             if (!string.IsNullOrWhiteSpace(_interactiveParameters.LoginHint) || _requestParams.CcsRoutingHint != null)
             {
                 string OidCcsHeader;
@@ -201,7 +201,8 @@ namespace Microsoft.Identity.Client.Internal
                     OidCcsHeader = CoreHelpers.GetCcsClientInfoHint(_requestParams.CcsRoutingHint.Value.Key, _requestParams.CcsRoutingHint.Value.Value);
                 }
 
-                //The CCS header is used by the CCS service to help route requests to resources in Azure during requests to speed up authentication.
+                //The AAD backup authentication system header is used by the AAD backup authentication system service
+                //to help route requests to resources in Azure during requests to speed up authentication.
                 //It consists of either the ObjectId.TenantId or the upn of the account signign in.
                 //See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2525
                 authorizationRequestParameters[Constants.CcsRoutingHintHeader] = OidCcsHeader;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -269,7 +269,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 cancellationToken);
         }
 
-        //The CCS header is used by the CCS service to help route requests to resources in Azure during requests to speed up authentication.
+        //The AAD backup authentication system header is used by the AAD backup authentication system service
+        //to help route requests to resources in Azure during requests to speed up authentication.
         //It consists of either the ObjectId.TenantId or the upn of the account signign in.
         //See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2525
         protected virtual KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)


### PR DESCRIPTION
Fixes # .
#2919 

**Changes proposed in this request**

- Replacing CCS by "backup authentication system" in docs, comments
- Updated Wiki Page : [https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Backup-Authentication-System](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Backup-Authentication-System)
- Couldn't find any aka/ms links or reference to the old CCS wiki page

Closes #2919 
