### PR TITLE
Disable cert size check

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopCryptographyManager.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopCryptographyManager.cs
@@ -55,13 +55,6 @@ namespace Microsoft.Identity.Client.Platforms.net45
       
         public byte[] SignWithCertificate(string message, X509Certificate2 certificate)
         {
-            if (certificate.PublicKey.Key.KeySize < CertificateClientCredential.MinKeySizeInBits)
-            {
-                throw new ArgumentOutOfRangeException(nameof(certificate),
-                    string.Format(CultureInfo.InvariantCulture, MsalErrorMessage.CertificateKeySizeTooSmallTemplate,
-                        CertificateClientCredential.MinKeySizeInBits));
-            }
-
 #if NET45
             var rsaCryptoProvider = GetCryptoProviderForSha256_Net45(certificate);
             using (var sha = new SHA256Cng())


### PR DESCRIPTION
Fixes #3324 
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
Disable the cert size check. We only perform it on .NET classic, which is a deprecated fwk. AAD enforces everything related to cert security, this is not an SDK concern.
