### PR TITLE
Adding `ExactSpelling = true` on [DllImport("ntdll.dll"] 

### DIFF
--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Win32VersionApi.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Win32VersionApi.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         /// which input structure is used by setting the dwOSVersionInfoSize member of the structure to the size in bytes of 
         /// the structure that is used.</param>
         /// <returns>RtlGetVersion returns Status_Success.</returns>
-        [DllImport("ntdll.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport("ntdll.dll", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         private static extern int RtlGetVersion(ref OSVERSIONINFOEXW versionInformation);
 
         /// <summary>


### PR DESCRIPTION
Adding `ExactSpelling = true` on [DllImport("ntdll.dll"] to fix UWP packaging warning `MCG : warning MCG0007: Unresolved P/Invoke method 'ntdll.dll!RtlGetVersion' for method 'System.Int32 `

Fixes #3184 

**Changes proposed in this request**
Adding `ExactSpelling = true` on [DllImport("ntdll.dll"] 

**Testing**
- Manual testing of UWP package publishing for all supported platforms. 
- WAM testing on all supported OSs

**Performance impact**
none
