### PR TITLE
WAM Fix for ADFS 2019

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Identity.Client
         public bool IsBrokerAvailable()
         {            
             return PlatformProxyFactory.CreatePlatformProxy(null)
-                .CreateBroker(base.Config, null).IsBrokerInstalledAndInvokable();
+                .CreateBroker(base.Config, null).IsBrokerInstalledAndInvokable(base.Config.Authority.AuthorityInfo.AuthorityType);
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Identity.Client
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var broker = ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null);
-                if (broker.IsBrokerInstalledAndInvokable())
+                if (broker.IsBrokerInstalledAndInvokable(authority.AuthorityInfo.AuthorityType))
                 {
                     await broker.RemoveAccountAsync(ServiceBundle.Config, account).ConfigureAwait(false);
                 }
@@ -272,7 +272,7 @@ namespace Microsoft.Identity.Client
             if (AppConfig.IsBrokerEnabled && ServiceBundle.PlatformProxy.CanBrokerSupportSilentAuth())
             {
                 var broker = ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null);
-                if (broker.IsBrokerInstalledAndInvokable())
+                if (broker.IsBrokerInstalledAndInvokable(ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType))
                 {
                     var brokerAccounts =
                         (await broker.GetAccountsAsync(

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
 
         public async Task<MsalTokenResponse> FetchTokensAsync(CancellationToken cancellationToken)
         {
-            if (Broker.IsBrokerInstalledAndInvokable())
+            if (Broker.IsBrokerInstalledAndInvokable(_authenticationRequestParameters.AuthorityInfo.AuthorityType))
             {
                 _logger.Info(LogMessages.CanInvokeBrokerAcquireTokenWithBroker);
             }

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
 {
     internal interface IBroker
     {
-        bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad);
+        bool IsBrokerInstalledAndInvokable(AuthorityType authorityType);
 
         Task<MsalTokenResponse> AcquireTokenInteractiveAsync(
             AuthenticationRequestParameters authenticationRequestParameters,

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
 {
     internal interface IBroker
     {
-        bool IsBrokerInstalledAndInvokable();
+        bool IsBrokerInstalledAndInvokable(AuthorityType authorityType);
         
         Task<MsalTokenResponse> AcquireTokenInteractiveAsync(
             AuthenticationRequestParameters authenticationRequestParameters,

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/IBroker.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Identity.Client.Internal.Broker
 {
     internal interface IBroker
     {
-        bool IsBrokerInstalledAndInvokable(AuthorityType authorityType);
-        
+        bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad);
+
         Task<MsalTokenResponse> AcquireTokenInteractiveAsync(
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenInteractiveParameters acquireTokenInteractiveParameters);

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/NullBroker.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             _logger = logger ?? new NullLogger();
         }
 
-        public virtual bool IsBrokerInstalledAndInvokable()
+        public virtual bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
         {
             _logger.Info("NullBroker - acting as not installed.");
             return false;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/BrokerSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/BrokerSilentStrategy.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (!Broker.IsBrokerInstalledAndInvokable())
+            if (!Broker.IsBrokerInstalledAndInvokable(_authenticationRequestParameters.AuthorityInfo.AuthorityType))
             {
                 _logger.Warning("Broker is not installed. Cannot respond to silent request.");
                 return null;

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             _brokerHelper = new AndroidBrokerHelper(Application.Context, logger);
         }
 
-        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
         {
-            return _brokerHelper.IsBrokerInstalledAndInvokable();
+            return _brokerHelper.IsBrokerInstalledAndInvokable(authorityType);
         }
 
         public async Task<MsalTokenResponse> AcquireTokenInteractiveAsync(
@@ -251,7 +251,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             using (_logger.LogMethodDuration())
             {
-                if (!IsBrokerInstalledAndInvokable())
+                if (!IsBrokerInstalledAndInvokable(authorityInfo.AuthorityType))
                 {
                     _logger.Warning("[Android broker] Broker is either not installed or is not reachable so no accounts will be returned. ");
                     return CollectionHelpers.GetEmptyReadOnlyList<IAccount>();
@@ -280,7 +280,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             using (_logger.LogMethodDuration())
             {
-                if (!IsBrokerInstalledAndInvokable())
+                if (!IsBrokerInstalledAndInvokable(appConfig.Authority.AuthorityInfo.AuthorityType))
                 {
                     _logger.Warning("[Android broker] Broker is either not installed or not reachable so no accounts will be removed. ");
                     return;

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             _brokerHelper = new AndroidBrokerHelper(Application.Context, logger);
         }
 
-        public bool IsBrokerInstalledAndInvokable()
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
         {
             return _brokerHelper.IsBrokerInstalledAndInvokable();
         }

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerFactory.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             AndroidBrokerHelper brokerHelper = new AndroidBrokerHelper(Application.Context, logger);
 
-            if (brokerHelper.IsBrokerInstalledAndInvokable())
+            AuthorityType authorityType = AuthorityType.Aad; //passing AAD as default authority
+
+            if (brokerHelper.IsBrokerInstalledAndInvokable(authorityType))
             {
                 try
                 {

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerFactory.cs
@@ -33,9 +33,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             AndroidBrokerHelper brokerHelper = new AndroidBrokerHelper(Application.Context, logger);
 
-            AuthorityType authorityType = AuthorityType.Aad; //passing AAD as default authority
-
-            if (brokerHelper.IsBrokerInstalledAndInvokable(authorityType))
+            if (brokerHelper.IsBrokerInstalledAndInvokable(AuthorityType.Aad)) //authorityType is actually not used by the brokerHelper.IsBrokerInstalledAndInvokable
             {
                 try
                 {

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerHelper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             AndroidAccountManager = AccountManager.Get(_androidContext);
         }
 
-        public bool IsBrokerInstalledAndInvokable()
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
         {
             using (_logger.LogMethodDuration())
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             _brokerHelper = new AndroidBrokerHelper(Application.Context, logger);
         }
 
-        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
         {
-            return _brokerHelper.IsBrokerInstalledAndInvokable();
+            return _brokerHelper.IsBrokerInstalledAndInvokable(authorityType);
         }
 
         public async Task InitiateBrokerHandShakeAsync()
@@ -236,7 +236,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             using (_logger.LogMethodDuration())
             {
-                if (!IsBrokerInstalledAndInvokable())
+                if (!IsBrokerInstalledAndInvokable(authorityInfo.AuthorityType))
                 {
                     _logger.Warning("[Android broker] Broker is either not installed or is not reachable so no accounts will be returned. ");
                     return null;
@@ -277,7 +277,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             using (_logger.LogMethodDuration())
             {
-                if (!IsBrokerInstalledAndInvokable())
+                if (!IsBrokerInstalledAndInvokable(appConfig.Authority.AuthorityInfo.AuthorityType))
                 {
                     _logger.Warning("[Android broker] Broker is either not installed or not reachable so no accounts will be removed. ");
                     return;

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             _brokerHelper = new AndroidBrokerHelper(Application.Context, logger);
         }
 
-        public bool IsBrokerInstalledAndInvokable()
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
         {
             return _brokerHelper.IsBrokerInstalledAndInvokable();
         }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -698,7 +698,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             throw new NotImplementedException();
         }
 
-        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
         {
 #if NET_CORE
             if (!DesktopOsHelper.IsWindows())

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -703,6 +703,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
 #if NET_CORE
             if (!DesktopOsHelper.IsWindows())
             {
+                _logger.Info("[WAM Broker] Not a Windows Operating System. WAM Broker will not be used. ");
                 return false;
             }
 #endif            
@@ -712,6 +713,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                 _logger.Info("[WAM Broker] Falling Back to Browser for ADFS Authority. ");
                 return false;
             }
+
+            _logger.Info("[WAM Broker] Authority is AAD. Using WAM Broker. ");
 
             // WAM is present on Win 10 only
             return ApiInformation.IsMethodPresent(

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -698,7 +698,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             throw new NotImplementedException();
         }
 
-        public bool IsBrokerInstalledAndInvokable()
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
         {
 #if NET_CORE
             if (!DesktopOsHelper.IsWindows())
@@ -706,6 +706,13 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                 return false;
             }
 #endif            
+            // WAM does not work on pure ADFS environments
+            if (authorityType == AuthorityType.Adfs)
+            {
+                _logger.Info("[WAM Broker] Falling Back to Browser for ADFS Authority. ");
+                return false;
+            }
+
             // WAM is present on Win 10 only
             return ApiInformation.IsMethodPresent(
                    "Windows.Security.Authentication.Web.Core.WebAuthenticationCoreManager",

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -698,19 +698,19 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             throw new NotImplementedException();
         }
 
-        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
         {
 #if NET_CORE
             if (!DesktopOsHelper.IsWindows())
             {
-                _logger.Info("[WAM Broker] Not a Windows Operating System. WAM Broker will not be used. ");
+                _logger.Info("[WAM Broker] Not a Windows operating system. WAM broker is not available. ");
                 return false;
             }
 #endif            
             // WAM does not work on pure ADFS environments
             if (authorityType == AuthorityType.Adfs)
             {
-                _logger.Info("[WAM Broker] Falling Back to Browser for ADFS Authority. ");
+                _logger.Info("[WAM Broker] WAM does not work in pure ADFS environments. Falling back to browser for an ADFS authority. ");
                 return false;
             }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             _uIParent = uIParent;
         }
 
-        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
         {
             using (_logger.LogMethodDuration())
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             _uIParent = uIParent;
         }
 
-        public bool IsBrokerInstalledAndInvokable()
+        public bool IsBrokerInstalledAndInvokable(AuthorityType authorityType = AuthorityType.Aad)
         {
             using (_logger.LogMethodDuration())
             {

--- a/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Identity.Client
         public bool IsBrokerAvailable()
         {
             return
-                ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null).IsBrokerInstalledAndInvokable();
+                ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null).IsBrokerInstalledAndInvokable(ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType);
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -675,6 +675,15 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             // broker is not available on ADFS
             Assert.AreEqual(false, builder1.IsBrokerAvailable());
+
+            var builder3 = PublicClientApplicationBuilder
+                   .Create(TestConstants.ClientId)
+                   .WithDesktopFeatures()
+                   .WithAdfsAuthority(TestConstants.ADFSAuthority);
+
+
+            // broker is not available on ADFS
+            Assert.AreEqual(false, builder1.IsBrokerAvailable());
         }
 #endif
     }

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -674,7 +674,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
 
             // broker is not available on ADFS
-            Assert.AreEqual(false, builder1.IsBrokerAvailable());
+            Assert.AreEqual(false, builder2.IsBrokerAvailable());
 
             var builder3 = PublicClientApplicationBuilder
                    .Create(TestConstants.ClientId)
@@ -683,7 +683,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
 
             // broker is not available on ADFS
-            Assert.AreEqual(false, builder1.IsBrokerAvailable());
+            Assert.AreEqual(false, builder3.IsBrokerAvailable());
         }
 #endif
     }

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -629,7 +629,8 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void IsBrokerAvailable_net5()
         {
             var appBuilder = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId);
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.AuthorityTenant);
 
             Assert.AreEqual(DesktopOsHelper.IsWin10OrServerEquivalent(), appBuilder.IsBrokerAvailable());
         }
@@ -640,18 +641,40 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void IsBrokerAvailable_OldDotNet()
         {
             var builder1 = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId);
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.AuthorityTenant);
 
             // broker is not available out of the box
             Assert.AreEqual(false, builder1.IsBrokerAvailable());
 
             var builder2 = PublicClientApplicationBuilder
                    .Create(TestConstants.ClientId)
-                   .WithDesktopFeatures();
+                   .WithDesktopFeatures()
+                   .WithAuthority(TestConstants.AuthorityTenant);
 
 
             // broker is not available out of the box
             Assert.AreEqual(DesktopOsHelper.IsWin10OrServerEquivalent(), builder2.IsBrokerAvailable());
+        }
+
+        [TestMethod]
+        public void NoBrokerADFS_OldDotNet()
+        {
+            var builder1 = PublicClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.ADFSAuthority);
+
+            // broker is not available out of the box
+            Assert.AreEqual(false, builder1.IsBrokerAvailable());
+
+            var builder2 = PublicClientApplicationBuilder
+                   .Create(TestConstants.ClientId)
+                   .WithDesktopFeatures()
+                   .WithAuthority(TestConstants.ADFSAuthority);
+
+
+            // broker is not available on ADFS
+            Assert.AreEqual(false, builder1.IsBrokerAvailable());
         }
 #endif
     }

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -200,9 +200,9 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                         broker,
                         "install_url");
 #if NET5_WIN
-                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
 #else
-                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
 #endif
             }
         }
@@ -224,9 +224,9 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                         broker);
 
 #if NET5_WIN
-                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
 #else
-                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
 #endif
             }
         }
@@ -277,7 +277,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Arg.Any<AuthorityInfo>(),
                 Arg.Any<ICacheSessionManager>(),
                 Arg.Any<IInstanceDiscoveryManager>()).Returns(new[] { expectedAccount, expectedAccount });
-            broker.IsBrokerInstalledAndInvokable().Returns(true);
+            broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
             var platformProxy = Substitute.For<IPlatformProxy>();
             platformProxy.CanBrokerSupportSilentAuth().Returns(true);
@@ -299,8 +299,14 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             {
 
             }
-            public override bool IsBrokerInstalledAndInvokable()
+            public override bool IsBrokerInstalledAndInvokable(AuthorityType authorityType)
             {
+                // WAM does not work on pure ADFS environments
+                if (authorityType == AuthorityType.Adfs)
+                {
+                    return false;
+                }
+
                 return true;
             }
         }
@@ -469,7 +475,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Arg.Any<ICacheSessionManager>(),
                 Arg.Any<IInstanceDiscoveryManager>())
                 .Returns(new[] { expectedAccount });
-            mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+            mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
             platformProxy.CreateBroker(null, null).ReturnsForAnyArgs(mockBroker);
 
@@ -499,7 +505,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                     AuthorityInfo.FromAuthorityUri(TestConstants.AuthorityCommonTenant, true),
                     Arg.Any<ICacheSessionManager>(),
                     Arg.Any<IInstanceDiscoveryManager>()).Returns(new[] { expectedAccount });
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(false);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(false);
 
                 var platformProxy = Substitute.For<IPlatformProxy>();
                 platformProxy.CanBrokerSupportSilentAuth().Returns(true);
@@ -553,7 +559,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             {
                 // Arrange
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(false);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(false);
 
                 var platformProxy = Substitute.For<IPlatformProxy>();
                 platformProxy.CanBrokerSupportSilentAuth().Returns(true);
@@ -602,7 +608,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 _parameters.Account = PublicClientApplication.OperatingSystemAccount;
                 broker.AcquireTokenSilentDefaultUserAsync(_parameters, _acquireTokenSilentParameters)
                     .Returns(Task.FromResult(_msalTokenResponse));
-                broker.IsBrokerInstalledAndInvokable().Returns(true);
+                broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
                 // Act
                 var result = await brokerSilentAuthStrategy.ExecuteAsync(default).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -200,9 +200,9 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                         broker,
                         "install_url");
 #if NET5_WIN
-                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad));
 #else
-                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad));
 #endif
             }
         }
@@ -224,9 +224,9 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                         broker);
 
 #if NET5_WIN
-                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad));
 #else
-                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
+                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad));
 #endif
             }
         }
@@ -277,7 +277,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Arg.Any<AuthorityInfo>(),
                 Arg.Any<ICacheSessionManager>(),
                 Arg.Any<IInstanceDiscoveryManager>()).Returns(new[] { expectedAccount, expectedAccount });
-            broker.IsBrokerInstalledAndInvokable().Returns(true);
+            broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
             var platformProxy = Substitute.For<IPlatformProxy>();
             platformProxy.CanBrokerSupportSilentAuth().Returns(true);
@@ -475,7 +475,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Arg.Any<ICacheSessionManager>(),
                 Arg.Any<IInstanceDiscoveryManager>())
                 .Returns(new[] { expectedAccount });
-            mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+            mockBroker.IsBrokerInstalledAndInvokable((pca.AppConfig as ApplicationConfiguration).Authority.AuthorityInfo.AuthorityType).Returns(true);
 
             platformProxy.CreateBroker(null, null).ReturnsForAnyArgs(mockBroker);
 
@@ -608,7 +608,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 _parameters.Account = PublicClientApplication.OperatingSystemAccount;
                 broker.AcquireTokenSilentDefaultUserAsync(_parameters, _acquireTokenSilentParameters)
                     .Returns(Task.FromResult(_msalTokenResponse));
-                broker.IsBrokerInstalledAndInvokable().Returns(true);
+                broker.IsBrokerInstalledAndInvokable(_parameters.Authority.AuthorityInfo.AuthorityType).Returns(true);
 
                 // Act
                 var result = await brokerSilentAuthStrategy.ExecuteAsync(default).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -200,9 +200,9 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                         broker,
                         "install_url");
 #if NET5_WIN
-                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
+                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
 #else
-                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
+                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
 #endif
             }
         }
@@ -224,9 +224,9 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                         broker);
 
 #if NET5_WIN
-                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
+                Assert.AreEqual(true, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
 #else
-                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable(harness.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType));
+                Assert.AreEqual(false, _brokerInteractiveRequest.Broker.IsBrokerInstalledAndInvokable());
 #endif
             }
         }
@@ -277,7 +277,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Arg.Any<AuthorityInfo>(),
                 Arg.Any<ICacheSessionManager>(),
                 Arg.Any<IInstanceDiscoveryManager>()).Returns(new[] { expectedAccount, expectedAccount });
-            broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
+            broker.IsBrokerInstalledAndInvokable().Returns(true);
 
             var platformProxy = Substitute.For<IPlatformProxy>();
             platformProxy.CanBrokerSupportSilentAuth().Returns(true);
@@ -475,7 +475,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Arg.Any<ICacheSessionManager>(),
                 Arg.Any<IInstanceDiscoveryManager>())
                 .Returns(new[] { expectedAccount });
-            mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
+            mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
 
             platformProxy.CreateBroker(null, null).ReturnsForAnyArgs(mockBroker);
 
@@ -608,7 +608,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 _parameters.Account = PublicClientApplication.OperatingSystemAccount;
                 broker.AcquireTokenSilentDefaultUserAsync(_parameters, _acquireTokenSilentParameters)
                     .Returns(Task.FromResult(_msalTokenResponse));
-                broker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
+                broker.IsBrokerInstalledAndInvokable().Returns(true);
 
                 // Act
                 var result = await brokerSilentAuthStrategy.ExecuteAsync(default).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 httpManager.AddInstanceDiscoveryMockHandler();
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
 
                 var msalTokenResponse = CreateMsalTokenResponseFromWam("wam1");
                 mockBroker.AcquireTokenInteractiveAsync(null, null).ReturnsForAnyArgs(Task.FromResult(msalTokenResponse));
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 httpManager.AddInstanceDiscoveryMockHandler();
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
 
                 var msalTokenResponse1 = CreateMsalTokenResponseFromWam("wam1");
                 var msalTokenResponse2 = CreateMsalTokenResponseFromWam("wam2");
@@ -141,7 +141,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 IReadOnlyList<IAccount> brokerAccounts = new List<IAccount>() { brokerAccount1, brokerAccount2 };
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
 
                 var msalTokenResponse = CreateMsalTokenResponseFromWam("wam_acc_id");
                 mockBroker.AcquireTokenInteractiveAsync(null, null).ReturnsForAnyArgs(Task.FromResult(msalTokenResponse));

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 httpManager.AddInstanceDiscoveryMockHandler();
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
                 var msalTokenResponse = CreateMsalTokenResponseFromWam("wam1");
                 mockBroker.AcquireTokenInteractiveAsync(null, null).ReturnsForAnyArgs(Task.FromResult(msalTokenResponse));
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 httpManager.AddInstanceDiscoveryMockHandler();
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
                 var msalTokenResponse1 = CreateMsalTokenResponseFromWam("wam1");
                 var msalTokenResponse2 = CreateMsalTokenResponseFromWam("wam2");
@@ -141,7 +141,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 IReadOnlyList<IAccount> brokerAccounts = new List<IAccount>() { brokerAccount1, brokerAccount2 };
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
                 var msalTokenResponse = CreateMsalTokenResponseFromWam("wam_acc_id");
                 mockBroker.AcquireTokenInteractiveAsync(null, null).ReturnsForAnyArgs(Task.FromResult(msalTokenResponse));

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 httpManager.AddInstanceDiscoveryMockHandler();
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
                 var msalTokenResponse = CreateMsalTokenResponseFromWam("wam1");
                 mockBroker.AcquireTokenInteractiveAsync(null, null).ReturnsForAnyArgs(Task.FromResult(msalTokenResponse));
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 httpManager.AddInstanceDiscoveryMockHandler();
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
                 var msalTokenResponse1 = CreateMsalTokenResponseFromWam("wam1");
                 var msalTokenResponse2 = CreateMsalTokenResponseFromWam("wam2");
@@ -141,7 +141,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 IReadOnlyList<IAccount> brokerAccounts = new List<IAccount>() { brokerAccount1, brokerAccount2 };
 
                 var mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().Returns(true);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
                 var msalTokenResponse = CreateMsalTokenResponseFromWam("wam_acc_id");
                 mockBroker.AcquireTokenInteractiveAsync(null, null).ReturnsForAnyArgs(Task.FromResult(msalTokenResponse));
@@ -169,10 +169,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
 #endif
             }
         }
-
-
-
-     
 
         private static MsalTokenResponse CreateMsalTokenResponseFromWam(string wamAccountId)
         {

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
@@ -82,12 +82,27 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Assert.Inconclusive("Needs to run on win10 or equivalent");
             }
             var pcaBuilder = PublicClientApplicationBuilder
-               .Create("d3adb33f-c0de-ed0c-c0de-deadb33fc0d3");
+               .Create("d3adb33f-c0de-ed0c-c0de-deadb33fc0d3")
+               .WithAuthority(TestConstants.AuthorityTenant);
 #if !NET5_WIN
             pcaBuilder = pcaBuilder.WithWindowsBroker();
 #endif
 
             Assert.IsTrue(pcaBuilder.IsBrokerAvailable());
+
+        }
+
+        [TestMethod]
+        public void NoWamOnADFS()
+        {
+            var pcaBuilder = PublicClientApplicationBuilder
+               .Create("d3adb33f-c0de-ed0c-c0de-deadb33fc0d3")
+               .WithAdfsAuthority(TestConstants.ADFSAuthority);
+#if !NET5_WIN
+            pcaBuilder = pcaBuilder.WithWindowsBroker();
+#endif
+
+            Assert.IsFalse(pcaBuilder.IsBrokerAvailable());
 
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             var pcaBuilder = PublicClientApplicationBuilder
                .Create("d3adb33f-c0de-ed0c-c0de-deadb33fc0d3")
                .WithAuthority(TestConstants.AuthorityTenant);
+
 #if !NET5_WIN
             pcaBuilder = pcaBuilder.WithWindowsBroker();
 #endif

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     brokerID);
 
                 IBroker mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().ReturnsForAnyArgs(brokerIsInstalledAndInvokable);
+                mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).ReturnsForAnyArgs(brokerIsInstalledAndInvokable);
 
                 harness.ServiceBundle.Config.BrokerCreatorFunc = (app, config, logger) => mockBroker;
 

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     brokerID);
 
                 IBroker mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable(harness.Authority.AuthorityInfo.AuthorityType).ReturnsForAnyArgs(brokerIsInstalledAndInvokable);
+                mockBroker.IsBrokerInstalledAndInvokable().ReturnsForAnyArgs(brokerIsInstalledAndInvokable);
 
                 harness.ServiceBundle.Config.BrokerCreatorFunc = (app, config, logger) => mockBroker;
 

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/SilentRequestTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                     brokerID);
 
                 IBroker mockBroker = Substitute.For<IBroker>();
-                mockBroker.IsBrokerInstalledAndInvokable().ReturnsForAnyArgs(brokerIsInstalledAndInvokable);
+                mockBroker.IsBrokerInstalledAndInvokable(harness.Authority.AuthorityInfo.AuthorityType).ReturnsForAnyArgs(brokerIsInstalledAndInvokable);
 
                 harness.ServiceBundle.Config.BrokerCreatorFunc = (app, config, logger) => mockBroker;
 


### PR DESCRIPTION
Fixes #2836 

**Changes proposed in this request**
WAM is not supported in pure ADFS environments. We do not get an ID token from WAM for ADFS scenarios, hence we are not able to properly form the TokenResponse object and also caching fails. TO fix the issue, we are falling back to browser if the Authority is set as ADFS. 

**Testing**
Unit Tests, Manual Testing. For Release 4.41.0 this needs a manual testing on an ADFS 2019 domain joined machine

**Performance impact**
N/A
