### PR TITLE
Use new Android device set for App Center tests

### DIFF
--- a/build/template-android-appcenter-tests.yaml
+++ b/build/template-android-appcenter-tests.yaml
@@ -36,12 +36,12 @@ steps:
     $secret | Out-File $(System.ArtifactsDirectory)\drop\msalTests\Microsoft.Identity.Test.Android.UIAutomation\bin\${{ parameters.DataFileDirectory }}\data.txt
   displayName: 'Get Credentials'
   
-- powershell: 'appcenter test run uitest --app "ADAL-DotNet/DotNet-Xamarin-ADAL" --devices ADAL-DotNet/android-9-and-10 --app-path $(System.ArtifactsDirectory)\Xamarin.Android\bin\Release\com.Microsoft.XFormsDroid.MSAL-Signed.apk --test-series "msal" --locale "en_US" --build-dir $(System.ArtifactsDirectory)\drop\msalTests\Microsoft.Identity.Test.Android.UIAutomation\bin\${{ parameters.DataFileDirectory }} --uitest-tools-dir $(System.ArtifactsDirectory)\drop --include-category ConsolidateAppCenterTests --include data.txt --token b3f171ce2e9ed2cfc11b8748ea8c7d3e4c9d37f5'
+- powershell: 'appcenter test run uitest --app "ADAL-DotNet/DotNet-Xamarin-ADAL" --devices ADAL-DotNet/android-devices --app-path $(System.ArtifactsDirectory)\Xamarin.Android\bin\Release\com.Microsoft.XFormsDroid.MSAL-Signed.apk --test-series "msal" --locale "en_US" --build-dir $(System.ArtifactsDirectory)\drop\msalTests\Microsoft.Identity.Test.Android.UIAutomation\bin\${{ parameters.DataFileDirectory }} --uitest-tools-dir $(System.ArtifactsDirectory)\drop --include-category ConsolidateAppCenterTests --include data.txt --token b3f171ce2e9ed2cfc11b8748ea8c7d3e4c9d37f5'
   displayName: 'Run App Center MSAL Tests (Fast)'
   condition: and(succeeded(), eq(variables['ConsolidateAppCenterTests'], 'true'), eq(variables['RunTests'], 'true'))
     
 
-- powershell: 'appcenter test run uitest --app "ADAL-DotNet/DotNet-Xamarin-ADAL" --devices ADAL-DotNet/android-9-and-10 --app-path $(System.ArtifactsDirectory)\Xamarin.Android\bin\Release\com.Microsoft.XFormsDroid.MSAL-Signed.apk --test-series "msal" --locale "en_US" --build-dir $(System.ArtifactsDirectory)\drop\msalTests\Microsoft.Identity.Test.Android.UIAutomation\bin\${{ parameters.DataFileDirectory }} --uitest-tools-dir $(System.ArtifactsDirectory)\drop --exclude-category ConsolidateAppCenterTests --include data.txt --token b3f171ce2e9ed2cfc11b8748ea8c7d3e4c9d37f5'
+- powershell: 'appcenter test run uitest --app "ADAL-DotNet/DotNet-Xamarin-ADAL" --devices ADAL-DotNet/android-devices --app-path $(System.ArtifactsDirectory)\Xamarin.Android\bin\Release\com.Microsoft.XFormsDroid.MSAL-Signed.apk --test-series "msal" --locale "en_US" --build-dir $(System.ArtifactsDirectory)\drop\msalTests\Microsoft.Identity.Test.Android.UIAutomation\bin\${{ parameters.DataFileDirectory }} --uitest-tools-dir $(System.ArtifactsDirectory)\drop --exclude-category ConsolidateAppCenterTests --include data.txt --token b3f171ce2e9ed2cfc11b8748ea8c7d3e4c9d37f5'
   displayName: 'Run App Center MSAL Tests (Full)'
   condition: and(succeeded(), eq(variables['ConsolidateAppCenterTests'], 'false'), eq(variables['RunTests'], 'true'))
   


### PR DESCRIPTION
**Changes proposed in this request**
Use new Android device set (Pixel 6 Pro Android 12, Pixel 5 Android 11) that covers the 2 latest OSs.