### PR TITLE
Fixing a typo in the public API `WithProofOfPosessionKeyId`

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Client.Extensibility
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="keyId">A key id to which the access token is associated. The token will not be retrieved from the cache unless the same key id is presented. Can be null.</param>
-        /// <param name="expectedTokenTypeFromAad">AAD issues sevearl types of bound tokens. MSAL checks the token type, which needs to match the value set by ESTS. Normal POP tokens have this as "pop"</param>
+        /// <param name="expectedTokenTypeFromAad">AAD issues several types of bound tokens. MSAL checks the token type, which needs to match the value set by ESTS. Normal POP tokens have this as "pop"</param>
         /// <returns>the builder</returns>
         public static AcquireTokenForClientParameterBuilder WithProofOfPosessionKeyId(
             this AcquireTokenForClientParameterBuilder builder,


### PR DESCRIPTION
Fixing a typo in the public API `WithProofOfPosessionKeyId`