### PR TITLE
Reduce allocations for access token cache retrieval for misses

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.ApiConfig.Parameters
 {
@@ -20,7 +21,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         ///  These need to be asked for to the /authorize endpoint (for consent)
         ///  but not to the /token endpoint
         /// </summary>
-        public IEnumerable<string> ExtraScopesToConsent { get; set; } = new List<string>();
+        public IEnumerable<string> ExtraScopesToConsent { get; set; } = CollectionHelpers.GetEmptyReadOnlyList<string>();
         public WebViewPreference UseEmbeddedWebView { get; set; } = WebViewPreference.NotSpecified;
         public string LoginHint { get; set; }
         public IAccount Account { get; set; }
@@ -34,7 +35,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
             builder.AppendLine("LoginHint provided: " + !string.IsNullOrEmpty(LoginHint));
             builder.AppendLine("User provided: " + (Account != null));
             builder.AppendLine("UseEmbeddedWebView: " + UseEmbeddedWebView);
-            builder.AppendLine("ExtraScopesToConsent: " + string.Join(";", ExtraScopesToConsent ?? new List<string>()));
+            builder.AppendLine("ExtraScopesToConsent: " + string.Join(";", ExtraScopesToConsent ?? CollectionHelpers.GetEmptyReadOnlyList<string>()));
             builder.AppendLine("Prompt: " + Prompt.PromptValue);
             builder.AppendLine("HasCustomWebUi: " + (CustomWebUi != null));
             UiParent.SystemWebViewOptions?.LogParameters(logger);

--- a/src/client/Microsoft.Identity.Client/AppConfig/TraceTelemetryConfig.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/TraceTelemetryConfig.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Identity.Client.TelemetryCore.Internal;
+using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Json;
 using Microsoft.Identity.Json.Linq;
 
@@ -74,6 +75,6 @@ namespace Microsoft.Identity.Client
         /// 
         /// </summary>
         /// <remarks>This API is experimental and it may change in future versions of the library without an major version increment</remarks>
-        public IEnumerable<string> AllowedScopes => new List<string>();
+        public IEnumerable<string> AllowedScopes => CollectionHelpers.GetEmptyReadOnlyList<string>();
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
@@ -9,6 +9,7 @@ using Microsoft.Identity.Client.Internal.Logger;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.UI;
+using Microsoft.Identity.Client.Utils;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -69,7 +70,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             IInstanceDiscoveryManager instanceDiscoveryManager)
         {
             _logger.Info("NullBroker - returning empty list on GetAccounts request.");
-            return Task.FromResult<IReadOnlyList<IAccount>>(new List<IAccount>()); // nop
+            return Task.FromResult(CollectionHelpers.GetEmptyReadOnlyList<IAccount>()); // nop
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
                 if (!IsBrokerInstalledAndInvokable())
                 {
                     _logger.Warning("[Android broker] Broker is either not installed or is not reachable so no accounts will be returned. ");
-                    return new List<IAccount>();
+                    return CollectionHelpers.GetEmptyReadOnlyList<IAccount>();
                 }
 
                 BrokerRequest brokerRequest = new BrokerRequest() { ClientId = clientId, RedirectUri = new Uri(redirectUri) };

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
                     ICacheSessionManager cacheSessionManager,
                     IInstanceDiscoveryManager instanceDiscoveryManager)
         {
-            return Task.FromResult<IReadOnlyList<IAccount>>(new List<IAccount>()); // nop
+            return Task.FromResult(CollectionHelpers.GetEmptyReadOnlyList<IAccount>()); // nop
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
@@ -9,6 +9,7 @@ using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Cache.Keys;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 {
@@ -181,28 +182,23 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 AccessTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList()
-#if NETSTANDARD || NETCOREAPP || NET461
-                    ?? Array.Empty<MsalAccessTokenCacheItem>() as IReadOnlyList<MsalAccessTokenCacheItem>;
-#else               
-                    ?? new List<MsalAccessTokenCacheItem>();
-#endif
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalAccessTokenCacheItem>();
             }
         }
 
         public virtual IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
         {
-            return new List<MsalRefreshTokenCacheItem>();
+            return CollectionHelpers.GetEmptyReadOnlyList<MsalRefreshTokenCacheItem>();
         }
 
         public virtual IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
         {
-            return new List<MsalIdTokenCacheItem>();
+            return CollectionHelpers.GetEmptyReadOnlyList<MsalIdTokenCacheItem>();
         }
 
         public virtual IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
         {
-            return new List<MsalAccountCacheItem>();
+            return CollectionHelpers.GetEmptyReadOnlyList<MsalAccountCacheItem>();
         }
 
         public IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
@@ -9,6 +9,7 @@ using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Cache.Keys;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 {
@@ -212,7 +213,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 AccessTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? new List<MsalAccessTokenCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalAccessTokenCacheItem>();
             }
         }
 
@@ -227,7 +228,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 RefreshTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalRefreshTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? new List<MsalRefreshTokenCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalRefreshTokenCacheItem>();
             }
         }
 
@@ -242,7 +243,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 IdTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalIdTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? new List<MsalIdTokenCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalIdTokenCacheItem>();
             }
         }
 
@@ -257,7 +258,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 AccountCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccountCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? new List<MsalAccountCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalAccountCacheItem>();
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/Utils/CollectionHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CollectionHelpers.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+#if HAVE_METHOD_IMPL_ATTRIBUTE
+using System.Runtime.CompilerServices;
+#endif
+
+namespace Microsoft.Identity.Client.Utils
+{
+    internal static class CollectionHelpers
+    {
+#if HAVE_METHOD_IMPL_ATTRIBUTE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static IReadOnlyList<T> GetEmptyReadOnlyList<T>()
+        {
+#if !net45
+            return Array.Empty<T>();
+#else
+            return new List<T>();
+#endif
+        }
+    }
+}


### PR DESCRIPTION
**Changes proposed in this request**
For cache miss scenarios there is no reason to allocate a new list only for followup calls to check whether there is any item in the list. For .Net Core/Standard and Framework versions after 4.6 we can use Array.Empty, however this does reduce readability. I completely understand if we want to keep the code as is for simplicity sake as this is not a major bottleneck.

**Testing**
Verified that the `Array.Empty<MsalAccessTokenCacheItem>() as IReadOnlyList<MsalAccessTokenCacheItem>` does not result in null.

**Performance impact**
Verified how much time is being spent on new List vs Array.Empty

|     Method |              Runtime |       Mean |     Error |    StdDev | Ratio | Allocated |
|----------- |--------------------- |-----------:|----------:|----------:|------:|----------:|
| ArrayEmpty |             .NET 5.0 |  0.5157 ns | 0.0944 ns | 0.1628 ns |  0.09 |         - |
| ArrayEmpty |             .NET 6.0 |  0.3559 ns | 0.0896 ns | 0.1546 ns |  0.07 |         - |
| ArrayEmpty | .NET Framework 4.7.2 |  5.4722 ns | 0.1890 ns | 0.3259 ns |  1.00 |         - |
|            |                      |            |           |           |       |           |
|    NewList |             .NET 5.0 |  4.5300 ns | 0.1699 ns | 0.4622 ns |  0.44 |      32 B |
|    NewList |             .NET 6.0 |  5.7998 ns | 0.1849 ns | 0.2987 ns |  0.55 |      32 B |
|    NewList | .NET Framework 4.7.2 | 10.6371 ns | 0.2900 ns | 0.5002 ns |  1.00 |      40 B |

Source
``` csharp
[ParamsSource(nameof(ValuesForInput))]
public IEnumerable<string> Input { get; set; }
public IEnumerable<IEnumerable<string>> ValuesForInput => new IEnumerable<string>[] { null };

[Benchmark]
public IReadOnlyList<string> ArrayEmpty()
{
    return Input?.ToList() ?? Array.Empty<string>() as IReadOnlyList<string>;
}
[Benchmark]
public IReadOnlyList<string> NewList()
{
    return Input?.ToList() ?? new List<string>();
}
```

