### PR TITLE
Adding a PublishNugetAndSymbols Build Variable

### DIFF
--- a/build/template-publish-packages-and-symbols.yaml
+++ b/build/template-publish-packages-and-symbols.yaml
@@ -25,11 +25,11 @@ steps:
     publishVstsFeed: '46419298-b96c-437f-bd4c-12c8df7f868d'
     allowPackageConflicts: true
   continueOnError: true
-  condition: eq(variables['PublishNugetAndSymbols'], 'true')
+  condition: eq(variables['PublishToVSTSFeed'], 'true')
 
 - task: PublishSymbols@2
   displayName: 'Publish symbols'
   inputs:
     SearchPattern: '${{ parameters.SymbolPublishWildcard }}'
     SymbolServerType: TeamServices
-  condition: eq(variables['PublishNugetAndSymbols'], 'true')
+  condition: eq(variables['PublishSymbols'], 'true')

--- a/build/template-publish-packages-and-symbols.yaml
+++ b/build/template-publish-packages-and-symbols.yaml
@@ -25,11 +25,11 @@ steps:
     publishVstsFeed: '46419298-b96c-437f-bd4c-12c8df7f868d'
     allowPackageConflicts: true
   continueOnError: true
-  condition: eq(${{ parameters.PublishArtifacts }}, 'true')
+  condition: eq(variables['PublishNugetAndSymbols'], 'true')
 
 - task: PublishSymbols@2
   displayName: 'Publish symbols'
   inputs:
     SearchPattern: '${{ parameters.SymbolPublishWildcard }}'
     SymbolServerType: TeamServices
-  condition: eq(${{ parameters.PublishArtifacts }}, 'true')
+  condition: eq(variables['PublishNugetAndSymbols'], 'true')


### PR DESCRIPTION
Fixes #3689 

**Changes proposed in this request**
Adding a PublishNugetAndSymbols Build Variable check on Task `'Publish packages to VSTS feed'` and on `'Publish symbols'`

**Testing**
none

**Performance impact**
n/a

**Documentation**
- [ ] All relevant documentation is updated.
