### PR TITLE
Use TopMost for WAM account picker splashscreen

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
@@ -153,6 +153,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             {
                 splash.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
                 splash.DialogResult = System.Windows.Forms.DialogResult.OK;
+                splash.TopMost = true;
+
                 splash.Shown += async (s, e) =>
                 {
                     var windowHandle = splash.Handle;


### PR DESCRIPTION
Partial fix for #2901

**Changes proposed in this request**
MSAL sometimes uses a splashscreen to display the account picker. This change makes the splashscreen topmost. This ensures that the account picker is brought to the front. 

**Testing**
No, we don't test UI

**Performance impact**

