### PR TITLE
Lab Access Cert update - Fix for CI test failures

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Test.Unit
         public static readonly string[] s_graphScopes = new[] { "user.read" };
         public const uint JwtToAadLifetimeInSeconds = 60 * 10; // Ten minutes
         public const string ClientCredentialAudience = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0";
-        public const string AutomationTestThumbprint = "378938210C976692D7F523B8C4FFBB645D17CE92";
+        public const string AutomationTestThumbprint = "4E87313FD450985A10BC0F14A292859F2DCD6CD3";
 
         public static readonly SortedSet<string> s_scopeForAnotherResource = new SortedSet<string>(new[] { "r2/scope1", "r2/scope2" }, StringComparer.OrdinalIgnoreCase);
         public static readonly SortedSet<string> s_cacheMissScope = new SortedSet<string>(new[] { "r3/scope1", "r3/scope2" }, StringComparer.OrdinalIgnoreCase);

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/LabAuthenticationHelper.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/LabAuthenticationHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
         private static InMemoryTokenCache s_staticCache = new InMemoryTokenCache();
         private const string LabAccessConfidentialClientId = "16dab2ba-145d-4b1b-8569-bf4b9aed4dc8";
         private const string LabAccessPublicClientId = "3c1e0e0d-b742-45ba-a35e-01c664e14b16";
-        private const string LabAccessThumbPrint = "378938210C976692D7F523B8C4FFBB645D17CE92";
+        private const string LabAccessThumbPrint = "4E87313FD450985A10BC0F14A292859F2DCD6CD3";
         private const string DataFileName = "data.txt";
         private static LabAccessAuthenticationType s_defaultAuthType = LabAccessAuthenticationType.ClientCertificate;
         private static string s_secret;


### PR DESCRIPTION
Fixes # 
Test failures

**Changes proposed in this request**
Lab Vault access cert was auto renewed, since we refer using thumbprints builds are broken. 

**Testing**
CI

**Performance impact**
None
