### PR TITLE
Extensibility APIs with new POP

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
@@ -17,10 +17,12 @@ namespace Microsoft.Identity.Client.Extensibility
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="keyId">A key id to which the access token is associated. The token will not be retrieved from the cache unless the same key id is presented. Can be null.</param>
+        /// <param name="tokenType">Bearer or pop</param>
         /// <returns>the builder</returns>
         public static AcquireTokenForClientParameterBuilder WithProofOfPosessionKeyId(
             this AcquireTokenForClientParameterBuilder builder,
-            string keyId)
+            string keyId, 
+            string tokenType = "Bearer")
         {
             if (string.IsNullOrEmpty(keyId))
             {
@@ -28,7 +30,7 @@ namespace Microsoft.Identity.Client.Extensibility
             }
 
             builder.ValidateUseOfExperimentalFeature();
-            builder.CommonParameters.AuthenticationScheme = new ExternalBoundTokenScheme(keyId);
+            builder.CommonParameters.AuthenticationScheme = new ExternalBoundTokenScheme(keyId, tokenType);
 
             return builder;
         }

--- a/src/client/Microsoft.Identity.Client/Extensibility/ExternalBoundTokenScheme.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/ExternalBoundTokenScheme.cs
@@ -11,17 +11,19 @@ namespace Microsoft.Identity.Client.Extensibility
     internal class ExternalBoundTokenScheme : IAuthenticationScheme
     {
         private readonly string _keyId;
+        private readonly string _tokenType;
 
-        public ExternalBoundTokenScheme(string keyId)
+        public ExternalBoundTokenScheme(string keyId, string tokenType = "Bearer")
         {
             _keyId = keyId;
+            _tokenType = tokenType;
         }
 
-        public string AuthorizationHeaderPrefix => "Bearer";
+        public string AuthorizationHeaderPrefix => _tokenType;
 
         public string KeyId => _keyId;
 
-        public string AccessTokenType => "Bearer";
+        public string AccessTokenType => _tokenType;
 
         public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
         {


### PR DESCRIPTION
Integration test showing how to use extensiblity to get pop tokens, with caching support. 
Also allows for the token_type to be configured in the WithPoPKey