### PR TITLE
Add a workaround for PRT update failure on /organizations

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/Interfaces/IWebAccountProviderFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/Interfaces/IWebAccountProviderFactory.cs
@@ -11,5 +11,6 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         Task<WebAccountProvider> GetDefaultProviderAsync();
         bool IsConsumerProvider(WebAccountProvider webAccountProvider);
         Task<bool> IsDefaultAccountMsaAsync();
+        bool IsOrganizationsProvider(WebAccountProvider webAccountProvider);
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -313,6 +313,12 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             }
         }
 
+        /// <summary>
+        /// Some WAM operations fail for work and school accounts when the authority is env/organizations
+        /// Chaing the authority to env/common in this case works around this problem.
+        /// 
+        /// https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3217
+        /// </summary>
         private async Task<string> WorkaroundOrganizationsBugAsync(
             AuthenticationRequestParameters authenticationRequestParameters,
             WebAccountProvider webAccountProvider)

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                     // For MSA-PT, the MSA provider will issue v1 token, which cannot be used.
                     // Only the AAD provider can issue a v2 token
                     accountProvider = await _webAccountProviderFactory.GetAccountProviderAsync(
-                        authenticationRequestParameters.Authority.TenantId)
+                            authenticationRequestParameters.AuthorityInfo.CanonicalAuthority)
                         .ConfigureAwait(false);
                 }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WebAccountProviderFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WebAccountProviderFactory.cs
@@ -40,5 +40,11 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             bool isConsumerTenant = string.Equals(webAccountProvider.Authority, "consumers", StringComparison.OrdinalIgnoreCase);
             return isConsumerTenant;
         }
-    }
+
+        public bool IsOrganizationsProvider(WebAccountProvider webAccountProvider)
+        {
+            bool isOrganizations = string.Equals(webAccountProvider.Authority, "organizations", StringComparison.OrdinalIgnoreCase);
+            return isOrganizations;
+        }
+    }    
 }

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
@@ -634,7 +634,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                     "https://login.microsoft.com", "organizations");
                 var webAccount = new WebAccount(wamAccountProvider, "user@contoso.com", WebAccountState.Connected);
                 var webTokenRequest = new WebTokenRequest(wamAccountProvider);
-
+                _webAccountProviderFactory.IsOrganizationsProvider(wamAccountProvider).Returns(true);
                 // will use the AAD provider because the authority is tenanted (i.e. AAD only)
                 _webAccountProviderFactory
                     .GetAccountProviderAsync(TestConstants.AuthorityHomeTenant)
@@ -1214,7 +1214,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             using (var harness = CreateTestHarness())
             {
                 var requestParams = harness.CreateAuthenticationRequestParameters(
-                    TestConstants.AuthorityOrganizationsTenant); // AAD authorities for whi
+                    TestConstants.AuthorityOrganizationsTenant); 
 
                 // msa-pt scenario
                 requestParams.AppConfig.WindowsBrokerOptions = new WindowsBrokerOptions() { MsaPassthrough = true };
@@ -1239,7 +1239,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                     .Returns(Task.FromResult("transfer_token"));
 
                 var aadProvider = new WebAccountProvider("aad", "user@contoso.com", null);
-                _webAccountProviderFactory.GetAccountProviderAsync("home").Returns(aadProvider);
+                _webAccountProviderFactory.GetAccountProviderAsync(TestConstants.AuthorityOrganizationsTenant).Returns(aadProvider);
 
                 // make sure the final request is done with the AAD provider
                 var webTokenRequest = new WebTokenRequest(aadProvider);
@@ -1247,8 +1247,8 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                     aadProvider,
                     requestParams,
                     isForceLoginPrompt: false,
-                     isInteractive: true,
-                     isAccountInWam: false)
+                    isInteractive: true,
+                    isAccountInWam: false)
                     .Returns(Task.FromResult(webTokenRequest));
 
                 var webTokenResponseWrapper = Substitute.For<IWebTokenRequestResultWrapper>();
@@ -1445,7 +1445,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                     .Returns(Task.FromResult<string>(null));
 
                 var aadProvider = new WebAccountProvider("aad", "user@contoso.com", null);
-                _webAccountProviderFactory.GetAccountProviderAsync("home").Returns(aadProvider);
+                _webAccountProviderFactory.GetAccountProviderAsync(TestConstants.AuthorityHomeTenant).Returns(aadProvider);
 
                 // make sure the final request is done with the AAD provider
                 var webTokenRequest = new WebTokenRequest(aadProvider);

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
@@ -1270,6 +1270,9 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 Assert.AreSame(_msalTokenResponse, result);
                 _msaPassthroughHandler.Received(1).AddTransferTokenToRequest(webTokenRequest, "transfer_token");
                 AssertTelemetryHeadersInRequest(webTokenRequest.Properties);
+                Assert.AreEqual(
+                   "https://login.microsoftonline.com/organizations/",
+                   webTokenRequest.Properties["authority"]);
             }
         }
 
@@ -1340,6 +1343,8 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
 
             }
         }
+
+     
 
         [TestMethod]
         public async Task ATS_MsaPt_Async()


### PR DESCRIPTION
Fixes #3217

Replace env/organizations with env/common when we can reliably detect an AAD interactive login. 

**Testing**
unit

manual

1. {normal app, msa-pt app} with authority {global cloud, sovereign cloud}/organizations logging in an {aad/msa} account, {silent, interactive}
(16 tests)

2. log in the default account {aad, msa}, {silent, interactive}  with {normal, msa-pt} app (8 tests) 


<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
only string comparisons
<!-- Describe any applicable performance impact or performance testing done. -->
