### PR TITLE
Automatically handle the case when `loginHint`== OperatingSystemAccount

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -10,7 +10,6 @@ using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.PlatformsCommon.Shared;
 
 namespace Microsoft.Identity.Client.Internal.Requests.Silent
 {

--- a/tests/devapps/WAM/NetFrameworkWam/Program.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Windows.Forms;
 using Microsoft.Identity.Client.NativeInterop;
 


### PR DESCRIPTION

Fixes #3200


**Changes proposed in this request**
If the loginHint is the current user, then don't just check the cache - actually use the current user account.

**Testing**
I ran the broker test app.

**Performance impact**
I didn't do perf testing.

**Documentation**
I'm not sure which documentation should be updated.
