### PR TITLE
[WAM Broker] Check if scopes are passed when broker is invoked

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -109,7 +109,10 @@ namespace Microsoft.Identity.Client.Broker
 
             if (authenticationRequestParameters?.Account?.HomeAccountId?.ObjectId != null)
             {
-                using (var authParams = WamAdapters.GetCommonAuthParameters(authenticationRequestParameters, _wamOptions.MsaPassthrough))
+                using (var authParams = WamAdapters.GetCommonAuthParameters(
+                    authenticationRequestParameters, 
+                    _wamOptions.MsaPassthrough, 
+                    _logger))
                 {
                     using (var readAccountResult = await s_lazyCore.Value.ReadAccountByIdAsync(
                     authenticationRequestParameters.Account.HomeAccountId.ObjectId,
@@ -161,7 +164,10 @@ namespace Microsoft.Identity.Client.Broker
             var cancellationToken = authenticationRequestParameters.RequestContext.UserCancellationToken;
             Debug.Assert(s_lazyCore.Value != null, "Should not call this API if msal runtime init failed");
 
-            using (var authParams = WamAdapters.GetCommonAuthParameters(authenticationRequestParameters, _wamOptions.MsaPassthrough))
+            using (var authParams = WamAdapters.GetCommonAuthParameters(
+                authenticationRequestParameters, 
+                _wamOptions.MsaPassthrough,
+                _logger))
             {
                 //Login Hint
                 string loginHint = authenticationRequestParameters.LoginHint ?? authenticationRequestParameters?.Account?.Username;
@@ -193,7 +199,10 @@ namespace Microsoft.Identity.Client.Broker
 
             _logger.Verbose("[WamBroker] Signing in with the default user account.");
 
-            using (var authParams = WamAdapters.GetCommonAuthParameters(authenticationRequestParameters, _wamOptions.MsaPassthrough))
+            using (var authParams = WamAdapters.GetCommonAuthParameters(
+                authenticationRequestParameters, 
+                _wamOptions.MsaPassthrough,
+                _logger))
             {
                 using (NativeInterop.AuthResult result = await s_lazyCore.Value.SignInAsync(
                         _parentHandle,
@@ -230,7 +239,10 @@ namespace Microsoft.Identity.Client.Broker
 
             _logger.Verbose("[WamBroker] Acquiring token silently.");
 
-            using (var authParams = WamAdapters.GetCommonAuthParameters(authenticationRequestParameters, _wamOptions.MsaPassthrough))
+            using (var authParams = WamAdapters.GetCommonAuthParameters(
+                authenticationRequestParameters, 
+                _wamOptions.MsaPassthrough,
+                _logger))
             {
                 using (var readAccountResult = await s_lazyCore.Value.ReadAccountByIdAsync(
                     acquireTokenSilentParameters.Account.HomeAccountId.ObjectId,
@@ -274,7 +286,10 @@ namespace Microsoft.Identity.Client.Broker
 
             _logger.Verbose("[WamBroker] Acquiring token silently for default account.");
 
-            using (var authParams = WamAdapters.GetCommonAuthParameters(authenticationRequestParameters, _wamOptions.MsaPassthrough))
+            using (var authParams = WamAdapters.GetCommonAuthParameters(
+                authenticationRequestParameters, 
+                _wamOptions.MsaPassthrough,
+                _logger))
             {
                 using (NativeInterop.AuthResult result = await s_lazyCore.Value.SignInSilentlyAsync(
                         authParams,
@@ -300,7 +315,10 @@ namespace Microsoft.Identity.Client.Broker
 
             _logger.Verbose("[WamBroker] Acquiring token with Username Password flow.");
 
-            using (AuthParameters authParams = WamAdapters.GetCommonAuthParameters(authenticationRequestParameters, _wamOptions.MsaPassthrough))
+            using (AuthParameters authParams = WamAdapters.GetCommonAuthParameters(
+                authenticationRequestParameters, 
+                _wamOptions.MsaPassthrough,
+                _logger))
             {
                 authParams.Properties["MSALRuntime_Username"] = acquireTokenByUsernamePasswordParameters.Username;
                 authParams.Properties["MSALRuntime_Password"] = acquireTokenByUsernamePasswordParameters.Password;
@@ -424,7 +442,7 @@ namespace Microsoft.Identity.Client.Broker
                 return false;
             }
 
-            _logger.Verbose($"[WAM Broker] MsalRuntime init succesful.");
+            _logger.Verbose($"[WAM Broker] MsalRuntime init successful.");
             return true;
         }
     }

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Identity.Client.Broker
             bool isMsaPassthrough,
             ILoggerAdapter logger)
         {
-            logger.Info("[WamBroker] Validating Common Auth Parameters.");
+            logger.Verbose("[WamBroker] Validating Common Auth Parameters.");
             ValidateAuthParams(authenticationRequestParameters, logger);
 
             var authParams = new NativeInterop.AuthParameters
@@ -176,7 +176,7 @@ namespace Microsoft.Identity.Client.Broker
 
             AddPopParams(authenticationRequestParameters, authParams);
 
-            logger.Info("[WamBroker] Acquired Common Auth Parameters.");
+            logger.Verbose("[WamBroker] Acquired Common Auth Parameters.");
 
             return authParams;
         }

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -299,18 +299,16 @@ namespace Microsoft.Identity.Client.Broker
             AuthenticationRequestParameters authenticationRequestParameters,
             ILoggerAdapter logger)
         {
-            string[] oidcScopes = { "offline_access", "openid", "profile" };
-
             //MSAL Runtime throws an ApiContractViolation Exception with Tag: 0x2039c1cb (InvalidArg)
             //When no scopes are passed, this will check if user is passing scopes
-            if (!authenticationRequestParameters.HasScopes || authenticationRequestParameters.Scope.All(oidcScopes.Contains))
+            if (!authenticationRequestParameters.HasScopes)
             {
                 logger.Error($"[WamBroker] {MsalError.WamScopesRequired} " +
-                    $"{MsalErrorMessage.WamScopesRequired}");
+                    $"{MsalErrorMessage.ScopesRequired}");
 
                 throw new MsalClientException(
                     MsalError.WamScopesRequired,
-                    MsalErrorMessage.WamScopesRequired);
+                    MsalErrorMessage.ScopesRequired);
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -299,16 +299,18 @@ namespace Microsoft.Identity.Client.Broker
             AuthenticationRequestParameters authenticationRequestParameters,
             ILoggerAdapter logger)
         {
+            string[] oidcScopes = { "offline_access", "openid", "profile" };
+
             //MSAL Runtime throws an ApiContractViolation Exception with Tag: 0x2039c1cb (InvalidArg)
             //When no scopes are passed, this will check if user is passing scopes
-            if (!authenticationRequestParameters.HasScopes)
+            if (!authenticationRequestParameters.HasScopes || authenticationRequestParameters.Scope.All(oidcScopes.Contains))
             {
                 logger.Error($"[WamBroker] {MsalError.WamScopesRequired} " +
-                    $"{MsalErrorMessage.ScopesRequired}");
+                    $"{MsalErrorMessage.WamScopesRequired}");
 
                 throw new MsalClientException(
                     MsalError.WamScopesRequired,
-                    MsalErrorMessage.ScopesRequired);
+                    MsalErrorMessage.WamScopesRequired);
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -130,10 +130,15 @@ namespace Microsoft.Identity.Client.Broker
         /// </summary>
         /// <param name="authenticationRequestParameters"></param>
         /// <param name="isMsaPassthrough"></param>
+        /// <param name="logger"></param>
         public static NativeInterop.AuthParameters GetCommonAuthParameters(
             AuthenticationRequestParameters authenticationRequestParameters, 
-            bool isMsaPassthrough)
+            bool isMsaPassthrough,
+            ILoggerAdapter logger)
         {
+            logger.Info("[WamBroker] Validating Common Auth Parameters.");
+            ValidateAuthParams(authenticationRequestParameters, logger);
+
             var authParams = new NativeInterop.AuthParameters
                 (authenticationRequestParameters.AppConfig.ClientId,
                 authenticationRequestParameters.Authority.AuthorityInfo.CanonicalAuthority.ToString());
@@ -170,6 +175,8 @@ namespace Microsoft.Identity.Client.Broker
             }
 
             AddPopParams(authenticationRequestParameters, authParams);
+
+            logger.Info("[WamBroker] Acquired Common Auth Parameters.");
 
             return authParams;
         }
@@ -280,6 +287,29 @@ namespace Microsoft.Identity.Client.Broker
         private static string GetExpectedRedirectUri(string clientId)
         {
             return $"ms-appx-web://microsoft.aad.brokerplugin/{clientId}";
+        }
+
+        /// <summary>
+        /// Validate common auth params
+        /// </summary>
+        /// <param name="authenticationRequestParameters"></param>
+        /// <param name="logger"></param>
+        /// <exception cref="MsalClientException"></exception>
+        public static void ValidateAuthParams(
+            AuthenticationRequestParameters authenticationRequestParameters,
+            ILoggerAdapter logger)
+        {
+            //MSAL Runtime throws an ApiContractViolation Exception with Tag: 0x2039c1cb (InvalidArg)
+            //When no scopes are passed, this will check if user is passing scopes
+            if (!authenticationRequestParameters.HasScopes)
+            {
+                logger.Error($"[WamBroker] {MsalError.WamScopesRequired} " +
+                    $"{MsalErrorMessage.ScopesRequired}");
+
+                throw new MsalClientException(
+                    MsalError.WamScopesRequired,
+                    MsalErrorMessage.ScopesRequired);
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1017,6 +1017,12 @@ namespace Microsoft.Identity.Client
         public const string WamPickerError = "wam_interactive_picker_error";
 
         /// <summary>
+        /// <para>What happens?</para>No scopes have been requested
+        /// <para>Mitigation</para>At least one scope must be specified for MSAL Runtime WAM
+        /// </summary>
+        public const string WamScopesRequired = "scopes_required_wam";
+
+        /// <summary>
         /// <para>What happens?</para>The embedded browser cannot be started because a runtime component is missing.
         /// <para>Mitigation</para>"The embedded browser needs WebView2 runtime to be installed. An end user of the app can download and install the WebView2 runtime from https://go.microsoft.com/fwlink/p/?LinkId=2124703 and restart the app.
         ///  or the app developer can install the WebView2 runtime https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -337,8 +337,6 @@ namespace Microsoft.Identity.Client
             "See https://aka.ms/msal-net-custom-instance-metadata for more details. ";
 
         public const string ScopesRequired = "At least one scope needs to be requested for this authentication flow. ";
-        public const string WamScopesRequired = "At least one resource based scope (For example, scope=User.Read or https://graph.microsoft.com/User.Read) " +
-            "is required to be passed, in addition to any OpenID Connect scopes (openid,  profile, and offline_access)";
         public const string InvalidAdalCacheMultipleRTs = "The ADAL cache is invalid as it contains multiple refresh token entries for one user. Deleting invalid ADAL cache. ";
 
         public const string CryptoNet45 =

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Identity.Client
 
         public const string ScopesRequired = "At least one scope needs to be requested for this authentication flow. ";
         public const string WamScopesRequired = "At least one resource based scope (For example, scope=User.Read or https://graph.microsoft.com/User.Read) " +
-            "is required to be passed in addition to any OpenID Connect scopes (openid,  profile, and offline_access)";
+            "is required to be passed, in addition to any OpenID Connect scopes (openid,  profile, and offline_access)";
         public const string InvalidAdalCacheMultipleRTs = "The ADAL cache is invalid as it contains multiple refresh token entries for one user. Deleting invalid ADAL cache. ";
 
         public const string CryptoNet45 =

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -337,6 +337,8 @@ namespace Microsoft.Identity.Client
             "See https://aka.ms/msal-net-custom-instance-metadata for more details. ";
 
         public const string ScopesRequired = "At least one scope needs to be requested for this authentication flow. ";
+        public const string WamScopesRequired = "At least one resource based scope (For example, scope=User.Read or https://graph.microsoft.com/User.Read) " +
+            "is required to be passed in addition to any OpenID Connect scopes (openid,  profile, and offline_access)";
         public const string InvalidAdalCacheMultipleRTs = "The ADAL cache is invalid as it contains multiple refresh token entries for one user. Deleting invalid ADAL cache. ";
 
         public const string CryptoNet45 =

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
 
             if (resultBundle != null)
             {
-                _logger.Verbose($"[Android broker] Content resolver operation completed succesfully. Operation: {operation} URI: {contentResolverUri}");
+                _logger.Verbose($"[Android broker] Content resolver operation completed successfully. Operation: {operation} URI: {contentResolverUri}");
             }
 
             return resultBundle;

--- a/tests/Microsoft.Identity.Test.Common/Mocks/MsalMockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Mocks/MsalMockHelpers.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Test.Common.Mocks
         }
 
         /// <summary>
-        /// Configures a web ui that returns a succesfull result
+        /// Configures a web ui that returns a successfull result
         /// </summary>
         public static void ConfigureMockWebUI(
             this IServiceBundle serviceBundle, 

--- a/tests/Microsoft.Identity.Test.Unit/Throttling/ThrottlingAcceptanceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/Throttling/ThrottlingAcceptanceTests.cs
@@ -458,7 +458,7 @@ namespace Microsoft.Identity.Test.Unit.Throttling
                 await app.AcquireTokenSilent(singleScope, account).WithForceRefresh(true).ExecuteAsync()
                       .ConfigureAwait(false);
 
-                // there will still be an entry here because the refresh token written by the first succesful ATS
+                // there will still be an entry here because the refresh token written by the first successful ATS
                 // is different from the initial RT
                 AssertThrottlingCacheEntryCount(throttlingManager, uiRequiredEntryCount: 1);
             }

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -273,9 +273,11 @@ namespace NetDesktopWinForms
         private string[] GetScopes()
         {
             string[] result = null;
+
             cbxScopes.Invoke((MethodInvoker)delegate
             {
-                result = cbxScopes.Text.Split(' ');
+                if(!string.IsNullOrWhiteSpace(cbxScopes.Text))
+                    result = cbxScopes.Text.Split(' ');
             });
 
             return result;

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -237,7 +237,8 @@ namespace NetDesktopWinForms
             string[] result = null;
             cbxScopes.Invoke((MethodInvoker)delegate
             {
-                result = cbxScopes.Text.Split(' ');
+                if (!string.IsNullOrWhiteSpace(cbxScopes.Text))
+                    result = cbxScopes.Text.Split(' ');
             });
 
             return result;


### PR DESCRIPTION
Fixes #3654 

**Changes proposed in this request**
- checks if user passes scopes in the request. MSAL Runtime needs scopes to be passed. Else users will hit this issue

`GlobalExceptionHandler: Status: ApiContractViolation
Context: (pii)
Tag: 0x2039c1cb`

- few dev app fixes to test this 
- typos
- more logging

**Testing**
Dev Apps

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
