### PR TITLE
CreateFromiOSBrokerResponse is safer now

### DIFF
--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -101,17 +101,17 @@ namespace Microsoft.Identity.Client.OAuth2
         {
             if (responseDictionary.TryGetValue(BrokerResponseConst.BrokerErrorCode, out string errorCode))
             {
-                string original = responseDictionary.ContainsKey(MsalTokenResponse.iOSBrokerErrorMetadata) ? responseDictionary[MsalTokenResponse.iOSBrokerErrorMetadata] : null;
-                Dictionary<string, string> dictionary = null;
+                string metadataOriginal = responseDictionary.ContainsKey(MsalTokenResponse.iOSBrokerErrorMetadata) ? responseDictionary[MsalTokenResponse.iOSBrokerErrorMetadata] : null;
+                Dictionary<string, string> metadataDictionary = null;
                 
-                if (original != null)
+                if (metadataOriginal != null)
                 {
-                    string dataUnescaped = Uri.UnescapeDataString(original);
-                    dictionary = Json.JsonConvert.DeserializeObject<Dictionary<string, string>>(dataUnescaped); 
+                    string brokerMetadataJson = Uri.UnescapeDataString(metadataOriginal);
+                    metadataDictionary = Json.JsonConvert.DeserializeObject<Dictionary<string, string>>(brokerMetadataJson); 
                 }
 
                 string homeAcctId = null;
-                dictionary?.TryGetValue(MsalTokenResponse.iOSBrokerHomeAccountId, out homeAcctId);
+                metadataDictionary?.TryGetValue(MsalTokenResponse.iOSBrokerHomeAccountId, out homeAcctId);
                 return new MsalTokenResponse
                 {
                     Error = errorCode,
@@ -119,7 +119,7 @@ namespace Microsoft.Identity.Client.OAuth2
                     SubError = responseDictionary.ContainsKey(OAuth2ResponseBaseClaim.SubError) ? responseDictionary[OAuth2ResponseBaseClaim.SubError] : string.Empty,
                     AccountUserId = homeAcctId != null ? AccountId.ParseFromString(homeAcctId).ObjectId : null,
                     TenantId = homeAcctId != null ?  AccountId.ParseFromString(homeAcctId).TenantId : null,
-                    Upn = (dictionary?.ContainsKey(TokenResponseClaim.Upn) ?? false) ? dictionary[TokenResponseClaim.Upn] : null,
+                    Upn = (metadataDictionary?.ContainsKey(TokenResponseClaim.Upn) ?? false) ? metadataDictionary[TokenResponseClaim.Upn] : null,
                 };
             }
 

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -101,19 +101,25 @@ namespace Microsoft.Identity.Client.OAuth2
         {
             if (responseDictionary.TryGetValue(BrokerResponseConst.BrokerErrorCode, out string errorCode))
             {
-                string original = responseDictionary[MsalTokenResponse.iOSBrokerErrorMetadata];
-                string dataUnescaped = Uri.UnescapeDataString(original);
-                Dictionary<string, string> dictionary = Json.JsonConvert.DeserializeObject<Dictionary<string, string>>(dataUnescaped);
+                string original = responseDictionary.ContainsKey(MsalTokenResponse.iOSBrokerErrorMetadata) ? responseDictionary[MsalTokenResponse.iOSBrokerErrorMetadata] : null;
+                Dictionary<string, string> dictionary = null;
+                
+                if (original != null)
+                {
+                    string dataUnescaped = Uri.UnescapeDataString(original);
+                    dictionary = Json.JsonConvert.DeserializeObject<Dictionary<string, string>>(dataUnescaped); 
+                }
+
                 string homeAcctId = null;
-                dictionary.TryGetValue(MsalTokenResponse.iOSBrokerHomeAccountId, out homeAcctId);
+                dictionary?.TryGetValue(MsalTokenResponse.iOSBrokerHomeAccountId, out homeAcctId);
                 return new MsalTokenResponse
                 {
                     Error = errorCode,
-                    ErrorDescription = CoreHelpers.UrlDecode(responseDictionary[BrokerResponseConst.BrokerErrorDescription]),
-                    SubError = responseDictionary[OAuth2ResponseBaseClaim.SubError],
+                    ErrorDescription = responseDictionary.ContainsKey(BrokerResponseConst.BrokerErrorDescription) ? CoreHelpers.UrlDecode(responseDictionary[BrokerResponseConst.BrokerErrorDescription]) : string.Empty,
+                    SubError = responseDictionary.ContainsKey(OAuth2ResponseBaseClaim.SubError) ? responseDictionary[OAuth2ResponseBaseClaim.SubError] : string.Empty,
                     AccountUserId = homeAcctId != null ? AccountId.ParseFromString(homeAcctId).ObjectId : null,
                     TenantId = homeAcctId != null ?  AccountId.ParseFromString(homeAcctId).TenantId : null,
-                    Upn = dictionary[TokenResponseClaim.Upn],
+                    Upn = (dictionary?.ContainsKey(TokenResponseClaim.Upn) ?? false) ? dictionary[TokenResponseClaim.Upn] : null,
                 };
             }
 

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -151,6 +151,12 @@ namespace Microsoft.Identity.Test.Unit
         public const string UserAssertion = "fake_access_token";
         public const string CodeVerifier = "someCodeVerifier";
 
+        public const string TestErrCode = "TestErrCode";
+        public const string iOSBrokerSuberrCode = "TestSuberrCode";
+        public const string iOSBrokerErrDescr = "Test Error Description";
+        public const string iOSBrokerErrorMetadata = "error_metadata";
+        public const string iOSBrokerErrorMetadataValue = @"{""home_account_id"":""test_home"", ""username"" : """ + Username + @""" }";
+
         //This value is only for testing purposes. It is for a certificate that is not used for anything other than running tests
         public const string _defaultx5cValue = @"MIIDHzCCAgegAwIBAgIQM6NFYNBJ9rdOiK+C91ZzFDANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwHhcNMTIwNTIyMj
 IxMTIyWhcNMzAwNTIyMDcwMDAwWjAgMR4wHAYDVQQDExVBQ1MyQ2xpZW50Q2VydGlmaWNhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCh7HjK

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -36,10 +36,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
     [TestCategory("Broker")]
     public class BrokerTests : TestBase
     {
-        const string TestErrCode = "TestErrCode";
-        const string TestSuberrCode = "TestSuberrCode";
-        const string TestErrDescr = "TestErrDescr";
-
         private BrokerInteractiveRequestComponent _brokerInteractiveRequest;
         private BrokerSilentStrategy _brokerSilentAuthStrategy;
         private AuthenticationRequestParameters _parameters;
@@ -300,20 +296,20 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             // Arrange
             Dictionary<string, string> responseDictionary = new Dictionary<string, string>();
-            responseDictionary["error_metadata"] = @"{""home_account_id"":""test_home"", ""username"" : ""Testacct@rreretr.com"" }";
-            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestErrCode;
-            responseDictionary[OAuth2ResponseBaseClaim.SubError] = TestSuberrCode;
-            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestErrDescr;
+            responseDictionary[TestConstants.iOSBrokerErrorMetadata] = TestConstants.iOSBrokerErrorMetadataValue;
+            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestConstants.TestErrCode;
+            responseDictionary[OAuth2ResponseBaseClaim.SubError] = TestConstants.iOSBrokerSuberrCode;
+            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestConstants.iOSBrokerErrDescr;
 
             // act
             var token = MsalTokenResponse.CreateFromiOSBrokerResponse(responseDictionary);
 
             // assert
-            Assert.AreEqual(TestErrCode, token.Error);
-            Assert.AreEqual(TestSuberrCode, token.SubError);
-            Assert.AreEqual(TestErrDescr, token.ErrorDescription);
+            Assert.AreEqual(TestConstants.TestErrCode, token.Error);
+            Assert.AreEqual(TestConstants.iOSBrokerSuberrCode, token.SubError);
+            Assert.AreEqual(TestConstants.iOSBrokerErrDescr, token.ErrorDescription);
             Assert.AreEqual("test_home", token.AccountUserId);
-            Assert.AreEqual("Testacct@rreretr.com", token.Upn);
+            Assert.AreEqual(TestConstants.Username, token.Upn);
         }
 
         [TestMethod]
@@ -321,19 +317,19 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             // Arrange
             Dictionary<string, string> responseDictionary = new Dictionary<string, string>();
-            responseDictionary["error_metadata"] = @"{""home_account_id"":""test_home"", ""username"" : ""Testacct@rreretr.com"" }";
-            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestErrCode;
-            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestErrDescr;
+            responseDictionary[TestConstants.iOSBrokerErrorMetadata] = TestConstants.iOSBrokerErrorMetadataValue;
+            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestConstants.TestErrCode;
+            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestConstants.iOSBrokerErrDescr;
 
             // act
             var token = MsalTokenResponse.CreateFromiOSBrokerResponse(responseDictionary);
 
             // assert
-            Assert.AreEqual(TestErrCode, token.Error);
+            Assert.AreEqual(TestConstants.TestErrCode, token.Error);
             Assert.AreEqual(string.Empty, token.SubError);
-            Assert.AreEqual(TestErrDescr, token.ErrorDescription);
+            Assert.AreEqual(TestConstants.iOSBrokerErrDescr, token.ErrorDescription);
             Assert.AreEqual("test_home", token.AccountUserId);
-            Assert.AreEqual("Testacct@rreretr.com", token.Upn);
+            Assert.AreEqual(TestConstants.Username, token.Upn);
         }
 
         [TestMethod]
@@ -341,19 +337,19 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             // Arrange
             Dictionary<string, string> responseDictionary = new Dictionary<string, string>();
-            responseDictionary["error_metadata"] = @"{""home_account_id"":""test_home"", ""username"" : ""Testacct@rreretr.com"" }";
-            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestErrCode;
-            responseDictionary[OAuth2ResponseBaseClaim.SubError] = TestSuberrCode;
+            responseDictionary[TestConstants.iOSBrokerErrorMetadata] = TestConstants.iOSBrokerErrorMetadataValue;
+            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestConstants.TestErrCode;
+            responseDictionary[OAuth2ResponseBaseClaim.SubError] = TestConstants.iOSBrokerSuberrCode;
 
             // act
             var token = MsalTokenResponse.CreateFromiOSBrokerResponse(responseDictionary);
 
             // assert
-            Assert.AreEqual(TestErrCode, token.Error);
-            Assert.AreEqual(TestSuberrCode, token.SubError);
+            Assert.AreEqual(TestConstants.TestErrCode, token.Error);
+            Assert.AreEqual(TestConstants.iOSBrokerSuberrCode, token.SubError);
             Assert.AreEqual(string.Empty, token.ErrorDescription);
             Assert.AreEqual("test_home", token.AccountUserId);
-            Assert.AreEqual("Testacct@rreretr.com", token.Upn);
+            Assert.AreEqual(TestConstants.Username, token.Upn);
         }
 
         [TestMethod]
@@ -361,17 +357,17 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             // Arrange
             Dictionary<string, string> responseDictionary = new Dictionary<string, string>();
-            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestErrCode;
-            responseDictionary[OAuth2ResponseBaseClaim.SubError] = TestSuberrCode;
-            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestErrDescr;
+            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestConstants.TestErrCode;
+            responseDictionary[OAuth2ResponseBaseClaim.SubError] = TestConstants.iOSBrokerSuberrCode;
+            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestConstants.iOSBrokerErrDescr;
 
             // act
             var token = MsalTokenResponse.CreateFromiOSBrokerResponse(responseDictionary);
 
             // assert
-            Assert.AreEqual(TestErrCode, token.Error);
-            Assert.AreEqual(TestSuberrCode, token.SubError);
-            Assert.AreEqual(TestErrDescr, token.ErrorDescription);
+            Assert.AreEqual(TestConstants.TestErrCode, token.Error);
+            Assert.AreEqual(TestConstants.iOSBrokerSuberrCode, token.SubError);
+            Assert.AreEqual(TestConstants.iOSBrokerErrDescr, token.ErrorDescription);
             Assert.AreEqual(null, token.AccountUserId);
             Assert.AreEqual(null, token.TenantId);
             Assert.AreEqual(null, token.Upn);
@@ -382,19 +378,19 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             // Arrange
             Dictionary<string, string> responseDictionary = new Dictionary<string, string>();
-            responseDictionary["error_metadata"] = @"{""username"" : ""Testacct@rreretr.com"" }";
-            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestErrCode;
-            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestErrDescr;
+            responseDictionary[TestConstants.iOSBrokerErrorMetadata] = @"{""username"" : """ + TestConstants.Username + @""" }";
+            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestConstants.TestErrCode;
+            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestConstants.iOSBrokerErrDescr;
 
             // act
             var token = MsalTokenResponse.CreateFromiOSBrokerResponse(responseDictionary);
 
             // assert
-            Assert.AreEqual(TestErrCode, token.Error);
+            Assert.AreEqual(TestConstants.TestErrCode, token.Error);
             Assert.AreEqual(string.Empty, token.SubError);
-            Assert.AreEqual(TestErrDescr, token.ErrorDescription);
+            Assert.AreEqual(TestConstants.iOSBrokerErrDescr, token.ErrorDescription);
             Assert.AreEqual(null, token.AccountUserId);
-            Assert.AreEqual("Testacct@rreretr.com", token.Upn);
+            Assert.AreEqual(TestConstants.Username, token.Upn);
         }
 
         [TestMethod]
@@ -403,16 +399,16 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             // Arrange
             Dictionary<string, string> responseDictionary = new Dictionary<string, string>();
             responseDictionary["error_metadata"] = @"{""home_account_id"":""test_home"" }";
-            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestErrCode;
-            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestErrDescr;
+            responseDictionary[BrokerResponseConst.BrokerErrorCode] = TestConstants.TestErrCode;
+            responseDictionary[BrokerResponseConst.BrokerErrorDescription] = TestConstants.iOSBrokerErrDescr;
 
             // act
             var token = MsalTokenResponse.CreateFromiOSBrokerResponse(responseDictionary);
 
             // assert
-            Assert.AreEqual(TestErrCode, token.Error);
+            Assert.AreEqual(TestConstants.TestErrCode, token.Error);
             Assert.AreEqual(string.Empty, token.SubError);
-            Assert.AreEqual(TestErrDescr, token.ErrorDescription);
+            Assert.AreEqual(TestConstants.iOSBrokerErrDescr, token.ErrorDescription);
             Assert.AreEqual("test_home", token.AccountUserId);
             Assert.AreEqual(null, token.Upn);
         }


### PR DESCRIPTION
Fixes # 3327

**Changes proposed in this request**
Accounts for null values

**Testing**
Added unit tests

**Performance impact**
None
