### PR TITLE
Revert "Fix path variables. (#3202) to fix OneBranch release"

### DIFF
--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -13,21 +13,21 @@ steps:
 - template: template-pack-and-sign-nuget.yaml
   parameters:
     BuildConfiguration: ${{ parameters.BuildConfiguration }}
-    ProjectRootPath: '$(Build.SourcesDirectory)\${{ parameters.MsalSourceDir }}\src\client'
+    ProjectRootPath: '$(Build.SourcesDirectory)\$(MsalSourceDir)src\client'
     AssemblyName: 'Microsoft.Identity.Client'
 
 # Pack and sign Microsoft.Identity.Client.Desktop
 - template: template-pack-and-sign-nuget.yaml
   parameters:
     BuildConfiguration: ${{ parameters.BuildConfiguration }}
-    ProjectRootPath: '$(Build.SourcesDirectory)\${{ parameters.MsalSourceDir }}\src\client'
+    ProjectRootPath: '$(Build.SourcesDirectory)\$(MsalSourceDir)src\client'
     AssemblyName: 'Microsoft.Identity.Client.Desktop'    
 
 # Copy all packages out to staging
 - task: CopyFiles@2
   displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)\packages'
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)\${{ parameters.MsalSourceDir }}\'
+    SourceFolder: '$(Build.SourcesDirectory)\$(MsalSourceDir)'
     Contents: '**\*nupkg'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\packages'
     flattenFolders: true


### PR DESCRIPTION
This reverts commit 4b194f533bf74606f5a456ea82429adb68bc7a3a which brakes the one branch release build. Need to do this in the meantime to make OneBranch build work again. Fix to make oneBranch and legacy release build work together coming shortly

Fixes # 
Fixes OneBranch build

**Changes proposed in this request**
revert commit 4b194f533bf74606f5a456ea82429adb68bc7a3a.

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->
