### PR TITLE
Adding PPE to known discovery endpoints

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -72,11 +72,19 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 PreferredCache = "login-us.microsoftonline.com"
             };
 
+            InstanceDiscoveryMetadataEntry ppeCloudEntry = new InstanceDiscoveryMetadataEntry()
+            {
+                Aliases = new[] { "login.windows-ppe.net" },
+                PreferredNetwork = "login.windows-ppe.net",
+                PreferredCache = "login.windows-ppe.net"
+            };
+
             AddToKnownCache(publicCloudEntry);
             AddToKnownCache(cloudEntryChina);
             AddToKnownCache(cloudEntryGermanay);
             AddToKnownCache(usGovCloudEntry);
             AddToKnownCache(usCloudEntry);
+            AddToKnownCache(ppeCloudEntry);
             AddToPublicEnvironment(publicCloudEntry);
         }
 

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 
             InstanceDiscoveryMetadataEntry ppeCloudEntry = new InstanceDiscoveryMetadataEntry()
             {
-                Aliases = new[] { "login.windows-ppe.net" },
+                Aliases = new[] { "login.windows-ppe.net", "sts.windows-ppe.net", "login.microsoft-ppe.com" },
                 PreferredNetwork = "login.windows-ppe.net",
                 PreferredCache = "login.windows-ppe.net"
             };

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string ProductionPrefInvalidRegionEnvironment = "invalidregion.r.login.microsoftonline.com";
         public const string ProductionNotPrefEnvironmentAlias = "sts.windows.net";
         public const string PpeEnvironment = "login.windows-ppe.net";
+        public const string PpeOrgEnvironment = "login.windows-ppe.org"; //This environment is not known to MSAL or AAD
 
         public const string AuthorityNotKnownCommon = "https://sts.access.edu/common/";
         public const string AuthorityNotKnownTenanted = "https://sts.access.edu/" + Utid + "/";

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         private static readonly string s_ppeCommonUri = $@"https://{TestConstants.PpeEnvironment}/{TestConstants.TenantId}";
         private static readonly Authority s_ppeAuthority =
           Authority.CreateAuthority(s_ppeCommonUri, true);
+        private static readonly string s_ppeOrgCommonUri = $@"https://{TestConstants.PpeOrgEnvironment}/{TestConstants.TenantId}";
+        private static readonly Authority s_ppeOrgAuthority =
+          Authority.CreateAuthority(s_ppeOrgCommonUri, true);
         private static readonly Authority s_utidAuthority =
             Authority.CreateAuthority(TestConstants.AuthorityUtidTenant, true);
         private static readonly Authority s_utid2Authority =
@@ -151,11 +154,11 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
             _testRequestContext.ServiceBundle.Config.HttpManager = _harness.HttpManager;
             _testRequestContext.ServiceBundle.Config.Authority = s_commonAuthority;
             var ex = await Assert.ThrowsExceptionAsync<MsalClientException>(
-                () => Authority.CreateAuthorityForRequestAsync(_testRequestContext, s_ppeAuthority.AuthorityInfo, null)).ConfigureAwait(false);
+                () => Authority.CreateAuthorityForRequestAsync(_testRequestContext, s_ppeOrgAuthority.AuthorityInfo, null)).ConfigureAwait(false);
             Assert.AreEqual(MsalError.AuthorityHostMismatch, ex.ErrorCode);
 
             _harness.HttpManager.AddInstanceDiscoveryMockHandler();
-            _testRequestContext.ServiceBundle.Config.Authority = s_ppeAuthority;
+            _testRequestContext.ServiceBundle.Config.Authority = s_ppeOrgAuthority;
             var ex2 = await Assert.ThrowsExceptionAsync<MsalClientException>(
               () => Authority.CreateAuthorityForRequestAsync(_testRequestContext, s_commonAuthority.AuthorityInfo, null)).ConfigureAwait(false);
             Assert.AreEqual(MsalError.AuthorityHostMismatch, ex2.ErrorCode);

--- a/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AuthorityAliasesTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Test.Unit
             using var harness = base.CreateTestHarness();
 
             PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                                        .WithAuthority(new Uri(TestConstants.AuthorityCommonPpeAuthority), true)
+                                                                        .WithAuthority(new Uri("https://" + TestConstants.PpeOrgEnvironment + "/common"), true) //login.windows-ppe.org is not known to MSAL
                                                                         .WithHttpManager(harness.HttpManager)
                                                                         .BuildConcrete();
             app.ServiceBundle.ConfigureMockWebUI();
@@ -155,7 +155,7 @@ namespace Microsoft.Identity.Test.Unit
             //Adding one instance discovery response to ensure the cache is hit for the subsiquent requests.
             //If MSAL tries to do an additional request this test will fail.
             harness.HttpManager.AddInstanceDiscoveryMockHandler();
-            harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonPpeAuthority);
+            harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost("https://" + TestConstants.PpeOrgEnvironment + "/common/");//login.windows-ppe.org is not known to MSAL
 
             AuthenticationResult result = app
                 .AcquireTokenInteractive(TestConstants.s_scope)

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/InstanceProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/InstanceProviderTests.cs
@@ -67,6 +67,10 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             Assert.IsNotNull(result);
 
             result = knownMetadataProvider.GetMetadata(
+                "login.windows-ppe.net", new[] { "login.windows-ppe.net", "sts.windows-ppe.net", "login.microsoft-ppe.com" }, _logger);
+            Assert.IsNotNull(result);
+
+            result = knownMetadataProvider.GetMetadata(
                LoginMicrosoftOnlineCom, new[] { "login.windows.net", "bogus", "login.partner.microsoftonline.cn" }, _logger);
             Assert.IsNull(result);
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var tokenHttpCallHandler = new MockHttpMessageHandler()
                 {
-                    ExpectedUrl = "https://eastus.login.windows-ppe.net/17b189bc-2b81-4ec5-aa51-3e628cbc931b/oauth2/v2.0/token",
+                    ExpectedUrl = "https://eastus.login.windows-ppe.org/17b189bc-2b81-4ec5-aa51-3e628cbc931b/oauth2/v2.0/token",
                     ExpectedMethod = HttpMethod.Post,
                     ResponseMessage = CreateResponse(true)
                 };
@@ -350,7 +350,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var app = ConfidentialClientApplicationBuilder
                                  .Create(TestConstants.ClientId)
-                                 .WithAuthority("https://login.windows-ppe.net/common", true)
+                                 .WithAuthority("https://login.windows-ppe.org/common", true)
                                  .WithHttpManager(httpManager)
                                  .WithAzureRegion(EastUsRegion)
                                  .WithClientSecret(TestConstants.ClientSecret)
@@ -359,14 +359,14 @@ namespace Microsoft.Identity.Test.Unit
 #pragma warning disable CS0618 // Type or member is obsolete
                 AuthenticationResult result = await app
                     .AcquireTokenForClient(TestConstants.s_scope)
-                    .WithAuthority("https://login.windows-ppe.net/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
+                    .WithAuthority("https://login.windows-ppe.org/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 Assert.AreEqual(EastUsRegion, result.ApiEvent.RegionUsed);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
                 Assert.AreEqual(
-                    "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.windows-ppe.net%2F17b189bc-2b81-4ec5-aa51-3e628cbc931b%2Foauth2%2Fv2.0%2Fauthorize",
+                    "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.windows-ppe.org%2F17b189bc-2b81-4ec5-aa51-3e628cbc931b%2Foauth2%2Fv2.0%2Fauthorize",
                     discoveryHandler.ActualRequestMessage.RequestUri.AbsoluteUri,
                     "Authority validation is made on https://login.microsoftonline.com/ and it validates the auth_endpoint of the non-regional authority");
                 Assert.AreEqual(EastUsRegion, result.AuthenticationResultMetadata.RegionDetails.RegionUsed);
@@ -375,7 +375,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 result = await app
                    .AcquireTokenForClient(TestConstants.s_scope)
-                   .WithAuthority("https://login.windows-ppe.net/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
+                   .WithAuthority("https://login.windows-ppe.org/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
                    .ExecuteAsync()
                    .ConfigureAwait(false);
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var app = ConfidentialClientApplicationBuilder
                                  .Create(TestConstants.ClientId)
-                                 .WithAuthority("https://login.windows-ppe.org/common", true) //login.windows-ppe.org is not known to MSAL
+                                 .WithAuthority("https://" + TestConstants.PpeOrgEnvironment + "/common", true) //login.windows-ppe.org is not known to MSAL
                                  .WithHttpManager(httpManager)
                                  .WithAzureRegion(EastUsRegion)
                                  .WithClientSecret(TestConstants.ClientSecret)
@@ -359,7 +359,7 @@ namespace Microsoft.Identity.Test.Unit
 #pragma warning disable CS0618 // Type or member is obsolete
                 AuthenticationResult result = await app
                     .AcquireTokenForClient(TestConstants.s_scope)
-                    .WithAuthority("https://login.windows-ppe.org/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
+                    .WithAuthority("https://" + TestConstants.PpeOrgEnvironment + "/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -375,7 +375,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 result = await app
                    .AcquireTokenForClient(TestConstants.s_scope)
-                   .WithAuthority("https://login.windows-ppe.org/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
+                   .WithAuthority("https://" + TestConstants.PpeOrgEnvironment + "/17b189bc-2b81-4ec5-aa51-3e628cbc931b")
                    .ExecuteAsync()
                    .ConfigureAwait(false);
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -498,7 +498,7 @@ namespace Microsoft.Identity.Test.Unit
                 }
                 var tokenHttpCallHandler = new MockHttpMessageHandler()
                 {
-                    ExpectedUrl = "https://eastus.login.windows-ppe.net/17b189bc-2b81-4ec5-aa51-3e628cbc931b/oauth2/v2.0/token",
+                    ExpectedUrl = "https://eastus.login.windows-ppe.org/17b189bc-2b81-4ec5-aa51-3e628cbc931b/oauth2/v2.0/token",//login.windows-ppe.org is not known to MSAL or AAD
                     ExpectedMethod = HttpMethod.Post,
                     ResponseMessage = CreateResponse(true)
                 };
@@ -511,7 +511,7 @@ namespace Microsoft.Identity.Test.Unit
                 harness.HttpManager.AddMockHandler(tokenHttpCallHandler);
                 var app = ConfidentialClientApplicationBuilder
                                  .Create(TestConstants.ClientId)
-                                 .WithAuthority("https://login.windows-ppe.net/common", validateAuthority)
+                                 .WithAuthority("https://" + TestConstants.PpeOrgEnvironment + "/common", validateAuthority)//login.windows-ppe.org is not known to MSAL or AAD
                                  .WithHttpManager(harness.HttpManager)
                                  .WithAzureRegion(EastUsRegion)
                                  .WithClientSecret(TestConstants.ClientSecret)
@@ -526,7 +526,7 @@ namespace Microsoft.Identity.Test.Unit
 
                     Assert.AreEqual(MsalError.InvalidInstance, ex.ErrorCode);
                     var qp = CoreHelpers.ParseKeyValueList(discoveryHandler.ActualRequestMessage.RequestUri.Query.Substring(1), '&', true, null);
-                    Assert.AreEqual("https://login.windows-ppe.net/17b189bc-2b81-4ec5-aa51-3e628cbc931b/oauth2/v2.0/authorize", qp["authorization_endpoint"]);
+                    Assert.AreEqual("https://login.windows-ppe.org/17b189bc-2b81-4ec5-aa51-3e628cbc931b/oauth2/v2.0/authorize", qp["authorization_endpoint"]);//login.windows-ppe.org is not known to MSAL or AAD
                 }
                 else
                 {
@@ -544,7 +544,7 @@ namespace Microsoft.Identity.Test.Unit
                     if (validateAuthority)
                     {
                         Assert.AreEqual(
-                            "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.windows-ppe.net%2F17b189bc-2b81-4ec5-aa51-3e628cbc931b%2Foauth2%2Fv2.0%2Fauthorize",
+                            "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.windows-ppe.org%2F17b189bc-2b81-4ec5-aa51-3e628cbc931b%2Foauth2%2Fv2.0%2Fauthorize",//login.windows-ppe.org is not known to MSAL or AAD
                             discoveryHandler.ActualRequestMessage.RequestUri.AbsoluteUri,
                             "Authority validation is made on https://login.microsoftonline.com/ and it validates the auth_endpoint of the non-regional authority");
                     }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Identity.Test.Unit
 
                 var app = ConfidentialClientApplicationBuilder
                                  .Create(TestConstants.ClientId)
-                                 .WithAuthority("https://login.windows-ppe.org/common", true)
+                                 .WithAuthority("https://login.windows-ppe.org/common", true) //login.windows-ppe.org is not known to MSAL
                                  .WithHttpManager(httpManager)
                                  .WithAzureRegion(EastUsRegion)
                                  .WithClientSecret(TestConstants.ClientSecret)


### PR DESCRIPTION
Fixes # 
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3265

**Changes proposed in this request**
Adding PPE to known instance discovery metadata

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->
