### PR TITLE
about:srcdoc to the list of safe non-https urls

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
     internal class WKWebNavigationDelegate : WKNavigationDelegate
     {
         private const string AboutBlankUri = "about:blank";
+        private const string AboutSrcDocUri = "about:srcdoc";
         private MsalAuthenticationAgentUIViewController _authenticationAgentUIViewController = null;
 
         public WKWebNavigationDelegate(MsalAuthenticationAgentUIViewController authUIViewController)
@@ -78,6 +79,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
             }
 
             if (!navigationAction.Request.Url.AbsoluteString.Equals(AboutBlankUri, StringComparison.OrdinalIgnoreCase)
+                && !navigationAction.Request.Url.AbsoluteString.Equals(AboutSrcDocUri, StringComparison.OrdinalIgnoreCase)
                 && !navigationAction.Request.Url.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
             {
                 AuthorizationResult result = AuthorizationResult.FromStatus(

--- a/tests/devapps/XForms/XForms.iOS/Main.cs
+++ b/tests/devapps/XForms/XForms.iOS/Main.cs
@@ -17,7 +17,7 @@ namespace XForms.iOS
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }


### PR DESCRIPTION
Fixes # 2735.
about:srcdoc is now added as a safe non-https url

**Changes proposed in this request**
Added the url as safe

**Testing**
Manual

**Performance impact**
None
