### PR TITLE
Bogavril/cpu

### DIFF
--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Identity.Client
             string partitionKey = CacheKeyFactory.GetKeyFromRequest(requestParams);
             Debug.Assert(partitionKey != null || !requestParams.IsConfidentialClient, "On confidential client, cache must be partitioned.");
 
-            IReadOnlyList<MsalAccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensWithNoLocks(true, partitionKey);
+            IReadOnlyList<MsalAccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensWithNoLocks(false, partitionKey);
             if (tokenCacheItems.Count == 0)
             {
                 logger.Verbose("No access tokens found in the cache. Skipping filtering. ");
@@ -413,9 +413,14 @@ namespace Microsoft.Identity.Client
                 return null;
             }
 
-            tokenCacheItems = FilterByHomeAccountTenantOrAssertion(requestParams, tokenCacheItems);
-            tokenCacheItems = FilterByTokenType(requestParams, tokenCacheItems);
-            tokenCacheItems = FilterByScopes(requestParams, tokenCacheItems);
+            tokenCacheItems = FilterAllTokens(
+                requestParams, 
+                tokenCacheItems, 
+                FilterByClientId(requestParams),
+                FilterByHomeAccountTenantOrAssertion(requestParams), 
+                FilterByTokenType(requestParams), 
+                FilterByScopes(requestParams));
+
             tokenCacheItems = await FilterByEnvironmentAsync(requestParams, tokenCacheItems).ConfigureAwait(false);
 
             CacheRefreshReason cacheInfoTelemetry = CacheRefreshReason.NotApplicable;
@@ -441,127 +446,120 @@ namespace Microsoft.Identity.Client
             return msalAccessTokenCacheItem;
         }
 
-        private static IReadOnlyList<MsalAccessTokenCacheItem> FilterByScopes(
-            AuthenticationRequestParameters requestParams,
-            IReadOnlyList<MsalAccessTokenCacheItem> tokenCacheItems)
+        private static Func<MsalAccessTokenCacheItem, bool> FilterByScopes(AuthenticationRequestParameters requestParams)
         {
             var logger = requestParams.RequestContext.Logger;
-            if (tokenCacheItems.Count == 0)
+
+            string[] requestScopes;
+            if (requestParams.ApiId != ApiEvent.ApiIds.AcquireTokenForClient)
             {
-                logger.Verbose("Not filtering by scopes, because there are no candidates");
-                return tokenCacheItems;
-            }
-
-            // For client credentials there is one and only one scope
-            if (requestParams.ApiId == ApiEvent.ApiIds.AcquireTokenForClient && requestParams.Scope.Count == 1)
-            {
-                tokenCacheItems = tokenCacheItems.FilterWithLogging(item =>
-                {
-                    bool accepted = string.Equals(
-                        item.ScopeString,
-                        requestParams.Scope.Single(),
-                        StringComparison.OrdinalIgnoreCase);
-
-                    if (logger.IsLoggingEnabled(LogLevel.Verbose))
-                    {
-                        logger.Verbose($"Access token with scope {string.Join(" ", item.ScopeSet)} " +
-                            $"passes scope filter? {accepted} ");
-                    }
-
-                    return accepted;
-
-                }, 
-                logger, 
-                "Filtering by scopes");
-            }
-            else
-            {
-                var requestScopes = requestParams.Scope.Where(s =>
+                requestScopes = requestParams.Scope.Where(s =>
                     !OAuth2Value.ReservedScopes.Contains(s)).ToArray();
-
-                tokenCacheItems = tokenCacheItems.FilterWithLogging(
-                    item =>
-                    {
-                        bool accepted = ScopeHelper.ScopeContains(item.ScopeSet, requestScopes);
-
-                        if (logger.IsLoggingEnabled(LogLevel.Verbose))
-                        {
-                            logger.Verbose($"Access token with scopes {string.Join(" ", item.ScopeSet)} " +
-                                $"passes scope filter? {accepted} ");
-                        }
-                        return accepted;
-                    },
-                    logger,
-                    "Filtering by scopes");
-            }
-
-            return tokenCacheItems;
-        }
-
-        private static IReadOnlyList<MsalAccessTokenCacheItem> FilterByTokenType(
-            AuthenticationRequestParameters requestParams,
-            IReadOnlyList<MsalAccessTokenCacheItem> tokenCacheItems)
-        {
-            tokenCacheItems = tokenCacheItems.FilterWithLogging(item =>
-                            string.Equals(
-                                item.TokenType ?? BearerAuthenticationScheme.BearerTokenType,
-                                requestParams.AuthenticationScheme.AccessTokenType,
-                                StringComparison.OrdinalIgnoreCase),
-                            requestParams.RequestContext.Logger,
-                            "Filtering by token type");
-            return tokenCacheItems;
-        }
-
-        private static IReadOnlyList<MsalAccessTokenCacheItem> FilterByHomeAccountTenantOrAssertion(
-            AuthenticationRequestParameters requestParams,
-            IReadOnlyList<MsalAccessTokenCacheItem> tokenCacheItems)
-        {
-            string requestTenantId = requestParams.Authority.TenantId;
-            bool filterByTenantId = true;
-
-            if (requestParams.ApiId == ApiEvent.ApiIds.AcquireTokenOnBehalfOf) // OBO
-            {
-                tokenCacheItems =
-                    tokenCacheItems.FilterWithLogging(item =>
-                        !string.IsNullOrEmpty(item.UserAssertionHash) &&
-                        item.UserAssertionHash.Equals(requestParams.UserAssertion.AssertionHash, StringComparison.OrdinalIgnoreCase),
-                        requestParams.RequestContext.Logger,
-                        $"Filtering AT by user assertion: {requestParams.UserAssertion.AssertionHash}");
-
-                // OBO calls FindAccessTokenAsync directly, but we are not able to resolve the authority 
-                // unless the developer has configured a tenanted authority. If they have configured /common
-                // then we cannot filter by tenant and will use whatever is in the cache.
-                filterByTenantId =
-                    !string.IsNullOrEmpty(requestTenantId) &&
-                    !AadAuthority.IsCommonOrganizationsOrConsumersTenant(requestTenantId);
-            }
-
-            if (filterByTenantId)
-            {
-                tokenCacheItems = tokenCacheItems.FilterWithLogging(item =>
-                    string.Equals(item.TenantId ?? string.Empty, requestTenantId ?? string.Empty, StringComparison.OrdinalIgnoreCase),
-                    requestParams.RequestContext.Logger,
-                    "Filtering AT by tenant id");
             }
             else
             {
-                requestParams.RequestContext.Logger.Warning("Have not filtered by tenant ID. " +
-                    "This can happen in OBO scenario where authority is /common or /organizations. " +
-                    "Please use tenanted authority.");
+                requestScopes = requestParams.Scope.ToArray();
             }
 
-            // Only AcquireTokenSilent has an IAccount in the request that can be used for filtering
-            if (requestParams.ApiId != ApiEvent.ApiIds.AcquireTokenForClient &&
-                requestParams.ApiId != ApiEvent.ApiIds.AcquireTokenOnBehalfOf)
+            return item =>
             {
-                tokenCacheItems = tokenCacheItems.FilterWithLogging(item => item.HomeAccountId.Equals(
-                                requestParams.Account.HomeAccountId?.Identifier, StringComparison.OrdinalIgnoreCase),
-                                requestParams.RequestContext.Logger,
-                                "Filtering AT by home account id");
-            }
+                bool accepted = ScopeHelper.ScopeContains(item.ScopeSet, requestScopes);
 
-            return tokenCacheItems;
+                if (logger.IsLoggingEnabled(LogLevel.Verbose))
+                {
+                    logger.Verbose($"Access token with scopes {string.Join(" ", item.ScopeSet)} " +
+                        $"passes scope filter? {accepted} ");
+                }
+                return accepted;
+            };
         }
+
+        private static IReadOnlyList<MsalAccessTokenCacheItem> FilterAllTokens(AuthenticationRequestParameters requestParams,
+            IReadOnlyList<MsalAccessTokenCacheItem> tokenCacheItems, params Func<MsalAccessTokenCacheItem, Boolean>[] predicates)
+        {
+            return tokenCacheItems.FilterWithLogging(item =>
+            {
+                return predicates.All(p => p(item));
+            }, requestParams.RequestContext.Logger, "Access token filters").ToList();
+        }
+
+        private static Func<MsalAccessTokenCacheItem, bool> FilterByTokenType(AuthenticationRequestParameters requestParams)
+        {
+            return item =>
+            {
+                return string.Equals(
+                                 item.TokenType ?? BearerAuthenticationScheme.BearerTokenType,
+                                 requestParams.AuthenticationScheme.AccessTokenType,
+                                 StringComparison.OrdinalIgnoreCase);
+            };
+        }
+
+        private static Func<MsalAccessTokenCacheItem, bool> FilterByClientId(AuthenticationRequestParameters requestParams)
+        {
+            return item =>
+            {
+                return string.Equals(item.ClientId, requestParams.AppConfig.ClientId, StringComparison.OrdinalIgnoreCase);
+            };
+        }
+
+        private static Func<MsalAccessTokenCacheItem, bool> FilterByHomeAccountTenantOrAssertion(AuthenticationRequestParameters requestParams)
+        {
+            var logger = requestParams.RequestContext.Logger;
+
+            return item =>
+            {
+                string requestTenantId = requestParams.Authority.TenantId;
+                bool filterByTenantId = true;
+
+                bool include = false;
+
+                if (requestParams.ApiId == ApiEvent.ApiIds.AcquireTokenOnBehalfOf) // OBO
+                {
+
+                    include = !string.IsNullOrEmpty(item.UserAssertionHash) &&
+                     item.UserAssertionHash.Equals(requestParams.UserAssertion.AssertionHash, StringComparison.OrdinalIgnoreCase);
+
+                    if (!include)
+                        return include;
+
+                    // OBO calls FindAccessTokenAsync directly, but we are not able to resolve the authority 
+                    // unless the developer has configured a tenanted authority. If they have configured /common
+                    // then we cannot filter by tenant and will use whatever is in the cache.
+                    filterByTenantId =
+                        !string.IsNullOrEmpty(requestTenantId) &&
+                        !AadAuthority.IsCommonOrganizationsOrConsumersTenant(requestTenantId);
+                }
+
+                if (!filterByTenantId)
+                {
+                    include = true;
+                    requestParams.RequestContext.Logger.Warning("Have not filtered by tenant ID. " +
+                          "This can happen in OBO scenario where authority is /common or /organizations. " +
+                          "Please use tenanted authority.");
+                }
+                else
+                {
+                    include = string.Equals(item.TenantId ?? string.Empty, requestTenantId ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+                }
+
+
+                if (!include)
+                    return include;
+
+
+                // Only AcquireTokenSilent has an IAccount in the request that can be used for filtering
+                if (requestParams.ApiId != ApiEvent.ApiIds.AcquireTokenForClient &&
+                    requestParams.ApiId != ApiEvent.ApiIds.AcquireTokenOnBehalfOf)
+                {
+                    include =
+                     item.HomeAccountId.Equals(
+                                    requestParams.Account.HomeAccountId?.Identifier, StringComparison.OrdinalIgnoreCase);
+                }
+
+                return include;
+            };
+        }
+
 
         private MsalAccessTokenCacheItem FilterByExpiry(MsalAccessTokenCacheItem msalAccessTokenCacheItem, AuthenticationRequestParameters requestParams)
         {
@@ -718,7 +716,7 @@ namespace Microsoft.Identity.Client
             {
                 accessor.SaveAccessToken(atItem.WithExpiresOn(DateTimeOffset.UtcNow));
             }
-               
+
             if (tokenCacheInternal.IsAppSubscribedToSerializationEvents())
             {
                 var args = new TokenCacheNotificationArgs(
@@ -730,8 +728,8 @@ namespace Microsoft.Identity.Client
                 tokenCacheInternal.HasTokensNoLocks(),
                 default,
                 suggestedCacheKey: null,
-                suggestedCacheExpiry: null); 
-             
+                suggestedCacheExpiry: null);
+
                 await tokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);
             }
         }

--- a/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Client.Utils
         {
             foreach (string key in possibleContainedSet)
             {
-                if (!outerSet.Contains(key) && !string.IsNullOrEmpty(key))
+                if (!string.IsNullOrEmpty(key) && !outerSet.Contains(key))
                 {
                     return false;
                 }
@@ -28,26 +28,23 @@ namespace Microsoft.Identity.Client.Utils
             return new HashSet<string>(userScopes.Concat(OAuth2Value.ReservedScopes));
         }
 
+        private static readonly Char[] SingleSpace = new Char[] { ' ' };
+
         public static HashSet<string> ConvertStringToScopeSet(string singleString)
         {
-            if (string.IsNullOrEmpty(singleString))
-            {
-                return new HashSet<string>();
-            }
+            String[] parts = singleString?.Split(SingleSpace, StringSplitOptions.RemoveEmptyEntries);
 
-            return new HashSet<string>(
-                singleString.Split(' '), 
-                StringComparer.OrdinalIgnoreCase);
+            return CreateScopeSet(parts);
         }
 
         public static HashSet<string> CreateScopeSet(IEnumerable<string> input)
         {
             if (input == null)
             {
-                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                return new HashSet<string>(StringComparer.Ordinal);
             }
 
-            return new HashSet<string>(input, StringComparer.OrdinalIgnoreCase);
-        }    
+            return new HashSet<string>(input.Select(i => i.ToLower()), StringComparer.Ordinal);
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Client.Utils
         {
             foreach (string key in possibleContainedSet)
             {
-                if (!string.IsNullOrEmpty(key) && !outerSet.Contains(key))
+                if (!outerSet.Contains(key) && !string.IsNullOrEmpty(key))
                 {
                     return false;
                 }
@@ -28,23 +28,26 @@ namespace Microsoft.Identity.Client.Utils
             return new HashSet<string>(userScopes.Concat(OAuth2Value.ReservedScopes));
         }
 
-        private static readonly Char[] SingleSpace = new Char[] { ' ' };
-
         public static HashSet<string> ConvertStringToScopeSet(string singleString)
         {
-            String[] parts = singleString?.Split(SingleSpace, StringSplitOptions.RemoveEmptyEntries);
+            if (string.IsNullOrEmpty(singleString))
+            {
+                return new HashSet<string>();
+            }
 
-            return CreateScopeSet(parts);
+            return new HashSet<string>(
+                singleString.Split(' '),
+                StringComparer.OrdinalIgnoreCase);
         }
 
         public static HashSet<string> CreateScopeSet(IEnumerable<string> input)
         {
             if (input == null)
             {
-                return new HashSet<string>(StringComparer.Ordinal);
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
 
-            return new HashSet<string>(input.Select(i => i.ToLower()), StringComparer.Ordinal);
+            return new HashSet<string>(input, StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Client.Utils
         {
             foreach (string key in possibleContainedSet)
             {
-                if (!outerSet.Contains(key) && !string.IsNullOrEmpty(key))
+                if (!string.IsNullOrEmpty(key) && !outerSet.Contains(key))
                 {
                     return false;
                 }
@@ -28,16 +28,13 @@ namespace Microsoft.Identity.Client.Utils
             return new HashSet<string>(userScopes.Concat(OAuth2Value.ReservedScopes));
         }
 
+        private static readonly char[] SingleSpace = new Char[] { ' ' };
+
         public static HashSet<string> ConvertStringToScopeSet(string singleString)
         {
-            if (string.IsNullOrEmpty(singleString))
-            {
-                return new HashSet<string>();
-            }
+            string[] parts = singleString?.Split(SingleSpace, StringSplitOptions.RemoveEmptyEntries);
 
-            return new HashSet<string>(
-                singleString.Split(' '),
-                StringComparer.OrdinalIgnoreCase);
+            return CreateScopeSet(parts);
         }
 
         public static HashSet<string> CreateScopeSet(IEnumerable<string> input)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
 
             public string Environment => "fs.msidlab8.com/adfs";
 
-            public string[] AppScopes => new[] { "openid", "profile" };
+            public string[] AppScopes => new[] { "openid" };
 
             public X509Certificate2 GetCertificate()
             {


### PR DESCRIPTION
CPU profiling numbers, based on a token cache with 100 tenants and 100 resources per tenant (so 100*100 total tokens). @pmaytak can help run the latency and memory consumption tests.

BEFORE
AcquireTokenForClient..... .. 100
FindAccessToken .. .. 59.6%
FilterByScopes  .. .. 25.2%


AFTER
AcquireTokenForClient... ... 100
FindAccessToken .. .. 61%
FilterByScopes  .... 18.3%

BenchmarkDotNet tests.
About 7% speed improvement.

|                Method |   Tenants |   TokensPerTenant |     Mean |    Error |    StdDev |   Median |      Min |      Max | Allocated |
|---------------------- |------------ |------------ |---------:|---------:|----------:|---------:|---------:|---------:|----------:|
| AcquireTokenForClient_Old | 1000 | 400 | 371.8&nbsp;μs | 10.20&nbsp;μs |  26.70&nbsp;μs | 368.4&nbsp;μs | 318.6&nbsp;μs | 478.1&nbsp;μs |     61 KB |
| AcquireTokenForClient_New | 1000 | 400 | 345.2&nbsp;μs | 13.84&nbsp;μs | 36.21&nbsp;μs | 339.2&nbsp;μs | 277.3&nbsp;μs | 497.6&nbsp;μs |     56 KB |
| AcquireTokenForClient_Old | 400 | 1000 | 703.1&nbsp;μs | 36.82&nbsp;μs | 100.79&nbsp;μs | 668.6&nbsp;μs | 572.7&nbsp;μs | 999.8&nbsp;μs |    110 KB |
| AcquireTokenForClient_New | 400 | 1000 | 650.9&nbsp;μs | 31.05&nbsp;μs | 85.00&nbsp;μs | 631.7&nbsp;μs | 530.6&nbsp;μs | 891.1&nbsp;μs |    105 KB |

CPU usage for slightly larger token cache is also about 7% improvement.
| Name                   | Tenants | Tokens | ms of CPU time | % of CPU time |
|------------------------|---------|--------|----------------|---------------|
| FindAccessToken_Before | 1000    | 400    | 15087          | 75.77%        |
| FindAccessToken_After  | 1000    | 400    | 13717          | 70.68%        |
| FindAccessToken_Before | 400     | 1000   | 18940          | 86.48%        |
| FindAccessToken_After  | 400     | 1000   | 17236          | 82.69%        |
