### PR TITLE
Update Microsoft.Identity.Client.NativeInterop to Version 0.12.2

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.12.1" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.12.2" />
     <ProjectReference Include="..\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
   </ItemGroup>
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">


### PR DESCRIPTION
Fixes # [Bug 1858419](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1858419) [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604) [3612](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3612)

**Changes proposed in this request**
Update to Microsoft.Identity.Client.NativeInterop Version 0.12.2, this fixes a few msal runtime bugs 

- [Bug 1858419](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1858419): [Tracking] Error when calling SignInInteractively twice


**Testing**
Dev Apps (WPF, Net Core, Net FWK)

**More on testing :** Tested with the WPF app where the 2nd interactive request will fail with the "Unexpected exception while waiting for accounts control to finish: '(pii)'" exception. I am not able to repro this issue in the WPF app with the 0.12.2 version of the Interop

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
