### PR TITLE
Test with and without await

### DIFF
--- a/tests/devapps/WebApi/Controllers/AsyncTestController.cs
+++ b/tests/devapps/WebApi/Controllers/AsyncTestController.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Client;
+using WebApi.MockHttp;
+
+namespace WebApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class AsyncTestController : Controller
+    {
+        private static readonly IConfidentialClientApplication s_app;
+        private static readonly IEnumerable<string> s_scope = new[] { "scope1" };
+        private static readonly MockHttpClientFactory s_mockHttpClientFactory = new MockHttpClientFactory(500);
+
+        static AsyncTestController()
+        {
+            s_app = ConfidentialClientApplicationBuilder
+                    .Create("clientId")
+                    .WithAuthority("https://login.microsoftonline.com/tenantId")
+                    .WithHttpClientFactory(s_mockHttpClientFactory)
+                    .WithClientSecret("secret")
+                    .Build();
+        }
+
+        [HttpGet]
+        public async Task<string> WithAsyncWithoutCache()
+        {
+            var result = await s_app.AcquireTokenForClient(s_scope)
+                .WithForceRefresh(true)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+            return result.AuthenticationResultMetadata.TokenSource.ToString();
+        }
+
+        [HttpGet]
+        public string WithoutAsyncWithoutCache()
+        {
+            var result = s_app.AcquireTokenForClient(s_scope)
+                .WithForceRefresh(true)
+                .ExecuteAsync()
+                .ConfigureAwait(false)
+                .GetAwaiter().GetResult();
+            return result.AuthenticationResultMetadata.TokenSource.ToString();
+        }
+    }
+}


### PR DESCRIPTION
**Changes proposed in this request**
- Added controller with actions to test with and without wait.
- Added ability to add delay to mocked Http client.

**Testing**
- Did a few test runs on my machine using [bombardier](https://github.com/codesenberg/bombardier) tool. Test results below using 500ms delay in mocked HTTP call. Seems like a method with `GetAwaiter().GetResult()` is faster than with using `await` but did result in a bit more timeout exceptions. This test could also probably be updated with something like adding a count of threads in a pool or maybe increasing the delay.

Each test run is 1m0s using 125 connection(s). The `others` error category is timeout exceptions, which is also probably why 99% numbers are outliers.

**bombardier -d 60s -l https://localhost:5001/AsyncTest/WithAsyncWithoutCache**
**125 connections**
```
Statistics        Avg      Stdev        Max
  Reqs/sec        58.00     120.04    1523.48
  Latency         2.11s      5.84s     45.26s
  Latency Distribution
     50%      0.99s
     75%      1.14s
     90%      1.33s
     95%      1.82s
     99%     40.62s
  HTTP codes:
    1xx - 0, 2xx - 3541, 3xx - 0, 4xx - 0, 5xx - 0
    others - 66
Throughput:    31.61KB/s
```
```
Statistics        Avg      Stdev        Max
  Reqs/sec        60.42     117.80     901.81
  Latency         2.01s      7.73s      1.02m
  Latency Distribution
     50%      0.90s
     75%      1.02s
     90%      1.18s
     95%      1.33s
     99%      1.01m
  HTTP codes:
    1xx - 0, 2xx - 3699, 3xx - 0, 4xx - 0, 5xx - 0
    others - 65
Throughput:    29.36KB/s
```
```
Statistics        Avg      Stdev        Max
  Reqs/sec        61.38     121.67    1054.90
  Latency         2.01s      6.34s      0.97m
  Latency Distribution
     50%      0.86s
     75%      0.98s
     90%      1.10s
     95%      1.89s
     99%     45.17s
  HTTP codes:
    1xx - 0, 2xx - 3723, 3xx - 0, 4xx - 0, 5xx - 0
    others - 71
Throughput:    32.88KB/s
```

**10 connections**
```
Statistics        Avg      Stdev        Max
  Reqs/sec        18.26      31.37     500.34
  Latency      545.47ms    34.43ms      1.54s
  Latency Distribution
     50%   531.69ms
     75%   543.20ms
     90%   555.62ms
     95%   566.61ms
     99%   652.03ms
  HTTP codes:
    1xx - 0, 2xx - 1104, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
Throughput:     6.13KB/s
```

**50 connections**
```
Statistics        Avg      Stdev        Max
  Reqs/sec        68.73     111.39     789.60
  Latency      722.70ms    96.77ms      3.32s
  Latency Distribution
     50%   715.03ms
     75%   763.97ms
     90%   813.43ms
     95%   845.01ms
     99%      0.94s
  HTTP codes:
    1xx - 0, 2xx - 4176, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
Throughput:    23.44KB/s
```

**bombardier -d 60s -l https://localhost:5001/AsyncTest/WithoutAsyncWithoutCache**
**125 connections**
```
Statistics        Avg      Stdev        Max
  Reqs/sec        62.37      67.97     803.34
  Latency         1.98s      5.76s     35.10s
  Latency Distribution
     50%   608.92ms
     75%   644.03ms
     90%   708.00ms
     95%      9.09s
     99%     34.79s
  HTTP codes:
    1xx - 0, 2xx - 3696, 3xx - 0, 4xx - 0, 5xx - 0
    others - 166
Throughput:    45.13KB/s
```
```
Statistics        Avg      Stdev        Max
  Reqs/sec        64.77      96.76    1597.18
  Latency         1.91s      5.87s     41.12s
  Latency Distribution
     50%   642.55ms
     75%   687.00ms
     90%   793.00ms
     95%      1.91s
     99%     33.63s
  HTTP codes:
    1xx - 0, 2xx - 3922, 3xx - 0, 4xx - 0, 5xx - 0
    others - 80
Throughput:    38.80KB/s
```
```
Statistics        Avg      Stdev        Max
  Reqs/sec        60.34      84.82     649.98
  Latency         2.03s      6.37s     43.27s
  Latency Distribution
     50%   635.50ms
     75%   679.00ms
     90%   738.00ms
     95%     10.26s
     99%     40.06s
  HTTP codes:
    1xx - 0, 2xx - 3609, 3xx - 0, 4xx - 0, 5xx - 0
    others - 120
Throughput:    42.31KB/s
```

**10 connections**
```
Statistics        Avg      Stdev        Max
  Reqs/sec        18.56      33.13     516.51
  Latency      536.97ms    16.64ms   717.22ms
  Latency Distribution
     50%   532.57ms
     75%   543.73ms
     90%   550.41ms
     95%   561.65ms
     99%   620.22ms
  HTTP codes:
    1xx - 0, 2xx - 1121, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
Throughput:     6.27KB/s
```

**50 connections**
```
Statistics        Avg      Stdev        Max
  Reqs/sec        47.43     125.78    2250.02
  Latency         1.04s      1.28s     17.06s
  Latency Distribution
     50%   687.93ms
     75%      0.85s
     90%      1.52s
     95%      2.03s
     99%      6.86s
  HTTP codes:
    1xx - 0, 2xx - 2883, 3xx - 0, 4xx - 0, 5xx - 0
    others - 9
Throughput:    20.87KB/s
```
```
  Reqs/sec        63.34     109.80    2215.65
  Latency      784.02ms   578.49ms      8.66s
  Latency Distribution
     50%   654.93ms
     75%   697.29ms
     90%      0.88s
     95%      1.28s
     99%      3.95s
  HTTP codes:
    1xx - 0, 2xx - 3847, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
Throughput:    23.93KB/s
```