### PR TITLE
Expose SetCacheOptions at the ITokenCache level

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="options">Options for the internal MSAL token caches. </param>
 #if !SUPPORTS_CUSTOM_CACHE || WINDOWS_APP
-        [EditorBrowsable(EditorBrowsableState.Never)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
 #endif
         public T WithCacheOptions(CacheOptions options)
         {
@@ -525,7 +525,7 @@ namespace Microsoft.Identity.Client
             return Config;
         }
 
-        #region Authority
+#region Authority
         private void ResolveAuthority()
         {
             if (Config.Authority?.AuthorityInfo != null)
@@ -826,7 +826,7 @@ namespace Microsoft.Identity.Client
             return (T)this;
         }
 
-        #endregion
+#endregion
 
         private static string GetValueIfNotEmpty(string original, string value)
         {

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1036,5 +1036,12 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string RegionalAndAuthorityOverride = "authority_override_regional";
 
+        /// <summary>
+        /// <para>What happens?</para>The token cache does not contain a token with an OBO cache key that
+        /// matches the <c>longRunningProcessSessionKey</c> passed into <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess"/>.
+        /// <para>Mitigation</para> Call <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi"/> with this <c>longRunningProcessSessionKey</c> 
+        /// first or call <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess"/> with an already used <c>longRunningProcessSessionKey</c>.
+        /// </summary>
+        public const string OboCacheKeyNotInCacheError = "obo_cache_key_not_in_cache_error";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1022,6 +1022,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string StaticCacheWithExternalSerialization = "static_cache_with_external_serialization";
 
+
         /// <summary>
         /// <para>What happens?</para>You configured WithTenant at the request level, but the application is using a non-AAD authority
         /// These are mutually exclusive.
@@ -1035,12 +1036,5 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string RegionalAndAuthorityOverride = "authority_override_regional";
 
-        /// <summary>
-        /// <para>What happens?</para>The token cache does not contain a token with an OBO cache key that
-        /// matches the <c>longRunningProcessSessionKey</c> passed into <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess"/>.
-        /// <para>Mitigation</para> Call <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi"/> with this <c>longRunningProcessSessionKey</c> 
-        /// first or call <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess"/> with an already used <c>longRunningProcessSessionKey</c>.
-        /// </summary>
-        public const string OboCacheKeyNotInCacheError = "obo_cache_key_not_in_cache_error";
     }
 }

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -183,22 +183,22 @@ namespace Microsoft.Identity.Client
                             msalAccessTokenCacheItem.HomeAccountId,
                             msalAccessTokenCacheItem.TokenType);
 
-                        _accessor.SaveAccessToken(msalAccessTokenCacheItem);
+                        Accessor.SaveAccessToken(msalAccessTokenCacheItem);
                     }
 
                     if (idToken != null)
                     {
                         requestParams.RequestContext.Logger.Info("Saving Id Token and Account in cache ...");
-                        _accessor.SaveIdToken(msalIdTokenCacheItem);
+                        Accessor.SaveIdToken(msalIdTokenCacheItem);
                         MergeWamAccountIds(msalAccountCacheItem);
-                        _accessor.SaveAccount(msalAccountCacheItem);
+                        Accessor.SaveAccount(msalAccountCacheItem);
                     }
 
                     // if server returns the refresh token back, save it in the cache.
                     if (msalRefreshTokenCacheItem != null)
                     {
                         requestParams.RequestContext.Logger.Info("Saving RT in cache...");
-                        _accessor.SaveRefreshToken(msalRefreshTokenCacheItem);
+                        Accessor.SaveRefreshToken(msalRefreshTokenCacheItem);
                     }
 
                     UpdateAppMetadata(
@@ -220,7 +220,7 @@ namespace Microsoft.Identity.Client
                     {
                         DateTimeOffset? cacheExpiry = null;
 
-                        if (!_accessor.GetAllRefreshTokens().Any())
+                        if (!Accessor.GetAllRefreshTokens().Any())
                         {
                             cacheExpiry = CalculateSuggestedCacheExpiry();
                         }
@@ -332,7 +332,7 @@ namespace Microsoft.Identity.Client
 
         private void MergeWamAccountIds(MsalAccountCacheItem msalAccountCacheItem)
         {
-            var existingAccount = _accessor.GetAccount(msalAccountCacheItem.GetKey());
+            var existingAccount = Accessor.GetAccount(msalAccountCacheItem.GetKey());
             var existingWamAccountIds = existingAccount?.WamAccountIds;
             msalAccountCacheItem.WamAccountIds.MergeDifferentEntries(existingWamAccountIds);
         }
@@ -740,7 +740,7 @@ namespace Microsoft.Identity.Client
             if (requestParams.Authority == null)
                 return null;
 
-            IReadOnlyList<MsalRefreshTokenCacheItem> allRts = _accessor.GetAllRefreshTokens(CacheKeyFactory.GetKeyFromRequest(requestParams));
+            IReadOnlyList<MsalRefreshTokenCacheItem> allRts = Accessor.GetAllRefreshTokens(CacheKeyFactory.GetKeyFromRequest(requestParams));
             if (allRts.Count != 0)
             {
                 var metadata =
@@ -852,7 +852,7 @@ namespace Microsoft.Identity.Client
                 return null;
             }
 
-            IEnumerable<MsalAppMetadataCacheItem> allAppMetadata = _accessor.GetAllAppMetadata();
+            IEnumerable<MsalAppMetadataCacheItem> allAppMetadata = Accessor.GetAllAppMetadata();
 
             var instanceMetadata = await ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
                     requestParams.AuthorityInfo,
@@ -862,7 +862,7 @@ namespace Microsoft.Identity.Client
 
             var appMetadata =
                 instanceMetadata.Aliases
-                .Select(env => _accessor.GetAppMetadata(new MsalAppMetadataCacheKey(ClientId, env)))
+                .Select(env => Accessor.GetAppMetadata(new MsalAppMetadataCacheKey(ClientId, env)))
                 .FirstOrDefault(item => item != null);
 
             // From a FOCI perspective, an app has 3 states - in the family, not in the family or unknown
@@ -895,7 +895,7 @@ namespace Microsoft.Identity.Client
             string partitionKey = CacheKeyFactory.GetKeyFromRequest(requestParameters);
 
             IReadOnlyList<MsalRefreshTokenCacheItem> rtCacheItems = GetAllRefreshTokensWithNoLocks(filterByClientId, partitionKey);
-            IReadOnlyList<MsalAccountCacheItem> accountCacheItems = _accessor.GetAllAccounts(partitionKey);
+            IReadOnlyList<MsalAccountCacheItem> accountCacheItems = Accessor.GetAllAccounts(partitionKey);
 
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
                 logger.Verbose($"GetAccounts found {rtCacheItems.Count} RTs and {accountCacheItems.Count} accounts in MSAL cache. ");
@@ -1037,7 +1037,7 @@ namespace Microsoft.Identity.Client
 
         MsalIdTokenCacheItem ITokenCacheInternal.GetIdTokenCacheItem(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
         {
-            var idToken = _accessor.GetIdToken(msalAccessTokenCacheItem);
+            var idToken = Accessor.GetIdToken(msalAccessTokenCacheItem);
             return idToken;
         }
 
@@ -1151,7 +1151,7 @@ namespace Microsoft.Identity.Client
 
         bool ITokenCacheInternal.HasTokensNoLocks()
         {
-            return _accessor.HasAccessOrRefreshTokens();
+            return Accessor.HasAccessOrRefreshTokens();
         }
 
         internal /* internal for test only */ void RemoveAccountInternal(IAccount account, RequestContext requestContext)
@@ -1179,7 +1179,7 @@ namespace Microsoft.Identity.Client
 
             foreach (MsalRefreshTokenCacheItem refreshTokenCacheItem in refreshTokensToDelete)
             {
-                _accessor.DeleteRefreshToken(refreshTokenCacheItem);
+                Accessor.DeleteRefreshToken(refreshTokenCacheItem);
             }
 
             requestContext.Logger.Info("Deleted refresh token count - " + allRefreshTokens.Count);
@@ -1188,7 +1188,7 @@ namespace Microsoft.Identity.Client
                 .ToList();
             foreach (MsalAccessTokenCacheItem accessTokenCacheItem in allAccessTokens)
             {
-                _accessor.DeleteAccessToken(accessTokenCacheItem);
+                Accessor.DeleteAccessToken(accessTokenCacheItem);
             }
 
             requestContext.Logger.Info("Deleted access token count - " + allAccessTokens.Count);
@@ -1198,16 +1198,16 @@ namespace Microsoft.Identity.Client
                 .ToList();
             foreach (MsalIdTokenCacheItem idTokenCacheItem in allIdTokens)
             {
-                _accessor.DeleteIdToken(idTokenCacheItem);
+                Accessor.DeleteIdToken(idTokenCacheItem);
             }
 
             requestContext.Logger.Info("Deleted Id token count - " + allIdTokens.Count);
 
-            _accessor.GetAllAccounts(partitionKey)
+            Accessor.GetAllAccounts(partitionKey)
                 .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
                                item.PreferredUsername.Equals(account.Username, StringComparison.OrdinalIgnoreCase))
                 .ToList()
-                .ForEach(accItem => _accessor.DeleteAccount(accItem));
+                .ForEach(accItem => Accessor.DeleteAccount(accItem));
         }
 
         // Returns whether AcquireTokenInLongRunningProcess was called (user assertion is null in this case)

--- a/src/client/Microsoft.Identity.Client/TokenCache.Serialization.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.Serialization.cs
@@ -24,17 +24,17 @@ namespace Microsoft.Identity.Client
 
         byte[] ITokenCacheSerializer.SerializeMsalV2()
         {
-            return new TokenCacheDictionarySerializer(_accessor).Serialize(_unknownNodes);
+            return new TokenCacheDictionarySerializer(Accessor).Serialize(_unknownNodes);
         }
 
         void ITokenCacheSerializer.DeserializeMsalV2(byte[] msalV2State)
         {
-            _unknownNodes = new TokenCacheDictionarySerializer(_accessor).Deserialize(msalV2State, false);
+            _unknownNodes = new TokenCacheDictionarySerializer(Accessor).Deserialize(msalV2State, false);
         }
 
         byte[] ITokenCacheSerializer.SerializeMsalV3()
         {
-            return new TokenCacheJsonSerializer(_accessor).Serialize(_unknownNodes);
+            return new TokenCacheJsonSerializer(Accessor).Serialize(_unknownNodes);
         }
 
         void ITokenCacheSerializer.DeserializeMsalV3(byte[] msalV3State, bool shouldClearExistingCache)
@@ -43,11 +43,11 @@ namespace Microsoft.Identity.Client
             {
                 if (shouldClearExistingCache)
                 {
-                    _accessor.Clear();
+                    Accessor.Clear();
                 }
                 return;
             }
-            _unknownNodes = new TokenCacheJsonSerializer(_accessor).Deserialize(msalV3State, shouldClearExistingCache);
+            _unknownNodes = new TokenCacheJsonSerializer(Accessor).Deserialize(msalV3State, shouldClearExistingCache);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TokenCacheExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheExtensions.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client.PlatformsCommon.Factories;
+
+namespace Microsoft.Identity.Client
+{
+    /// <summary>
+    /// Extension methods for ITokenCache
+    /// </summary>
+    public static class TokenCacheExtensions
+    {
+        /// <summary>
+        /// Options for MSAL token caches. 
+        /// 
+        /// MSAL maintains a token cache internally in memory. By default, this cache object is part of each instance of <see cref="PublicClientApplication"/> or <see cref="ConfidentialClientApplication"/>.
+        /// This method allows customization of the in-memory token cache of MSAL. 
+        /// 
+        /// MSAL's memory cache is different than token cache serialization. Cache serialization pulls the tokens from a cache (e.g. Redis, Cosmos, or a file on disk), 
+        /// where they are stored in JSON format, into MSAL's internal memory cache. Memory cache operations do not involve JSON operations. 
+        /// 
+        /// External cache serialization remains the recommended way to handle desktop apps, web site and web APIs, as it provides persistence. These options
+        /// do not currently control external cache serialization.
+        /// 
+        /// Detailed guidance for each application type and platform:
+        /// https://aka.ms/msal-net-token-cache-serialization
+        /// </summary>
+        /// <param name="tokenCache">Either the UserTokenCache or the AppTokenCache, for which these options apply.</param>
+        /// <param name="options">Options for the internal MSAL token caches. </param>
+#if !SUPPORTS_CUSTOM_CACHE || WINDOWS_APP
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+#endif
+        public static void SetCacheOptions(this ITokenCache tokenCache, CacheOptions options)
+        {
+            ValidatePlatform();
+            TokenCache cache = (TokenCache)tokenCache;
+            ITokenCacheInternal tokenCacheInternal = (ITokenCacheInternal)tokenCache;
+
+            cache.ServiceBundle.Config.AccessorOptions = options;
+
+            if (tokenCacheInternal.IsAppSubscribedToSerializationEvents())
+            {
+                throw new MsalClientException(
+                    MsalError.StaticCacheWithExternalSerialization,
+                    MsalErrorMessage.StaticCacheWithExternalSerialization);
+            }
+
+            var proxy = cache.ServiceBundle?.PlatformProxy ?? PlatformProxyFactory.CreatePlatformProxy(null);
+            cache.Accessor = proxy.CreateTokenCacheAccessor(options, tokenCacheInternal.IsApplicationCache);
+        }
+
+        private static void ValidatePlatform()
+        {
+#if !SUPPORTS_CUSTOM_CACHE || WINDOWS_APP
+            throw new System.PlatformNotSupportedException("You should not use these TokenCache methods on mobile platforms. " +
+                "They are meant to allow applications to define their own storage strategy on .NET desktop and non-mobile platforms such as .NET Core. " +
+                "On mobile platforms, MSAL.NET implements a secure and performant storage mechanism. " +
+                "For more details about custom token cache serialization, visit https://aka.ms/msal-net-token-cache-serialization.");
+#endif
+        }
+    }
+}


### PR DESCRIPTION
This will enable `Microsoft.Identity.Web.TokenCache` to migrate the uses of `InMemoryCache` to MSAL's static cache.