### PR TITLE
Removes experimental flag from Hybrid SPA feature

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenByAuthorizationCodeParameterBuilder.cs
@@ -155,15 +155,12 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Requests an auth code for the frontend (SPA using MSAL.js for instance). 
         /// See https://aka.ms/msal-net/spa-auth-code for details.
-        /// This is an experimental API. The method signature may change in the future without involving a major version upgrade.
         /// </summary>
         /// <param name="requestSpaAuthorizationCode "><c>true</c> if a SPA Authorization Code should be returned,
         /// <c>false</c></param> otherwise.
         /// <returns>The builder to chain the .With methods</returns>
         public AcquireTokenByAuthorizationCodeParameterBuilder WithSpaAuthorizationCode(bool requestSpaAuthorizationCode = true)
         {
-            ValidateUseOfExperimentalFeature();
-
             Parameters.SpaCode = requestSpaAuthorizationCode;
 
             return this;

--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
@@ -123,7 +123,6 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
                 .WithCertificate(cert)
                 .WithRedirectUri(redirectUri)
                 .WithTestLogging(out factory)
-                .WithExperimentalFeatures(true)
                 .Build();
 
             var cacheAccess = (cca as ConfidentialClientApplication).UserTokenCache.RecordAccess();

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
@@ -30,21 +30,5 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         }
 #endif
 
-        [TestMethod]
-        public async Task HybridSpaExperimentalFeatureExceptionAsync()
-        {
-            var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
-                .WithRedirectUri(TestConstants.RedirectUri)
-                .WithClientSecret(TestConstants.ClientSecret)
-                .BuildConcrete();
-
-            MsalClientException ex = await AssertException.TaskThrowsAsync<MsalClientException>(
-                () => cca.AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
-                        .WithSpaAuthorizationCode(true).ExecuteAsync())
-                        .ConfigureAwait(false);
-            
-            Assert.AreEqual(MsalError.ExperimentalFeature, ex.ErrorCode);
-        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1254,7 +1254,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 .WithRedirectUri(TestConstants.RedirectUri)
                 .WithClientSecret(TestConstants.ClientSecret)
                 .WithHttpManager(httpManager)
-                .WithExperimentalFeatures(true)
                 .BuildConcrete();
 
 


### PR DESCRIPTION
Fixes #2920 

**Changes proposed in this request**
- Removed experimental flag from the hybrid SPA feature.
- Removed the experimental feature test for the flag.
- Updated hybrid spa tests and removed .WithExperimentalFeatures().

**Testing**
unit and integration.

**Performance impact**
none
