### PR TITLE
Remove build warnings, consolidate Package versions

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
@@ -73,7 +73,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>  
 
 </Project>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -293,7 +293,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tests/CacheCompat/CommonCache.Test.AdalV3/CommonCache.Test.AdalV3.csproj
+++ b/tests/CacheCompat/CommonCache.Test.AdalV3/CommonCache.Test.AdalV3.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="System.Linq.Expressions" version="4.1.0" />
     <PackageReference Include="System.Reflection" version="4.1.0" />
     <PackageReference Include="System.Reflection.Extensions" version="4.0.1" />
-    <PackageReference Include="System.Reflection.TypeExtensions" version="4.1.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" version="4.7.0" />
     <PackageReference Include="System.Resources.ResourceManager" version="4.0.1" />
     <PackageReference Include="System.Runtime" version="4.1.0" />
     <PackageReference Include="System.Runtime.Extensions" version="4.1.0" />

--- a/tests/CacheCompat/CommonCache.Test.AdalV4/CommonCache.Test.AdalV4.csproj
+++ b/tests/CacheCompat/CommonCache.Test.AdalV4/CommonCache.Test.AdalV4.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="System.Linq.Expressions" version="4.1.0" />
     <PackageReference Include="System.Reflection" version="4.1.0" />
     <PackageReference Include="System.Reflection.Extensions" version="4.0.1" />
-    <PackageReference Include="System.Reflection.TypeExtensions" version="4.1.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" version="4.7.0" />
     <PackageReference Include="System.Resources.ResourceManager" version="4.0.1" />
     <PackageReference Include="System.Runtime" version="4.1.0" />
     <PackageReference Include="System.Runtime.Extensions" version="4.1.0" />

--- a/tests/CacheCompat/CommonCache.Test.AdalV5/CommonCache.Test.AdalV5.csproj
+++ b/tests/CacheCompat/CommonCache.Test.AdalV5/CommonCache.Test.AdalV5.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\CommonCache.Test.Common\CommonCache.Test.Common.csproj" />
     <PackageReference Include="CommandLineParser" version="2.4.3" />
     <PackageReference Include="Newtonsoft.Json" version="13.0.1" />    
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
   </ItemGroup>
 </Project>

--- a/tests/CacheCompat/CommonCache.Test.Unit/CommonCache.Test.Unit.csproj
+++ b/tests/CacheCompat/CommonCache.Test.Unit/CommonCache.Test.Unit.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/tests/Microsoft.Identity.Test.Common/Microsoft.Identity.Test.Common.csproj
+++ b/tests/Microsoft.Identity.Test.Common/Microsoft.Identity.Test.Common.csproj
@@ -5,10 +5,14 @@
     <AssemblyName>Microsoft.Identity.Test.Common</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.0.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />

--- a/tests/Microsoft.Identity.Test.Integration.Win8/Microsoft.Identity.Test.Integration.Win8.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.Win8/Microsoft.Identity.Test.Integration.Win8.csproj
@@ -19,9 +19,9 @@
       <Name>Microsoft.Identity.Test.LabInfrastructure</Name>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <!-- This reference is a workaround for a bug in .net46
     https://stackoverflow.com/questions/45563560/could-not-load-file-or-assembly-system-net-http-version-4-1-1-1-net-standard-->

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
@@ -19,9 +19,9 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.15.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.15.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
@@ -33,6 +33,7 @@
     <PackageReference Include="StrongNamer">
       <Version>0.2.5</Version>
     </PackageReference>
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
 
   </ItemGroup>

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Microsoft.Identity.Test.Integration.NetFx.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Microsoft.Identity.Test.Integration.NetFx.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.15.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.15.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />

--- a/tests/Microsoft.Identity.Test.Performance/Microsoft.Identity.Test.Performance.csproj
+++ b/tests/Microsoft.Identity.Test.Performance/Microsoft.Identity.Test.Performance.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
+    <PackageReference Include="System.CodeDom" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -20,10 +20,14 @@
     <ProjectReference Include="..\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
     <!-- This reference is a workaround for a bug in .net46
     https://stackoverflow.com/questions/45563560/could-not-load-file-or-assembly-system-net-http-version-4-1-1-1-net-standard-->

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.IsNotNull(result);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
                 Assert.IsTrue(!string.IsNullOrEmpty(result.AccessToken));
-                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
+                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count);
 
                 // Assert - orchestration
 #pragma warning disable VSTHRD101 // Avoid unsupported async delegates
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.IsNotNull(result);
                 Assert.AreEqual(TokenSource.Broker, result.AuthenticationResultMetadata.TokenSource);
                 Assert.IsTrue(!string.IsNullOrEmpty(result.AccessToken));
-                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
+                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count);
 
                 // Assert - orchestration
                 await _brokerExchangeComponentOverride
@@ -210,7 +210,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 // Assert - common stuff
                 Assert.IsNotNull(result);
                 Assert.IsTrue(!string.IsNullOrEmpty(result.AccessToken));
-                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
+                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count);
 
                 // Assert - orchestration
 
@@ -279,7 +279,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 // Assert - common stuff
                 Assert.IsNotNull(result);
                 Assert.IsTrue(!string.IsNullOrEmpty(result.AccessToken));
-                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
+                Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count);
 
                 // Assert - orchestration
 #pragma warning disable VSTHRD101 // Avoid unsupported async delegates

--- a/tests/Microsoft.Identity.Test.iOS.UIAutomation/Microsoft.Identity.Test.iOS.UIAutomation.csproj
+++ b/tests/Microsoft.Identity.Test.iOS.UIAutomation/Microsoft.Identity.Test.iOS.UIAutomation.csproj
@@ -29,11 +29,6 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>5.0.3</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>

--- a/tests/devapps/RegionalTestApp/RegionalTestApp.csproj
+++ b/tests/devapps/RegionalTestApp/RegionalTestApp.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
     <ProjectReference Include="..\..\Microsoft.Identity.Test.Integration.netcore\Microsoft.Identity.Test.Integration.NetCore.csproj" />
   </ItemGroup>

--- a/tests/devapps/XForms/XForms/XForms.csproj
+++ b/tests/devapps/XForms/XForms/XForms.csproj
@@ -10,7 +10,7 @@
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="StrongNamer" Version="0.0.8">
+    <PackageReference Include="StrongNamer" Version="0.2.5">
     </PackageReference>
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.7.0.1351" />


### PR DESCRIPTION
Working on #2912 
- Consolidate some low-risk libraries and/or only Test projects
- Removing build warnings
- Add NSubstitute.Analyzers (as per NSub Docs best practices)
  - Note: This adds some NSub specific warnings for things that don't seem to be done "correctly"