### PR TITLE
WAM integration tests (DRAFT)

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Microsoft.Identity.Test.LabInfrastructure\Microsoft.Identity.Test.LabInfrastructure.csproj" />
     <ProjectReference Include="..\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.8.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.15.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.15.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/tests/Microsoft.Identity.Test.Integration.netcore/WAM/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/WAM/RuntimeBrokerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
 
         public static IntPtr hWnd;
         public static string CorrelationId = "b0435a5c-6d97-41d6-9372-812e7fac3c10";
-        public static string VSApplicationId = "04f0c124-f2bc-4f59-8241-bf6df9866bbd";
+        public static string VSApplicationId = "26a7ee05-5602-4d76-a7ba-eae8b7b67941";
         public const string MicrosoftCommonAuthority = "https://login.microsoftonline.com/common";
         public const string Scopes = "user.read";
         public const string RedirectUri = "http://localhost";

--- a/tests/Microsoft.Identity.Test.Integration.netcore/WAM/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/WAM/RuntimeBrokerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
 
         public static IntPtr hWnd;
         public static string CorrelationId = "b0435a5c-6d97-41d6-9372-812e7fac3c10";
-        public static string VSApplicationId = "26a7ee05-5602-4d76-a7ba-eae8b7b67941";
+        public static string VSApplicationId = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
         public const string MicrosoftCommonAuthority = "https://login.microsoftonline.com/common";
         public const string Scopes = "user.read";
         public const string RedirectUri = "http://localhost";


### PR DESCRIPTION
Fixes # 

**Changes proposed in this request**
WAM Integration test. Checking to see if we can use Interop NuGet to get the default account and use it in our Broker APIs. For now testing with Interop APIs directly. Still work in progress. But as of how it is currently, it can be used in the C++ pipeline as integration test if this logic works. 

**Testing**
n/a

**Performance impact**
none
