### PR TITLE
Move the api for ITelemetryClient to Confidential Client app

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -542,38 +542,6 @@ namespace Microsoft.Identity.Client
             return (T)this;
         }
 
-        /// <summary>
-        /// Sets telemetry client for the application.
-        /// </summary>
-        /// <param name="telemetryClients">List of telemetry clients to add telemetry logs.</param>
-        /// <returns>The builder to chain the .With methods</returns>
-        public T WithTelemetryClient(params ITelemetryClient[] telemetryClients)
-        {
-            ValidateUseOfExperimentalFeature("ITelemetryClient");
-
-            if (telemetryClients == null)
-            {
-                throw new ArgumentNullException(nameof(telemetryClients));
-            }
-
-            if (telemetryClients.Length > 0)
-            {
-                foreach (var telemetryClient in telemetryClients)
-                {
-                    if (telemetryClient == null)
-                    { 
-                        throw new ArgumentNullException(nameof(telemetryClient));
-                    }
-
-                    telemetryClient.Initialize();
-                }
-
-                Config.TelemetryClients = telemetryClients;
-            }
-            
-            return (T)this;
-        }
-
         internal virtual void Validate()
         {
             if (string.IsNullOrWhiteSpace(Config.ClientId))

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.ClientCredential;
+using Microsoft.IdentityModel.Abstractions;
 
 namespace Microsoft.Identity.Client
 {
@@ -310,6 +311,38 @@ namespace Microsoft.Identity.Client
         public ConfidentialClientApplicationBuilder WithCacheSynchronization(bool enableCacheSynchronization)
         {
             Config.CacheSynchronizationEnabled = enableCacheSynchronization;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets telemetry client for the application.
+        /// </summary>
+        /// <param name="telemetryClients">List of telemetry clients to add telemetry logs.</param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public ConfidentialClientApplicationBuilder WithTelemetryClient(params ITelemetryClient[] telemetryClients)
+        {
+            ValidateUseOfExperimentalFeature("ITelemetryClient");
+
+            if (telemetryClients == null)
+            {
+                throw new ArgumentNullException(nameof(telemetryClients));
+            }
+
+            if (telemetryClients.Length > 0)
+            {
+                foreach (var telemetryClient in telemetryClients)
+                {
+                    if (telemetryClient == null)
+                    {
+                        throw new ArgumentNullException(nameof(telemetryClient));
+                    }
+
+                    telemetryClient.Initialize();
+                }
+
+                Config.TelemetryClients = telemetryClients;
+            }
+
             return this;
         }
 


### PR DESCRIPTION
Fixes #
Move .WithTelemetryClient() api to ConfidentialCLientApplicationBuilder

**Changes proposed in this request**
Move .WithTelemetryClient() api to ConfidentialCLientApplicationBuilder

**Testing**
Updated the unit tests

**Performance impact**


**Documentation**
- [x] All relevant documentation is updated.
