### PR TITLE
Update ConfidentialClientAuthorizationTests.cs to use lab app

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         private static readonly TimeSpan s_timeout = TimeSpan.FromMinutes(1);
 
         private static readonly string[] s_scopes = { "User.Read" };
-        private const string ConfidentialClientID = "88f91eac-c606-4c67-a0e2-a5e8a186854f";
+        private const string ConfidentialClientID = "35dc5034-9b65-4a5d-ad81-73cca468c1e0";
         private const string TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         private const string CertificateName = "for-cca-testing";
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         private static readonly TimeSpan s_timeout = TimeSpan.FromMinutes(1);
 
         private static readonly string[] s_scopes = { "User.Read" };
-        private const string ConfidentialClientID = "8b5195c6-3cc2-4e81-ad28-1e07ad219f3e";
+        private const string ConfidentialClientID = "88f91eac-c606-4c67-a0e2-a5e8a186854f";
         private const string TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         private const string CertificateName = "for-cca-testing";
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/SeleniumTests/ConfidentialClientAuthorizationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         private static readonly TimeSpan s_timeout = TimeSpan.FromMinutes(1);
 
         private static readonly string[] s_scopes = { "User.Read" };
-        private const string ConfidentialClientID = "35dc5034-9b65-4a5d-ad81-73cca468c1e0";
+        private const string ConfidentialClientID = "35dc5034-9b65-4a5d-ad81-73cca468c1e0"; //msidlab4.com app
         private const string TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         private const string CertificateName = "for-cca-testing";
 


### PR DESCRIPTION
Fixes #3809

**Changes proposed in this request**
Using the lab app for integration tests. The lab app needed an updated redirectURI and the for-cca-testing certificate. I will also add comments to the test on which lab is hosting this app, so it is easier to update the app when the next cert rollover happens 

**Testing**
CI

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
