### PR TITLE
Run .NET 6 unit tests, separate .NET 6 and .NET Core 3.1 integration tests

### DIFF
--- a/build/template-run-integration-tests.yaml
+++ b/build/template-run-integration-tests.yaml
@@ -19,11 +19,25 @@ steps:
     pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to screw something up
 
 - task: VSTest@2
-  displayName: 'Run integration tests (.NET Core)'
+  displayName: 'Run integration tests (.NET Core 3.1)'
   condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
-    testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netcore\bin\**\Microsoft.Identity.Test.Integration.NetCore.dll'
+    testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netcore\bin\**\netcoreapp3.1\Microsoft.Identity.Test.Integration.NetCore.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    rerunFailedTests: true
+    rerunMaxAttempts: '3'
+    runInParallel: false
+    codeCoverageEnabled: true
+    failOnMinTestsNotRun: true
+    minimumExpectedTests: '1'
+
+- task: VSTest@2
+  displayName: 'Run integration tests (.NET 6)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netcore\bin\**\net6.0\Microsoft.Identity.Test.Integration.NetCore.dll'
     searchFolder: '$(System.DefaultWorkingDirectory)'
     rerunFailedTests: true
     rerunMaxAttempts: '3'

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -24,7 +24,7 @@ steps:
   condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
-    testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\netcore3.1\Microsoft.Identity.Test.Unit.dll'
+    testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\netcoreapp3.1\Microsoft.Identity.Test.Unit.dll'
     searchFolder: '$(System.DefaultWorkingDirectory)'
     runInParallel: true
     codeCoverageEnabled: true

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -20,11 +20,23 @@ steps:
     pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to screw something up
 
 - task: VSTest@2
-  displayName: 'Run unit tests (.NET CORE)'
+  displayName: 'Run unit tests (.NET CORE 3.1)'
   condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:
     testSelector: 'testAssemblies'
-    testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\netcore*\Microsoft.Identity.Test.Unit.dll'
+    testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\netcore3.1\Microsoft.Identity.Test.Unit.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    runInParallel: true
+    codeCoverageEnabled: true
+    failOnMinTestsNotRun: true
+    minimumExpectedTests: '1'
+
+- task: VSTest@2
+  displayName: 'Run unit tests (.NET 6)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\net6.0\Microsoft.Identity.Test.Unit.dll'
     searchFolder: '$(System.DefaultWorkingDirectory)'
     runInParallel: true
     codeCoverageEnabled: true


### PR DESCRIPTION
**Changes proposed in this request**
Run .NET 6 unit tests
Separate .NET 6 and .NET Core 3.1 integration tests into separate tasks for clarity

![image](https://user-images.githubusercontent.com/34331512/190342063-ab56d0fc-8e9a-4fdd-a9d4-90810b770111.png)
