### PR TITLE
Update to point to latest version of gson

### DIFF
--- a/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>[2.8.6,)</version>
+            <version>[2.8.9,)</version>
         </dependency>
     </dependencies>
 

--- a/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>[2.8.6,)</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes # 
#3098 

**Changes proposed in this request**
Update pom.xml for cache compat tests for java to pull latest version for gson.

**Testing**


**Performance impact**

