### PR TITLE
Reuse lists in token cache filtering logic.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/ITokenCacheAccessor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client.Cache
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
         /// Not all classes that implement this method are required to filter by partition (e.g. mobile)
         /// </remarks>
-        IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string optionalPartitionKey = null);
+        List<MsalAccessTokenCacheItem> GetAllAccessTokens(string optionalPartitionKey = null);
 
         /// <summary>
         /// Returns all refresh tokens from the underlying cache collection.
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Client.Cache
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
         /// Not all classes that implement this method are required to filter by partition (e.g. mobile)
         /// </remarks>
-        IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string optionalPartitionKey = null);
+        List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string optionalPartitionKey = null);
 
         /// <summary>
         /// Returns all ID tokens from the underlying cache collection.
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Client.Cache
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
         /// Not all classes that implement this method are required to filter by partition (e.g. mobile)
         /// </remarks>
-        IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string optionalPartitionKey = null);
+        List<MsalIdTokenCacheItem> GetAllIdTokens(string optionalPartitionKey = null);
 
         /// <summary>
         /// Returns all accounts from the underlying cache collection.
@@ -75,9 +75,9 @@ namespace Microsoft.Identity.Client.Cache
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
         /// Not all classes that implement this method are required to filter by partition (e.g. mobile)
         /// </remarks>
-        IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string optionalPartitionKey = null);
+        List<MsalAccountCacheItem> GetAllAccounts(string optionalPartitionKey = null);
 
-        IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata();
+        List<MsalAppMetadataCacheItem> GetAllAppMetadata();
 
 #if iOS
         void SetiOSKeychainSecurityGroup(string keychainSecurityGroup);

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AndroidTokenCacheAccessor.cs
@@ -139,22 +139,22 @@ namespace Microsoft.Identity.Client.Platforms.Android
         #endregion
 
         #region GetAll
-        public IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string optionalPartitionKey = null)
+        public List<MsalAccessTokenCacheItem> GetAllAccessTokens(string optionalPartitionKey = null)
         {
             return _accessTokenSharedPreference.All.Values.Cast<string>().Select(x => MsalAccessTokenCacheItem.FromJsonString(x)).ToList();
         }
 
-        public IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string optionalPartitionKey = null)
+        public List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string optionalPartitionKey = null)
         {
             return _refreshTokenSharedPreference.All.Values.Cast<string>().Select(x => MsalRefreshTokenCacheItem.FromJsonString(x)).ToList();
         }
 
-        public IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string optionalPartitionKey = null)
+        public List<MsalIdTokenCacheItem> GetAllIdTokens(string optionalPartitionKey = null)
         {
             return _idTokenSharedPreference.All.Values.Cast<string>().Select(x => MsalIdTokenCacheItem.FromJsonString(x)).ToList();
         }
 
-        public IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string optionalPartitionKey = null)
+        public List<MsalAccountCacheItem> GetAllAccounts(string optionalPartitionKey = null)
         {
             return _accountSharedPreference.All.Values.Cast<string>().Select(x => MsalAccountCacheItem.FromJsonString(x)).ToList();
         }
@@ -189,7 +189,7 @@ namespace Microsoft.Identity.Client.Platforms.Android
             throw new NotImplementedException();
         }
 
-        public IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()
+        public List<MsalAppMetadataCacheItem> GetAllAppMetadata()
         {
             throw new NotImplementedException();
         }

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -137,28 +137,28 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         #endregion
 
         #region GetAllItems
-        public IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string optionalPartitionKey = null)
+        public List<MsalAccessTokenCacheItem> GetAllAccessTokens(string optionalPartitionKey = null)
         {
             return GetPayloadAsString((int)MsalCacheKeys.iOSCredentialAttrType.AccessToken)
                 .Select(x => MsalAccessTokenCacheItem.FromJsonString(x))
                 .ToList();
         }
 
-        public IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string optionalPartitionKey = null)
+        public List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string optionalPartitionKey = null)
         {
             return GetPayloadAsString((int)MsalCacheKeys.iOSCredentialAttrType.RefreshToken)
                 .Select(x => MsalRefreshTokenCacheItem.FromJsonString(x))
                 .ToList();
         }
 
-        public IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string optionalPartitionKey = null)
+        public List<MsalIdTokenCacheItem> GetAllIdTokens(string optionalPartitionKey = null)
         {
             return GetPayloadAsString((int)MsalCacheKeys.iOSCredentialAttrType.IdToken)
                 .Select(x => MsalIdTokenCacheItem.FromJsonString(x))
                 .ToList();
         }
 
-        public IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string optionalPartitionKey = null)
+        public List<MsalAccountCacheItem> GetAllAccounts(string optionalPartitionKey = null)
         {
             return GetPayloadAsString(MsalCacheKeys.iOSAuthorityTypeToAttrType[CacheAuthorityType.MSSTS.ToString()])
                 .Select(x => MsalAccountCacheItem.FromJsonString(x))
@@ -366,7 +366,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             throw new NotImplementedException();
         }
 
-        public IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()
+        public List<MsalAppMetadataCacheItem> GetAllAppMetadata()
         {
             throw new NotImplementedException();
         }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         /// WARNING: if partitonKey = null, this API is slow as it loads all tokens, not just from 1 partition. 
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
         /// </summary>
-        public virtual IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
+        public virtual List<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
         {
             _logger.Always($"[GetAllAccessTokens] Total number of cache partitions found while getting access tokens: {AccessTokenCacheDictionary.Count}");
             if (string.IsNullOrEmpty(partitionKey))
@@ -183,26 +183,26 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 AccessTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalAccessTokenCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyList<MsalAccessTokenCacheItem>();
             }
         }
 
-        public virtual IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
+        public virtual List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
         {
-            return CollectionHelpers.GetEmptyReadOnlyList<MsalRefreshTokenCacheItem>();
+            return CollectionHelpers.GetEmptyList<MsalRefreshTokenCacheItem>();
         }
 
-        public virtual IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
+        public virtual List<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
         {
-            return CollectionHelpers.GetEmptyReadOnlyList<MsalIdTokenCacheItem>();
+            return CollectionHelpers.GetEmptyList<MsalIdTokenCacheItem>();
         }
 
-        public virtual IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
+        public virtual List<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
         {
-            return CollectionHelpers.GetEmptyReadOnlyList<MsalAccountCacheItem>();
+            return CollectionHelpers.GetEmptyList<MsalAccountCacheItem>();
         }
 
-        public IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()
+        public List<MsalAppMetadataCacheItem> GetAllAppMetadata()
         {
             return AppMetadataDictionary.Select(kv => kv.Value).ToList();
         }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 
         /// WARNING: if partitionKey is null, this API is slow as it loads all tokens, not just from 1 partition. 
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
-        public virtual IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
+        public virtual List<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
         {
             _logger.Always($"[GetAllAccessTokens] Total number of cache partitions found while getting access tokens: {AccessTokenCacheDictionary.Count}");
             if (string.IsNullOrEmpty(partitionKey))
@@ -214,13 +214,13 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 AccessTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalAccessTokenCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyList<MsalAccessTokenCacheItem>();
             }
         }
 
         /// WARNING: if partitionKey is null, this API is slow as it loads all tokens, not just from 1 partition. 
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
-        public virtual IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
+        public virtual List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
         {
             _logger.Always($"[GetAllAccessTokens] Total number of cache partitions found while getting refresh tokens: {RefreshTokenCacheDictionary.Count}");
             if (string.IsNullOrEmpty(partitionKey))
@@ -230,13 +230,13 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 RefreshTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalRefreshTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalRefreshTokenCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyList<MsalRefreshTokenCacheItem>();
             }
         }
 
         /// WARNING: if partitionKey is null, this API is slow as it loads all tokens, not just from 1 partition. 
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
-        public virtual IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
+        public virtual List<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
         {
             if (string.IsNullOrEmpty(partitionKey))
             {
@@ -245,13 +245,13 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 IdTokenCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalIdTokenCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalIdTokenCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyList<MsalIdTokenCacheItem>();
             }
         }
 
         /// WARNING: if partitionKey is null, this API is slow as it loads all tokens, not just from 1 partition. 
         /// It should only support external token caching, in the hope that the external token cache is partitioned.
-        public virtual IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
+        public virtual List<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
         {
             if (string.IsNullOrEmpty(partitionKey))
             {
@@ -260,11 +260,11 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             else
             {
                 AccountCacheDictionary.TryGetValue(partitionKey, out ConcurrentDictionary<string, MsalAccountCacheItem> partition);
-                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyReadOnlyList<MsalAccountCacheItem>();
+                return partition?.Select(kv => kv.Value)?.ToList() ?? CollectionHelpers.GetEmptyList<MsalAccountCacheItem>();
             }
         }
 
-        public virtual IReadOnlyList<MsalAppMetadataCacheItem> GetAllAppMetadata()
+        public virtual List<MsalAppMetadataCacheItem> GetAllAppMetadata()
         {
             return AppMetadataDictionary.Select(kv => kv.Value).ToList();
         }

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -200,36 +200,6 @@ namespace Microsoft.Identity.Client
             return homeAccIdMatch && clientIdMatch;
         }
 
-        private List<MsalRefreshTokenCacheItem> GetAllRefreshTokensWithNoLocks(bool filterByClientId, string partitionKey = null)
-        {
-            var refreshTokens = Accessor.GetAllRefreshTokens(partitionKey);
-            if (filterByClientId)
-            {
-                refreshTokens.RemoveAll(x => !x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase));
-            }
-            return refreshTokens;
-        }
-
-        private List<MsalAccessTokenCacheItem> GetAllAccessTokensWithNoLocks(bool filterByClientId, string partitionKey = null)
-        {
-            var accessTokens = Accessor.GetAllAccessTokens(partitionKey);
-            if (filterByClientId)
-            {
-                accessTokens.RemoveAll(x => !x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase));
-            }
-            return accessTokens;
-        }
-
-        private List<MsalIdTokenCacheItem> GetAllIdTokensWithNoLocks(bool filterByClientId, string partitionKey)
-        {
-            var idTokens = Accessor.GetAllIdTokens(partitionKey);
-            if (filterByClientId)
-            {
-                idTokens.RemoveAll(x => !x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase));
-            }
-            return idTokens;
-        }
-
         private static bool FrtExists(IEnumerable<MsalRefreshTokenCacheItem> refreshTokens)
         {
             return refreshTokens.Any(rt => rt.IsFRT);

--- a/src/client/Microsoft.Identity.Client/Utils/CollectionHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CollectionHelpers.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 #if HAVE_METHOD_IMPL_ATTRIBUTE
 using System.Runtime.CompilerServices;
@@ -18,11 +17,19 @@ namespace Microsoft.Identity.Client.Utils
 #endif
         public static IReadOnlyList<T> GetEmptyReadOnlyList<T>()
         {
-#if !NET45
-            return Array.Empty<T>();
-#else
+#if NET45
             return new List<T>();
+#else
+            return Array.Empty<T>();
 #endif
+        }
+
+#if HAVE_METHOD_IMPL_ATTRIBUTE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static List<T> GetEmptyList<T>()
+        {
+            return new List<T>();
         }
 
         public static IDictionary<TKey, TValue> GetEmptyDictionary<TKey, TValue>()

--- a/src/client/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
@@ -30,18 +30,25 @@ namespace Microsoft.Identity.Client.Utils
             return set.Any(el => el.Equals(toLookFor, System.StringComparison.OrdinalIgnoreCase));
         }
 
-        internal static IReadOnlyList<T> FilterWithLogging<T>(
-            this IReadOnlyList<T> list,
+        internal static List<T> FilterWithLogging<T>(
+            this List<T> list,
             Func<T, bool> predicate,
             ICoreLogger logger,
-            string logPrefix)
+            string logPrefix,
+            bool updateOriginalCollection = true)
         {
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
             {
                 logger.Verbose($"{logPrefix} - item count before: {list.Count} ");
             }
-
-            list = list.Where(predicate).ToList();
+            if (updateOriginalCollection)
+            {
+                list.RemoveAll(e => !predicate(e));
+            }
+            else
+            {
+                list = list.Where(predicate).ToList();
+            }
 
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
             {

--- a/tests/Microsoft.Identity.Test.Common/Core/Helpers/AppAccessorWithPartitionAsserts.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Helpers/AppAccessorWithPartitionAsserts.cs
@@ -14,26 +14,26 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
     internal class AppAccessorWithPartitionAsserts : InMemoryPartitionedAppTokenCacheAccessor
     {
         public AppAccessorWithPartitionAsserts(
-            ICoreLogger logger, 
+            ICoreLogger logger,
             CacheOptions tokenCacheAccessorOptions) : base(logger, tokenCacheAccessorOptions)
         {
 
         }
 
-        public override IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
+        public override List<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
             return base.GetAllAccessTokens(partitionKey);
         }
 
-        public override IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
+        public override List<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
             Assert.Fail("App token cache - do not call GetAllAccounts");
             throw new InvalidOperationException();
         }
 
-        public override IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
+        public override List<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
 
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
             throw new InvalidOperationException();
         }
 
-        public override IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
+        public override List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
 

--- a/tests/Microsoft.Identity.Test.Common/Core/Helpers/UserAccessorWithPartitionAsserts.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Helpers/UserAccessorWithPartitionAsserts.cs
@@ -18,25 +18,25 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
 
         }
 
-        public override IReadOnlyList<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
+        public override List<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
             return base.GetAllAccessTokens(partitionKey);
         }
 
-        public override IReadOnlyList<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
+        public override List<MsalAccountCacheItem> GetAllAccounts(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
             return base.GetAllAccounts(partitionKey);
         }
 
-        public override IReadOnlyList<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
+        public override List<MsalIdTokenCacheItem> GetAllIdTokens(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
             return base.GetAllIdTokens(partitionKey);
         }
 
-        public override IReadOnlyList<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
+        public override List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null)
         {
             Assert.IsNotNull(partitionKey);
             return base.GetAllRefreshTokens(partitionKey);

--- a/tests/Microsoft.Identity.Test.Performance/Microsoft.Identity.Test.Performance.csproj
+++ b/tests/Microsoft.Identity.Test.Performance/Microsoft.Identity.Test.Performance.csproj
@@ -3,10 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <!-- Uncomment only when running EtwProfiler diagnoser on Release-->
+    <!-- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation#debugtype -->
+    <!--<DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>-->
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Identity.Test.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Test.Performance/Program.cs
@@ -13,13 +13,19 @@ namespace Microsoft.Identity.Test.Performance
     {
         static void Main(string[] args)
         {
-            BenchmarkRunner.Run<TokenCacheTests>(
-                DefaultConfig.Instance
-                    .WithOptions(ConfigOptions.DontOverwriteResults)
-                    .AddDiagnoser(MemoryDiagnoser.Default)
-                    .AddJob(
-                        Job.Default
-                            .WithId("Job-PerfTests")));
+            BenchmarkSwitcher.FromTypes(new[] {
+                typeof(AcquireTokenForClientCacheTests),
+                typeof(AcquireTokenForOboCacheTests),
+                typeof(TokenCacheTests),
+            }).RunAll(DefaultConfig.Instance
+                //.WithOptions(ConfigOptions.DisableLogFile)
+                .WithOptions(ConfigOptions.JoinSummary)
+                .WithOptions(ConfigOptions.DontOverwriteResults) // Uncomment when running manually
+                .AddDiagnoser(MemoryDiagnoser.Default) // https://benchmarkdotnet.org/articles/configs/diagnosers.html
+                                                       //.AddDiagnoser(new EtwProfiler()) // https://adamsitnik.com/ETW-Profiler/
+                .AddJob(
+                    Job.Default
+                        .WithId("Job-PerfTests")));
 
             Console.ReadKey();
         }

--- a/tests/Microsoft.Identity.Test.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Test.Performance/Program.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Test.Performance
                 typeof(AcquireTokenForOboCacheTests),
                 typeof(TokenCacheTests),
             }).RunAll(DefaultConfig.Instance
-                //.WithOptions(ConfigOptions.DisableLogFile)
+                .WithOptions(ConfigOptions.DisableLogFile)
                 .WithOptions(ConfigOptions.JoinSummary)
                 .WithOptions(ConfigOptions.DontOverwriteResults) // Uncomment when running manually
                 .AddDiagnoser(MemoryDiagnoser.Default) // https://benchmarkdotnet.org/articles/configs/diagnosers.html


### PR DESCRIPTION
Fixes #3178

**Changes proposed in this request**
- Replace `IReadOnlyList` with `List` in accessor and filtering methods (`RemoveAll` is in concrete `List` implementation).
- In `FilterWithLogging`, replace `list = list.Where(predicate).ToList();` with `list.RemoveAll(e => !predicate(e));`
  - Add a boolean parameter whether to filter on the current list or create a new one.
- In other methods, replace `Where` with `RemoveAll` and reverse filtering predicate (since instead of keeping the items based on a filter, we now remove items based on the opposite of that filter).

**Testing**
Existing tests.

**Performance impact**
Tested with 1 tenant and 10K tokens in cache (tenants don't matter in this scenario). About 40% reduction in memory allocated for client, OBO, and silent calls. Perf improvement is minimal, only about .5 ms for silent call.
**Before**
|                Method |  CacheSize |        Mean |     Error |      StdDev |      Median |         Min |         Max |     Gen 0 | Allocated |
|---------------------- |----------- |------------:|----------:|------------:|------------:|------------:|------------:|----------:|----------:|
| AcquireTokenForClient | (1, 10000) |  5,353.3&nbsp;μs | 411.87&nbsp;μs | 1,207.93&nbsp;μs |  5,424.8&nbsp;μs | 2,887.60&nbsp;μs |  7,847.5&nbsp;μs |         - |  1,988&nbsp;KB |
|    AcquireTokenForOBO | (1, 10000) |  6,193.0&nbsp;μs | 341.06&nbsp;μs |   978.57&nbsp;μs |  6,045.6&nbsp;μs | 4,182.15&nbsp;μs |  8,638.4&nbsp;μs |         - |  2,256&nbsp;KB |
|    AcquireTokenSilent | (1, 10000) |  5,652.5&nbsp;μs | 378.56&nbsp;μs | 1,086.15&nbsp;μs |  5,605.9&nbsp;μs | 3,390.45&nbsp;μs |  8,480.9&nbsp;μs |         - |  2,249&nbsp;KB |
|            GetAccount | (1, 10000) |    184.6&nbsp;μs |  31.33&nbsp;μs |    87.85&nbsp;μs |    152.3&nbsp;μs |    92.75&nbsp;μs |    432.4&nbsp;μs |         - |     11&nbsp;KB |
|           GetAccounts | (1, 10000) |    175.9&nbsp;μs |  29.71&nbsp;μs |    81.82&nbsp;μs |    151.8&nbsp;μs |    95.20&nbsp;μs |    431.2&nbsp;μs |         - |     11&nbsp;KB |
|         RemoveAccount | (1, 10000) | 10,414.1&nbsp;μs | 211.16&nbsp;μs |   615.97&nbsp;μs | 10,262.3&nbsp;μs | 8,266.30&nbsp;μs | 12,159.5&nbsp;μs | 1000.0000 | 11,075&nbsp;KB |


**After**
|                Method |  CacheSize |        Mean |     Error |      StdDev |      Median |         Min |         Max |     Gen 0 | Allocated |
|---------------------- |----------- |------------:|----------:|------------:|------------:|------------:|------------:|----------:|----------:|
| AcquireTokenForClient | (1, 10000) |  4,716.3&nbsp;μs  | 349.99&nbsp;μs | 1,020.94&nbsp;μs |  4,567.2&nbsp;μs | 2,504.50&nbsp;μs |  6,964.0&nbsp;μs |         - |  1,219&nbsp;KB |
|    AcquireTokenForOBO | (1, 10000) |  5,997.8&nbsp;μs | 300.82&nbsp;μs |   882.25&nbsp;μs |  5,898.9&nbsp;μs | 4,146.40&nbsp;μs |  8,369.4&nbsp;μs |         - |  1,230&nbsp;KB |
|    AcquireTokenSilent | (1, 10000) |  4,847.9&nbsp;μs | 298.60&nbsp;μs |   861.54&nbsp;μs |  4,939.9&nbsp;μs | 2,915.85&nbsp;μs |  7,107.8&nbsp;μs |         - |  1,224&nbsp;KB |
|            GetAccount | (1, 10000) |    167.0&nbsp;μs |  29.82&nbsp;μs |    83.61&nbsp;μs |    129.5&nbsp;μs |    81.10&nbsp;μs |    449.9&nbsp;μs |         - |     10&nbsp;KB |
|           GetAccounts | (1, 10000) |    180.4&nbsp;μs |  36.04&nbsp;μs |   102.24&nbsp;μs |    138.6&nbsp;μs |    82.80&nbsp;μs |    514.6&nbsp;μs |         - |     10&nbsp;KB |
|         RemoveAccount | (1, 10000) | 10,475.1&nbsp;μs | 376.17&nbsp;μs | 1,085.33&nbsp;μs | 10,465.9&nbsp;μs | 7,783.30&nbsp;μs | 13,363.2&nbsp;μs | 1000.0000 | 10,562&nbsp;KB |
