### PR TITLE
Fix for UWP packaging

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/Win32VersionApi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/Win32VersionApi.cs
@@ -6,9 +6,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 {
+
     /// <summary>
     /// Windows OS Version checks
     /// </summary>
+    /// <remarks>Do not include this code in UWP, it causes packaging errors</remarks>
     internal static class Win32VersionApi
     {
 
@@ -215,4 +217,5 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             }
         }
     }
+
 }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DesktopOsHelper.cs
@@ -89,12 +89,14 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         {
 #if WINDOWS_APP
             return true;
-#else
+#elif SUPPORTS_WIN32
             if (IsWindows() && Win32VersionApi.IsWamSupportedOs())
             {
                 return true;
             }
 
+            return false;
+#else
             return false;
 #endif
         }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DesktopOsHelper.cs
@@ -87,12 +87,16 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         /// <returns>Returns <c>true</c> if the Windows Version has WAM support</returns>
         private static bool IsWamSuportedOSInternal()
         {
+#if WINDOWS_APP
+            return true;
+#else
             if (IsWindows() && Win32VersionApi.IsWamSupportedOs())
             {
                 return true;
             }
 
             return false;
+#endif
         }
 
         private static string GetWindowsVersionStringInternal()


### PR DESCRIPTION
Fixes #3184

UWP does not provide a mechanism to tell if machine is running Win Server 2016, so we just assume WAM is present on all UWP compatible OSes. 

On UWP, it seems that we cannot have any "illegal" DllImport statetems in the code, even if these are not in the call path. 