### PR TITLE
Change the logger.Always messages to logger.Info as it creates too mu…

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -147,9 +147,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationTotalInMs.ToString());
             sb.Append("[LogMetricsFromAuthResult] DurationInHttpInMs: ");
             sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationInHttpInMs.ToString());
-            logger.Always(sb.ToString());
-            logger.AlwaysPii($"[LogMetricsFromAuthResult] TokenEndpoint: {authenticationResult.AuthenticationResultMetadata.TokenEndpoint ?? ""}",
-                                "TokenEndpoint: ****");
+            logger.Info(sb.ToString());
+            logger.InfoPii($"[LogMetricsFromAuthResult] TokenEndpoint: {authenticationResult.AuthenticationResultMetadata.TokenEndpoint ?? ""}",
+                                "TokenEndpoint: ****. ");
         }
 
         private static void UpdateTelemetry(Stopwatch sw, ApiEvent apiEvent, AuthenticationResult authenticationResult)

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public virtual List<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null, ILoggerAdapter requestlogger = null)
         {
             ILoggerAdapter logger = requestlogger ?? _logger;
-            logger.Always($"[Internal cache] Total number of cache partitions found while getting access tokens: {AccessTokenCacheDictionary.Count}");
+            logger.Info($"[Internal cache] Total number of cache partitions found while getting access tokens: {AccessTokenCacheDictionary.Count}. ");
             if (string.IsNullOrEmpty(partitionKey))
             {
                 return AccessTokenCacheDictionary.SelectMany(dict => dict.Value).Select(kv => kv.Value).ToList();
@@ -220,7 +220,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         {
             var logger = requestlogger ?? _logger;
             AccessTokenCacheDictionary.Clear();
-            logger.Always("[Internal cache] Clearing app token cache accessor.");
+            logger.Info("[Internal cache] Clearing app token cache accessor. ");
             // app metadata isn't removable
         }
 

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public virtual List<MsalAccessTokenCacheItem> GetAllAccessTokens(string partitionKey = null, ILoggerAdapter requestlogger = null)
         {
             var logger = requestlogger ?? _logger;
-            logger.Always($"[Internal cache] Total number of cache partitions found while getting access tokens: {AccessTokenCacheDictionary.Count}");
+            logger.Info($"[Internal cache] Total number of cache partitions found while getting access tokens: {AccessTokenCacheDictionary.Count}. ");
             if (string.IsNullOrEmpty(partitionKey))
             {
                 return AccessTokenCacheDictionary.SelectMany(dict => dict.Value).Select(kv => kv.Value).ToList();
@@ -224,7 +224,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public virtual List<MsalRefreshTokenCacheItem> GetAllRefreshTokens(string partitionKey = null, ILoggerAdapter requestlogger = null)
         {
             var logger = requestlogger ?? _logger;
-            logger.Always($"[Internal cache] Total number of cache partitions found while getting refresh tokens: {RefreshTokenCacheDictionary.Count}");
+            logger.Info($"[Internal cache] Total number of cache partitions found while getting refresh tokens: {RefreshTokenCacheDictionary.Count}. ");
             if (string.IsNullOrEmpty(partitionKey))
             {
                 return RefreshTokenCacheDictionary.SelectMany(dict => dict.Value).Select(kv => kv.Value).ToList();
@@ -280,7 +280,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public virtual void Clear(ILoggerAdapter requestlogger = null)
         {
             var logger = requestlogger ?? _logger;
-            logger.Always("[Internal cache] Clearing user token cache accessor.");
+            logger.Info("[Internal cache] Clearing user token cache accessor. ");
             AccessTokenCacheDictionary.Clear();
             RefreshTokenCacheDictionary.Clear();
             IdTokenCacheDictionary.Clear();

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -427,7 +427,7 @@ namespace Microsoft.Identity.Client
 
             var accessTokens = Accessor.GetAllAccessTokens(partitionKey, logger);
 
-            requestParams.RequestContext.Logger.Always($"[FindAccessTokenAsync] Discovered {accessTokens.Count} access tokens in cache using partition key: {partitionKey}");
+            requestParams.RequestContext.Logger.Info($"[FindAccessTokenAsync] Discovered {accessTokens.Count} access tokens in cache using partition key: {partitionKey}. ");
 
             if (accessTokens.Count == 0)
             {
@@ -756,7 +756,7 @@ namespace Microsoft.Identity.Client
 
             var requestKey = CacheKeyFactory.GetKeyFromRequest(requestParams);
             var refreshTokens = Accessor.GetAllRefreshTokens(requestKey);
-            requestParams.RequestContext.Logger.Always($"[FindRefreshTokenAsync] Discovered {refreshTokens.Count} refresh tokens in cache using key: {requestKey}");
+            requestParams.RequestContext.Logger.Info($"[FindRefreshTokenAsync] Discovered {refreshTokens.Count} refresh tokens in cache using key: {requestKey}. ");
 
             if (refreshTokens.Count != 0)
             {


### PR DESCRIPTION
…ch noise for services. Many are already taking the metrics from the authResult, so they may not want it always again in the logs.

Fixes #
#3683 

In .NET Core, the mapping Always to Critical is not going to work, because they appear as Critical (see the linked item for details). Service owners will not want this level appearing in their logs. Based on the logs, they can all be added an information and not always.