### PR TITLE
WwwAuthenticateParameters should not expose Resource/Scopes

### DIFF
--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -33,24 +33,7 @@ namespace Microsoft.Identity.Client
         /// If it's not provided by the web API, it's computed from the Resource.
         /// </summary>
         [Obsolete("The client apps should know which scopes to request for.", true)]
-        public IEnumerable<string> Scopes
-        {
-            get
-            {
-                if (_scopes != null)
-                {
-                    return _scopes;
-                }
-
-                return null;
-            }
-            set
-            {
-                _scopes = value;
-            }
-        }
-
-        private IEnumerable<string> _scopes;
+        public IEnumerable<string> Scopes { get; set; }
 
         /// <summary>
         /// Authority from which to request an access token.

--- a/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
+++ b/src/client/Microsoft.Identity.Client/WwwAuthenticateParameters.cs
@@ -25,12 +25,14 @@ namespace Microsoft.Identity.Client
         /// Resource for which to request scopes.
         /// This is the App ID URI of the API that returned the WWW-Authenticate header.
         /// </summary>
+        [Obsolete("The client apps should know which App ID URI it requests scopes for.", true)]
         public string Resource { get; set; }
 
         /// <summary>
         /// Scopes to request.
         /// If it's not provided by the web API, it's computed from the Resource.
         /// </summary>
+        [Obsolete("The client apps should know which scopes to request for.", true)]
         public IEnumerable<string> Scopes
         {
             get
@@ -38,11 +40,6 @@ namespace Microsoft.Identity.Client
                 if (_scopes != null)
                 {
                     return _scopes;
-                }
-
-                if (!string.IsNullOrEmpty(Resource))
-                {
-                    return new[] { $"{Resource}/.default" };
                 }
 
                 return null;
@@ -238,27 +235,6 @@ namespace Microsoft.Identity.Client
                 if (values.TryGetValue("authority", out value))
                 {
                     wwwAuthenticateParameters.Authority = value.TrimEnd('/');
-                }
-            }
-
-            if (values.TryGetValue("resource_id", out value))
-            {
-                wwwAuthenticateParameters.Resource = value;
-            }
-
-            if (string.IsNullOrEmpty(wwwAuthenticateParameters.Resource))
-            {
-                if (values.TryGetValue("resource", out value))
-                {
-                    wwwAuthenticateParameters.Resource = value;
-                }
-            }
-
-            if (string.IsNullOrEmpty(wwwAuthenticateParameters.Resource))
-            {
-                if (values.TryGetValue("client_id", out value))
-                {
-                    wwwAuthenticateParameters.Resource = value;
                 }
             }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -17,10 +17,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         {
             var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync("https://buildautomation.vault.azure.net/secrets/CertName/CertVersion").ConfigureAwait(false);
 
-            Assert.AreEqual("https://vault.azure.net", authParams.Resource);
             Assert.AreEqual("login.windows.net", new Uri(authParams.Authority).Host);
             Assert.AreEqual("72f988bf-86f1-41af-91ab-2d7cd011db47", authParams.GetTenantId()); // because the Key Vault resource belong to Microsoft Corp tenant
-            Assert.AreEqual("https://vault.azure.net/.default", authParams.Scopes.FirstOrDefault());
             Assert.AreEqual(2, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
@@ -31,10 +29,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         {
             var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync("https://graph.microsoft.com/v1.0/me").ConfigureAwait(false);
 
-            Assert.AreEqual("00000003-0000-0000-c000-000000000000", authParams.Resource);
             Assert.AreEqual("https://login.microsoftonline.com/common", authParams.Authority);
             Assert.AreEqual("common", authParams.GetTenantId());
-            Assert.AreEqual("00000003-0000-0000-c000-000000000000/.default", authParams.Scopes.FirstOrDefault());
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
@@ -58,10 +54,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync(url).ConfigureAwait(false);
 
-            Assert.IsNull(authParams.Resource);
             Assert.AreEqual($"https://{authority}/{tenantId}", authParams.Authority); // authority URI consists of AAD endpoint and tenant ID
             Assert.AreEqual(tenantId, authParams.GetTenantId()); // tenant ID is extracted out of authority URI
-            Assert.IsNull(authParams.Scopes);
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.AreEqual("invalid_token", authParams.Error);

--- a/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WwwAuthenticateParametersTests.cs
@@ -50,9 +50,7 @@ namespace Microsoft.Identity.Test.Unit
             var authParams = WwwAuthenticateParameters.CreateFromResponseHeaders(httpResponse.Headers);
 
             // Assert
-            Assert.AreEqual(GraphGuid, authParams.Resource);
             Assert.AreEqual(TestConstants.AuthorityCommonTenant.TrimEnd('/'), authParams.Authority);
-            Assert.AreEqual($"{GraphGuid}/.default", authParams.Scopes.FirstOrDefault());
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);
@@ -136,9 +134,7 @@ namespace Microsoft.Identity.Test.Unit
             var authParams = WwwAuthenticateParameters.CreateFromWwwAuthenticateHeaderValue(wwwAuthenticateResponse);
 
             // Assert
-            Assert.AreEqual(GraphGuid, authParams.Resource);
             Assert.AreEqual(TestConstants.AuthorityCommonTenant.TrimEnd('/'), authParams.Authority);
-            Assert.AreEqual($"{GraphGuid}/.default", authParams.Scopes.First());
             Assert.AreEqual(3, authParams.RawParameters.Count);
             Assert.IsNull(authParams.Claims);
             Assert.IsNull(authParams.Error);


### PR DESCRIPTION
Fixes #3144 

**Changes proposed in this request**
- WwwAuthenticateParameters should not expose Resource/Scopes
- Marked both resource and scopes property in WwwAuthenticateParameters as Obsolete
- Added notes to bug [3144](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3144) to update docs 

**Testing**
- unit, integration
- created a test app based on suggested usage, [How to - use the WwwAuthenticateParameters class](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/WWW-Authenticate-parameters#how-to---use-the-wwwauthenticateparameters-class), found scopes will be null if we marked Resource as obsolete. Per discussion marking scope as obsolete. 

**Performance impact**
none. we no longer calculate scope based on the resource that is returned maybe a minor improvement. 
