### PR TITLE
[SAL] Add support for POP tokens without signed http envelope

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Identity.Client.AppConfig
         public string Nonce { get; set; }
 
         /// <summary>
-        /// Allows app developers to bypass the creation of the SingedHttpRequest envelope by setting this property to true.
+        /// Allows app developers to bypass the creation of the SignedHttpRequest envelope by setting this property to true.
         /// App developers can use a package like Microsoft.IdentityModel.Protocols.SignedHttpRequest to later create and sign the envelope. 
         /// </summary>
         /// <remarks>

--- a/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Identity.Client.AppConfig
         /// App developers can use a package like Microsoft.IdentityModel.Protocols.SignedHttpRequest to later create and sign the envelope. 
         /// </summary>
         /// <remarks>
-        /// If set to true, you do not need to implement the <see cref="IPoPCryptoProvider.Sign(byte[])"/> method when using custom keys. 
+        /// If set to false, you do not need to implement the <see cref="IPoPCryptoProvider.Sign(byte[])"/> method when using custom keys. 
         /// </remarks>
-        public bool DoNotSignHttpRequest { get; set; } = false;
+        public bool SignHttpRequest { get; set; } = true;
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PopAuthenticationConfiguration.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Identity.Client.AppConfig
     public class PoPAuthenticationConfiguration
     {
         /// <summary>
-        /// Creates a configuration using the default key management. Use the properties <see cref="HttpMethod"/>, <see cref="HttpHost"/> etc. 
-        /// to control which elements of the request should be included in the POP token.
+        /// Creates a configuration using the default key management - an RSA key will be created in memory and rotated every 8h.
+        /// Uses <see cref="HttpMethod"/>, <see cref="HttpHost"/> etc. to control which elements of the request should be included in the POP token.
         /// </summary>
         /// <remarks>
         /// See https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#page-3 for details about signed HTTP requests.
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Client.AppConfig
 
             HttpMethod = httpRequestMessage.Method;
             HttpHost = httpRequestMessage.RequestUri.Authority; // this includes the optional port
-            HttpPath = httpRequestMessage.RequestUri.AbsolutePath; 
+            HttpPath = httpRequestMessage.RequestUri.AbsolutePath;
         }
 
         /// <summary>
@@ -95,5 +95,14 @@ namespace Microsoft.Identity.Client.AppConfig
         /// or as part of the AuthorityInfo header associated with 200 response. Set it here to make it part of the Signed HTTP Request part of the POP token.
         /// </summary>
         public string Nonce { get; set; }
+
+        /// <summary>
+        /// Allows app developers to bypass the creation of the SingedHttpRequest envelope by setting this property to true.
+        /// App developers can use a package like Microsoft.IdentityModel.Protocols.SignedHttpRequest to later create and sign the envelope. 
+        /// </summary>
+        /// <remarks>
+        /// If set to true, you do not need to implement the <see cref="IPoPCryptoProvider.Sign(byte[])"/> method when using custom keys. 
+        /// </remarks>
+        public bool DoNotSignHttpRequest { get; set; } = false;
     }
 }

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/IPoPCryptoProvider.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/IPoPCryptoProvider.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
     public interface IPoPCryptoProvider
     {
         /// <summary>
-        /// The canonical representation of the JWK.  See https://tools.ietf.org/html/rfc7638#section-3
+        /// The canonical representation of the JWK.         
+        /// See https://tools.ietf.org/html/rfc7638#section-3
         /// </summary>
         string CannonicalPublicKeyJwk { get; }
 

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PoPAuthenticationScheme.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PoPAuthenticationScheme.cs
@@ -64,6 +64,11 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
 
         public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
         {
+            if (_popAuthenticationConfiguration.DoNotSignHttpRequest)
+            {
+                return msalAccessTokenCacheItem.Secret;
+            }
+
             JObject header = new JObject
             {
                 { JsonWebTokenConstants.ReservedHeaderParameters.Algorithm, _popCryptoProvider.CryptographicAlgorithm },

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PoPAuthenticationScheme.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PoPAuthenticationScheme.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
 
         public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
         {
-            if (_popAuthenticationConfiguration.DoNotSignHttpRequest)
+            if (!_popAuthenticationConfiguration.SignHttpRequest)
             {
                 return msalAccessTokenCacheItem.Secret;
             }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
@@ -16,7 +16,8 @@
     <ProjectReference Include="..\Microsoft.Identity.Test.LabInfrastructure\Microsoft.Identity.Test.LabInfrastructure.csproj" />
     <ProjectReference Include="..\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.15.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.15.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var popConfig = new PoPAuthenticationConfiguration() 
             {                 
                 PopCryptoProvider = new SigningCredentialsToPopCryptoProviderAdapter(popCredentials, true),                
-                DoNotSignHttpRequest = true,
+                SignHttpRequest = true,
             };
 
             var result = await confidentialApp.AcquireTokenForClient(s_keyvaultScope)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var popConfig = new PoPAuthenticationConfiguration() 
             {                 
                 PopCryptoProvider = new SigningCredentialsToPopCryptoProviderAdapter(popCredentials, true),                
-                SignHttpRequest = true,
+                SignHttpRequest = false,
             };
 
             var result = await confidentialApp.AcquireTokenForClient(s_keyvaultScope)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Microsoft.Identity.Test.Integration.NetFx.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Microsoft.Identity.Test.Integration.NetFx.csproj
@@ -12,7 +12,8 @@
     <ProjectReference Include="..\Microsoft.Identity.Test.LabInfrastructure\Microsoft.Identity.Test.LabInfrastructure.csproj" />
     <ProjectReference Include="..\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.15.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.15.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />

--- a/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Test.Integration
             }
 
             var popAuthenticationConfiguration
-                = new PoPAuthenticationConfiguration() { DoNotSignHttpRequest = true };
+                = new PoPAuthenticationConfiguration() { SignHttpRequest = false };
 
             if (popCredentials != null)
             {

--- a/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.AuthScheme.PoP;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Integration
+{
+    /// <summary>
+    /// Helper methods for creating 
+    /// </summary>
+    internal static class MsalExtensions
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="popCredentials"></param>
+        /// <returns></returns>
+        public static AcquireTokenForClientParameterBuilder WithPoPSignedRequest(
+            this AcquireTokenForClientParameterBuilder builder,
+            SigningCredentials popCredentials) // TODO: this only supports RSA for now
+        {
+
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (popCredentials is null)
+            {
+                throw new ArgumentNullException(nameof(popCredentials));
+            }
+
+            var popAuthenticationConfiguration
+                = new PoPAuthenticationConfiguration() { DoNotSignHttpRequest = true };
+
+            if (popCredentials != null)
+            {
+                popAuthenticationConfiguration.PopCryptoProvider =
+                    new SigningCredentialsToPopCryptoProviderAdapter(popCredentials, assertNotSigned: true);
+            }
+
+            return builder.WithProofOfPossession(popAuthenticationConfiguration);
+        }
+    }
+
+    internal class SigningCredentialsToPopCryptoProviderAdapter : IPoPCryptoProvider
+    {
+        private readonly SigningCredentials _popCredentials;
+        private readonly bool _assertNotSigned;
+
+        public SigningCredentialsToPopCryptoProviderAdapter(SigningCredentials popCredentials, bool assertNotSigned)
+        {
+            if (popCredentials is null)
+            {
+                throw new ArgumentNullException(nameof(popCredentials));
+            }
+
+            var rsaKey = popCredentials.Key as RsaSecurityKey;
+            if (rsaKey == null)
+            {
+                throw new NotImplementedException("Only RSA POP keys are supported"); // TODO: support for other crypto?
+            }
+
+            CannonicalPublicKeyJwk = CreateJwkClaim(rsaKey, popCredentials.Algorithm);
+            CryptographicAlgorithm = popCredentials.Algorithm;
+            _popCredentials = popCredentials;
+            _assertNotSigned = assertNotSigned;
+        }
+
+        private string CreateJwkClaim(RsaSecurityKey key, string algorithm)
+        {
+            var parameters = key.Rsa == null ? key.Parameters : key.Rsa.ExportParameters(false);
+            //return "{\"kty\":\"RSA\",\"n\":\"" + Base64UrlEncoder.Encode(parameters.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(parameters.Exponent) + "\",\"alg\":\"" + algorithm + "\"}";
+            return $@"{{""e"":""{Base64UrlHelpers.Encode(parameters.Exponent)}"",""kty"":""RSA"",""n"":""{Base64UrlHelpers.Encode(parameters.Modulus)}""}}";
+
+        }
+
+        public string CannonicalPublicKeyJwk { get; }
+
+        public string CryptographicAlgorithm { get; }
+
+        // This will not be called if SAL constructs the SignedHttpRequest
+        public byte[] Sign(byte[] data)
+        {
+            if (_assertNotSigned)
+            {
+                Assert.Fail("Sing call is not expected");
+            }
+
+            var cryptoFactory = _popCredentials.CryptoProviderFactory;
+            var signatureProvider = cryptoFactory.CreateForSigning(_popCredentials.Key, _popCredentials.Algorithm);
+            try
+            {
+                return signatureProvider.Sign(data);
+            }
+            finally
+            {
+                cryptoFactory.ReleaseSignatureProvider(signatureProvider);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
@@ -13,18 +13,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Integration
 {
-    /// <summary>
-    /// Helper methods for creating 
-    /// </summary>
     internal static class MsalExtensions
     {
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="builder"></param>
-        /// <param name="popCredentials"></param>
-        /// <returns></returns>
         public static AcquireTokenForClientParameterBuilder WithPoPSignedRequest(
             this AcquireTokenForClientParameterBuilder builder,
             SigningCredentials popCredentials) // TODO: this only supports RSA for now
@@ -41,13 +31,11 @@ namespace Microsoft.Identity.Test.Integration
             }
 
             var popAuthenticationConfiguration
-                = new PoPAuthenticationConfiguration() { SignHttpRequest = false };
-
-            if (popCredentials != null)
-            {
-                popAuthenticationConfiguration.PopCryptoProvider =
-                    new SigningCredentialsToPopCryptoProviderAdapter(popCredentials, assertNotSigned: true);
-            }
+                = new PoPAuthenticationConfiguration()
+                {
+                    SignHttpRequest = false,
+                    PopCryptoProvider = new SigningCredentialsToPopCryptoProviderAdapter(popCredentials, assertNotSigned: true)
+                };
 
             return builder.WithProofOfPossession(popAuthenticationConfiguration);
         }
@@ -94,7 +82,7 @@ namespace Microsoft.Identity.Test.Integration
         {
             if (_assertNotSigned)
             {
-                Assert.Fail("Sign call is not expected");
+                Assert.Fail("Sing call is not expected");
             }
 
             var cryptoFactory = _popCredentials.CryptoProviderFactory;

--- a/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/MsalExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Test.Integration
         {
             if (_assertNotSigned)
             {
-                Assert.Fail("Sing call is not expected");
+                Assert.Fail("Sign call is not expected");
             }
 
             var cryptoFactory = _popCredentials.CryptoProviderFactory;


### PR DESCRIPTION
Fixes # 
TBD

**Changes proposed in this request**
SAL likes to create the Singed Http Request envelope separately, so MSAL should just give the assertion from the cache.

**Testing**
integration test 

**Performance impact**

