### PR TITLE
Remove net6 target

### DIFF
--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -7,7 +7,6 @@
     <TargetFrameworkNetCore>netcoreapp2.1</TargetFrameworkNetCore>
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
     <TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
-    <!--<TargetFrameworkNet6>net6.0</TargetFrameworkNet6>-->
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
   </PropertyGroup>
 

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworkNetCore>netcoreapp2.1</TargetFrameworkNetCore>
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
     <TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
-    <TargetFrameworkNet6>net6.0</TargetFrameworkNet6>
+    <!--<TargetFrameworkNet6>net6.0</TargetFrameworkNet6>-->
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
   </PropertyGroup>
 

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -4,9 +4,8 @@
     <TargetFrameworkNetDesktop461>net48</TargetFrameworkNetDesktop461>
     <TargetFrameworkNetCore>netcoreapp3.1</TargetFrameworkNetCore>
     <TargetFrameworkNet5Win>net5.0-windows10.0.17763.0</TargetFrameworkNet5Win>
-    <TargetFrameworkNet6>net6.0</TargetFrameworkNet6>
 
-    <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetCore);$(TargetFrameworkNet5Win);$(TargetFrameworkNet6)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetCore);$(TargetFrameworkNet5Win);</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Remove net6 target from MSAL and unit tests, instead of reverting the whole code base. Since SUPPORTS_SYSTEM_TEXT_JSON flag is only added for net6, the code paths for other targets are unchanged. Left net6 target in integration tests, but it'll run using netcoreapp2.1 MSAL binary.