### PR TITLE
Replace obsolete KeyVault library

### DIFF
--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -9,12 +9,12 @@
 
   <!-- Mobile and legacy targets - comment these out or set env variable MSAL_DESKTOP_ONLY_DEV to speedup the build -->
   <PropertyGroup Condition="'$(MSAL_DESKTOP_ONLY_DEV)' == ''">
-    <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
+    <!--<TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
     <TargetFrameworkUap>uap10.0.17763</TargetFrameworkUap>
     <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -9,12 +9,12 @@
 
   <!-- Mobile and legacy targets - comment these out or set env variable MSAL_DESKTOP_ONLY_DEV to speedup the build -->
   <PropertyGroup Condition="'$(MSAL_DESKTOP_ONLY_DEV)' == ''">
-    <!--<TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
+    <TargetFrameworkNetDesktop45>net45</TargetFrameworkNetDesktop45>
     <TargetFrameworkUap>uap10.0.17763</TargetFrameworkUap>
     <TargetFrameworkIos>Xamarin.iOS10</TargetFrameworkIos>
     <TargetFrameworkMac>xamarinmac20</TargetFrameworkMac>
     <TargetFrameworkAndroid9>MonoAndroid9.0</TargetFrameworkAndroid9>
-    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>-->
+    <TargetFrameworkAndroid10>MonoAndroid10.0</TargetFrameworkAndroid10>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Interfaces/IPlatformProxy.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
         /// <summary>
         /// Go to a URL using the OS default browser. 
         /// </summary>
-        Task StartDefaultOsBrowserAsync(string url, bool IsBrokerConfigured);
+        Task StartDefaultOsBrowserAsync(string url, bool isBrokerConfigured);
 
         IBroker CreateBroker(ApplicationConfiguration appConfig, CoreUIParent uiParent);
 

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -194,11 +194,17 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         }
 
         public const string MsalCCAKeyVaultUri = "https://buildautomation.vault.azure.net/secrets/AzureADIdentityDivisionTestAgentSecret/";
+        public const string MsalCCAKeyVaultSecretName = "AzureADIdentityDivisionTestAgentSecret";
         public const string MsalOBOKeyVaultUri = "https://buildautomation.vault.azure.net/secrets/IdentityDivisionDotNetOBOServiceSecret/";
+        public const string MsalOBOKeyVaultSecretName = "IdentityDivisionDotNetOBOServiceSecret";
         public const string MsalArlingtonOBOKeyVaultUri = "https://msidlabs.vault.azure.net:443/secrets/ARLMSIDLAB1-IDLASBS-App-CC-Secret";
+        public const string MsalArlingtonOBOKeyVaultSecretName = "ARLMSIDLAB1-IDLASBS-App-CC-Secret";
         public const string FociApp1 = "https://buildautomation.vault.azure.net/secrets/automation-foci-app1/";
+        public const string FociApp1KeyVaultSecretName = "automation-foci-app1";
         public const string FociApp2 = "https://buildautomation.vault.azure.net/secrets/automation-foci-app2/";
+        public const string FociApp2KeyVaultSecretName = "automation-foci-app2";
         public const string MsalArlingtonCCAKeyVaultUri = "https://msidlabs.vault.azure.net:443/secrets/ARLMSIDLAB1-IDLASBS-App-CC-Secret";
+        public const string MsalArlingtonCCAKeyVaultSecretName = "ARLMSIDLAB1-IDLASBS-App-CC-Secret";
 
         public enum AuthorityType { B2C };
         public static string[] s_prodEnvAliases = new[] {
@@ -427,5 +433,6 @@ m1t9gRT1mNeeluL4cZa6WyVXqXc6U2wfR5DY6GOMUubN5Nr1n8Czew8TPfab4OG37BuEMNmBpqoRrRgF
         public const string ClientRedirectUri = "http://localhost:8080";
         public static readonly SortedSet<string> s_supportedScopes = new SortedSet<string>(new[] { "openid", "email", "profile" }, StringComparer.OrdinalIgnoreCase);
         public const string ADFS2019ClientSecretURL = "https://buildautomation.vault.azure.net/secrets/ADFS2019ClientCredSecret/";
+        public const string ADFS2019ClientSecretName = "ADFS2019ClientCredSecret";
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private static InMemoryTokenCache s_inMemoryTokenCache = new InMemoryTokenCache();
         private string _confidentialClientSecret;
 
-        private readonly KeyVaultSecretsProvider _keyVault = new KeyVaultSecretsProvider();
+        private readonly KeyVaultSecretsProvider _keyVault = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
 
         #region Test Hooks
         [ClassInitialize]
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             TestCommon.ResetInternalStaticCaches();
             if (string.IsNullOrEmpty(_confidentialClientSecret))
             {
-                _confidentialClientSecret = _keyVault.GetSecret(TestConstants.MsalOBOKeyVaultUri).Value;
+                _confidentialClientSecret = _keyVault.GetSecretByName(TestConstants.MsalOBOKeyVaultSecretName).Value;
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests2.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests2.cs
@@ -4,24 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Security;
-using System.Security.Claims;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
-using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.Instance;
-using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Json.Utilities;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
@@ -30,10 +18,7 @@ using Microsoft.Identity.Test.Integration.net45.Infrastructure;
 using Microsoft.Identity.Test.Integration.NetFx.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Test.Unit;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
 {
@@ -59,16 +44,22 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private const string PublicCloudHost = "https://login.microsoftonline.com/";
         private const string ArlingtonCloudHost = "https://login.microsoftonline.us/";
 
-        private KeyVaultSecretsProvider _keyVault;
+        private KeyVaultSecretsProvider _keyVaultMsidLab;
+        private KeyVaultSecretsProvider _keyVaultMsalTeam;
 
         [TestInitialize]
         public void TestInitialize()
         {
             TestCommon.ResetInternalStaticCaches();
 
-            if (_keyVault == null)
+            if (_keyVaultMsidLab == null)
             {
-                _keyVault = new KeyVaultSecretsProvider();
+                _keyVaultMsidLab = new KeyVaultSecretsProvider(KeyVaultInstance.MSIDLab);
+            }
+
+            if (_keyVaultMsalTeam == null)
+            {
+                _keyVaultMsalTeam = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
             }
         }
         
@@ -259,7 +250,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             string[] oboScope;
 
             oboHost = PublicCloudHost;
-            secret = _keyVault.GetSecret(TestConstants.MsalOBOKeyVaultUri).Value;
+            secret = _keyVaultMsalTeam.GetSecretByName(TestConstants.MsalOBOKeyVaultSecretName).Value;
             authority = TestConstants.AuthorityOrganizationsTenant;
             publicClientID = PublicCloudPublicClientIDOBO;
             confidentialClientID = PublicCloudConfidentialClientIDOBO;
@@ -396,7 +387,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             {
                 case AzureEnvironment.azureusgovernment:
                     oboHost = ArlingtonCloudHost;
-                    secret = _keyVault.GetSecret(TestConstants.MsalArlingtonOBOKeyVaultUri).Value;
+                    secret = _keyVaultMsidLab.GetSecretByName(TestConstants.MsalArlingtonOBOKeyVaultSecretName).Value;
                     authority = labResponse.Lab.Authority + "organizations";
                     publicClientID = ArlingtonPublicClientIDOBO;
                     confidentialClientID = ArlingtonConfidentialClientIDOBO;
@@ -404,7 +395,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                     break;
                 default:
                     oboHost = PublicCloudHost;
-                    secret = _keyVault.GetSecret(TestConstants.MsalOBOKeyVaultUri).Value;
+                    secret = _keyVaultMsalTeam.GetSecretByName(TestConstants.MsalOBOKeyVaultSecretName).Value;
                     authority = TestConstants.AuthorityOrganizationsTenant;
                     publicClientID = PublicCloudPublicClientIDOBO;
                     confidentialClientID = PublicCloudConfidentialClientIDOBO;

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -17,18 +14,14 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.AuthScheme.PoP;
-using Microsoft.Identity.Client.PlatformsCommon;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common;
-using Microsoft.Identity.Test.Integration.net45;
 using Microsoft.Identity.Test.Integration.net45.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Test.Unit;
 using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
 {
@@ -57,14 +50,13 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             TestCommon.ResetInternalStaticCaches();
             if (_popValidationEndpointSecret == null)
             {
-                _popValidationEndpointSecret = LabUserHelper.KeyVaultSecretsProvider.GetSecret(
-                    "https://buildautomation.vault.azure.net/secrets/automation-pop-validation-endpoint/841fc7c2ccdd48d7a9ef727e4ae84325").Value;
+                _popValidationEndpointSecret = LabUserHelper.KeyVaultSecretsProviderMsal.GetSecretByName("automation-pop-validation-endpoint", "841fc7c2ccdd48d7a9ef727e4ae84325").Value;
             }
 
             if (_keyVault == null)
             {
-                _keyVault = new KeyVaultSecretsProvider();
-                s_publicCloudCcaSecret = _keyVault.GetSecret(TestConstants.MsalCCAKeyVaultUri).Value;
+                _keyVault = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
+                s_publicCloudCcaSecret = _keyVault.GetSecretByName(TestConstants.MsalCCAKeyVaultSecretName).Value;
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.PeerToPeer;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.Identity.Test.Unit;
 
@@ -58,7 +53,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
 
             public string GetSecret()
             {
-                return GetSecretLazy(TestConstants.MsalCCAKeyVaultUri).Value;
+                return GetSecretLazy(KeyVaultInstance.MsalTeam, TestConstants.MsalCCAKeyVaultSecretName).Value;
             }
         }
 
@@ -77,7 +72,6 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
             public X509Certificate2 GetCertificate()
             {
                 return s_certLazy.Value;
-
             }
 
             private static Lazy<X509Certificate2> s_certLazy => new Lazy<X509Certificate2>(() =>
@@ -88,7 +82,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
 
             public string GetSecret()
             {                
-                return GetSecretLazy(Adfs2019LabConstants.ADFS2019ClientSecretURL).Value;
+                return GetSecretLazy(KeyVaultInstance.MsalTeam, Adfs2019LabConstants.ADFS2019ClientSecretName).Value;
             }
 
             public string Authority => $@"https://{Environment}";
@@ -141,7 +135,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
 
             public string GetSecret()
             {
-                return GetSecretLazy(TestConstants.MsalArlingtonCCAKeyVaultUri).Value;
+                return GetSecretLazy(KeyVaultInstance.MSIDLab, TestConstants.MsalArlingtonCCAKeyVaultSecretName).Value;
             }
 
             public string Authority => $@"https://{Environment}/{TenantId}";
@@ -177,10 +171,10 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
             }
         }
 
-        private static Lazy<string> GetSecretLazy(string secretName) => new Lazy<string>(() =>
+        private static Lazy<string> GetSecretLazy(string keyVaultInstance, string secretName) => new Lazy<string>(() =>
         {
-            var keyVault = new KeyVaultSecretsProvider();
-            var secret = keyVault.GetSecret(secretName).Value;
+            var keyVault = new KeyVaultSecretsProvider(keyVaultInstance);
+            var secret = keyVault.GetSecretByName(secretName).Value;
             return secret;
         });
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
@@ -2,25 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Advanced;
-using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.UI;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Integration.Infrastructure;
 using Microsoft.Identity.Test.Integration.net45.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
-using Microsoft.Identity.Test.UIAutomation.Infrastructure;
 using Microsoft.Identity.Test.Unit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -56,7 +50,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         public static void ClassInitialize(TestContext context)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            s_secretProvider = new KeyVaultSecretsProvider();
+            s_secretProvider = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
         }
 
         [TestInitialize]
@@ -109,7 +103,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
             string authority, bool usePkce = false, string redirectUri = null, bool spaCode = true)
         {
             var cert = await s_secretProvider.GetCertificateWithPrivateMaterialAsync(
-                CertificateName, KeyVaultInstance.MsalTeam).ConfigureAwait(false);
+                CertificateName).ConfigureAwait(false);
 
             IConfidentialClientApplication cca;
             redirectUri = redirectUri ?? SeleniumWebUI.FindFreeLocalhostRedirectUri();

--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/FociTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/FociTests.cs
@@ -122,9 +122,9 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
 
         private static void CreateFamilyApps(LabResponse labResponse, string cacheFilePath, out IPublicClientApplication pca_fam1, out IPublicClientApplication pca_fam2, out IPublicClientApplication pca_nonFam)
         {
-            var keyvault = new KeyVaultSecretsProvider();
-            var clientId1 = keyvault.GetSecret(TestConstants.FociApp1).Value;
-            var clientId2 = keyvault.GetSecret(TestConstants.FociApp2).Value;
+            var keyvault = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
+            var clientId1 = keyvault.GetSecretByName(TestConstants.FociApp1KeyVaultSecretName).Value;
+            var clientId2 = keyvault.GetSecretByName(TestConstants.FociApp2KeyVaultSecretName).Value;
 
             pca_fam1 = PublicClientApplicationBuilder
                .Create(clientId1)

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
@@ -4,8 +4,9 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using Microsoft.Azure.KeyVault;
-using Microsoft.Azure.KeyVault.Models;
+using Azure.Core;
+using Azure.Security.KeyVault.Certificates;
+using Azure.Security.KeyVault.Secrets;
 
 namespace Microsoft.Identity.Test.LabInfrastructure
 {
@@ -25,7 +26,8 @@ namespace Microsoft.Identity.Test.LabInfrastructure
 
     public class KeyVaultSecretsProvider : IDisposable
     {
-        private KeyVaultClient _keyVaultClient;
+        private CertificateClient _certificateClient;
+        private SecretClient _secretClient;
 
         /// <summary>Initialize the secrets provider with the "keyVault" configuration section.</summary>
         /// <remarks>
@@ -54,9 +56,12 @@ namespace Microsoft.Identity.Test.LabInfrastructure
         ///         "clientId": [client ID]
         /// </para>
         /// </remarks>
-        public KeyVaultSecretsProvider()
+        public KeyVaultSecretsProvider(string keyVaultAddress = KeyVaultInstance.MSIDLab)
         {
-            _keyVaultClient = new KeyVaultClient(AuthenticationCallbackAsync);
+            var credentials = GetKeyVaultCredentialAsync().GetAwaiter().GetResult();
+            var keyVaultAddressUri = new Uri(keyVaultAddress);
+            _certificateClient = new CertificateClient(keyVaultAddressUri, credentials);
+            _secretClient = new SecretClient(keyVaultAddressUri, credentials);
         }
 
         ~KeyVaultSecretsProvider()
@@ -64,39 +69,35 @@ namespace Microsoft.Identity.Test.LabInfrastructure
             Dispose();
         }
 
-        public SecretBundle GetSecret(string secretUrl)
+        //public KeyVaultSecret GetSecret(string secretUrl)
+        //{
+        //    return _secretClient.GetSecretAsync(secretUrl).GetAwaiter().GetResult().Value;
+        //}
+
+        public KeyVaultSecret GetSecretByName(string secretName)
         {
-            return _keyVaultClient.GetSecretAsync(secretUrl).GetAwaiter().GetResult();
+            return _secretClient.GetSecret(secretName).Value;
         }
 
-        public SecretBundle GetSecretByName(
-            string secretName, 
-            string keyVaultAddress = KeyVaultInstance.MSIDLab)
+        public KeyVaultSecret GetSecretByName(string secretName, string secretVersion)
         {
-            return _keyVaultClient.GetSecretAsync(
-                keyVaultAddress, 
-                secretName).GetAwaiter().GetResult();
+            return _secretClient.GetSecret(secretName, secretVersion).Value;
         }
 
-        public async Task<X509Certificate2> GetCertificateWithPrivateMaterialAsync(
-            string certName, 
-            string keyVaultAddress = KeyVaultInstance.MSIDLab)
+        public async Task<X509Certificate2> GetCertificateWithPrivateMaterialAsync(string certName)
         {
-            SecretBundle secret = await _keyVaultClient.GetSecretAsync(keyVaultAddress, certName).ConfigureAwait(false);
-            X509Certificate2 certificate = new X509Certificate2(Convert.FromBase64String(secret.Value));
-            return certificate;
+            return await _certificateClient.DownloadCertificateAsync(certName).ConfigureAwait(false);
         }
 
-        private async Task<string> AuthenticationCallbackAsync(string authority, string resource, string scope)
+        private async Task<TokenCredential> GetKeyVaultCredentialAsync()
         {
-            return await LabAuthenticationHelper.GetLabAccessTokenAsync(authority, new[] { resource + "/.default" }).ConfigureAwait(false);
+            var accessToken = await LabAuthenticationHelper.GetLabAccessTokenAsync("https://login.microsoftonline.com/", new[] { "https://vault.azure.net/.default" }).ConfigureAwait(false);
+            return DelegatedTokenCredential.Create((_, __) => accessToken);
         }
 
         public void Dispose()
         {
-            _keyVaultClient?.Dispose();
             GC.SuppressFinalize(this);
         }
     }
-
 }

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/LabAuthenticationHelper.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/LabAuthenticationHelper.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Security;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 
@@ -38,7 +36,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
             }
         }
 
-        public static async Task<string> GetAccessTokenForLabAPIAsync(string labAccessClientId, string labAccessSecret)
+        public static async Task<AccessToken> GetAccessTokenForLabAPIAsync(string labAccessClientId, string labAccessSecret)
         {
             string[] scopes = new string[] { "https://msidlab.com/.default" };
 
@@ -51,7 +49,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
                 labAccessSecret).ConfigureAwait(false);
         }
 
-        public static async Task<string> GetLabAccessTokenAsync(string authority, string[] scopes)
+        public static async Task<AccessToken> GetLabAccessTokenAsync(string authority, string[] scopes)
         {
             return await GetLabAccessTokenAsync(
                 authority,
@@ -62,7 +60,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
                 String.Empty).ConfigureAwait(false);
         }
 
-        public static async Task<string> GetLabAccessTokenAsync(string authority, string[] scopes, LabAccessAuthenticationType authType, string clientId, string certThumbprint, string clientSecret)
+        public static async Task<AccessToken> GetLabAccessTokenAsync(string authority, string[] scopes, LabAccessAuthenticationType authType, string clientId, string certThumbprint, string clientSecret)
         {
             AuthenticationResult authResult;
             IConfidentialClientApplication confidentialApp;
@@ -128,7 +126,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
                     throw new ArgumentOutOfRangeException();
             }
 
-            return authResult?.AccessToken;
+            return new AccessToken(authResult.AccessToken, authResult.ExpiresOn);
         }
     }
 

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/LabServiceApi.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/LabServiceApi.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Azure.Core;
 using Newtonsoft.Json;
 
 namespace Microsoft.Identity.Test.LabInfrastructure
@@ -18,7 +19,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
     {
         private string _labAccessAppId;
         private string _labAccessClientSecret;
-        private string _labApiAccessToken;
+        private AccessToken? _labApiAccessToken;
 
         public LabServiceApi()
         {
@@ -140,12 +141,12 @@ namespace Microsoft.Identity.Test.LabInfrastructure
 
         internal async Task<string> GetLabResponseAsync(string address)
         {
-            if (string.IsNullOrWhiteSpace(_labApiAccessToken))
+            if (_labApiAccessToken == null)
                 _labApiAccessToken = await LabAuthenticationHelper.GetAccessTokenForLabAPIAsync(_labAccessAppId, _labAccessClientSecret).ConfigureAwait(false);
 
             using (HttpClient httpClient = new HttpClient())
             {
-                httpClient.DefaultRequestHeaders.Add("Authorization", string.Format(CultureInfo.InvariantCulture, "bearer {0}", _labApiAccessToken));
+                httpClient.DefaultRequestHeaders.Add("Authorization", string.Format(CultureInfo.InvariantCulture, "bearer {0}", _labApiAccessToken.Value.Token));
                 return await httpClient.GetStringAsync(address).ConfigureAwait(false);
             }
         }

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/LabUserHelper.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/LabUserHelper.cs
@@ -14,11 +14,13 @@ namespace Microsoft.Identity.Test.LabInfrastructure
         private static readonly IDictionary<UserQuery, LabResponse> s_userCache =
             new Dictionary<UserQuery, LabResponse>();
 
-        public static KeyVaultSecretsProvider KeyVaultSecretsProvider { get; }
+        public static KeyVaultSecretsProvider KeyVaultSecretsProviderMsal { get; }
+        public static KeyVaultSecretsProvider KeyVaultSecretsProviderMsid { get; }
 
         static LabUserHelper()
         {
-            KeyVaultSecretsProvider = new KeyVaultSecretsProvider();
+            KeyVaultSecretsProviderMsal = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
+            KeyVaultSecretsProviderMsid = new KeyVaultSecretsProvider(KeyVaultInstance.MSIDLab);
             s_labService = new LabServiceApi();
         }
 
@@ -135,7 +137,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
                 throw new InvalidOperationException("Error: lab name is not set on user. Password retrieval failed.");
             }
 
-            if (KeyVaultSecretsProvider == null)
+            if (KeyVaultSecretsProviderMsid == null || KeyVaultSecretsProviderMsal == null)
             {
                 throw new InvalidOperationException("Error: KeyVault secrets provider is not set");
             }

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/Microsoft.Identity.Test.LabInfrastructure.csproj
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/Microsoft.Identity.Test.LabInfrastructure.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.3.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
**Changes proposed in this request**
- Replace obsolete Microsoft.Azure.KeyVault with Azure.Security.KeyVault.* libraries
- As long as the integration tests pass, this seems like a low risk PR. Only test projects changed.

**Testing**
- We'll see when Integration tests run :)
