### PR TITLE
Resolving issue with IByRefreshToken

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ByRefreshTokenRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ByRefreshTokenRequest.cs
@@ -45,7 +45,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
             var dict = new Dictionary<string, string>
             {
                 [OAuth2Parameter.GrantType] = OAuth2GrantType.RefreshToken,
-                [OAuth2Parameter.RefreshToken] = refreshTokenSecret
+                [OAuth2Parameter.RefreshToken] = refreshTokenSecret,
+                [OAuth2Parameter.ClientInfo] = "1"
             };
 
             return dict;

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
@@ -210,6 +210,11 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             //Ensure we can get account from application
             var account = await confidentialApp.GetAccountAsync(authResult.Account.HomeAccountId.Identifier).ConfigureAwait(false);
 
+            //Ensure we can get account from application using GetAccountsAsync
+            var accounts = await confidentialApp.GetAccountsAsync().ConfigureAwait(false);
+
+            var account2 = accounts.FirstOrDefault();
+
             //Validate that the refreshed token can be used
             authResult = await confidentialApp.AcquireTokenSilent(s_scopes, account).ExecuteAsync().ConfigureAwait(false);
 
@@ -218,6 +223,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.AreEqual(labResponse.User.Upn, authResult.Account.Username);
             Assert.AreEqual(labResponse.User.ObjectId.ToString(), authResult.Account.HomeAccountId.ObjectId);
             Assert.AreEqual(labResponse.User.TenantId, authResult.Account.HomeAccountId.TenantId);
+            Assert.AreEqual(labResponse.User.Upn, account2.Username);
+            Assert.AreEqual(labResponse.User.ObjectId.ToString(), account2.HomeAccountId.ObjectId);
+            Assert.AreEqual(labResponse.User.TenantId, account2.HomeAccountId.TenantId);
         }
 
         private static void ModifyRequest(OnBeforeTokenRequestData data, X509Certificate2 certificate)

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ClientCredentialsTests.cs
@@ -207,7 +207,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // Act
             authResult = await (confidentialApp as IByRefreshToken).AcquireTokenByRefreshToken(s_scopes, rt.Secret).ExecuteAsync().ConfigureAwait(false);
 
-            var account = authResult.Account;
+            //Ensure we can get account from application
+            var account = await confidentialApp.GetAccountAsync(authResult.Account.HomeAccountId.Identifier).ConfigureAwait(false);
+
             //Validate that the refreshed token can be used
             authResult = await confidentialApp.AcquireTokenSilent(s_scopes, account).ExecuteAsync().ConfigureAwait(false);
 
@@ -215,6 +217,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.IsNotNull(authResult);
             Assert.AreEqual(labResponse.User.Upn, authResult.Account.Username);
             Assert.AreEqual(labResponse.User.ObjectId.ToString(), authResult.Account.HomeAccountId.ObjectId);
+            Assert.AreEqual(labResponse.User.TenantId, authResult.Account.HomeAccountId.TenantId);
         }
 
         private static void ModifyRequest(OnBeforeTokenRequestData data, X509Certificate2 certificate)


### PR DESCRIPTION
Fixes #3736
[[Bug] Incorrect HomeAccount details populated in AuthenticationResult of AcquireTokenByRefreshToken](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3736)

**Changes proposed in this request**
Adding client info to IByRefreshToken request

**Testing**
Integration test

**Performance impact**
N/A

**Documentation**
- [ ] All relevant documentation is updated.
