### PR TITLE
Unify licenses for IDE0073 warning

### DIFF
--- a/src/client/Microsoft.Identity.Client.Desktop/DesktopExtensions.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/DesktopExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
 
 namespace Microsoft.Identity.Client.Desktop
 {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Identity.Client.Core;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client.Core;
 
 namespace Microsoft.Identity.Client.ApiConfig.Parameters
 {

--- a/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Threading;
 namespace Microsoft.Identity.Client
 {

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/JWKConstants.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/JWKConstants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/client/Microsoft.Identity.Client/Cache/CacheImpl/ICacheSerializationProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheImpl/ICacheSerializationProvider.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.;
+// Licensed under the MIT License.
 
 namespace Microsoft.Identity.Client.Cache.CacheImpl
 {

--- a/src/client/Microsoft.Identity.Client/Instance/Region/RegionAutodetectionSource.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/RegionAutodetectionSource.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.;
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/client/Microsoft.Identity.Client/Instance/Region/RegionOutcome.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/RegionOutcome.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.;
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/client/Microsoft.Identity.Client/IntuneAppProtectionPolicyRequiredException.cs
+++ b/src/client/Microsoft.Identity.Client/IntuneAppProtectionPolicyRequiredException.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 namespace Microsoft.Identity.Client
 {
     /// <summary>

--- a/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/Kerberos/TicketCacheWriter.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DesktopOS/Kerberos/TicketCacheWriter.cs
@@ -1,4 +1,4 @@
-﻿// -// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/Interfaces/IWebTokenRequestResultWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/Interfaces/IWebTokenRequestResultWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Windows.Security.Authentication.Web.Core;
 
 namespace Microsoft.Identity.Client.Platforms.Features.WamBroker

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WebTokenRequestResultWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WebTokenRequestResultWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/win32/Splash.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/win32/Splash.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.	// Licensed under the MIT License.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/win32/Win32Window.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/win32/Win32Window.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.	// Licensed under the MIT License.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Http/EndpointCacheKey.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Http/EndpointCacheKey.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Identity.Client.Platforms.net45.Http

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Native/ICngAlgorithm.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/Native/ICngAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿//--------// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Security.Cryptography;

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/NullLegacyCachePersistence.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/NullLegacyCachePersistence.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Identity.Client.Cache;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client.Cache;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/PKeyAuthConstants.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/PKeyAuthConstants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/client/Microsoft.Identity.Client/json/.editorconfig
+++ b/src/client/Microsoft.Identity.Client/json/.editorconfig
@@ -1,0 +1,7 @@
+﻿# Code files
+[*.{cs,vb}]
+
+#### Diagnostic configuration ####
+
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = none


### PR DESCRIPTION
Working on https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/2912

Not the most glamurous, but reduces analyzer warnings :)