### PR TITLE
Broker Silent NRE

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Identity.Client.Broker
                 _logger))
             {
                 using (var readAccountResult = await s_lazyCore.Value.ReadAccountByIdAsync(
-                    acquireTokenSilentParameters.Account.HomeAccountId.ObjectId,
+                    authenticationRequestParameters.Account.HomeAccountId.ObjectId,
                     authenticationRequestParameters.CorrelationId.ToString("D"),
                     cancellationToken).ConfigureAwait(false))
                 {

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -208,13 +208,6 @@ namespace NetDesktopWinForms
 
             if (!string.IsNullOrEmpty(loginHint))
             {
-                //if (IsMsaPassthroughConfigured())
-                //{
-                //    // TODO: bogavril - move this exception in WAM
-                //    throw new InvalidOperationException(
-                //        "[TEST APP FAILURE] Do not use login hint on AcquireTokenSilent for MSA-Passthrough. Use the IAccount overload.");
-                //}
-
                 Log($"ATS with login hint: " + loginHint);
                 var builder = pca.AcquireTokenSilent(GetScopes(), loginHint);
 

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -208,12 +208,12 @@ namespace NetDesktopWinForms
 
             if (!string.IsNullOrEmpty(loginHint))
             {
-                if (IsMsaPassthroughConfigured())
-                {
-                    // TODO: bogavril - move this exception in WAM
-                    throw new InvalidOperationException(
-                        "[TEST APP FAILURE] Do not use login hint on AcquireTokenSilent for MSA-Passthrough. Use the IAccount overload.");
-                }
+                //if (IsMsaPassthroughConfigured())
+                //{
+                //    // TODO: bogavril - move this exception in WAM
+                //    throw new InvalidOperationException(
+                //        "[TEST APP FAILURE] Do not use login hint on AcquireTokenSilent for MSA-Passthrough. Use the IAccount overload.");
+                //}
 
                 Log($"ATS with login hint: " + loginHint);
                 var builder = pca.AcquireTokenSilent(GetScopes(), loginHint);

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -181,12 +181,12 @@ namespace NetDesktopWinForms
 
             if (!string.IsNullOrEmpty(loginHint))
             {
-                if (IsMsaPassthroughConfigured())
-                {
-                    // TODO: bogavril - move this exception in WAM
-                    throw new InvalidOperationException(
-                        "[TEST APP FAILURE] Do not use login hint on AcquireTokenSilent for MSA-Passthrough. Use the IAccount overload.");
-                }
+                //if (IsMsaPassthroughConfigured())
+                //{
+                //    // TODO: bogavril - move this exception in WAM
+                //    throw new InvalidOperationException(
+                //        "[TEST APP FAILURE] Do not use login hint on AcquireTokenSilent for MSA-Passthrough. Use the IAccount overload.");
+                //}
 
                 Log($"ATS with login hint: " + loginHint);
                 return await pca.AcquireTokenSilent(GetScopes(), loginHint)

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -181,13 +181,6 @@ namespace NetDesktopWinForms
 
             if (!string.IsNullOrEmpty(loginHint))
             {
-                //if (IsMsaPassthroughConfigured())
-                //{
-                //    // TODO: bogavril - move this exception in WAM
-                //    throw new InvalidOperationException(
-                //        "[TEST APP FAILURE] Do not use login hint on AcquireTokenSilent for MSA-Passthrough. Use the IAccount overload.");
-                //}
-
                 Log($"ATS with login hint: " + loginHint);
                 return await pca.AcquireTokenSilent(GetScopes(), loginHint)
                         .ExecuteAsync(cancellationToken)


### PR DESCRIPTION
Fixes : #3743 

With the new broker, ATS with loginHint fails with a Null Reference Exception. When we do a silent call with the new broker we need to pass an account. This works when we call ATS with the IAccount overload. With login_hint the acquireTokenSilentParameters.Account comes back as null. Using authenticationRequestParameters.Account instead.

```cs
// Fails with NRE
var result2 = await app.AcquireTokenSilent(scopes, loginHint).ExecuteAsync();
Console.WriteLine(result2.AccessToken);
```

