### PR TITLE
Add instance_aware extra query param only if one does not exist

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         private readonly AcquireTokenInteractiveParameters _interactiveParameters;
         private readonly IServiceBundle _serviceBundle;
         private readonly ICoreLogger _logger;
-        private readonly string _instanceAware = "instance_aware";
+        private readonly const string InstanceAwareParam = "instance_aware";
 
         #region For Test
         private readonly IAuthCodeRequestComponent _authCodeRequestComponentOverride;
@@ -113,9 +113,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            if (_requestParams.AppConfig.MultiCloudSupportEnabled && !_requestParams.AppConfig.ExtraQueryParameters.ContainsKey(_instanceAware))
+            if (_requestParams.AppConfig.MultiCloudSupportEnabled)
             {
-                _requestParams.AppConfig.ExtraQueryParameters.Add(_instanceAware, "true");
+                _requestParams.AppConfig.ExtraQueryParameters[InstanceAwareParam] = "true";
             }
 
             IAuthCodeRequestComponent authorizationFetcher =

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         private readonly AcquireTokenInteractiveParameters _interactiveParameters;
         private readonly IServiceBundle _serviceBundle;
         private readonly ICoreLogger _logger;
-        private readonly const string InstanceAwareParam = "instance_aware";
+        private const string InstanceAwareParam = "instance_aware";
 
         #region For Test
         private readonly IAuthCodeRequestComponent _authCodeRequestComponentOverride;
@@ -115,6 +115,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             if (_requestParams.AppConfig.MultiCloudSupportEnabled)
             {
+                _logger.Info("Instance Aware was configured.");
                 _requestParams.AppConfig.ExtraQueryParameters[InstanceAwareParam] = "true";
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         private readonly AcquireTokenInteractiveParameters _interactiveParameters;
         private readonly IServiceBundle _serviceBundle;
         private readonly ICoreLogger _logger;
+        private readonly string _instanceAware = "instance_aware";
 
         #region For Test
         private readonly IAuthCodeRequestComponent _authCodeRequestComponentOverride;
@@ -112,9 +113,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            if (_requestParams.AppConfig.MultiCloudSupportEnabled)
+            if (_requestParams.AppConfig.MultiCloudSupportEnabled && !_requestParams.AppConfig.ExtraQueryParameters.ContainsKey(_instanceAware))
             {
-                _requestParams.AppConfig.ExtraQueryParameters.Add("instance_aware", "true");
+                _requestParams.AppConfig.ExtraQueryParameters.Add(_instanceAware, "true");
             }
 
             IAuthCodeRequestComponent authorizationFetcher =


### PR DESCRIPTION
Fixes: Update to the PR #3141 for #2524 

**Changes proposed in this request**
When user selects .WithMultiCloudSupport(true) and calls interactive request we need to add the extraQueryParam to the request. But if the query param is already added, then ExtraQueryParam.Add() will throw an exception. So checking if the key exists before adding it.

**Testing**


**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->
