### PR TITLE
Update analysis build tools versions (per warnings)

### DIFF
--- a/LibsAndSamples.sln
+++ b/LibsAndSamples.sln
@@ -89,6 +89,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "all", "all", "{C44AADC0-1E9
 		build\MSAL.CodeCoverage.runsettings = build\MSAL.CodeCoverage.runsettings
 		NuGet.Config = NuGet.Config
 		build\platform_and_feature_flags.props = build\platform_and_feature_flags.props
+		build\policheck_exclusion.xml = build\policheck_exclusion.xml
+		build\policheck_filetypes.xml = build\policheck_filetypes.xml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetFxConsoleApp", "tests\devapps\NetFxConsoleTestApp\NetFxConsoleApp.csproj", "{2EBB7FFE-47E0-46F8-A4D6-79A4CF44729C}"

--- a/build/policheck_exclusion.xml
+++ b/build/policheck_exclusion.xml
@@ -1,0 +1,12 @@
+<PoliCheckExclusions>
+  <!-- Each of these exclusions is a folder name - if \[name]\ exists in the file path, it will be skipped -->
+  <!--<Exclusion Type="FolderPathFull">ABC|XYZ</Exclusion>-->
+  <!-- Each of these exclusions is a folder name - if any folder or file starts with "\[name]", it will be 
+skipped -->
+  <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
+  <!-- Each of these file types will be completely skipped for the entire scan -->
+  <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
+  <!-- The specified file names will be skipped during the scan regardless which folder they are in -->
+  <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
+  <Exclusion Type="FolderPathFull">JSON</Exclusion>
+</PoliCheckExclusions>

--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -16,8 +16,11 @@ jobs: #Build and stage projects
   container: mcr.microsoft.com/windows/servercore:ltsc2022-KB5017316
 
   steps:
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '16.x'
   #Pre build analysis
-  - template: template-prebuild-code-analysis.yaml
+    - template: template-prebuild-code-analysis.yaml
 
 - job: 'BuildAndStageProjects'
   pool:

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -2,11 +2,11 @@
 # Run post-build code analysis (e.g. Roslyn analyzers)
 
 steps:
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
   displayName: 'Run Roslyn Analyzers'
   continueOnError: true
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Check Roslyn Results '
   inputs:
     RoslynAnalyzers: true

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -4,6 +4,7 @@
 steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
   displayName: 'Run Roslyn Analyzers'
+  userProvideBuildInfo: auto
   continueOnError: true
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -9,4 +9,4 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Check Roslyn Results '
   inputs:
-    RoslynAnalyzers: true
+    GdnBreakGdnToolRoslynAnalyzers: true

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -2,9 +2,8 @@
 # Run post-build code analysis (e.g. Roslyn analyzers)
 
 steps:
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
   displayName: 'Run Roslyn Analyzers'
-  userProvideBuildInfo: auto
   continueOnError: true
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2

--- a/build/template-prebuild-code-analysis.yaml
+++ b/build/template-prebuild-code-analysis.yaml
@@ -6,7 +6,7 @@ steps:
   displayName: 'Run PoliCheck'
   inputs:
     targetType: F
-    optionsUEPATH: 'build/policheck_exclusion.xml'
+    optionsUEPATH: '$(Build.SourcesDirectory)/build/policheck_exclusion.xml'
     optionsFTPATH: 'build/policheck_filetypes.xml'
   continueOnError: true
 

--- a/build/template-prebuild-code-analysis.yaml
+++ b/build/template-prebuild-code-analysis.yaml
@@ -2,21 +2,21 @@
 # Run pre-build code analysis (e.g. credscan, policheck)
 
 steps:
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
   displayName: 'Run PoliCheck'
   inputs:
     targetType: F
     optionsFTPATH: 'build/policheck_filetypes.xml'
   continueOnError: true
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: 'Run CredScan'
   inputs:
     suppressionsFile: 'build/credscan-exclusion.json'
     toolMajorVersion: V2
     debugMode: false
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Post Analysis'
   inputs:
     CredScan: true

--- a/build/template-prebuild-code-analysis.yaml
+++ b/build/template-prebuild-code-analysis.yaml
@@ -20,5 +20,5 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Post Analysis'
   inputs:
-    CredScan: true
-    PoliCheck: true
+    GdnBreakGdnToolCredScan: true
+    GdnBreakGdnToolPoliCheck: true

--- a/build/template-prebuild-code-analysis.yaml
+++ b/build/template-prebuild-code-analysis.yaml
@@ -6,6 +6,7 @@ steps:
   displayName: 'Run PoliCheck'
   inputs:
     targetType: F
+    optionsUEPATH: 'build/policheck_exclusion.xml'
     optionsFTPATH: 'build/policheck_filetypes.xml'
   continueOnError: true
 

--- a/build/template-publish-analysis-and-cleanup.yaml
+++ b/build/template-publish-analysis-and-cleanup.yaml
@@ -6,7 +6,7 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
   displayName: 'Publish Security Analysis Logs'
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
   displayName: 'TSA upload to Codebase: Unified .NET Core Stamp: Azure'
   inputs:
     tsaVersion: TsaV2

--- a/build/template-publish-analysis-and-cleanup.yaml
+++ b/build/template-publish-analysis-and-cleanup.yaml
@@ -3,10 +3,10 @@
 # Should be LAST step of any build it's used in.
 
 steps:
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
   displayName: 'Publish Security Analysis Logs'
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
   displayName: 'TSA upload to Codebase: Unified .NET Core Stamp: Azure'
   inputs:
     tsaVersion: TsaV2

--- a/build/template-run-integration-tests.yaml
+++ b/build/template-run-integration-tests.yaml
@@ -16,7 +16,7 @@ steps:
     codeCoverageEnabled: true
     failOnMinTestsNotRun: true
     minimumExpectedTests: '1'
-    pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to screw something up
+    pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to mess something up
 
 - task: VSTest@2
   displayName: 'Run integration tests (.NET Core)'

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -17,7 +17,7 @@ steps:
     codeCoverageEnabled: true
     failOnMinTestsNotRun: true
     minimumExpectedTests: '1'
-    pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to screw something up
+    pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to mess something up
 
 - task: VSTest@2
   displayName: 'Run unit tests (.NET CORE 3.1)'

--- a/build/template-sign-binary.yaml
+++ b/build/template-sign-binary.yaml
@@ -70,4 +70,4 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Check BinSkim Results'
   inputs:
-    BinSkim: true
+    GdnBreakGdnToolBinSkim: true

--- a/build/template-sign-binary.yaml
+++ b/build/template-sign-binary.yaml
@@ -63,7 +63,7 @@ steps:
   displayName: 'Run BinSkim ${{ parameters.Pattern }}'
   inputs:
     InputType: Basic
-    AnalyzeTarget: ${{ parameters.Pattern }}
+    AnalyzeTargetGlob: ${{ parameters.Pattern }}
     AnalyzeVerbose: true
     AnalyzeHashes: true
 

--- a/build/template-sign-binary.yaml
+++ b/build/template-sign-binary.yaml
@@ -59,7 +59,7 @@ steps:
     VerboseLogin: true
   timeoutInMinutes: 10
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
   displayName: 'Run BinSkim ${{ parameters.Pattern }}'
   inputs:
     InputType: Basic
@@ -67,7 +67,7 @@ steps:
     AnalyzeVerbose: true
     AnalyzeHashes: true
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Check BinSkim Results'
   inputs:
     BinSkim: true


### PR DESCRIPTION
- Update analysis build tool versions
- Exclude Newtonsoft code from Policheck
- Fix Policheck warnings