### PR TITLE
Fix for #3130 - if no tokens are in the cache, suggested expiry = null

### DIFF
--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -12,6 +12,7 @@ using Microsoft.Identity.Client.AuthScheme.Bearer;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Cache.Keys;
+using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Client.Internal;
@@ -34,7 +35,8 @@ namespace Microsoft.Identity.Client
             AuthenticationRequestParameters requestParams,
             MsalTokenResponse response)
         {
-            response.Log(requestParams.RequestContext.Logger, LogLevel.Verbose);
+            var logger = requestParams.RequestContext.Logger;
+            response.Log(logger, LogLevel.Verbose);
 
             MsalAccessTokenCacheItem msalAccessTokenCacheItem = null;
             MsalRefreshTokenCacheItem msalRefreshTokenCacheItem = null;
@@ -44,7 +46,7 @@ namespace Microsoft.Identity.Client
             IdToken idToken = IdToken.Parse(response.IdToken);
             if (idToken == null)
             {
-                requestParams.RequestContext.Logger.Info("ID Token not present in response. ");
+                logger.Info("ID Token not present in response. ");
             }
 
             var tenantId = GetTenantId(idToken, requestParams);
@@ -138,9 +140,9 @@ namespace Microsoft.Identity.Client
 
             #endregion
 
-            requestParams.RequestContext.Logger.Verbose($"[SaveTokenResponseAsync] Entering token cache semaphore. Count {_semaphoreSlim.GetCurrentCountLogMessage()}.");
+            logger.Verbose($"[SaveTokenResponseAsync] Entering token cache semaphore. Count {_semaphoreSlim.GetCurrentCountLogMessage()}.");
             await _semaphoreSlim.WaitAsync(requestParams.RequestContext.UserCancellationToken).ConfigureAwait(false);
-            requestParams.RequestContext.Logger.Verbose("[SaveTokenResponseAsync] Entered token cache semaphore. ");
+            logger.Verbose("[SaveTokenResponseAsync] Entered token cache semaphore. ");
             ITokenCacheInternal tokenCacheInternal = this;
 
             try
@@ -174,7 +176,7 @@ namespace Microsoft.Identity.Client
 
                     if (msalAccessTokenCacheItem != null)
                     {
-                        requestParams.RequestContext.Logger.Info("Saving AT in cache and removing overlapping ATs...");
+                        logger.Info("Saving AT in cache and removing overlapping ATs...");
 
                         DeleteAccessTokensWithIntersectingScopes(
                             requestParams,
@@ -189,7 +191,7 @@ namespace Microsoft.Identity.Client
 
                     if (idToken != null)
                     {
-                        requestParams.RequestContext.Logger.Info("Saving Id Token and Account in cache ...");
+                        logger.Info("Saving Id Token and Account in cache ...");
                         Accessor.SaveIdToken(msalIdTokenCacheItem);
                         MergeWamAccountIds(msalAccountCacheItem);
                         Accessor.SaveAccount(msalAccountCacheItem);
@@ -198,7 +200,7 @@ namespace Microsoft.Identity.Client
                     // if server returns the refresh token back, save it in the cache.
                     if (msalRefreshTokenCacheItem != null)
                     {
-                        requestParams.RequestContext.Logger.Info("Saving RT in cache...");
+                        logger.Info("Saving RT in cache...");
                         Accessor.SaveRefreshToken(msalRefreshTokenCacheItem);
                     }
 
@@ -219,12 +221,7 @@ namespace Microsoft.Identity.Client
                 {
                     if (tokenCacheInternal.IsAppSubscribedToSerializationEvents())
                     {
-                        DateTimeOffset? cacheExpiry = null;
-
-                        if (!Accessor.GetAllRefreshTokens().Any())
-                        {
-                            cacheExpiry = CalculateSuggestedCacheExpiry();
-                        }
+                        DateTimeOffset? cacheExpiry = CalculateSuggestedCacheExpiry(Accessor, logger);
 
                         var args = new TokenCacheNotificationArgs(
                             tokenCache: this,
@@ -255,7 +252,7 @@ namespace Microsoft.Identity.Client
             finally
             {
                 _semaphoreSlim.Release();
-                requestParams.RequestContext.Logger.Verbose("[SaveTokenResponseAsync] Released token cache semaphore. ");
+                logger.Verbose("[SaveTokenResponseAsync] Released token cache semaphore. ");
             }
         }
 
@@ -346,11 +343,26 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        private DateTimeOffset CalculateSuggestedCacheExpiry()
+        internal /* for testing */ static DateTimeOffset? CalculateSuggestedCacheExpiry(
+            ITokenCacheAccessor accessor, 
+            ICoreLogger logger)
         {
-            IEnumerable<MsalAccessTokenCacheItem> tokenCacheItems = GetAllAccessTokensWithNoLocks(true);
-            DateTimeOffset cacheExpiry = tokenCacheItems.Max(item => item.ExpiresOn);
-            return cacheExpiry;
+            // If we have refresh tokens in the cache, we cannot suggest expiration
+            // because refresh token expiration is not disclosed to SDKs and RTs are long lived anyway (3 months by default)
+            if (accessor.GetAllRefreshTokens().Count == 0)
+            {
+                IReadOnlyList<MsalAccessTokenCacheItem> tokenCacheItems = accessor.GetAllAccessTokens(optionalPartitionKey: null);
+                if (tokenCacheItems.Count == 0)
+                {
+                    logger.Warning("[CalculateSuggestedCacheExpiry] No access tokens or refresh tokens found in the accessor. Suggesting immediate expiration.");
+                    return DateTimeOffset.UtcNow;
+                }
+
+                DateTimeOffset cacheExpiry = tokenCacheItems.Max(item => item.ExpiresOn);
+                return cacheExpiry;
+            }
+
+            return null;
         }
 
         private string GetTenantId(IdToken idToken, AuthenticationRequestParameters requestParams)

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/TokenCacheHelper.cs
@@ -27,8 +27,10 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             string tenant = TestConstants.Utid,
             string homeAccountId = TestConstants.HomeAccountId,
             bool isExpired = false,
-            string oboCacheKey = null)
+            string oboCacheKey = null, 
+            TimeSpan? exiresIn = null)
         {
+            var expiresIn = (exiresIn.HasValue ? exiresIn.Value : TimeSpan.FromSeconds(ValidExpiresIn));
             MsalAccessTokenCacheItem atItem = new MsalAccessTokenCacheItem(
                TestConstants.ProductionPrefCacheEnvironment,
                TestConstants.ClientId,
@@ -36,7 +38,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                tenantId: tenant,
                secret: "",
                cachedAt: DateTimeOffset.UtcNow,
-               expiresOn: isExpired ? new DateTimeOffset(DateTime.UtcNow) : new DateTimeOffset(DateTime.UtcNow + TimeSpan.FromSeconds(ValidExpiresIn)),
+               expiresOn: isExpired ? new DateTimeOffset(DateTime.UtcNow) : new DateTimeOffset(DateTime.UtcNow + expiresIn),
                extendedExpiresOn: isExpired ? new DateTimeOffset(DateTime.UtcNow) : new DateTimeOffset(DateTime.UtcNow + TimeSpan.FromSeconds(ValidExtendedExpiresIn)),
                MockHelpers.CreateClientInfo(),
                homeAccountId, 

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -476,7 +476,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 var t1 = TokenCacheHelper.CreateAccessTokenItem(isExpired: true);
                 var t2 = TokenCacheHelper.CreateAccessTokenItem(isExpired: true);
-                var t3 = TokenCacheHelper.CreateAccessTokenItem(exiresIn: TimeSpan.FromMinutes(4));
+                // token that expires in less than 5 min and is seen as expired by msal
+                var t3 = TokenCacheHelper.CreateAccessTokenItem(exiresIn: Constants.AccessTokenExpirationBuffer - TimeSpan.FromSeconds(1));
 
                 appTokenCache.Accessor.SaveAccessToken(t1);
                 appTokenCache.Accessor.SaveAccessToken(t2);
@@ -495,8 +496,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 Assert.IsFalse(appTokenCache.Accessor.HasAccessOrRefreshTokens());
                 Assert.IsFalse(userTokenCache.Accessor.HasAccessOrRefreshTokens());
 
-                // Arrange
-                var t4 = TokenCacheHelper.CreateAccessTokenItem(exiresIn: TimeSpan.FromMinutes(10));
+                // Arrange - token that is not seen as expired
+                var t4 = TokenCacheHelper.CreateAccessTokenItem(exiresIn: Constants.AccessTokenExpirationBuffer + TimeSpan.FromMinutes(1));
                 appTokenCache.Accessor.SaveAccessToken(t4);
                 userTokenCache.Accessor.SaveAccessToken(t4);
 
@@ -507,7 +508,9 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 // Assert
                 CoreAssert.IsWithinRange(t4.ExpiresOn, appAccessorExpiration.Value, TimeSpan.FromSeconds(3));
                 CoreAssert.IsWithinRange(t4.ExpiresOn, userAccessorExpiration.Value, TimeSpan.FromSeconds(3));
-                
+                Assert.IsTrue(appTokenCache.Accessor.HasAccessOrRefreshTokens());
+                Assert.IsTrue(userTokenCache.Accessor.HasAccessOrRefreshTokens());
+
             }
         }
 


### PR DESCRIPTION
Fixes #3130 
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
 if no tokens are in the cache, suggested expiry = NOW

**Testing**
unit

**Performance impact**
1 extra int comparison will not degrade perf
