### PR TITLE
Add system.text.json support on UWP

### DIFF
--- a/build/platform_and_feature_flags.props
+++ b/build/platform_and_feature_flags.props
@@ -9,7 +9,7 @@
     <DefineConstants>$(DefineConstants);NET6_WIN;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_CUSTOM_CACHE;SUPPORTS_BROKER;SUPPORTS_WIN32;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkUap)' ">
-    <DefineConstants>$(DefineConstants);WINDOWS_APP;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE;IS_XAMARIN_OR_UWP</DefineConstants>
+    <DefineConstants>$(DefineConstants);WINDOWS_APP;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE;IS_XAMARIN_OR_UWP;SUPPORTS_SYSTEM_TEXT_JSON</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) Or '$(TargetFramework)' == '$(TargetFrameworkNet6Android)'">
     <DefineConstants>$(DefineConstants);ANDROID;SUPPORTS_BROKER;IS_XAMARIN_OR_UWP</DefineConstants>

--- a/src/client/Microsoft.Identity.Client/Cache/Adal/AdalResult.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Adal/AdalResult.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonIncludeAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Cache/Adal/AdalResultWrapper.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Adal/AdalResultWrapper.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Identity.Client.Utils;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 #else
 using Microsoft.Identity.Json;
 #endif

--- a/src/client/Microsoft.Identity.Client/Cache/Adal/AdalUserInfo.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Adal/AdalUserInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonIncludeAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryMetadataEntry.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryMetadataEntry.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryResponse.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryResponse.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Identity.Client.OAuth2;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Instance/Region/LocalImdsErrorResponse.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/LocalImdsErrorResponse.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Instance/Validation/AdfsWebFingerResponse.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Validation/AdfsWebFingerResponse.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.Identity.Client.OAuth2;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using System.Text.Json.Nodes;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else

--- a/src/client/Microsoft.Identity.Client/Internal/ClientInfo.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientInfo.cs
@@ -5,7 +5,7 @@ using System;
 using System.Globalization;
 using Microsoft.Identity.Client.Utils;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Internal/DeviceCodeResponse.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/DeviceCodeResponse.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Identity.Client.OAuth2;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -9,7 +9,7 @@ using System.Text;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.Utils;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using System.Text.Json.Serialization;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 using JObject = System.Text.Json.Nodes.JsonObject;

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityErrorResponse.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityErrorResponse.cs
@@ -3,7 +3,7 @@
 
 using System;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityResponse.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityResponse.cs
@@ -3,7 +3,7 @@
 
 using System;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -8,6 +8,8 @@
     <TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
     <TargetFrameworkNet6>net6.0</TargetFrameworkNet6>
     <TargetFrameworkNet6Win>net6.0-windows10.0.17763.0</TargetFrameworkNet6Win>
+    <TargetFrameworkUap>uap10.0.17763</TargetFrameworkUap>
+
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
   </PropertyGroup>
 
@@ -144,7 +146,7 @@
     <!-- Manually include the cs files -->
     <Compile Include="$(PathToMsalSources)\**\*.cs" Exclude="$(PathToMsalSources)\obj\**\*.*" />
     <Compile Remove="$(PathToMsalSources)\Platforms\**\*.*;$(PathToMsalSources)\Resources\*.cs" />
-    <Compile Remove="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
+    <Compile Remove="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />   
     <EmbeddedResource Include="$(PathToMsalSources)\Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
 
@@ -245,8 +247,15 @@
     <PackageReference Include="System.ServiceModel.Http" Version="4.5.3" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.5.3" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.5.3" />
-
+    
+    
+    
+    <!--System.Text.Json replaces internal NewtonSoft for NET 6-->
+    <Compile Remove="$(PathToMsalSources)\json\**\*.*" />
+    <PackageReference Include="System.Text.Json" Version="7.0.1" />
+  
   </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkIos)'">
     <Compile Include="$(PathToMsalSources)\Platforms\iOS\**\*.cs" />    
     <Compile Include="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />

--- a/src/client/Microsoft.Identity.Client/OAuth2/DeviceAuthJWTResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/DeviceAuthJWTResponse.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Identity.Client.Utils;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -12,7 +12,7 @@ using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.Utils;
 #if SUPPORTS_SYSTEM_TEXT_JSON
 using System.Text.Json;
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JObject = System.Text.Json.Nodes.JsonObject;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuth2ResponseBase.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuth2ResponseBase.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Json/JsonObjectAttribute.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Json/JsonObjectAttribute.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#if SUPPORTS_SYSTEM_TEXT_JSON
 
 using System;
 
-namespace Microsoft.Identity.Client.Platforms.net6
+namespace Microsoft.Identity.Client.PlatformsCommon.Shared.Json
 {
     /// <summary>
-    /// Dummy class to mimic Microsoft.Identity.Json.JsonObjectAttribute on Net 6 platform to reduce the number of compilation flags in the code
+    /// Dummy class to mimic Microsoft.Identity.Json.JsonObjectAttribute platform to reduce the number of compilation flags in the code
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false)]
     internal class JsonObjectAttribute : Attribute
@@ -14,3 +15,4 @@ namespace Microsoft.Identity.Client.Platforms.net6
         public string Title { get; set; }
     }
 }
+#endif

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Json/JsonStringConverter.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Json/JsonStringConverter.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#if SUPPORTS_SYSTEM_TEXT_JSON
 
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.Identity.Client.Platforms.net6
+namespace Microsoft.Identity.Client.PlatformsCommon.Shared.Json
 {
     internal class JsonStringConverter : JsonConverter<string>
     {
@@ -40,3 +41,4 @@ namespace Microsoft.Identity.Client.Platforms.net6
         }
     }
 }
+#endif

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Json/MsalJsonSerializerContext.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/Json/MsalJsonSerializerContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#if SUPPORTS_SYSTEM_TEXT_JSON
 
 using System.Collections.Generic;
 using System.Text.Json;
@@ -14,7 +15,7 @@ using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.Region;
 using Microsoft.Identity.Client.WsTrust;
 
-namespace Microsoft.Identity.Client.Platforms.net6
+namespace Microsoft.Identity.Client.PlatformsCommon.Shared.Json
 {
     /// <summary>
     /// This class specifies metadata for System.Text.Json source generation.
@@ -61,3 +62,4 @@ namespace Microsoft.Identity.Client.Platforms.net6
         }
     }
 }
+#endif

--- a/src/client/Microsoft.Identity.Client/UI/AuthorizationResult.cs
+++ b/src/client/Microsoft.Identity.Client/UI/AuthorizationResult.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.Utils;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 #else
 using Microsoft.Identity.Json;
 #endif

--- a/src/client/Microsoft.Identity.Client/Utils/JsonHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/JsonHelper.cs
@@ -8,7 +8,7 @@ using System.Text;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using JObject = System.Text.Json.Nodes.JsonObject;

--- a/src/client/Microsoft.Identity.Client/WsTrust/UserRealmDiscoveryResponse.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/UserRealmDiscoveryResponse.cs
@@ -3,7 +3,7 @@
 
 using System;
 #if SUPPORTS_SYSTEM_TEXT_JSON
-using Microsoft.Identity.Client.Platforms.net6;
+using Microsoft.Identity.Client.PlatformsCommon.Shared.Json;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
 #else
 using Microsoft.Identity.Json;


### PR DESCRIPTION
[Probably] Fixes #2187 

Note to reviewers: there are 2 commits, pls review them separately. Commit 2 is just a rename of namespaces.

Tested: ATS / ATI with and without WAM
Not tested if the actual bug is fixed due to lack of ARM64 device 

