### PR TITLE
Remove some build warnings (#3444)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,6 @@
          For clarity, without PrivateAssets marked here, anyone consuming Microsoft.Identity.Client
          would also be forced to install these dependencies.  PrivateAssets avoids this problem. -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project> 

--- a/tests/Microsoft.Identity.Test.Common/Microsoft.Identity.Test.Common.csproj
+++ b/tests/Microsoft.Identity.Test.Common/Microsoft.Identity.Test.Common.csproj
@@ -19,7 +19,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
-  </ItemGroup>
 </Project>

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/Microsoft.Identity.Test.LabInfrastructure.csproj
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/Microsoft.Identity.Test.LabInfrastructure.csproj
@@ -23,8 +23,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
-  </ItemGroup>
 </Project>

--- a/tests/devapps/WAM/NetDesktopWpf/MainWindow.xaml.cs
+++ b/tests/devapps/WAM/NetDesktopWpf/MainWindow.xaml.cs
@@ -197,7 +197,7 @@ namespace NetDesktopWpf
                    });
         }
 
-        private async void ClearCache(object sender, RoutedEventArgs e)
+        private void ClearCache(object sender, RoutedEventArgs e)
         {
 
         }

--- a/tests/devapps/XamarinDev/XamarinDev/CachePage.xaml.cs
+++ b/tests/devapps/XamarinDev/XamarinDev/CachePage.xaml.cs
@@ -20,7 +20,7 @@ namespace XamarinDev
             InitializeComponent();
         }
 
-        private async Task RefreshCacheViewAsync()
+        private Task RefreshCacheViewAsync()
         {
             var tokenCache = App.MsalPublicClient.UserTokenCacheInternal;
 
@@ -51,6 +51,7 @@ namespace XamarinDev
                 accounts.Add(accountItem.GetKey().ToString(), accountItem);
             }
             accountsCacheItems.ItemsSource = accounts;
+            return Task.CompletedTask;
         }
 
         protected override async void OnAppearing()


### PR DESCRIPTION
Merges https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/3444 into main after tests are run.