### PR TITLE
WAM - throw when msalruntime.dll is not found

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -41,8 +41,9 @@ namespace Microsoft.Identity.Client.Broker
 
                 return new NativeInterop.Core();
             }
-            catch (Exception ex)
+            catch (MsalRuntimeException ex) when (ex.Status == ResponseStatus.ApiContractViolation)
             {
+                // failed to initialize msal runtime - can happen on older versions of Windows. Means broker is not available.
                 s_initException = ex;
 
                 // ignored
@@ -440,7 +441,6 @@ namespace Microsoft.Identity.Client.Broker
                 _logger.Info("[WAM Broker] MsalRuntime init failed...");
                 _logger.InfoPii(s_initException);
 
-                throw new MsalServiceException("wam_runtime_init_failed", "MsalRuntime init failed.");
             }
 
             _logger.Verbose($"[WAM Broker] MsalRuntime init successful.");

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Client.Broker
                 // When MSAL Runtime dlls fails to load then we catch the exception and throw with a meaningful
                 // message with information on how to troubleshoot
                 throw new MsalClientException(
-                    "wam_runtime_init_failed", ex.Message + " See https://aka.ms/msal-net-wam#troubleshooting");
+                    "wam_runtime_init_failed", ex.Message + " See https://aka.ms/msal-net-wam#troubleshooting", ex);
             }
         });
 

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Identity.Client.Broker
                 _logger.Info("[WAM Broker] MsalRuntime init failed...");
                 _logger.InfoPii(s_initException);
 
-                return false;
+                throw new MsalServiceException("wam_runtime_init_failed", "MsalRuntime init failed.");
             }
 
             _logger.Verbose($"[WAM Broker] MsalRuntime init successful.");

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -448,12 +448,12 @@ namespace Microsoft.Identity.Client.Broker
 
             if (s_lazyCore.Value == null)
             {
-                _logger.Info("[WAM Broker] MsalRuntime init failed...");
+                _logger.Info("[WAM Broker] MsalRuntime initialization failed. See https://aka.ms/msal-net-wam#wam-limitations");
                 _logger.InfoPii(s_initException);
                 return false;
             }
 
-            _logger.Verbose($"[WAM Broker] MsalRuntime init successful.");
+            _logger.Verbose($"[WAM Broker] MsalRuntime initialization successful.");
             return true;
         }
     }

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Identity.Client.Broker
             {
                 _logger.Info("[WAM Broker] MsalRuntime init failed...");
                 _logger.InfoPii(s_initException);
-
+                return false;
             }
 
             _logger.Verbose($"[WAM Broker] MsalRuntime init successful.");


### PR DESCRIPTION
Fixes #3699

**Changes proposed in this request**
throwing when MSAL runtime init fails

**Testing**
Dev App

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
