### PR TITLE
WAM Dev app Perf test update

### DIFF
--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -80,7 +80,14 @@ namespace NetDesktopWinForms
         private AuthMethod GetAuthMethod()
         {
             AuthMethod status;
-            if (Enum.TryParse<AuthMethod>(cbxUseWam.SelectedValue.ToString(), out status))
+            string result = string.Empty;
+
+            cbxUseWam.Invoke((MethodInvoker)delegate
+            {
+                result = cbxUseWam.Text;
+            });
+
+            if (Enum.TryParse<AuthMethod>(result, out status))
             {
                 return status;
             }
@@ -193,7 +200,9 @@ namespace NetDesktopWinForms
         {
             string reqAuthority = pca.Authority;
             string loginHint = GetLoginHint();
-            if (!string.IsNullOrEmpty(loginHint) && cbxAccount.SelectedIndex > 0)
+            IAccount acc = GetAccount();
+
+            if (!string.IsNullOrEmpty(loginHint) && (acc != null))
             {
                 throw new InvalidOperationException("[TEST APP FAILURE] Please use either the login hint or the account");
             }
@@ -218,11 +227,8 @@ namespace NetDesktopWinForms
                 return await builder.ExecuteAsync().ConfigureAwait(false);
             }
 
-            if (cbxAccount.SelectedItem != null &&
-                (cbxAccount.SelectedItem as AccountModel).Account != s_nullAccount)
+            if (acc != null)
             {
-                var acc = GetAccount();
-
                 var builder = pca.AcquireTokenSilent(GetScopes(), acc);
                 if (IsMsaPassthroughConfigured() && (GetAuthMethod() == AuthMethod.SystemBrowser || GetAuthMethod() == AuthMethod.EmbeddedBrowser))
                 {
@@ -314,9 +320,9 @@ namespace NetDesktopWinForms
             Log(message);
 
             await _syncContext;
-            
+
             Log("Refreshing accounts");
-            
+
             if(refresAccounts)
                 await RefreshAccountsAsync().ConfigureAwait(true);
         }
@@ -417,8 +423,11 @@ namespace NetDesktopWinForms
         private IAccount GetAccount()
         {
             IAccount acc = null;
-            loginHintTxt.Invoke((MethodInvoker)delegate
+            cbxAccount.Invoke((MethodInvoker)delegate
             {
+                if (cbxAccount.SelectedIndex <= 0)
+                    return;
+
                 acc = (cbxAccount.SelectedItem as AccountModel).Account;
             });
 
@@ -640,6 +649,7 @@ namespace NetDesktopWinForms
             try
             {
                 //Old Broker
+                btnExpire_Click(sender, e);
                 var pca = CreatePca(AuthMethod.WAM);
                 brokerTimer.Start();
                 AuthenticationResult result1 = await RunAtsAsync(pca).ConfigureAwait(false);
@@ -651,6 +661,7 @@ namespace NetDesktopWinForms
                 Log("---------------------------------------- ");
 
                 //New Broker
+                btnExpire_Click(sender, e);
                 pca = CreatePca(AuthMethod.WAMRuntime);
                 brokerTimer.Reset();
                 brokerTimer.Start();


### PR DESCRIPTION
Fixes # 

**Changes proposed in this request**
Clearing the cache for the WAM perf test so the calls are made to the broker every time

**Testing**
used the app 

**Performance impact**
none
