### PR TITLE
Use Latest msal4j library for cache compatibility tests

### DIFF
--- a/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
+++ b/tests/CacheCompat/CommonCache.Test.MsalJava/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>[1.11,)</version>
+            <version>LATEST</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Moving to use latest msal4j library for cache compatibility tests, this will ensure we always consume the latest MSAL Java release. 

During MSAL release we found that we were using an older version of the msal4j that had some issues. This will help us test against the latest msal4j as they fix and release newer versions