### PR TITLE
Add support for cleanup of expired access token

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Identity.Client
 {
     /// <summary>
@@ -34,9 +36,16 @@ namespace Microsoft.Identity.Client
         /// Constructor
         /// </summary>
         /// <param name="useSharedCache">Set to true to share the cache between all ClientApplication objects. The cache becomes static. <see cref="UseSharedCache"/> for a detailed description. </param>
-        public CacheOptions(bool useSharedCache)
+        /// <param name="accessTokenExpirationScanFrequency">Sets to non-null to enable expiration of access tokens. <see cref="AccessTokenExpirationScanFrequency"/> for a detailed description. </param>
+        public CacheOptions(bool useSharedCache, TimeSpan? accessTokenExpirationScanFrequency = null)
         {
+            if (accessTokenExpirationScanFrequency.HasValue && accessTokenExpirationScanFrequency.Value <= TimeSpan.Zero)
+            {
+                throw new ArgumentException("accessTokenExpirationScanFrequency must be a positive TimeSpan", nameof(accessTokenExpirationScanFrequency));
+            }
+
             UseSharedCache = useSharedCache;
+            AccessTokenExpirationScanFrequency = accessTokenExpirationScanFrequency;
         }
 
         /// <summary>
@@ -49,6 +58,11 @@ namespace Microsoft.Identity.Client
         /// ADAL used a static cache by default.
         /// </remarks>
         public bool UseSharedCache { get; set; }
+
+        /// <summary>
+        /// The minimum time between scans for expired access tokens. Defaults to null meaning no expiration scans are performed.
+        /// </summary>
+        public TimeSpan? AccessTokenExpirationScanFrequency { get; }
 
     }
 }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Cache.Keys;
@@ -23,12 +26,11 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
     {
         // perf: do not use ConcurrentDictionary.Values as it takes a lock
         // internal for test only
-        internal readonly ConcurrentDictionary<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>> AccessTokenCacheDictionary;
+        internal readonly CacheWrapper AccessTokenCacheWrapper;
         internal readonly ConcurrentDictionary<string, MsalAppMetadataCacheItem> AppMetadataDictionary;
 
         // static versions to support the "shared cache" mode
-        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>> s_accessTokenCacheDictionary =
-            new ConcurrentDictionary<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>>();
+        private static readonly CacheWrapper s_accessTokenCacheWrapper = new CacheWrapper(null);
         private static readonly ConcurrentDictionary<string, MsalAppMetadataCacheItem> s_appMetadataDictionary =
            new ConcurrentDictionary<string, MsalAppMetadataCacheItem>(1, 1);
 
@@ -44,12 +46,16 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 
             if (_tokenCacheAccessorOptions.UseSharedCache)
             {
-                AccessTokenCacheDictionary = s_accessTokenCacheDictionary;
+                AccessTokenCacheWrapper = s_accessTokenCacheWrapper;
                 AppMetadataDictionary = s_appMetadataDictionary;
+                if (_tokenCacheAccessorOptions.AccessTokenExpirationScanFrequency.HasValue)
+                {
+                    AccessTokenCacheWrapper.UpdateFrequencyIfLower(_tokenCacheAccessorOptions.AccessTokenExpirationScanFrequency.Value);
+                }
             }
             else
             {
-                AccessTokenCacheDictionary = new ConcurrentDictionary<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>>();
+                AccessTokenCacheWrapper = new CacheWrapper(_tokenCacheAccessorOptions.AccessTokenExpirationScanFrequency);
                 AppMetadataDictionary = new ConcurrentDictionary<string, MsalAppMetadataCacheItem>();
             }
         }
@@ -61,8 +67,10 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             string partitionKey = CacheKeyFactory.GetClientCredentialKey(item.ClientId, item.TenantId);
 
             // if a conflict occurs, pick the latest value
-            AccessTokenCacheDictionary
+            AccessTokenCacheWrapper.AccessTokenCacheDictionary
                 .GetOrAdd(partitionKey, new ConcurrentDictionary<string, MsalAccessTokenCacheItem>())[itemKey] = item;
+
+            AccessTokenCacheWrapper.StartScanForExpiredItemsIfNeeded();
         }
 
         /// <summary>
@@ -130,7 +138,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         {
             var partitionKey = CacheKeyFactory.GetClientCredentialKey(item.ClientId, item.TenantId);
 
-            AccessTokenCacheDictionary.TryGetValue(partitionKey, out var partition);
+            AccessTokenCacheWrapper.AccessTokenCacheDictionary.TryGetValue(partitionKey, out var partition);
             if (partition == null || !partition.TryRemove(item.GetKey().ToString(), out _))
             {
                 _logger.InfoPii(
@@ -175,14 +183,15 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         /// </summary>
         public virtual IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
         {
-            _logger.Always($"[GetAllAccessTokens] Total number of cache partitions found while getting access tokens: {AccessTokenCacheDictionary.Count}");
+            _logger.Always($"[GetAllAccessTokens] Total number of cache partitions found while getting access tokens: {AccessTokenCacheWrapper.AccessTokenCacheDictionary.Count}");
+            AccessTokenCacheWrapper.StartScanForExpiredItemsIfNeeded();
             if (string.IsNullOrEmpty(partitionKey))
             {
-                return AccessTokenCacheDictionary.SelectMany(dict => dict.Value).Select(kv => kv.Value).ToList();
+                return AccessTokenCacheWrapper.AccessTokenCacheDictionary.SelectMany(dict => dict.Value).Select(kv => kv.Value).ToList();
             }
             else
             {
-                AccessTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition);
+                AccessTokenCacheWrapper.AccessTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition);
                 return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalAccessTokenCacheItem>();
             }
         }
@@ -215,14 +224,84 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 
         public virtual void Clear()
         {
-            AccessTokenCacheDictionary.Clear();
+            AccessTokenCacheWrapper.AccessTokenCacheDictionary.Clear();
             _logger.Always("[Clear] Clearing access token cache data.");
             // app metadata isn't removable
         }
 
         public virtual bool HasAccessOrRefreshTokens()
         {
-            return AccessTokenCacheDictionary.Any(partition => partition.Value.Any(token => !token.Value.IsExpiredWithBuffer()));
+            return AccessTokenCacheWrapper.AccessTokenCacheDictionary.Any(partition => partition.Value.Any(token => !token.Value.IsExpiredWithBuffer()));
+        }
+
+        internal class CacheWrapper
+        {
+            // perf: do not use ConcurrentDictionary.Values as it takes a lock
+            // internal for test only
+            internal readonly ConcurrentDictionary<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>> AccessTokenCacheDictionary;
+
+            private DateTimeOffset _lastExpirationScan;
+
+            private TimeSpan? _expirationScanFrequency;
+
+            internal CacheWrapper(TimeSpan? expirationScanFrequency)
+            {
+                _expirationScanFrequency = expirationScanFrequency;
+                _lastExpirationScan = DateTimeOffset.UtcNow;
+                AccessTokenCacheDictionary = new ConcurrentDictionary<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>>();
+            }
+
+            internal void UpdateFrequencyIfLower(TimeSpan expirationScanFrequency)
+            {
+                if (!_expirationScanFrequency.HasValue || _expirationScanFrequency.Value > expirationScanFrequency)
+                {
+                    _expirationScanFrequency = expirationScanFrequency;
+                }
+            }
+
+            // Called by multiple actions to see how long it's been since we last checked for expired items.
+            // If sufficient time has elapsed then a scan is initiated on a background task.
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal void StartScanForExpiredItemsIfNeeded()
+            {
+
+                if (_expirationScanFrequency.HasValue)
+                {
+                    var utcNow = DateTimeOffset.UtcNow;
+                    if (_expirationScanFrequency.Value < utcNow - _lastExpirationScan)
+                    {
+                        ScheduleTask(utcNow);
+                    }
+                }
+
+                void ScheduleTask(DateTimeOffset utcNow)
+                {
+                    _lastExpirationScan = utcNow;
+                    Task.Factory.StartNew(state => ScanForExpiredItems((CacheWrapper)state), this,
+                        CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                }
+            }
+
+            private static void ScanForExpiredItems(CacheWrapper cacheWrapper)
+            {
+                DateTimeOffset now = cacheWrapper._lastExpirationScan = DateTimeOffset.UtcNow;
+
+                foreach (KeyValuePair<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>> partitionItem in cacheWrapper.AccessTokenCacheDictionary)
+                {
+                    var partitionItemValue = partitionItem.Value;
+                    foreach (KeyValuePair<string, MsalAccessTokenCacheItem> item in partitionItemValue)
+                    {
+                        if (item.Value.ExpiresOn < now)
+                        {
+                            partitionItemValue.TryRemove(item.Key, out _);
+                        }
+                    }
+                    if (partitionItemValue.IsEmpty)
+                    {
+                        cacheWrapper.AccessTokenCacheDictionary.TryRemove(partitionItem.Key, out _);
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             // avoid calling GetAllAccessTokens() on the strict accessors, as they will throw
             if (tokenCache.Accessor is AppAccessorWithPartitionAsserts appPartitionedAccessor)
             {
-                allAccessTokens = appPartitionedAccessor.AccessTokenCacheDictionary.SelectMany(dict => dict.Value).Select(kv => kv.Value).ToList();
+                allAccessTokens = appPartitionedAccessor.AccessTokenCacheWrapper.AccessTokenCacheDictionary.SelectMany(dict => dict.Value).Select(kv => kv.Value).ToList();
             }
             else if (tokenCache.Accessor is UserAccessorWithPartitionAsserts userPartitionedAccessor)
             {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 string partitionKey = CacheKeyFactory.GetClientCredentialKey(TestConstants.ClientId, TestConstants.Utid);
                 Assert.AreEqual(
                     partitionKey,
-                    ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary.Keys.Single());
+                    ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary.Keys.Single());
 
                 httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
 
@@ -188,11 +188,11 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
 
                 Assert.IsNotNull(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single(at => at.TenantId == TestConstants.Utid2));
-                Assert.AreEqual(2, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary.Count);
+                Assert.AreEqual(2, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary.Count);
                 string partitionKey2 = CacheKeyFactory.GetClientCredentialKey(TestConstants.ClientId, TestConstants.Utid2);
 
-                Assert.IsTrue(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary.Keys.Any(k => k.Equals(partitionKey)));
-                Assert.IsTrue(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary.Keys.Any(k => k.Equals(partitionKey2)));
+                Assert.IsTrue(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary.Keys.Any(k => k.Equals(partitionKey)));
+                Assert.IsTrue(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary.Keys.Any(k => k.Equals(partitionKey2)));
             }
         }
 
@@ -217,11 +217,11 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 // One tenant partition with one token
                 Assert.AreEqual(1, app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Count);
-                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary.Count);
+                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary.Count);
                 string partitionKey = CacheKeyFactory.GetClientCredentialKey(TestConstants.ClientId, TestConstants.Utid);
 
-                Assert.IsNotNull(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary[partitionKey]);
-                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary[partitionKey].Count);
+                Assert.IsNotNull(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary[partitionKey]);
+                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary[partitionKey].Count);
 
                 httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
 
@@ -231,9 +231,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 // One tenant partition with two tokens
                 Assert.AreEqual(2, app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Count);
-                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary.Count);
-                Assert.IsNotNull(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary[partitionKey]);
-                Assert.AreEqual(2, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary[partitionKey].Count);
+                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary.Count);
+                Assert.IsNotNull(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary[partitionKey]);
+                Assert.AreEqual(2, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary[partitionKey].Count);
 
                 httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
 
@@ -245,9 +245,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual(3, app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Count);
                 string partitionKey2 = CacheKeyFactory.GetClientCredentialKey(TestConstants.ClientId, TestConstants.Utid2);
 
-                Assert.AreEqual(2, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary.Count);
-                Assert.IsNotNull(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary[partitionKey2]);
-                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheDictionary[partitionKey2].Count);
+                Assert.AreEqual(2, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary.Count);
+                Assert.IsNotNull(((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary[partitionKey2]);
+                Assert.AreEqual(1, ((InMemoryPartitionedAppTokenCacheAccessor)app.AppTokenCacheInternal.Accessor).AccessTokenCacheWrapper.AccessTokenCacheDictionary[partitionKey2].Count);
 
             }
         }


### PR DESCRIPTION
Adds support for expiring access tokens as suggested in #2976. Initially this only is being done on AppTokenCache but if the change makes sense I can push changes for UserTokenCache.

**Changes proposed in this request**
Adds nullable property `AccessTokenExpirationScanFrequency` in `CacheOptions`
Adds logic in `InMemoryPartitionedAppTokenCacheAccessor` to fire off a cleanup task when tokens are saved or retrieved and a scan hasn't recently occurred.

**Testing**
Adds a unit test which verifies the cleanup logic works as expected.

**Performance impact**
Ran Performance benchmark before and after and didn't see any regressions