### PR TITLE
Throw TaskCancelledException when request gets cancelled.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -143,13 +143,14 @@ namespace Microsoft.Identity.Client.Http
             }
             catch (TaskCanceledException exception)
             {
-                logger.Error("The HTTP request failed or it was canceled. " + exception.Message);
-                isRetryable = true;
-
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    throw exception;
+                    logger.Info("The HTTP request was cancelled. ");
+                    throw;
                 }
+
+                logger.Error("The HTTP request failed. " + exception.Message);
+                isRetryable = true;
 
                 timeoutException = exception;
             }

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Identity.Client.Http
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    isRetryable = false;
+                    throw exception;
                 }
 
                 timeoutException = exception;

--- a/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -83,7 +83,11 @@ namespace Microsoft.Identity.Client.WsTrust
                 wsTrustRequest,
                 Encoding.UTF8, "application/soap+xml");
 
-            HttpResponse resp = await _httpManager.SendPostForceResponseAsync(wsTrustEndpoint.Uri, headers, body, requestContext.Logger).ConfigureAwait(false);
+            HttpResponse resp = await _httpManager.SendPostForceResponseAsync(wsTrustEndpoint.Uri, 
+                headers, 
+                body, 
+                requestContext.Logger, 
+                cancellationToken: requestContext.UserCancellationToken).ConfigureAwait(false);
 
             if (resp.StatusCode != System.Net.HttpStatusCode.OK)
             {
@@ -140,7 +144,8 @@ namespace Microsoft.Identity.Client.WsTrust
             var httpResponse = await _httpManager.SendGetAsync(
                 uri,
                 msalIdParams,
-                requestContext.Logger).ConfigureAwait(false);
+                requestContext.Logger,
+                cancellationToken: requestContext.UserCancellationToken).ConfigureAwait(false);
 
             if (httpResponse.StatusCode == System.Net.HttpStatusCode.OK)
             {

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
                 catch (AggregateException exc)
                 {
                     Assert.IsNotNull(exc);
-                    Assert.IsTrue(exc.InnerException is MsalServiceException);
+                    Assert.IsTrue(exc.InnerException is TaskCanceledException);
                 }
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
@@ -106,8 +106,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
             }
         }
 
+        // This is a regression test for the bug https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3283
         [TestMethod]
-        public void TestSendGetWithCanceledToken()
+        public async Task TestSendGetWithCanceledTokenAsync()
         {
             var queryParams = new Dictionary<string, string>
             {
@@ -122,21 +123,11 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
                 CancellationTokenSource cts = new CancellationTokenSource();
                 cts.Cancel();
 
-                try
-                {
-                    var response = httpManager.SendGetAsync(
+                await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => httpManager.SendGetAsync(
                         new Uri(TestConstants.AuthorityHomeTenant + "oauth2/token?key1=qp1&key2=qp2"),
                         queryParams,
                         Substitute.For<ICoreLogger>(),
-                        cancellationToken: cts.Token).Result;
-                    
-                    Assert.Fail("Request should have failed due to cancelled token.");
-                }
-                catch (AggregateException exc)
-                {
-                    Assert.IsNotNull(exc);
-                    Assert.IsTrue(exc.InnerException is TaskCanceledException);
-                }
+                        cancellationToken: cts.Token)).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Fixes #3283 

**Changes proposed in this request**
When auth is cancelled, throw TaskCancelledException instead of converting it to TimeoutException

**Testing**
Updated an existing unit test

**Performance impact**
None
