### PR TITLE
Update NativeInterop to 0.13.0 in Broker project

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.12.4" IncludeAssets="all" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.13.0" IncludeAssets="all" />
     <ProjectReference Include="..\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
   </ItemGroup>
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">


### PR DESCRIPTION
Fixes #

**Changes proposed in this request**
Update NativeInterop to 0.13.0 in Broker project. This will fail in the PR till we publish the Interop to NuGet

**Testing**
Dev Apps

**Performance impact**
None

**Documentation**
- [ ] All relevant documentation is updated.
