### PR TITLE
ATS split (prototype)

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -15,12 +15,83 @@ using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 
 namespace Microsoft.Identity.Client
 {
+    /// <summary>
+    /// 
+    /// </summary>
+    public class PCAAcquireTokenSilentParameterBuilder :
+        AcquireTokenSilentParameterBuilder
+    {
+        internal PCAAcquireTokenSilentParameterBuilder(IClientApplicationBaseExecutor clientApplicationBaseExecutor) : base(clientApplicationBaseExecutor)
+        {
+        }
+
+        private new AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
+        {
+            return null;
+        }
+
+
+        /// <summary>
+        ///  Modifies the token acquisition request so that the acquired token is a Proof of Possession token (PoP), rather than a Bearer token. 
+        ///  PoP tokens are similar to Bearer tokens, but are bound to the HTTP request and to a cryptographic key, which MSAL can manage on Windows.
+        ///  Note that only the host and path parts of the request URI will be bound.
+        ///  See https://aka.ms/msal-net-pop
+        /// </summary>
+        /// <param name="httpMethod">The HTTP method ("GET", "POST" etc.) method that will be bound to the token. Leave null and the POP token will not be bound to the method.
+        /// Corresponds to the "m" part of the a signed HTTP request.</param>
+        /// <param name="requestUri">The URI to bind the signed HTTP request to.</param>
+        /// <param name="nonce">Nonce of the protected resource (RP) which will be published as part of the WWWAuthenticate header associated with a 401 HTTP response
+        /// or as part of the AuthorityInfo header associated with 200 response. Set it here to make it part of the Signed HTTP Request part of the POP token.</param>
+        /// <returns>The builder.</returns>
+        /// <remarks>
+        /// <list type="bullet">
+        /// <item><description>An Authentication header is automatically added to the request</description></item>
+        /// <item><description>The PoP token is bound to the HTTP request, more specifically to the HTTP method (GET, POST, etc.) and to the Uri (path and query, but not query parameters).</description></item>
+        /// <item><description>MSAL creates, reads and stores a key in memory that will be cycled every 8 hours.</description></item>
+        /// <item><description>This is an experimental API. The method signature may change in the future without involving a major version upgrade.</description></item>
+        /// </list>
+        /// </remarks>
+#if iOS || ANDROID || WINDOWS_UWP
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#endif
+        public PCAAcquireTokenSilentParameterBuilder WithProofOfPossession(HttpMethod httpMethod, Uri requestUri, string nonce)
+        {
+            ClientApplicationBase.GuardMobileFrameworks();
+            PoPAuthenticationConfiguration popConfig = new PoPAuthenticationConfiguration(requestUri ?? throw new ArgumentNullException(nameof(requestUri)));
+            popConfig.HttpMethod = httpMethod ?? throw new ArgumentNullException(nameof(httpMethod));
+            popConfig.Nonce = nonce ?? throw new ArgumentNullException(nameof(nonce));
+
+            CommonParameters.PopAuthenticationConfiguration = popConfig;
+            var broker = ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null);
+
+            if (CommonParameters.PopAuthenticationConfiguration != null)
+            {
+                if (!broker.IsPopSupported)
+                {
+                    throw new MsalClientException(MsalError.BrokerDoesNotSupportPop, MsalErrorMessage.BrokerDoesNotSupportPop);
+                }
+
+                if (!ServiceBundle.Config.IsBrokerEnabled)
+                {
+                    throw new MsalClientException(MsalError.BrokerRequiredForPop, MsalErrorMessage.BrokerRequiredForPop);
+                }
+            }
+
+            return this;
+        }
+
+        private new PCAAcquireTokenSilentParameterBuilder WithProofOfPossession(PoPAuthenticationConfiguration config)
+        {
+            return null;// throw
+        }
+    }
+    
     /// <inheritdoc />
     /// <summary>
     /// Parameter builder for the <see cref="IClientApplicationBase.AcquireTokenSilent(IEnumerable{string}, IAccount)"/>
     /// operation. See https://aka.ms/msal-net-acquiretokensilent
     /// </summary>
-    public sealed class AcquireTokenSilentParameterBuilder :
+    public class AcquireTokenSilentParameterBuilder :
         AbstractClientAppBaseAcquireTokenParameterBuilder<AcquireTokenSilentParameterBuilder>
     {
         private AcquireTokenSilentParameters Parameters { get; } = new AcquireTokenSilentParameters();
@@ -149,53 +220,5 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
-        /// <summary>
-        ///  Modifies the token acquisition request so that the acquired token is a Proof of Possession token (PoP), rather than a Bearer token. 
-        ///  PoP tokens are similar to Bearer tokens, but are bound to the HTTP request and to a cryptographic key, which MSAL can manage on Windows.
-        ///  Note that only the host and path parts of the request URI will be bound.
-        ///  See https://aka.ms/msal-net-pop
-        /// </summary>
-        /// <param name="httpMethod">The HTTP method ("GET", "POST" etc.) method that will be bound to the token. Leave null and the POP token will not be bound to the method.
-        /// Corresponds to the "m" part of the a signed HTTP request.</param>
-        /// <param name="requestUri">The URI to bind the signed HTTP request to.</param>
-        /// <param name="nonce">Nonce of the protected resource (RP) which will be published as part of the WWWAuthenticate header associated with a 401 HTTP response
-        /// or as part of the AuthorityInfo header associated with 200 response. Set it here to make it part of the Signed HTTP Request part of the POP token.</param>
-        /// <returns>The builder.</returns>
-        /// <remarks>
-        /// <list type="bullet">
-        /// <item><description>An Authentication header is automatically added to the request</description></item>
-        /// <item><description>The PoP token is bound to the HTTP request, more specifically to the HTTP method (GET, POST, etc.) and to the Uri (path and query, but not query parameters).</description></item>
-        /// <item><description>MSAL creates, reads and stores a key in memory that will be cycled every 8 hours.</description></item>
-        /// <item><description>This is an experimental API. The method signature may change in the future without involving a major version upgrade.</description></item>
-        /// </list>
-        /// </remarks>
-#if iOS || ANDROID || WINDOWS_UWP
-        [EditorBrowsable(EditorBrowsableState.Never)]
-#endif
-        public AcquireTokenSilentParameterBuilder WithProofOfPossession(HttpMethod httpMethod, Uri requestUri, string nonce)
-        {
-            ClientApplicationBase.GuardMobileFrameworks();
-            PoPAuthenticationConfiguration popConfig = new PoPAuthenticationConfiguration(requestUri ?? throw new ArgumentNullException(nameof(requestUri)));
-            popConfig.HttpMethod = httpMethod ?? throw new ArgumentNullException(nameof(httpMethod));
-            popConfig.Nonce = nonce ?? throw new ArgumentNullException(nameof(nonce));
-
-            CommonParameters.PopAuthenticationConfiguration = popConfig;
-            var broker = ServiceBundle.PlatformProxy.CreateBroker(ServiceBundle.Config, null);
-
-            if (CommonParameters.PopAuthenticationConfiguration != null)
-            {
-                if (!broker.IsPopSupported)
-                {
-                    throw new MsalClientException(MsalError.BrokerDoesNotSupportPop, MsalErrorMessage.BrokerDoesNotSupportPop);
-                }
-
-                if (!ServiceBundle.Config.IsBrokerEnabled)
-                {
-                    throw new MsalClientException(MsalError.BrokerRequiredForPop, MsalErrorMessage.BrokerRequiredForPop);
-                }
-            }
-
-            return this;
-        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client
         public new AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
         {
             // nop
-            return this;
+            throw new NotSupportedException("Cannot use this method on public client");
         }
 
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -25,9 +25,17 @@ namespace Microsoft.Identity.Client
         {
         }
 
-        private new AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
+        /// <summary>
+        /// Do not use on public client.
+        /// </summary>
+        /// <param name="withSendX5C"></param>
+        /// <returns></returns>
+        [Obsolete("Do not use on public client", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new AcquireTokenSilentParameterBuilder WithSendX5C(bool withSendX5C)
         {
-            return null;
+            // nop
+            return this;
         }
 
 

--- a/src/client/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client
 {
+    
     /// <summary>
     /// Interface to be used with desktop or mobile applications (Desktop / UWP / Xamarin.iOS / Xamarin.Android).
     /// public client applications are not trusted to safely keep application secrets, and therefore they only access web APIs in the name of the user only.
@@ -15,6 +16,60 @@ namespace Microsoft.Identity.Client
     /// </summary>
     public partial interface IPublicClientApplication : IClientApplicationBase
     {
+
+        /// <summary>
+        /// Attempts to acquire an access token for the <paramref name="account"/> from the user token cache,
+        /// with advanced parameters controlling the network call. See https://aka.ms/msal-net-acquiretokensilent for more details
+        /// </summary>
+        /// <param name="scopes">Scopes requested to access a protected API</param>
+        /// <param name="account">Account for which the token is requested. <see cref="IAccount"/></param>
+        /// <returns>An <see cref="AcquireTokenSilentParameterBuilder"/> used to build the token request, adding optional
+        /// parameters</returns>
+        /// <exception cref="MsalUiRequiredException">will be thrown in the case where an interaction is required with the end user of the application,
+        /// for instance, if no refresh token was in the cache,a or the user needs to consent, or re-sign-in (for instance if the password expired),
+        /// or the user needs to perform two factor authentication</exception>
+        /// <remarks>
+        /// The access token is considered a match if it contains <b>at least</b> all the requested scopes. This means that an access token with more scopes than
+        /// requested could be returned as well. If the access token is expired or close to expiration (within a 5 minute window),
+        /// then the cached refresh token (if available) is used to acquire a new access token by making a silent network call.
+        ///
+        /// See also the additional parameters that you can set chain:
+        /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithTenantId(string)"/> 
+        /// to request a token for a different authority than the one set at the application construction
+        /// <see cref="AcquireTokenSilentParameterBuilder.WithForceRefresh(bool)"/> to bypass the user token cache and
+        /// force refreshing the token, as well as
+        /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithExtraQueryParameters(Dictionary{string, string})"/> to
+        /// specify extra query parameters
+        /// </remarks>
+        new PCAAcquireTokenSilentParameterBuilder AcquireTokenSilent(IEnumerable<string> scopes, IAccount account);
+
+        /// <summary>
+        /// Attempts to acquire an access token for the <paramref name="loginHint"/> from the user token cache,
+        /// with advanced parameters controlling the network call. See https://aka.ms/msal-net-acquiretokensilent for more details
+        /// </summary>
+        /// <param name="scopes">Scopes requested to access a protected API</param>
+        /// <param name="loginHint">Typically the username, in UPN format, e.g. johnd@contoso.com </param>
+        /// <returns>An <see cref="AcquireTokenSilentParameterBuilder"/> used to build the token request, adding optional
+        /// parameters</returns>
+        /// <exception cref="MsalUiRequiredException">will be thrown in the case where an interaction is required with the end user of the application,
+        /// for instance, if no refresh token was in the cache,a or the user needs to consent, or re-sign-in (for instance if the password expired),
+        /// or the user needs to perform two factor authentication</exception>
+        /// <remarks>
+        /// The access token is considered a match if it contains <b>at least</b> all the requested scopes. This means that an access token with more scopes than
+        /// requested could be returned as well. If the access token is expired or close to expiration (within a 5 minute window),
+        /// then the cached refresh token (if available) is used to acquire a new access token by making a silent network call.
+        ///
+        /// See also the additional parameters that you can set chain:
+        /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithTenantId(string)"/>
+        /// to request a token for a different authority than the one set at the application construction
+        /// <see cref="AcquireTokenSilentParameterBuilder.WithForceRefresh(bool)"/> to bypass the user token cache and
+        /// force refreshing the token, as well as
+        /// <see cref="AbstractAcquireTokenParameterBuilder{T}.WithExtraQueryParameters(Dictionary{string, string})"/> to
+        /// specify extra query parameters
+        /// </remarks>
+        new PCAAcquireTokenSilentParameterBuilder AcquireTokenSilent(IEnumerable<string> scopes, string loginHint);
+
+        
         /// <summary>
         /// Tells if the application can use the system web browser, therefore getting single-sign-on with web applications.
         /// By default, MSAL will try to use a system browser on the mobile platforms, if it is available.

--- a/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Identity.Client
             return string.Equals(account?.HomeAccountId?.Identifier, CurrentOSAccountDescriptor, StringComparison.Ordinal);
         }
 
+
+
         /// <summary>
         /// Returns true if MSAL can use a system browser.
         /// </summary>
@@ -233,6 +235,16 @@ namespace Microsoft.Identity.Client
                 scopes,
                 username,
                 password);
+        }
+
+        PCAAcquireTokenSilentParameterBuilder IPublicClientApplication.AcquireTokenSilent(IEnumerable<string> scopes, IAccount account)
+        {
+            throw new NotImplementedException();
+        }
+
+        PCAAcquireTokenSilentParameterBuilder IPublicClientApplication.AcquireTokenSilent(IEnumerable<string> scopes, string loginHint)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Today, AcquireTokenSilent is on both PCA and CCA. This prevents us from adding `WithPOP(string, string, string)` on PCA only and throwing meaningful expcetions if broker is not configured.

Can we re-create the object hirearchy on PCA and CCA without incurring a brekaing change? 