### PR TITLE
Default to WebView1 instead of WebView2 when using AAD or ADFS author…

### DIFF
--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -179,7 +179,7 @@
     <Compile Include="$(PathToMsalSources)\Platforms\Features\DesktopOS\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\WinFormsLegacyWebUi\**\*.cs" />
 
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.864.35" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1185.39" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)' ">

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUiFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUiFactory.cs
@@ -43,14 +43,25 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
                     coreUIParent.SystemWebViewOptions);
             }
 
-            if (_isWebView2AvailableFunc())
+            AuthorityType authorityType = requestContext.ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType;
+            bool isAadOrAdfsAuthority =
+                authorityType == AuthorityType.Aad ||
+                authorityType == AuthorityType.Adfs;
+
+            if (isAadOrAdfsAuthority)
             {
-                requestContext.Logger.Info("Using WebView2 embedded browser.");
-                return new WebView2WebUi(coreUIParent, requestContext);
+                requestContext.Logger.Info($"Using WebView1 embedded browser because the authority is {authorityType}. WebView2 does not provide SSO.");
+                return new InteractiveWebUI(coreUIParent, requestContext);
             }
 
-            requestContext.Logger.Info("Using legacy embedded browser.");
-            return new InteractiveWebUI(coreUIParent, requestContext);
+            if (!_isWebView2AvailableFunc())
+            {
+                requestContext.Logger.Info("Using WebView1 embedded browser because WebView2 is not available.");
+                return new InteractiveWebUI(coreUIParent, requestContext);
+            }
+
+            requestContext.Logger.Info("Using WebView2 embedded browser.");
+            return new WebView2WebUi(coreUIParent, requestContext);
         }
 
         private bool IsWebView2Available()

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -93,6 +93,11 @@ namespace Microsoft.Identity.Test.Common
             return CreateServiceBundleWithCustomHttpManager(null, authority: TestConstants.OnPremiseAuthority);
         }
 
+        public static IServiceBundle CreateDefaultB2CServiceBundle()
+        {
+            return CreateServiceBundleWithCustomHttpManager(null, authority: TestConstants.B2CAuthority);
+        }
+
         public static AuthenticationRequestParameters CreateAuthenticationRequestParameters(
             IServiceBundle serviceBundle,
             Authority authority = null,

--- a/tests/Microsoft.Identity.Test.Unit/WebUITests/WebView2WebUiFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/WebUITests/WebView2WebUiFactoryTests.cs
@@ -19,8 +19,14 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
     public class WebView2WebUiFactoryTests
     {
         private readonly CoreUIParent _parent = new CoreUIParent();
-        private readonly RequestContext _requestContext =
+        private readonly RequestContext _requestContextAad =
             new RequestContext(TestCommon.CreateDefaultServiceBundle(), Guid.NewGuid());
+
+        private readonly RequestContext _requestContextB2C =
+            new RequestContext(TestCommon.CreateDefaultB2CServiceBundle(), Guid.NewGuid());
+
+        private readonly RequestContext _requestContextAdfs =
+          new RequestContext(TestCommon.CreateDefaultAdfsServiceBundle(), Guid.NewGuid());
 
         [TestMethod]
         public void IsSystemWebUiAvailable()
@@ -30,8 +36,8 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             Assert.IsTrue(webUIFactory.IsSystemWebViewAvailable);
         }
 
-        [TestMethod]
-        public void DefaultEmbedded_WebView2Available()
+        [DataRow()]
+        public void WebViewTypeNotConfigured_AAD_WebView1()
         {
             // Arrange
             var webUIFactory = new WebView2WebUiFactory(() => true);
@@ -40,11 +46,45 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             var webUi = webUIFactory.CreateAuthenticationDialog(
                     _parent,
                     WebViewPreference.NotSpecified,
-                    _requestContext);
+                    _requestContextAad);
+
+            // Assert
+            Assert.IsTrue(webUi is InteractiveWebUI);
+
+        }
+
+
+        [TestMethod]
+        public void WebViewTypeNotConfigured_ADFS_WebView1()
+        {
+            // Arrange
+            var webUIFactory = new WebView2WebUiFactory(() => true);
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(
+                    _parent,
+                    WebViewPreference.NotSpecified,
+                    _requestContextAdfs);
+
+            // Assert
+            Assert.IsTrue(webUi is InteractiveWebUI);
+
+        }
+
+        [TestMethod]
+        public void WebViewTypeNotConfigured_B2C_WebView2()
+        {
+            // Arrange
+            var webUIFactory = new WebView2WebUiFactory(() => true);
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(
+                    _parent,
+                    WebViewPreference.NotSpecified,
+                    _requestContextB2C);
 
             // Assert
             Assert.IsTrue(webUi is WebView2WebUi);
-
         }
 
         [TestMethod]
@@ -58,20 +98,46 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             var webUi = webUIFactory.CreateAuthenticationDialog(
                     _parent,
                     WebViewPreference.NotSpecified,
-                    _requestContext);
+                    _requestContextAad);
 
             // Assert
             Assert.IsTrue(webUi is InteractiveWebUI);
         }
 
         [TestMethod]
-        public void Embedded()
+        public void WebViewTypeEmbedded_AAD_WebView1()
         {
             // Arrange
             var webUIFactory = new WebView2WebUiFactory(() => true);
 
             // Act
-            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContext);
+            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContextAad);
+
+            // Assert
+            Assert.IsTrue(webUi is InteractiveWebUI);
+        }
+
+        [TestMethod]
+        public void WebViewTypeEmbedded_ADFS_WebView1()
+        {
+            // Arrange
+            var webUIFactory = new WebView2WebUiFactory(() => true);
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContextAdfs);
+
+            // Assert
+            Assert.IsTrue(webUi is InteractiveWebUI);
+        }
+
+        [TestMethod]
+        public void WebViewTypeEmbedded_B2C_WebView2()
+        {
+            // Arrange
+            var webUIFactory = new WebView2WebUiFactory(() => true);
+
+            // Act
+            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.Embedded, _requestContextB2C);
 
             // Assert
             Assert.IsTrue(webUi is WebView2WebUi);
@@ -84,7 +150,7 @@ namespace Microsoft.Identity.Test.Unit.WebUITests
             var webUIFactory = new WebView2WebUiFactory();
 
             // Act
-            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.System, _requestContext);
+            var webUi = webUIFactory.CreateAuthenticationDialog(_parent, WebViewPreference.System, _requestContextAad);
 
             // Assert
             Assert.IsTrue(webUi is DefaultOsBrowserWebUi);

--- a/tests/devapps/Net5TestApp/Program.cs
+++ b/tests/devapps/Net5TestApp/Program.cs
@@ -6,11 +6,11 @@ namespace Net5TestApp
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             try
             {
-                var result = TryAuthAsync().Result;
+                var result = await TryAuthAsync().ConfigureAwait(false);
                 Console.BackgroundColor = ConsoleColor.DarkGreen;
                 Console.WriteLine("Access Token = " + result?.AccessToken);
                 Console.ResetColor();
@@ -27,16 +27,17 @@ namespace Net5TestApp
 
         private static async Task<AuthenticationResult> TryAuthAsync()
         {
-            var pca = PublicClientApplicationBuilder.Create("16dab2ba-145d-4b1b-8569-bf4b9aed4dc8")
-                .WithLogging(MyLoggingMethod, LogLevel.Info,
-                             enablePiiLogging: true,
-                             enableDefaultPlatformLogging: true)
-                .WithDefaultRedirectUri()
-                .Build();
+            var pca = PublicClientApplicationBuilder.Create("04b07795-8ddb-461a-bbee-02f9e1bf7b46")
+                 .WithTenantId("72f988bf-86f1-41af-91ab-2d7cd011db47")
+                 .WithDefaultRedirectUri()
+                 .WithLogging(MyLoggingMethod, LogLevel.Info, true, false)
+                 .Build();
 
-            return await pca.AcquireTokenInteractive(new[] { "user.read" })
-               .WithUseEmbeddedWebView(true)
-               .ExecuteAsync().ConfigureAwait(false);
+            var result = await pca.AcquireTokenInteractive(new[] { "https://storage.azure.com/.default" })
+                .WithUseEmbeddedWebView(true)
+                .ExecuteAsync().ConfigureAwait(false);
+
+            return result;
         }
 
         static void MyLoggingMethod(LogLevel level, string message, bool containsPii)


### PR DESCRIPTION
…ities

Partial fix for #3270


<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
- if authority is AAD or ADFS, use WebView1
- if authority is B2C - use previous logic (use WebView2 if available)


**Testing**
unit 
dev app which reproduces the problem

**Performance impact**
interactive flow is not perf critical
