### PR TITLE
Fix warnings in merge validation build for System.Windows.Forms

### DIFF
--- a/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
@@ -52,10 +52,13 @@
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop)'">
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop)' or '$(TargetFramework)' == '$(TargetFrameworkNetCore)'">
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WamBroker\**\*.cs" LinkBase="Features/WAM" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.17763.1000" />
-    <Reference Include="System.Windows.Forms" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WebView2WebUi\**\*.cs" LinkBase="Features/WebView2WebUi" />
 
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.864.35" />

--- a/tests/Microsoft.Identity.Test.Integration.Win8/Microsoft.Identity.Test.Integration.Win8.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.Win8/Microsoft.Identity.Test.Integration.Win8.csproj
@@ -29,8 +29,10 @@
 
   <Import Project="../../build/platform_and_feature_flags.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Windows.Forms" Version="4.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
     <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj" />
   </ItemGroup>

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -40,8 +40,11 @@
 
   <Import Project="../../build/platform_and_feature_flags.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Windows.Forms" Version="4.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
     <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj" />
   </ItemGroup>

--- a/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
+++ b/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
@@ -20,6 +20,5 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows10.0.17763.0'">             
     <ProjectReference Include="..\..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**Changes proposed in this request**
Moves reference of System.Windows.Forms to only be applicable for NetDesktop and not NetCore.
The following warning exists in several places in the merge validation builds.
"##[warning]C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2203,5): Warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Windows.Forms". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors."

**Testing**
Validated unit tests locally.
