### PR TITLE
GetAccountAsync fix by checking for null on accountId

### DIFF
--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -169,7 +169,12 @@ namespace Microsoft.Identity.Client
         /// </param>
         public async Task<IAccount> GetAccountAsync(string accountId)
         {
-            return await GetAccountAsync(accountId, default(CancellationToken)).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(accountId))
+            {
+                return await GetAccountAsync(accountId, default(CancellationToken)).ConfigureAwait(false);
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1561,6 +1561,52 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
             }
         }
+
+        [TestMethod]
+        public async Task ValidateGetAccountAsyncWithNullAccountIdAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithHttpManager(httpManager)
+                                                              .BuildConcrete();
+
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddSuccessTokenResponseMockHandlerForPost();
+
+                var result = await app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var acc = await app.GetAccountAsync(null).ConfigureAwait(false);
+
+                Assert.IsNull(acc);
+            }
+        }
+
+        [TestMethod]
+        public async Task ValidateGetAccountAsyncWithEmptyAccountIdAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithHttpManager(httpManager)
+                                                              .BuildConcrete();
+
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddSuccessTokenResponseMockHandlerForPost();
+
+                var result = await app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var acc = await app.GetAccountAsync("").ConfigureAwait(false);
+
+                Assert.IsNull(acc);
+            }
+        }
     }
 }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1563,7 +1563,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         }
 
         [TestMethod]
-        public async Task ValidateGetAccountAsyncWithNullAccountIdAsync()
+        [DataRow("")]
+        [DataRow(null)]
+        public async Task ValidateGetAccountAsyncWithNullAccountIdAsync(string accountId)
         {
             using (var httpManager = new MockHttpManager())
             {
@@ -1579,30 +1581,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
-                var acc = await app.GetAccountAsync(null).ConfigureAwait(false);
-
-                Assert.IsNull(acc);
-            }
-        }
-
-        [TestMethod]
-        public async Task ValidateGetAccountAsyncWithEmptyAccountIdAsync()
-        {
-            using (var httpManager = new MockHttpManager())
-            {
-                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                              .WithClientSecret(TestConstants.ClientSecret)
-                                                              .WithHttpManager(httpManager)
-                                                              .BuildConcrete();
-
-                httpManager.AddInstanceDiscoveryMockHandler();
-                httpManager.AddSuccessTokenResponseMockHandlerForPost();
-
-                var result = await app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
-                    .ExecuteAsync()
-                    .ConfigureAwait(false);
-
-                var acc = await app.GetAccountAsync("").ConfigureAwait(false);
+                var acc = await app.GetAccountAsync(accountId).ConfigureAwait(false);
 
                 Assert.IsNull(acc);
             }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1565,7 +1565,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [TestMethod]
         [DataRow("")]
         [DataRow(null)]
-        public async Task ValidateGetAccountAsyncWithNullAccountIdAsync(string accountId)
+        public async Task ValidateGetAccountAsyncWithNullEmptyAccountIdAsync(string accountId)
         {
             using (var httpManager = new MockHttpManager())
             {


### PR DESCRIPTION
Fixes # 

**Changes proposed in this request**
GetAccountAsync fix by checking for null on accountId

**Testing**
unit tests

**Performance impact**
n/a
