### PR TITLE
Add cancellation support for acquire token interactive

### DIFF
--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -9,12 +9,12 @@
 
   <!-- Mobile and legacy targets - comment these out or set env variable MSAL_DESKTOP_ONLY_DEV to speedup the build -->
   <PropertyGroup Condition="'$(MSAL_DESKTOP_ONLY_DEV)' == ''">
-    <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
+    <!--<TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
     <TargetFrameworkUap>uap10.0.17763</TargetFrameworkUap>
     <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -9,12 +9,12 @@
 
   <!-- Mobile and legacy targets - comment these out or set env variable MSAL_DESKTOP_ONLY_DEV to speedup the build -->
   <PropertyGroup Condition="'$(MSAL_DESKTOP_ONLY_DEV)' == ''">
-    <!--<TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
+    <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
     <TargetFrameworkUap>uap10.0.17763</TargetFrameworkUap>
     <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WebView2WebUi.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             AuthorizationResult result = null;
             var sendAuthorizeRequest = new Action(() =>
             {
-                result = InvokeEmbeddedWebview(authorizationUri, redirectUri);
+                result = InvokeEmbeddedWebview(authorizationUri, redirectUri, cancellationToken);
             });
 
             if (Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA)
@@ -49,7 +49,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
                     {
                         try
                         {
-                            result = InvokeEmbeddedWebview(authorizationUri, redirectUri);
+                            result = InvokeEmbeddedWebview(authorizationUri, redirectUri, cancellationToken);
                             ((TaskCompletionSource<object>)tcs).TrySetResult(null);
                         }
                         catch (Exception e)
@@ -111,7 +111,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             return redirectUri;
         }
 
-        private AuthorizationResult InvokeEmbeddedWebview(Uri startUri, Uri endUri)
+        private AuthorizationResult InvokeEmbeddedWebview(Uri startUri, Uri endUri, CancellationToken cancellationToken)
         {
             using (var form = new WinFormsPanelWithWebView2(
                 _parent.OwnerWindow, 
@@ -120,7 +120,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
                 startUri, 
                 endUri))
             {
-                return form.DisplayDialogAndInterceptUri();
+                return form.DisplayDialogAndInterceptUri(cancellationToken);
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -97,7 +97,9 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
                     {
                         if (Application.OpenForms.OfType<WinFormsPanelWithWebView2>().Any())
                         {
-                            InvokeHandlingOwnerWindow(Close);
+                            InvokeOnly(Close);
+                            cts.Cancel();
+                            return;
                         }
                     }
 
@@ -106,7 +108,6 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             }, cts.Token);
 
             InvokeHandlingOwnerWindow(() => uiResult = ShowDialog(_ownerWindow));
-            cts.Cancel();
             cancellationToken.ThrowIfCancellationRequested();
             
             switch (uiResult)
@@ -144,6 +145,22 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
             if (_ownerWindow != null && _ownerWindow is Control winFormsControl)
             {
                 winFormsControl.Invoke(action);
+            }
+            else
+            {
+                action();
+            }
+        }
+
+        /// <summary>
+        /// Some calls need to be made on the UI thread and this is the central place to do so and if so, ensure we invoke on that proper thread.
+        /// </summary>
+        /// <param name="action"></param>
+        private void InvokeOnly(Action action)
+        {
+            if (InvokeRequired)
+            {
+                this.Invoke(action);
             }
             else
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/InteractiveWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/InteractiveWebUI.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.UI;
 
@@ -20,13 +21,13 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 
         public EmbeddedWebViewOptions EmbeddedWebViewOptions { get; }
 
-        protected override AuthorizationResult OnAuthenticate()
+        protected override AuthorizationResult OnAuthenticate(CancellationToken cancellationToken)
         {
             AuthorizationResult result;
 
             using (_dialog = new WindowsFormsWebAuthenticationDialog(OwnerWindow, EmbeddedWebViewOptions) { RequestContext = RequestContext })
             {
-                result = _dialog.AuthenticateAAD(RequestUri, CallbackUri);
+                result = _dialog.AuthenticateAAD(RequestUri, CallbackUri, cancellationToken);
             }
 
             return result;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/SilentWebUI.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 
                         _threadInitializedEvent.Set();
 
-                        _dialog.AuthenticateAAD(RequestUri, CallbackUri);
+                        _dialog.AuthenticateAAD(RequestUri, CallbackUri, CancellationToken.None);
 
                         // Start and turn control over to the message loop.
                         Application.Run();
@@ -135,7 +135,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
         /// UI thread completes.
         /// </summary>
         /// <returns></returns>
-        protected override AuthorizationResult OnAuthenticate()
+        protected override AuthorizationResult OnAuthenticate(CancellationToken cancellationToken)
         {
             if (null == CallbackUri)
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WebUI.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 
             var sendAuthorizeRequest = new Action(() =>
             {
-                authorizationResult = Authenticate(authorizationUri, redirectUri);
+                authorizationResult = Authenticate(authorizationUri, redirectUri, cancellationToken);
             });
 
             var sendAuthorizeRequestWithTcs = new Action<object>((tcs) =>
             {
                 try
                 {
-                    authorizationResult = Authenticate(authorizationUri, redirectUri);
+                    authorizationResult = Authenticate(authorizationUri, redirectUri, cancellationToken);
                     ((TaskCompletionSource<object>)tcs).TrySetResult(null);
                 }
                 catch (Exception e)
@@ -102,15 +102,15 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
             return await Task.Factory.StartNew(() => authorizationResult).ConfigureAwait(false);
         }
 
-        internal AuthorizationResult Authenticate(Uri requestUri, Uri callbackUri)
+        internal AuthorizationResult Authenticate(Uri requestUri, Uri callbackUri, CancellationToken cancellationToken)
         {
             RequestUri = requestUri;
             CallbackUri = callbackUri;
 
-            return OnAuthenticate();
+            return OnAuthenticate(cancellationToken);
         }
 
-        protected abstract AuthorizationResult OnAuthenticate();
+        protected abstract AuthorizationResult OnAuthenticate(CancellationToken cancellationToken);
 
         public Uri UpdateRedirectUri(Uri redirectUri)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows.Forms;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
@@ -263,7 +264,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
         /// </summary>
         protected abstract void OnNavigationCanceled(int statusCode);
 
-        internal AuthorizationResult AuthenticateAAD(Uri requestUri, Uri callbackUri)
+        internal AuthorizationResult AuthenticateAAD(Uri requestUri, Uri callbackUri, CancellationToken cancellationToken)
         {
             _desiredCallbackUri = callbackUri;
             Result = null;
@@ -276,14 +277,14 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
             _webBrowser.NavigateError += WebBrowserNavigateErrorHandler;
 
             _webBrowser.Navigate(requestUri);
-            OnAuthenticate();
+            OnAuthenticate(cancellationToken);
 
             return Result;
         }
 
         /// <summary>
         /// </summary>
-        protected virtual void OnAuthenticate()
+        protected virtual void OnAuthenticate(CancellationToken cancellationToken)
         {
         }
 
@@ -298,6 +299,22 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
             if (ownerWindow != null && ownerWindow is Control winFormsControl)
             {
                 winFormsControl.Invoke(action);
+            }
+            else
+            {
+                action();
+            }
+        }
+
+        /// <summary>
+        /// Some calls need to be made on the UI thread and this is the central place to do so and if so, ensure we invoke on that proper thread.
+        /// </summary>
+        /// <param name="action"></param>
+        protected void InvokeOnly(Action action)
+        {
+            if (InvokeRequired)
+            {
+                this.Invoke(action);
             }
             else
             {

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.Designer.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.Designer.cs
@@ -56,6 +56,9 @@
             this.cbxListOsAccounts = new System.Windows.Forms.CheckBox();
             this.cbxUseWam = new System.Windows.Forms.ComboBox();
             this.cbxPOP = new System.Windows.Forms.CheckBox();
+            this.nudAutocancelSeconds = new System.Windows.Forms.NumericUpDown();
+            this.label7 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutocancelSeconds)).BeginInit();
             this.SuspendLayout();
             // 
             // resultTbx
@@ -157,7 +160,7 @@
             // 
             // atsBtn
             // 
-            this.atsBtn.Location = new System.Drawing.Point(14, 205);
+            this.atsBtn.Location = new System.Drawing.Point(14, 222);
             this.atsBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.atsBtn.Name = "atsBtn";
             this.atsBtn.Size = new System.Drawing.Size(88, 27);
@@ -168,7 +171,7 @@
             // 
             // atiBtn
             // 
-            this.atiBtn.Location = new System.Drawing.Point(108, 205);
+            this.atiBtn.Location = new System.Drawing.Point(108, 222);
             this.atiBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.atiBtn.Name = "atiBtn";
             this.atiBtn.Size = new System.Drawing.Size(88, 27);
@@ -179,7 +182,7 @@
             // 
             // atsAtiBtn
             // 
-            this.atsAtiBtn.Location = new System.Drawing.Point(203, 205);
+            this.atsAtiBtn.Location = new System.Drawing.Point(203, 222);
             this.atsAtiBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.atsAtiBtn.Name = "atsAtiBtn";
             this.atsAtiBtn.Size = new System.Drawing.Size(88, 27);
@@ -190,7 +193,7 @@
             // 
             // accBtn
             // 
-            this.accBtn.Location = new System.Drawing.Point(368, 205);
+            this.accBtn.Location = new System.Drawing.Point(368, 222);
             this.accBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.accBtn.Name = "accBtn";
             this.accBtn.Size = new System.Drawing.Size(93, 27);
@@ -303,7 +306,7 @@
             // 
             // btnRemoveAccount
             // 
-            this.btnRemoveAccount.Location = new System.Drawing.Point(469, 205);
+            this.btnRemoveAccount.Location = new System.Drawing.Point(469, 222);
             this.btnRemoveAccount.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnRemoveAccount.Name = "btnRemoveAccount";
             this.btnRemoveAccount.Size = new System.Drawing.Size(104, 27);
@@ -354,11 +357,34 @@
             this.cbxPOP.Text = "With Proof-of-Possesion";
             this.cbxPOP.UseVisualStyleBackColor = true;
             // 
+            // nudAutocancelSeconds
+            // 
+            this.nudAutocancelSeconds.Location = new System.Drawing.Point(132, 193);
+            this.nudAutocancelSeconds.Maximum = new decimal(new int[] {
+            120,
+            0,
+            0,
+            0});
+            this.nudAutocancelSeconds.Name = "nudAutocancelSeconds";
+            this.nudAutocancelSeconds.Size = new System.Drawing.Size(68, 23);
+            this.nudAutocancelSeconds.TabIndex = 30;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(12, 195);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(114, 15);
+            this.label7.TabIndex = 31;
+            this.label7.Text = "Autocancel Seconds";
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(735, 740);
+            this.Controls.Add(this.label7);
+            this.Controls.Add(this.nudAutocancelSeconds);
             this.Controls.Add(this.cbxPOP);
             this.Controls.Add(this.cbxUseWam);
             this.Controls.Add(this.cbxListOsAccounts);
@@ -388,6 +414,7 @@
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "Form1";
             this.Text = "Form1";
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutocancelSeconds)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -422,6 +449,8 @@
         private System.Windows.Forms.CheckBox cbxListOsAccounts;
         private System.Windows.Forms.ComboBox cbxUseWam;
         private System.Windows.Forms.CheckBox cbxPOP;
+        private System.Windows.Forms.NumericUpDown nudAutocancelSeconds;
+        private System.Windows.Forms.Label label7;
     }
 }
 

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -175,7 +175,7 @@ namespace NetDesktopWinForms
             try
             {
                 var pca = CreatePca();
-                AuthenticationResult result = await RunAtsAsync(pca).ConfigureAwait(false);
+                AuthenticationResult result = await RunAtsAsync(pca, GetAutocancelToken()).ConfigureAwait(false);
 
                 await LogResultAndRefreshAccountsAsync(result).ConfigureAwait(false);
             }
@@ -186,7 +186,7 @@ namespace NetDesktopWinForms
 
         }
 
-        private async Task<AuthenticationResult> RunAtsAsync(IPublicClientApplication pca)
+        private async Task<AuthenticationResult> RunAtsAsync(IPublicClientApplication pca, CancellationToken cancellationToken)
         {
             string reqAuthority = pca.Authority;
             string loginHint = GetLoginHint();
@@ -212,7 +212,7 @@ namespace NetDesktopWinForms
                     builder = builder.WithProofOfPossession(_popNonce, System.Net.Http.HttpMethod.Get, new Uri(pca.Authority));
                 }
 
-                return await builder.ExecuteAsync().ConfigureAwait(false);
+                return await builder.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }
 
             if (cbxAccount.SelectedItem != null &&
@@ -249,14 +249,14 @@ namespace NetDesktopWinForms
 
                 Log($"ATS with IAccount for {acc?.Username ?? acc.HomeAccountId.ToString() ?? "null"}");
                 return await builder
-                    .ExecuteAsync()
+                    .ExecuteAsync(cancellationToken)
                     .ConfigureAwait(false);
             }
 
             Log($"ATS with no account or login hint ... will fail with UiRequiredEx");
             return await pca.AcquireTokenSilent(GetScopes(), (IAccount)null)
 
-                .ExecuteAsync()
+                .ExecuteAsync(cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -318,7 +318,7 @@ namespace NetDesktopWinForms
             try
             {
                 var pca = CreatePca();
-                AuthenticationResult result = await RunAtiAsync(pca).ConfigureAwait(false);
+                AuthenticationResult result = await RunAtiAsync(pca, GetAutocancelToken()).ConfigureAwait(false);
 
                 await LogResultAndRefreshAccountsAsync(result).ConfigureAwait(false);
 
@@ -329,7 +329,7 @@ namespace NetDesktopWinForms
             }
         }
 
-        private async Task<AuthenticationResult> RunAtiAsync(IPublicClientApplication pca)
+        private async Task<AuthenticationResult> RunAtiAsync(IPublicClientApplication pca, CancellationToken cancellationToken)
         {
             string loginHint = GetLoginHint();
             if (!string.IsNullOrEmpty(loginHint) && cbxAccount.SelectedIndex > 0)
@@ -382,7 +382,7 @@ namespace NetDesktopWinForms
             {
                 await Task.Delay(500).ConfigureAwait(false);
             }
-            result = await builder.ExecuteAsync().ConfigureAwait(false);
+            result = await builder.ExecuteAsync(cancellationToken).ConfigureAwait(false);
 
             return result;
         }
@@ -483,7 +483,7 @@ namespace NetDesktopWinForms
 
             try
             {
-                var result = await RunAtsAsync(pca).ConfigureAwait(false);
+                var result = await RunAtsAsync(pca, GetAutocancelToken()).ConfigureAwait(false);
 
                 await LogResultAndRefreshAccountsAsync(result).ConfigureAwait(false);
 
@@ -495,7 +495,7 @@ namespace NetDesktopWinForms
                 Log("UI required Exception! " + ex.ErrorCode + " " + ex.Message);
                 try
                 {
-                    var result = await RunAtiAsync(pca).ConfigureAwait(false);
+                    var result = await RunAtiAsync(pca, GetAutocancelToken()).ConfigureAwait(false);
                     await LogResultAndRefreshAccountsAsync(result).ConfigureAwait(false);
                 }
                 catch (Exception ex3)
@@ -603,6 +603,18 @@ namespace NetDesktopWinForms
             {
                 Log("Exception: " + ex);
             }
+        }
+
+        private CancellationToken GetAutocancelToken()
+        {
+            CancellationToken cancellationToken = CancellationToken.None;
+            if (nudAutocancelSeconds.Value > 0)
+            {
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds((int)nudAutocancelSeconds.Value));
+                cancellationToken = cts.Token;
+            }
+
+            return cancellationToken;
         }
 
     }

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.Designer.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.Designer.cs
@@ -55,6 +55,9 @@
             this.cbxBackgroundThread = new System.Windows.Forms.CheckBox();
             this.cbxListOsAccounts = new System.Windows.Forms.CheckBox();
             this.cbxUseWam = new System.Windows.Forms.ComboBox();
+            this.label7 = new System.Windows.Forms.Label();
+            this.nudAutocancelSeconds = new System.Windows.Forms.NumericUpDown();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutocancelSeconds)).BeginInit();
             this.SuspendLayout();
             // 
             // resultTbx
@@ -148,7 +151,7 @@
             // 
             // atsBtn
             // 
-            this.atsBtn.Location = new System.Drawing.Point(12, 178);
+            this.atsBtn.Location = new System.Drawing.Point(12, 193);
             this.atsBtn.Name = "atsBtn";
             this.atsBtn.Size = new System.Drawing.Size(75, 23);
             this.atsBtn.TabIndex = 11;
@@ -158,7 +161,7 @@
             // 
             // atiBtn
             // 
-            this.atiBtn.Location = new System.Drawing.Point(93, 178);
+            this.atiBtn.Location = new System.Drawing.Point(93, 193);
             this.atiBtn.Name = "atiBtn";
             this.atiBtn.Size = new System.Drawing.Size(75, 23);
             this.atiBtn.TabIndex = 12;
@@ -168,7 +171,7 @@
             // 
             // atsAtiBtn
             // 
-            this.atsAtiBtn.Location = new System.Drawing.Point(174, 178);
+            this.atsAtiBtn.Location = new System.Drawing.Point(174, 193);
             this.atsAtiBtn.Name = "atsAtiBtn";
             this.atsAtiBtn.Size = new System.Drawing.Size(75, 23);
             this.atsAtiBtn.TabIndex = 13;
@@ -178,7 +181,7 @@
             // 
             // accBtn
             // 
-            this.accBtn.Location = new System.Drawing.Point(315, 178);
+            this.accBtn.Location = new System.Drawing.Point(315, 193);
             this.accBtn.Name = "accBtn";
             this.accBtn.Size = new System.Drawing.Size(80, 23);
             this.accBtn.TabIndex = 15;
@@ -281,7 +284,7 @@
             // 
             // btnRemoveAccount
             // 
-            this.btnRemoveAccount.Location = new System.Drawing.Point(402, 178);
+            this.btnRemoveAccount.Location = new System.Drawing.Point(402, 193);
             this.btnRemoveAccount.Name = "btnRemoveAccount";
             this.btnRemoveAccount.Size = new System.Drawing.Size(89, 23);
             this.btnRemoveAccount.TabIndex = 25;
@@ -311,17 +314,40 @@
             // 
             // cbxUseWam
             // 
-            this.cbxUseWam.FormattingEnabled = true;            
+            this.cbxUseWam.FormattingEnabled = true;
             this.cbxUseWam.Location = new System.Drawing.Point(12, 130);
             this.cbxUseWam.Name = "cbxUseWam";
             this.cbxUseWam.Size = new System.Drawing.Size(156, 21);
             this.cbxUseWam.TabIndex = 28;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(12, 174);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(104, 13);
+            this.label7.TabIndex = 29;
+            this.label7.Text = "Autocancel seconds";
+            // 
+            // nudAutocancelSeconds
+            // 
+            this.nudAutocancelSeconds.Location = new System.Drawing.Point(122, 172);
+            this.nudAutocancelSeconds.Maximum = new decimal(new int[] {
+            120,
+            0,
+            0,
+            0});
+            this.nudAutocancelSeconds.Name = "nudAutocancelSeconds";
+            this.nudAutocancelSeconds.Size = new System.Drawing.Size(46, 20);
+            this.nudAutocancelSeconds.TabIndex = 30;
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(634, 642);
+            this.Controls.Add(this.nudAutocancelSeconds);
+            this.Controls.Add(this.label7);
             this.Controls.Add(this.cbxUseWam);
             this.Controls.Add(this.cbxListOsAccounts);
             this.Controls.Add(this.cbxBackgroundThread);
@@ -350,6 +376,7 @@
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "Form1";
             this.Text = "Form1";
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutocancelSeconds)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -383,6 +410,8 @@
         private System.Windows.Forms.CheckBox cbxBackgroundThread;
         private System.Windows.Forms.CheckBox cbxListOsAccounts;
         private System.Windows.Forms.ComboBox cbxUseWam;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.NumericUpDown nudAutocancelSeconds;
     }
 }
 


### PR DESCRIPTION
Fixes #3225 

**Changes proposed in this request**
- Add checking of CancellationToken to DisplayDialog (NetCore)
- Check cancellation Token and Close Dialog on Cancellation
- Add Integration Test to NetCore

**Testing**
Integration Test added to NetCoreWinFormsWAM, you can set Autocancel Seconds and authentication will be cancelled automatically without user interaction

**Performance impact**
None expected
