### PR TITLE
Update Microsoft.Identity.Client.NativeInterop reference to 0.12.1

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.11.1" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.12.1" />
     <ProjectReference Include="..\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
   </ItemGroup>
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">


### PR DESCRIPTION
Fixes #3612 

**Changes proposed in this request**
Fixes a bug where netstandard2.0 support was dropped for Interop. [Interop fix PR here](https://github.com/AzureAD/microsoft-authentication-library-for-cpp/pull/3067)

**Testing**
Dev Apps

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
