### PR TITLE
Fix for empty scopes. HasScopes does return true when empty scopes are passed

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Identity.Client.Broker
         {
             //MSAL Runtime throws an ApiContractViolation Exception with Tag: 0x2039c1cb (InvalidArg)
             //When no scopes are passed, this will check if user is passing scopes
-            var scopes = authenticationRequestParameters.Scope.ElementAtOrDefault(0);
+            var scopes = authenticationRequestParameters.Scope?.ElementAtOrDefault(0);
 
             if (string.IsNullOrWhiteSpace(scopes))
             {

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -322,7 +322,9 @@ namespace Microsoft.Identity.Client.Broker
         {
             //MSAL Runtime throws an ApiContractViolation Exception with Tag: 0x2039c1cb (InvalidArg)
             //When no scopes are passed, this will check if user is passing scopes
-            if (!authenticationRequestParameters.HasScopes)
+            var scopes = authenticationRequestParameters.Scope.ElementAtOrDefault(0);
+
+            if (string.IsNullOrWhiteSpace(scopes))
             {
                 logger.Error($"[WamBroker] {MsalError.WamScopesRequired} " +
                     $"{MsalErrorMessage.ScopesRequired}");


### PR DESCRIPTION
Fixes #3654 

**Changes proposed in this request**
Fix for empty/null scopes. HasScopes does return true when empty scopes are passed but works for null scopes.  

This fixes the user issue 

`GlobalExceptionHandler: 
Status: ApiContractViolation
Context: (pii)`

**Testing**
Dev Apps

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
