### PR TITLE
Fix PerformanceTests.sln not building

### DIFF
--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup Label="Targets required for unit tests to run">
-    
     <TargetFrameworkNetDesktop461>net461</TargetFrameworkNetDesktop461>
     <TargetFrameworkNetCore>netcoreapp2.1</TargetFrameworkNetCore>
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
+    <TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
   </PropertyGroup>
 
   <!-- Mobile and legacy targets - comment these out or set env variable MSAL_DESKTOP_ONLY_DEV to speedup the build -->
   <PropertyGroup Condition="'$(MSAL_DESKTOP_ONLY_DEV)' == ''">
-    <TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
     <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
     <TargetFrameworkUap>uap10.0.17763</TargetFrameworkUap>
     <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>


### PR DESCRIPTION
**Changes proposed in this request**
Moved netstandard target out of `MSAL_DESKTOP_ONLY_DEV` conditional, which is set for perf tests.