### PR TITLE
Gladjohn/b2c ccs header fix

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -316,13 +316,13 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         protected KeyValuePair<string, string>? GetCcsUpnHeader(string upnHeader)
         {
-            string OidCcsHeader = CoreHelpers.GetCcsUpnHint(upnHeader);
-
             if (AuthenticationRequestParameters.Authority.AuthorityInfo.AuthorityType == AuthorityType.B2C)
             {
                 return new KeyValuePair<string, string>();
             }
-            
+
+            string OidCcsHeader = CoreHelpers.GetCcsUpnHint(upnHeader);
+
             return new KeyValuePair<string, string>(Constants.CcsRoutingHintHeader, OidCcsHeader) as KeyValuePair<string, string>?;
         }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -311,14 +311,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return GetCcsUpnHeader(AuthenticationRequestParameters.LoginHint);
             }
 
-            return new KeyValuePair<string, string>();
+            return null;
         }
 
         protected KeyValuePair<string, string>? GetCcsUpnHeader(string upnHeader)
         {
             if (AuthenticationRequestParameters.Authority.AuthorityInfo.AuthorityType == AuthorityType.B2C)
             {
-                return new KeyValuePair<string, string>();
+                return null;
             }
 
             string OidCcsHeader = CoreHelpers.GetCcsUpnHint(upnHeader);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -317,6 +317,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
         protected KeyValuePair<string, string>? GetCcsUpnHeader(string upnHeader)
         {
             string OidCcsHeader = CoreHelpers.GetCcsUpnHint(upnHeader);
+
+            if (AuthenticationRequestParameters.Authority.AuthorityInfo.AuthorityType == AuthorityType.B2C)
+            {
+                return new KeyValuePair<string, string>();
+            }
+            
             return new KeyValuePair<string, string>(Constants.CcsRoutingHintHeader, OidCcsHeader) as KeyValuePair<string, string>?;
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             "1003,ad8c894a-557f-48c0-b045-c129590c344e";
         private const string InvalidGrantError = "invalid_grant";
         private const string UPApiId = "1003";
+        private const string _b2CROPCAuthority = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth";
+        private static readonly string[] s_b2cScopes = { "https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read" };
 
         [ClassInitialize]
         public static void ClassInitialize(TestContext context)
@@ -157,6 +159,13 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.AreEqual(MsalError.RopcDoesNotSupportMsaAccounts, result.ErrorCode);
             Assert.AreEqual(MsalErrorMessage.RopcDoesNotSupportMsaAccounts, result.Message);
 
+        }
+
+        [TestMethod]
+        public async Task ROPC_B2C_Async()
+        {
+            var labResponse = await LabUserHelper.GetB2CLocalAccountAsync().ConfigureAwait(false);
+            await RunB2CHappyPathTestAsync(labResponse).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -296,6 +305,42 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // 4) After successful log-in, remove the password line you added in with step 1, and run the integration test again.
         }
 
+        private async Task RunB2CHappyPathTestAsync(LabResponse labResponse, string federationMetadata = "")
+        {
+            var factory = new HttpSnifferClientFactory();
+            var user = labResponse.User;
+
+            SecureString securePassword = new NetworkCredential("", user.GetOrFetchPassword()).SecurePassword;
+
+            var msalPublicClient = PublicClientApplicationBuilder
+                .Create(labResponse.App.AppId)
+                .WithB2CAuthority(_b2CROPCAuthority)
+                .WithTestLogging()
+                .WithHttpClientFactory(factory)
+                .Build();
+
+            AuthenticationResult authResult = await msalPublicClient
+                .AcquireTokenByUsernamePassword(s_b2cScopes, labResponse.User.Upn, new NetworkCredential("", labResponse.User.GetOrFetchPassword()).SecurePassword)
+                .WithCorrelationId(CorrelationId)
+                .WithFederationMetadata(federationMetadata)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(authResult);
+            Assert.AreEqual(TokenSource.IdentityProvider, authResult.AuthenticationResultMetadata.TokenSource);
+            Assert.IsNotNull(authResult.AccessToken);
+            Assert.IsNotNull(authResult.IdToken);
+            AssertCcsRoutingInformationIsNotSent(factory);
+
+            // If test fails with "user needs to consent to the application, do an interactive request" error,
+            // Do the following: 
+            // 1) Add in code to pull the user's password before creating the SecureString, and put a breakpoint there.
+            // string password = ((LabUser)user).GetPassword();
+            // 2) Using the MSAL Desktop app, make sure the ClientId matches the one used in integration testing.
+            // 3) Do the interactive sign-in with the MSAL Desktop app with the username and password from step 1.
+            // 4) After successful log-in, remove the password line you added in with step 1, and run the integration test again.
+        }
+
         private async Task<AuthenticationResult> GetAuthenticationResultWithAssertAsync(
             LabResponse labResponse,
             HttpSnifferClientFactory factory,
@@ -325,6 +370,14 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         {
             var CcsHeader = TestCommon.GetCcsHeaderFromSnifferFactory(factory);
             Assert.AreEqual($"x-anchormailbox:upn:{labResponse.User.Upn}", $"{CcsHeader.Key}:{CcsHeader.Value.FirstOrDefault()}");
+        }
+
+        private void AssertCcsRoutingInformationIsNotSent(HttpSnifferClientFactory factory)
+        {
+            var (req, res) = factory.RequestsAndResponses.Single(x => x.Item1.RequestUri.AbsoluteUri.Contains("oauth2/v2.0/token") &&
+               x.Item2.StatusCode == HttpStatusCode.OK);
+
+            Assert.IsTrue(!req.Headers.Any(h => h.Key == Constants.CcsRoutingHintHeader));
         }
 
         private void AssertTenantProfiles(IEnumerable<TenantProfile> tenantProfiles, string tenantId)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/UsernamePasswordIntegrationTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             "1003,ad8c894a-557f-48c0-b045-c129590c344e";
         private const string InvalidGrantError = "invalid_grant";
         private const string UPApiId = "1003";
-        private const string _b2CROPCAuthority = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth";
+        private const string B2CROPCAuthority = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth";
         private static readonly string[] s_b2cScopes = { "https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read" };
 
         [ClassInitialize]
@@ -314,7 +314,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             var msalPublicClient = PublicClientApplicationBuilder
                 .Create(labResponse.App.AppId)
-                .WithB2CAuthority(_b2CROPCAuthority)
+                .WithB2CAuthority(B2CROPCAuthority)
                 .WithTestLogging()
                 .WithHttpClientFactory(factory)
                 .Build();


### PR DESCRIPTION
Fixes #2748 

**Changes proposed in this request**
Fixed by not adding CCS header when Authority Type is B2C

**Testing**
Added an Integration test

**Performance impact**
None
