### PR TITLE
Setting broker and desktop AssemblyVersion to a pre-released version

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup Label="NuGet and AssemblyInfo metadata">
     <!--This should be passed from the VSTS build-->
-    <MsalClientSemVer Condition="'$(MsalClientSemVer)' == ''">4.7.1-preview</MsalClientSemVer>
+    <MsalClientSemVer Condition="'$(MsalClientSemVer)' == ''">4.46.0-preview</MsalClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MsalClientSemVer)-preview</Version>
     <!-- Copyright needs to be in the form of © not (c) to be compliant -->

--- a/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup Label="NuGet and AssemblyInfo metadata">
     <!--This should be passed from the VSTS build-->
-    <MsalClientSemVer Condition="'$(MsalClientSemVer)' == ''">4.7.1</MsalClientSemVer>
+    <MsalClientSemVer Condition="'$(MsalClientSemVer)' == ''">4.46.0</MsalClientSemVer>
     <MsalClientSemVer>$(MsalClientSemVer)</MsalClientSemVer>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
     <Version>$(MsalClientSemVer)</Version>


### PR DESCRIPTION
Fixes #

**Changes proposed in this request**
Setting broker and desktop AssemblyVersion to a pre-released version. This the version we use in the client project as well. Our build pipeline sets the `MsalClientSemVer` but if it is not set then `4.7.1` will be used. 

**Testing**
none

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
