### PR TITLE
Minor fix to SuggestedCacheKey comment and update NuGet icon in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@ Quick links:
 | [Conceptual documentation](https://aka.ms/msalnet) | [Getting Started](https://docs.microsoft.com/en-us/azure/active-directory/develop/#quickstarts) | [Sample Code](https://aka.ms/aaddevsamplesv2) | [Library Reference](https://docs.microsoft.com/dotnet/api/microsoft.identity.client?view=azure-dotnet) | [Support](README.md#community-help-and-support) | [Feedback](https://ncv.microsoft.com/JvKFQ1WGSh)
 | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 
-## Nuget package
+## NuGet package
 
- [![NuGet](https://img.shields.io/nuget/v/Microsoft.Identity.Client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/) 
+**Microsoft.Identity.Client**  
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Identity.Client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)  
+
+**Microsoft.Identity.Client.Desktop**  
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Identity.Client.Desktop.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client.Desktop/)  
+
 
 ## Build Status
  
@@ -32,7 +37,7 @@ MSAL.NET became Generally Available with MSAL.NET 3.0.8. Since MSAL.NET moved to
 ## Using MSAL.NET
 
 - The conceptual documentation is currently available from the [Microsoft identity platform documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-overview) and our [Wiki pages](https://aka.ms/msal-net)
-- The reference documentation is available from the dotnet APIs reference in [docs.microsoft.com](https://docs.microsoft.com/dotnet/api/microsoft.identity.client?view=azure-dotnet)
+- The reference documentation is available from the .NET APIs reference in [docs.microsoft.com](https://docs.microsoft.com/dotnet/api/microsoft.identity.client?view=azure-dotnet)
 - A number of quickstarts are available for:
   - [.NET desktop application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-windows-desktop)
   - [Universal Windows Platform (UWP)](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v2-uwp)
@@ -41,7 +46,7 @@ MSAL.NET became Generally Available with MSAL.NET 3.0.8. Since MSAL.NET moved to
 
 ## Where do I file issues
 
-This is the correct repo to file [issues](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues)
+This is the correct repo to file [issues](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues).
 
 ## Requirements
 

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -37,19 +37,19 @@ namespace Microsoft.Identity.Client
                    suggestedCacheExpiry,
                    cancellationToken,
                    default)
-            {
-            }
+        {
+        }
 
         /// <summary>
         /// This constructor is for test purposes only. It allows apps to unit test their MSAL token cache implementation code.
         /// </summary>
         public TokenCacheNotificationArgs(
-            ITokenCacheSerializer tokenCache, 
-            string clientId, 
-            IAccount account, 
-            bool hasStateChanged, 
-            bool isApplicationCache, 
-            string suggestedCacheKey, 
+            ITokenCacheSerializer tokenCache,
+            string clientId,
+            IAccount account,
+            bool hasStateChanged,
+            bool isApplicationCache,
+            string suggestedCacheKey,
             bool hasTokens,
             DateTimeOffset? suggestedCacheExpiry,
             CancellationToken cancellationToken,
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client
             CorrelationId = correlationId;
             SuggestedCacheExpiry = suggestedCacheExpiry;
         }
-        
+
         /// <summary>
         /// Gets the <see cref="ITokenCacheSerializer"/> involved in the transaction
         /// </summary>
@@ -100,16 +100,16 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// A suggested token cache key, which can be used with general purpose storage mechanisms that allow 
-        /// storing key-value pairs and key based retrieval. Useful in applications that store 1 token cache per user, 
+        /// storing key-value pairs and key based retrieval. Useful in applications that store one token cache per user, 
         /// the recommended pattern for web apps.
         /// 
         /// The value is: 
         /// 
         /// <list type="bullet">
-        /// <item><description>the homeAccountId for AcquireTokenSilent, GetAccount(homeAccountId), RemoveAccount and when writing tokens on confidential client calls</description></item>
-        /// <item><description>clientID + "_AppTokenCache" for AcquireTokenForClient</description></item>
-        /// <item><description>clientID_tenantID + "_AppTokenCache" for AcquireTokenForClient when tenant specific authority</description></item>
-        /// <item><description>the hash of the original token for AcquireTokenOnBehalfOf</description></item>
+        /// <item><description><c>homeAccountId</c> for <c>AcquireTokenSilent</c>, <c>GetAccount(homeAccountId)</c>, <c>RemoveAccount</c> and when writing tokens on confidential client calls</description></item>
+        /// <item><description><c>"{clientId}__AppTokenCache"</c> for <c>AcquireTokenForClient</c></description></item>
+        /// <item><description><c>"{clientId}_{tenantId}_AppTokenCache"</c> for <c>AcquireTokenForClient</c> when using a tenant specific authority</description></item>
+        /// <item><description>the hash of the original token for <c>AcquireTokenOnBehalfOf</c></description></item>
         /// </list>
         /// </summary>
         public string SuggestedCacheKey { get; }


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3147 actually references broken XML in Azure SDK, that XML comment in MSAL works.

Created PR https://github.com/Azure/azure-sdk-for-net/pull/28128 to fix it there.

**Changes proposed in this request**
- Minor fix to SuggestedCacheKey comment.
- Add Msal.Desktop NuGet icon in Readme.