### PR TITLE
#2289 Do not show account picker if authority is AAD only

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeUtils.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeUtils.cs
@@ -25,16 +25,23 @@ namespace Microsoft.Identity.Client.Utils.Windows
         /// </remarks>
         public static void InitializeProcessSecurity()
         {
-            int result = CoInitializeSecurity(
-                IntPtr.Zero, -1, IntPtr.Zero,
-                IntPtr.Zero, RpcAuthnLevel.None,
-                RpcImpLevel.Impersonate, IntPtr.Zero,
-                EoAuthnCap.None, IntPtr.Zero);
+            int result = InitializeProcessSecurityInternal();
 
             if (result != 0)
             {
                 throw new MsalClientException(MsalError.InitializeProcessSecurityError, MsalErrorMessage.InitializeProcessSecurityError($"0x{result:x}"));
             }
+        }
+
+        internal static int InitializeProcessSecurityInternal()
+        {
+            int result = CoInitializeSecurity(
+               IntPtr.Zero, -1, IntPtr.Zero,
+               IntPtr.Zero, RpcAuthnLevel.None,
+               RpcImpLevel.Impersonate, IntPtr.Zero,
+               EoAuthnCap.None, IntPtr.Zero);
+
+            return result;
         }
 
         [DllImport("shell32.dll")]

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeUtils.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/WindowsNativeUtils.cs
@@ -25,23 +25,16 @@ namespace Microsoft.Identity.Client.Utils.Windows
         /// </remarks>
         public static void InitializeProcessSecurity()
         {
-            int result = InitializeProcessSecurityInternal();
+            int result = CoInitializeSecurity(
+                IntPtr.Zero, -1, IntPtr.Zero,
+                IntPtr.Zero, RpcAuthnLevel.None,
+                RpcImpLevel.Impersonate, IntPtr.Zero,
+                EoAuthnCap.None, IntPtr.Zero);
 
             if (result != 0)
             {
                 throw new MsalClientException(MsalError.InitializeProcessSecurityError, MsalErrorMessage.InitializeProcessSecurityError($"0x{result:x}"));
             }
-        }
-
-        internal static int InitializeProcessSecurityInternal()
-        {
-            int result = CoInitializeSecurity(
-               IntPtr.Zero, -1, IntPtr.Zero,
-               IntPtr.Zero, RpcAuthnLevel.None,
-               RpcImpLevel.Impersonate, IntPtr.Zero,
-               EoAuthnCap.None, IntPtr.Zero);
-
-            return result;
         }
 
         [DllImport("shell32.dll")]


### PR DESCRIPTION
Fixes #2289  
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
- Use AAD plugin's account selector if authority is AAD only 
- But not for msa-pt
- Use "select_account" prompt unless the user set smth else.

**Testing**
ut

**Performance impact**
part of AcquireTokenInteractive, which is not perf sensitive.
