### PR TITLE
Broker : Updating to Interop 0.13.2 and passing Broker Options Header text to Interop

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.13.0" IncludeAssets="all" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.13.2" IncludeAssets="all" />
     <ProjectReference Include="..\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
   </ItemGroup>
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Client.Broker
             {
                 using (var authParams = WamAdapters.GetCommonAuthParameters(
                     authenticationRequestParameters, 
-                    _wamOptions.MsaPassthrough, 
+                    _wamOptions, 
                     _logger))
                 {
                     using (var readAccountResult = await s_lazyCore.Value.ReadAccountByIdAsync(
@@ -178,7 +178,7 @@ namespace Microsoft.Identity.Client.Broker
 
             using (var authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
-                _wamOptions.MsaPassthrough,
+                _wamOptions,
                 _logger))
             {
                 //Login Hint
@@ -213,7 +213,7 @@ namespace Microsoft.Identity.Client.Broker
 
             using (var authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
-                _wamOptions.MsaPassthrough,
+                _wamOptions,
                 _logger))
             {
                 using (NativeInterop.AuthResult result = await s_lazyCore.Value.SignInAsync(
@@ -253,7 +253,7 @@ namespace Microsoft.Identity.Client.Broker
 
             using (var authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
-                _wamOptions.MsaPassthrough,
+                _wamOptions,
                 _logger))
             {
                 using (var readAccountResult = await s_lazyCore.Value.ReadAccountByIdAsync(
@@ -300,7 +300,7 @@ namespace Microsoft.Identity.Client.Broker
 
             using (var authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
-                _wamOptions.MsaPassthrough,
+                _wamOptions,
                 _logger))
             {
                 using (NativeInterop.AuthResult result = await s_lazyCore.Value.SignInSilentlyAsync(
@@ -329,7 +329,7 @@ namespace Microsoft.Identity.Client.Broker
 
             using (AuthParameters authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
-                _wamOptions.MsaPassthrough,
+                _wamOptions,
                 _logger))
             {
                 authParams.Properties["MSALRuntime_Username"] = acquireTokenByUsernamePasswordParameters.Username;

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -174,11 +174,15 @@ namespace Microsoft.Identity.Client.Broker
 
             //MSA-PT
             if (brokerOptions.MsaPassthrough)
+            {
                 authParams.Properties[NativeInteropMsalRequestType] = ConsumersPassthroughRequest;
+            }
 
             //WAM Header Title
             if (!string.IsNullOrEmpty(brokerOptions.HeaderText))
+            {
                 authParams.Properties[WamHeaderTitle] = brokerOptions.HeaderText;
+            }
 
             //Client Claims
             if (!string.IsNullOrWhiteSpace(authenticationRequestParameters.ClaimsAndClientCapabilities))

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Identity.Client.Broker
             if (brokerOptions.MsaPassthrough)
                 authParams.Properties[NativeInteropMsalRequestType] = ConsumersPassthroughRequest;
 
-            //MSA-PT
+            //WAM Header Title
             if (!string.IsNullOrEmpty(brokerOptions.HeaderText))
                 authParams.Properties[WamHeaderTitle] = brokerOptions.HeaderText;
 

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Identity.Client.Broker
         //MSA-PT Auth Params
         private const string NativeInteropMsalRequestType = "msal_request_type";
         private const string ConsumersPassthroughRequest = "consumer_passthrough";
+        private const string WamHeaderTitle = "msal_accounts_control_title";
 
         //MSAL Runtime Error Response 
         private enum ResponseStatus
@@ -150,11 +151,11 @@ namespace Microsoft.Identity.Client.Broker
         /// Gets the Common Auth Parameters to be passed to Native Interop
         /// </summary>
         /// <param name="authenticationRequestParameters"></param>
-        /// <param name="isMsaPassthrough"></param>
+        /// <param name="brokerOptions"></param>
         /// <param name="logger"></param>
         public static NativeInterop.AuthParameters GetCommonAuthParameters(
             AuthenticationRequestParameters authenticationRequestParameters, 
-            bool isMsaPassthrough,
+            WindowsBrokerOptions brokerOptions,
             ILoggerAdapter logger)
         {
             logger.Verbose("[WamBroker] Validating Common Auth Parameters.");
@@ -172,8 +173,12 @@ namespace Microsoft.Identity.Client.Broker
             authParams.RedirectUri = authenticationRequestParameters.RedirectUri.ToString();
 
             //MSA-PT
-            if (isMsaPassthrough)
+            if (brokerOptions.MsaPassthrough)
                 authParams.Properties[NativeInteropMsalRequestType] = ConsumersPassthroughRequest;
+
+            //MSA-PT
+            if (!string.IsNullOrEmpty(brokerOptions.HeaderText))
+                authParams.Properties[WamHeaderTitle] = brokerOptions.HeaderText;
 
             //Client Claims
             if (!string.IsNullOrWhiteSpace(authenticationRequestParameters.ClaimsAndClientCapabilities))

--- a/tests/devapps/WAM/NetFrameworkWam/Program.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Program.cs
@@ -18,8 +18,6 @@ namespace NetDesktopWinForms
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Form1());
-
-            Core.VerifyHandleLeaksForTest();
         }
     }
 }


### PR DESCRIPTION
Fixes #
[Internal tracking item VS#1988070)](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1988070)

**Changes proposed in this request**
- Updated to Microsoft.Identity.Client.NativeInterop 0.13.2, that fixes a bug around ORG workaround. ESTS fixed the issue and MSAL Runtime removed the local fix. This fixes an issue with getting AAD account token in MSA-PT scenario
- Providing Broker options header text to Interop that will add a title to the AAD Account picker (works only on non-admin mode). Bug [2159876](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2159876), is tracking a fix for admin mode header title

**Testing**
Dev App

**Performance impact**
None

**Documentation**
- [ ] All relevant documentation is updated.
