### PR TITLE
Add MSALRuntime TelemetryData to verbose logging when an exception is thrown

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Identity.Client.Broker
             long errorCode = authResult.Error.ErrorCode;
             string errorMessage;
 
+            logger.Info("[WamBroker] Processing WAM exception");
+            logger.Verbose($"[WamBroker] TelemetryData: {authResult.TelemetryData}");
+
             switch ((ResponseStatus)authResult.Error.Status)
             {
                 case ResponseStatus.UserCanceled:


### PR DESCRIPTION
Fixes #3585

**Changes proposed in this request**
Add MSALRuntime TelemetryData to verbose logging when an exception is thrown

**Testing**
Dev Apps

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
