### PR TITLE
Updated Changelog for MSAL 4.46.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 
 ### New Features
 - Added .NET 4.5 support for new MSAL WAM preview. See [#3539](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3539)
-- Logging additional exceptions to telemetry. See [#3547](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3547)
 
 ### Bug Fixes
 - Fixed 'Authenticator Factory has already been started` exception in new MSAL WAM preview. See [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604)
 - Added back missing .NET Standard 2.0 target to MSAL.NativeInterop package. See [#3612](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3612)
 - [Resilience] Changed to an improved implementation of HTTP client factory on .NET Framework to improve resiliency (for ex. by reducing the amount of request timeouts). See [#3546](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3546)
+- Logging additional exceptions to telemetry. See [#3547](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3547)
 
 4.46.1
 ==========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 - Fixed 'Authenticator Factory has already been started` exception in new MSAL WAM preview. See [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604)
 - Added back missing .NET Standard 2.0 target to MSAL.NativeInterop package. See [#3612](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3612)
+- [Resilience] Changed to an improved implementation of HTTP client factory on .NET Framework to improve resiliency (for ex. by reducing the amount of request timeouts). See [#3546](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3546)
 
 4.46.1
 ==========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ==========
 
 ### New Features
-- Added .NET 4.5 support for new MSAL WAM preview. See [#3539](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3539)
+- WAM Authentication Library now explicitly supports .NET 4.6.2. See [#3539](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3539)
 
 ### Bug Fixes
 - Fixed 'Authenticator Factory has already been started` exception in new MSAL WAM preview. See [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+4.46.2
+==========
+
+### New Features
+- WAM Authentication Library Should Support .NET 4.5 for Back Compatibility. See [#3539](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3539)
+- Log exceptions which are not converted to MsalExceptions to telemetry. See [#3547](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3547)
+
+### Bug Fixes
+- Authenticator Factory has already been started. See [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604)
+- MSAL.NativeInterop only targets .net fwk See [#3612](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3612)
+
 4.46.1
 ==========
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 ==========
 
 ### New Features
-- WAM Authentication Library Should Support .NET 4.5 for Back Compatibility. See [#3539](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3539)
-- Log exceptions which are not converted to MsalExceptions to telemetry. See [#3547](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3547)
+- Added .NET 4.5 support for new MSAL WAM preview. See [#3539](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3539)
+- Logging additional exceptions to telemetry. See [#3547](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3547)
 
 ### Bug Fixes
-- Authenticator Factory has already been started. See [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604)
-- MSAL.NativeInterop only targets .net fwk See [#3612](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3612)
+- Fixed 'Authenticator Factory has already been started` exception in new MSAL WAM preview. See [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604)
+- Added back missing .NET Standard 2.0 target to MSAL.NativeInterop package. See [#3612](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3612)
 
 4.46.1
 ==========


### PR DESCRIPTION
**Updated Changelog for MSAL 4.46.2**

[Feature Request] WAM Authentication Library Should Support .NET 4.5 for Back Compatibility. See [#3539](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3539)
Log exceptions which are not converted to MsalExceptions to telemetry. See [#3547](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3547)

[Bug]Authenticator Factory has already been started. See [#3604](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3604)
[Bug] MSAL.NativeInterop only targets .net fwk. See [#3612](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3612)

Fixes #

**Changes proposed in this request**
changelog update

**Testing**
N/A

**Performance impact**
N/A

**Documentation**
- [ ] All relevant documentation is updated.
