### PR TITLE
Add cache details to token cache notification args

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -129,7 +129,8 @@ namespace Microsoft.Identity.Client.Cache
                                   requestScopes: _requestParams.Scope, 
                                   requestTenantId: _requestParams.AuthorityManager.OriginalAuthority.TenantId,
                                   identityLogger: _requestParams.RequestContext.Logger.IdentityLogger,
-                                  piiLoggingEnabled: _requestParams.RequestContext.Logger.PiiLoggingEnabled);
+                                  piiLoggingEnabled: _requestParams.RequestContext.Logger.PiiLoggingEnabled,
+                                  cacheDetails: RequestContext.CacheDetails);
 
                                 stopwatch.Start();
                                 await TokenCacheInternal.OnBeforeAccessAsync(args).ConfigureAwait(false);
@@ -155,7 +156,8 @@ namespace Microsoft.Identity.Client.Cache
                                   requestScopes: _requestParams.Scope,
                                   requestTenantId: _requestParams.AuthorityManager.OriginalAuthority.TenantId,
                                   identityLogger: _requestParams.RequestContext.Logger.IdentityLogger,
-                                  piiLoggingEnabled: _requestParams.RequestContext.Logger.PiiLoggingEnabled);
+                                  piiLoggingEnabled: _requestParams.RequestContext.Logger.PiiLoggingEnabled,
+                                  cacheDetails: RequestContext.CacheDetails);
 
                                 await TokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);
                                 RequestContext.ApiEvent.DurationInCacheInMs += stopwatch.ElapsedMilliseconds;

--- a/src/client/Microsoft.Identity.Client/Internal/RequestContext.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/RequestContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal.Logger;
@@ -23,6 +24,8 @@ namespace Microsoft.Identity.Client.Internal
         public ApiEvent ApiEvent { get; set; }
 
         public CancellationToken UserCancellationToken { get; }
+
+        public Dictionary<string, object> CacheDetails { get; } = new Dictionary<string, object>();
 
         public RequestContext(IServiceBundle serviceBundle, Guid correlationId, CancellationToken cancellationToken = default)
         {

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryClient/TelemetryCacheConstants.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryClient/TelemetryCacheConstants.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.IdentityModel.Abstractions;
+
+namespace Microsoft.Identity.Client.TelemetryCore.TelemetryClient
+{
+    /// <summary>
+    /// Contains the parameters of cache to log to telemetry.
+    /// </summary>
+    public class TelemetryCacheConstants
+    {
+        /// <summary>
+        /// Constant to use as key to Cache Details dictionary.
+        /// </summary>
+        public const string CacheUsed = "CacheUsed";
+
+        /// <summary>
+        /// Constant to use as key to Cache Details dictionary.
+        /// </summary>
+        public const string L1Latency = "L1Latency";
+
+        /// <summary>
+        /// Constant to use as key to Cache Details dictionary.
+        /// </summary>
+        public const string L2Latency = "L2Latency";
+    }
+
+    /// <summary>
+    /// Indicates the cache which was used to get the token.
+    /// </summary>
+    public enum CacheUsed
+    {
+        /// <summary>
+        /// Indicates that the token was not cached
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Token was obtained from L1
+        /// </summary>
+        L1 = 1,
+
+        /// <summary>
+        /// Token was obtained from L2
+        /// </summary>
+        L2 = 2
+    }
+}

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
         public const string DurationInHttp = "DurationInHttp";
         public const string ActivityId = "ActivityId";
         public const string Resource = "Resource";
+        public const string RefreshOn = "RefreshOn";
 
 #endregion
     }

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -177,7 +177,8 @@ namespace Microsoft.Identity.Client
                             requestScopes: requestParams.Scope,
                             requestTenantId: requestParams.AuthorityManager.OriginalAuthority.TenantId,
                             identityLogger: requestParams.RequestContext.Logger.IdentityLogger,
-                            piiLoggingEnabled: requestParams.RequestContext.Logger.PiiLoggingEnabled);
+                            piiLoggingEnabled: requestParams.RequestContext.Logger.PiiLoggingEnabled,
+                            cacheDetails: requestParams.RequestContext.CacheDetails);
 
                         Stopwatch sw = Stopwatch.StartNew();
 
@@ -249,7 +250,8 @@ namespace Microsoft.Identity.Client
                             requestScopes: requestParams.Scope,
                             requestTenantId: requestParams.AuthorityManager.OriginalAuthority.TenantId,
                             identityLogger: requestParams.RequestContext.Logger.IdentityLogger,
-                            piiLoggingEnabled: requestParams.RequestContext.Logger.PiiLoggingEnabled);
+                            piiLoggingEnabled: requestParams.RequestContext.Logger.PiiLoggingEnabled,
+                            cacheDetails: requestParams.RequestContext.CacheDetails);
 
                         Stopwatch sw = Stopwatch.StartNew();
                         await tokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);
@@ -741,7 +743,8 @@ namespace Microsoft.Identity.Client
                             requestScopes: null,
                             requestTenantId: null,
                             identityLogger: null,
-                            piiLoggingEnabled: false);
+                            piiLoggingEnabled: false,
+                            cacheDetails: new Dictionary<string, object>());
 
                 await tokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);
             }
@@ -1162,7 +1165,8 @@ namespace Microsoft.Identity.Client
                             requestScopes: requestParameters.Scope,
                             requestTenantId: requestParameters.AuthorityManager.OriginalAuthority.TenantId,
                             identityLogger: requestParameters.RequestContext.Logger.IdentityLogger,
-                            piiLoggingEnabled: requestParameters.RequestContext.Logger.PiiLoggingEnabled);
+                            piiLoggingEnabled: requestParameters.RequestContext.Logger.PiiLoggingEnabled,
+                            cacheDetails: requestParameters.RequestContext.CacheDetails);
 
 
                         await tokenCacheInternal.OnBeforeAccessAsync(args).ConfigureAwait(false);
@@ -1198,7 +1202,8 @@ namespace Microsoft.Identity.Client
                            requestScopes: requestParameters.Scope,
                            requestTenantId: requestParameters.AuthorityManager.OriginalAuthority.TenantId,
                            identityLogger: requestParameters.RequestContext.Logger.IdentityLogger,
-                            piiLoggingEnabled: requestParameters.RequestContext.Logger.PiiLoggingEnabled);
+                           piiLoggingEnabled: requestParameters.RequestContext.Logger.PiiLoggingEnabled,
+                           cacheDetails: requestParameters.RequestContext.CacheDetails);
 
 
                         await tokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -147,6 +147,44 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// This constructor is for test purposes only. It allows apps to unit test their MSAL token cache implementation code.
+        /// </summary>
+        public TokenCacheNotificationArgs(    // only use this constructor in product code
+            ITokenCacheSerializer tokenCache,
+            string clientId,
+            IAccount account,
+            bool hasStateChanged,
+            bool isApplicationCache,
+            string suggestedCacheKey,
+            bool hasTokens,
+            DateTimeOffset? suggestedCacheExpiry,
+            CancellationToken cancellationToken,
+            Guid correlationId,
+            IEnumerable<string> requestScopes,
+            string requestTenantId,
+            IIdentityLogger identityLogger,
+            bool piiLoggingEnabled,
+            Dictionary<string, object> cacheDetails)
+
+        {
+            TokenCache = tokenCache;
+            ClientId = clientId;
+            Account = account;
+            HasStateChanged = hasStateChanged;
+            IsApplicationCache = isApplicationCache;
+            SuggestedCacheKey = suggestedCacheKey;
+            HasTokens = hasTokens;
+            CancellationToken = cancellationToken;
+            CorrelationId = correlationId;
+            RequestScopes = requestScopes;
+            RequestTenantId = requestTenantId;
+            SuggestedCacheExpiry = suggestedCacheExpiry;
+            IdentityLogger = identityLogger;
+            PiiLoggingEnabled = piiLoggingEnabled;
+            CacheDetails = cacheDetails;
+        }
+
+        /// <summary>
         /// Gets the <see cref="ITokenCacheSerializer"/> involved in the transaction
         /// </summary>
         /// <remarks><see cref="TokenCache" > objects</see> implement this interface.</remarks>
@@ -248,5 +286,10 @@ namespace Microsoft.Identity.Client
         /// Boolean used to determine if Personally Identifiable Information (PII) logging is enabled.
         /// </summary>
         public bool PiiLoggingEnabled { get; }
+
+        /// <summary>
+        /// Cache Details contains the details of L1/ L2 cache for telemetry logging.
+        /// </summary>
+        public Dictionary<string, object> CacheDetails { get; }
     }
 }


### PR DESCRIPTION
Fixes #
#3596 

**Changes proposed in this request**
Add cache details to token cache notification args and log data to telemetry pipeline.

**Testing**


**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
