### PR TITLE
Proxy HTTP instead of Managed Identity

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/Http/HttpRequestFacade.cs
+++ b/tests/Microsoft.Identity.Test.Common/Http/HttpRequestFacade.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Microsoft.Identity.Test.Common.Http
+{
+    public class HttpRequestFacade
+    {
+        public string Uri { get; set; }
+
+        public HttpMethod Method { get; set; }
+        public string ContentForPost { get; set; }
+        public List<KeyValuePair<string, string>> Headers { get; set; }
+
+        public HttpRequestMessage ToHttpRequestMessage()
+        {
+            var httpRequestMessage = new HttpRequestMessage(Method, Uri);
+            foreach (var header in Headers)
+            {
+                httpRequestMessage.Headers.Add(header.Key, header.Value);
+            }
+
+            if (Method == HttpMethod.Post)
+            {
+                httpRequestMessage.Content = new StringContent(ContentForPost);
+            }
+
+            return httpRequestMessage;
+        }
+
+        public FormUrlEncodedContent ToFormUrlEncodedContent()
+        {
+            var values = new Dictionary<string, string>
+            {
+                {"Uri", Uri},
+                {"Method", Method.ToString()},
+                {"ContentForPost", ContentForPost},
+                {"Headers", string.Join(";", Headers.Select(h => $"{h.Key}={h.Value}"))}
+            };
+
+            var content = new FormUrlEncodedContent(values);
+            return content;
+        }
+
+        public static HttpRequestFacade FromHttpRequestMessage(HttpRequestMessage requestMessage)
+        {
+            var httpRequestFacade = new HttpRequestFacade
+            {
+                Uri = requestMessage.RequestUri.AbsoluteUri,
+                Method = requestMessage.Method,
+                Headers = requestMessage.Headers.SelectMany(h => h.Value, (h, v) => new KeyValuePair<string, string>(h.Key, v)).ToList()
+            };
+
+            if (requestMessage.Content != null)
+            {
+                httpRequestFacade.ContentForPost = requestMessage.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            }
+
+            return httpRequestFacade;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Common/Http/HttpResponseFacade.cs
+++ b/tests/Microsoft.Identity.Test.Common/Http/HttpResponseFacade.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net;
+using System.Linq;
+
+namespace Microsoft.Identity.Test.Common.Http
+{
+    public class HttpResponseFacade
+    {
+        public List<KeyValuePair<string, string>> Headers { get; set; }
+
+        public HttpStatusCode HttpStatusCode { get; set; }
+
+        public string Content { get; set; }
+
+        public HttpResponseMessage ToHttpResponseMessage()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode);
+            foreach (var header in Headers)
+            {
+                response.Headers.Add(header.Key, header.Value);
+            }
+
+            response.Content = new StringContent(Content);
+            return response;
+        }
+
+        public static HttpResponseFacade FromHttpResponseMessage(HttpResponseMessage response)
+        {
+            var facade = new HttpResponseFacade
+            {
+                HttpStatusCode = response.StatusCode,
+                Headers = response.Headers.SelectMany(h => h.Value, (h, v) => new KeyValuePair<string, string>(h.Key, v)).ToList(),
+                Content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            };
+
+            return facade;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Common/Http/ProxyHttpClientFactory.cs
+++ b/tests/Microsoft.Identity.Test.Common/Http/ProxyHttpClientFactory.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Text;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Identity.Test.Common.Http
+{
+    public class RemoteHttpFactory : IMsalHttpClientFactory
+    {
+        private readonly HttpClient _httpClient;
+
+        public RemoteHttpFactory(Uri proxyUri)
+        {
+
+            _httpClient = new HttpClient(new RemoteServiceHostHandler(proxyUri));
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return _httpClient;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Common/Http/RemoteServiceHostHandler.cs
+++ b/tests/Microsoft.Identity.Test.Common/Http/RemoteServiceHostHandler.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Collections.Generic;
+
+namespace Microsoft.Identity.Test.Common.Http
+{
+    public class RemoteServiceHostHandler : DelegatingHandler
+    {
+        private static readonly HttpClient _httpClient = new HttpClient();
+        private readonly Uri _proxyUri;
+
+        public RemoteServiceHostHandler(Uri proxyUri)
+        {
+            _proxyUri = proxyUri;
+        }
+
+
+        /// <summary>
+        /// Stop the request. Instead, call the MSI helper.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            // HttpRequestMessage is not serializable, so we need to create a facade
+            HttpRequestFacade requestFacade = HttpRequestFacade.FromHttpRequestMessage(request);
+            
+
+            // Send the request to the helper service
+            var response = await _httpClient.PostAsync(_proxyUri, requestFacade.ToFormUrlEncodedContent())
+                .ConfigureAwait(false);
+
+            return response;
+        }
+    }
+}

--- a/tests/devapps/MSI/HelperService/MSIHelperService/Controllers/GetMSITokenController.cs
+++ b/tests/devapps/MSI/HelperService/MSIHelperService/Controllers/GetMSITokenController.cs
@@ -2,11 +2,36 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Test.Common.Http;
 using MSIHelperService.Helper;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace MSIHelperService.Controllers
 {
+    [ApiController]
+    [Route("[controller]")]
+    [SwaggerTag(description: "Gets MSI Token")]
+    public class HttpController : ControllerBase
+    {
+        private readonly ILogger _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public HttpController(ILogger<GetMSITokenController> logger, IHttpClientFactory httpClientFactory)
+        {
+            _logger = logger;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        [HttpPost]
+        public async Task<HttpResponseFacade> SendAsync(HttpRequestFacade requestFacade)
+        {
+            HttpRequestMessage request = requestFacade.ToHttpRequestMessage();
+            HttpResponseMessage response = await _httpClientFactory.CreateClient().SendAsync(request).ConfigureAwait(false);
+            return HttpResponseFacade.FromHttpResponseMessage(response);
+        }
+    }
+    
+    
     [ApiController]
     [Route("[controller]")]
     [SwaggerTag(description: "Gets MSI Token")]

--- a/tests/devapps/MSI/HelperService/MSIHelperService/MSIHelperService.csproj
+++ b/tests/devapps/MSI/HelperService/MSIHelperService/MSIHelperService.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
+    <ProjectReference Include="..\..\..\..\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/devapps/MSI/HelperService/MSIHelperService/Program.cs
+++ b/tests/devapps/MSI/HelperService/MSIHelperService/Program.cs
@@ -17,6 +17,8 @@ builder.Services.AddEndpointsApiExplorer();
 // Register the Swagger generator, defining 1 or more Swagger documents
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddHttpClient();
+
 builder.Services.AddApplicationInsightsTelemetry();
 
 builder.Services.AddAuthorization(options =>

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Desktop;
 using Microsoft.Identity.Client.Extensibility;
+using Microsoft.Identity.Test.Common.Http;
 using Microsoft.Identity.Test.Integration.NetFx.Infrastructure;
 using NetCoreTestApp.Experimental;
 
@@ -54,7 +55,7 @@ namespace NetCoreTestApp
             var ccaSettings = ConfidentialAppSettings.GetSettings(Cloud.Public);
             s_clientIdForConfidentialApp = ccaSettings.ClientId;
             s_ccaAuthority = ccaSettings.Authority;
-            s_confidentialClientSecret = ccaSettings.GetSecret();
+            //s_confidentialClientSecret = ccaSettings.GetSecret();
 
             var pca = CreatePca();
             RunConsoleAppLogicAsync(pca).Wait();
@@ -68,9 +69,12 @@ namespace NetCoreTestApp
 
         private static IPublicClientApplication CreatePca()
         {
+            var proxyHttpFactory = new RemoteHttpFactory(new Uri("https://localhost:7059/Http"));
+            
             var pcaBuilder = PublicClientApplicationBuilder
                             .Create(s_clientIdForPublicApp)
                             .WithAuthority(GetAuthority())
+                            .WithHttpClientFactory(proxyHttpFactory)
                             .WithLogging(Log, LogLevel.Verbose, true)
                             .WithExperimentalFeatures()
                             .WithDesktopFeatures();

--- a/tests/devapps/WebApi/Program.cs
+++ b/tests/devapps/WebApi/Program.cs
@@ -13,7 +13,9 @@ namespace WebApi
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().
+                
+                Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>


### PR DESCRIPTION
Shows an example of prox-ing HTTP call at a more general level

Sadly I could not get it to work end to end, but it should be close.