### PR TITLE
NRE fix in authority creation logic when using ATS with OS account.

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -130,13 +130,13 @@ namespace Microsoft.Identity.Client
         public string UserRealmUriPrefix { get; }
         public bool ValidateAuthority { get; }
 
-        internal bool IsInstanceDiscoverySupported => (AuthorityType == AuthorityType.Aad);
+        internal bool IsInstanceDiscoverySupported => AuthorityType == AuthorityType.Aad;
 
-        internal bool IsUserAssertionSupported => (AuthorityType != AuthorityType.Adfs && AuthorityType != AuthorityType.B2C);
+        internal bool IsUserAssertionSupported => AuthorityType != AuthorityType.Adfs && AuthorityType != AuthorityType.B2C;
 
-        internal bool IsTenantOverrideSupported => (AuthorityType == AuthorityType.Aad);
-        internal bool IsMultiTenantSupported => (AuthorityType != AuthorityType.Adfs);
-        internal bool IsClientInfoSupported => (AuthorityType == AuthorityType.Aad || AuthorityType == AuthorityType.Dsts || AuthorityType == AuthorityType.B2C);
+        internal bool IsTenantOverrideSupported => AuthorityType == AuthorityType.Aad;
+        internal bool IsMultiTenantSupported => AuthorityType != AuthorityType.Adfs;
+        internal bool IsClientInfoSupported => AuthorityType == AuthorityType.Aad || AuthorityType == AuthorityType.Dsts || AuthorityType == AuthorityType.B2C;
 
         #region Builders
         internal static AuthorityInfo FromAuthorityUri(string authorityUri, bool validateAuthority)
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Client
 
             return new AuthorityInfo(authorityType, canonicalUri, validateAuthority);
         }
-        
+
         internal static AuthorityInfo FromAadAuthority(Uri cloudInstanceUri, Guid tenantId, bool validateAuthority)
         {
 #pragma warning disable CA1305 // Specify IFormatProvider
@@ -272,7 +272,7 @@ namespace Microsoft.Identity.Client
         {
             if (!string.IsNullOrWhiteSpace(uri) && !uri.EndsWith("/", StringComparison.OrdinalIgnoreCase))
             {
-                uri = uri + "/";
+                uri += "/";
             }
 
             return uri?.ToLowerInvariant() ?? string.Empty;
@@ -390,7 +390,7 @@ namespace Microsoft.Identity.Client
             throw new InvalidOperationException(MsalErrorMessage.DstsAuthorityDoesNotHaveThreeSegments);
         }
 
-        private static AuthorityType GetAuthorityType(string authority) 
+        private static AuthorityType GetAuthorityType(string authority)
         {
             string firstPathSegment = GetFirstPathSegment(authority);
 
@@ -411,7 +411,7 @@ namespace Microsoft.Identity.Client
 
             return AuthorityType.Aad;
         }
-        
+
         private static string[] GetPathSegments(string absolutePath)
         {
             string[] pathSegments = absolutePath.Substring(1).Split(
@@ -494,7 +494,7 @@ namespace Microsoft.Identity.Client
 
                     case AuthorityType.Aad:
 
-                        bool updateEnvironment = requestContext.ServiceBundle.Config.MultiCloudSupportEnabled && account != null;
+                        bool updateEnvironment = requestContext.ServiceBundle.Config.MultiCloudSupportEnabled && account != null && account != PublicClientApplication.OperatingSystemAccount;
 
                         if (requestAuthorityInfo == null)
                         {

--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Identity.Client
 
                     case AuthorityType.Aad:
 
-                        bool updateEnvironment = requestContext.ServiceBundle.Config.MultiCloudSupportEnabled && account != null && account != PublicClientApplication.OperatingSystemAccount;
+                        bool updateEnvironment = requestContext.ServiceBundle.Config.MultiCloudSupportEnabled && account != null && !PublicClientApplication.IsOperatingSystemAccount(account);
 
                         if (requestAuthorityInfo == null)
                         {

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -29,6 +29,7 @@ using Microsoft.Identity.Test.Common.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using NSubstitute.Extensions;
 
 namespace Microsoft.Identity.Test.Unit.BrokerTests
 {
@@ -461,9 +462,14 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         private static IBroker CreateBroker(Type brokerType)
         {
             if (brokerType == typeof(NullBroker))
+            {
                 return new NullBroker(null);
+            }
+
             if (brokerType == typeof(IosBrokerMock))
+            {
                 return new IosBrokerMock(null);
+            }
 
             throw new NotImplementedException();
         }
@@ -771,8 +777,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             }
         }
 
-        
-
         [TestMethod]
         public void NoTokenFoundThrowsUIRequiredTest()
         {
@@ -862,7 +866,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                    .WithMultiCloudSupport(true)
                    .WithHttpManager(harness.HttpManager);
 
-                var broker = NSubstitute.Substitute.For<IBroker>();
+                var broker = Substitute.For<IBroker>();
                 builder.Config.BrokerCreatorFunc = (_, _, _) => broker;
 
                 var globalPca = builder.WithBroker(true).BuildConcrete();
@@ -878,10 +882,13 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 var result = await globalPca.AcquireTokenInteractive(TestConstants.s_graphScopes).ExecuteAsync().ConfigureAwait(false);
                 Assert.AreEqual("login.microsoftonline.us", result.Account.Environment);
                 Assert.AreEqual(TestConstants.Utid, result.TenantId);
-                
+
                 var account = (await globalPca.GetAccountsAsync().ConfigureAwait(false)).Single();
                 Assert.AreEqual("login.microsoftonline.us", account.Environment);
                 Assert.AreEqual(TestConstants.Utid, result.TenantId);
+
+                await Assert.ThrowsExceptionAsync<MsalUiRequiredException>(
+                    async () => await globalPca.AcquireTokenSilent(TestConstants.s_graphScopes, PublicClientApplication.OperatingSystemAccount).ExecuteAsync().ConfigureAwait(false)).ConfigureAwait(false);
             }
         }
 
@@ -995,7 +1002,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         }
 
         private MsalTokenResponse CreateTokenResponseForTest()
-            
+
         {
             return new MsalTokenResponse()
             {
@@ -1011,7 +1018,5 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             };
         }
     }
-
-   
 
 }


### PR DESCRIPTION
Fixes #3769

**Changes proposed in this request**
Add check for OS account in authority creation logic

**Testing**
Tested manually.
Added tests.

**Performance impact**
N/A

**Documentation**
- [x] All relevant documentation is updated.
