### PR TITLE
Update TSA upload and Roslyn analyzer tasks

### DIFF
--- a/LibsAndSamples.sln
+++ b/LibsAndSamples.sln
@@ -91,6 +91,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "all", "all", "{C44AADC0-1E9
 		build\platform_and_feature_flags.props = build\platform_and_feature_flags.props
 		build\policheck_exclusion.xml = build\policheck_exclusion.xml
 		build\policheck_filetypes.xml = build\policheck_filetypes.xml
+		build\tsaConfig.json = build\tsaConfig.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetFxConsoleApp", "tests\devapps\NetFxConsoleTestApp\NetFxConsoleApp.csproj", "{2EBB7FFE-47E0-46F8-A4D6-79A4CF44729C}"
@@ -110,6 +111,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pipelines", "pipelines", "{
 		build\pipeline-ci.yaml = build\pipeline-ci.yaml
 		build\pipeline-perf-tests-automation.yaml = build\pipeline-perf-tests-automation.yaml
 		build\pipeline-pullrequest.yaml = build\pipeline-pullrequest.yaml
+		build\pipeline-releasebuild-netonly.yaml = build\pipeline-releasebuild-netonly.yaml
 		build\pipeline-releasebuild.yaml = build\pipeline-releasebuild.yaml
 		build\template-android-appcenter-tests.yaml = build\template-android-appcenter-tests.yaml
 		build\template-build-and-prep-automation.yaml = build\template-build-and-prep-automation.yaml

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -2,8 +2,9 @@
 # Run post-build code analysis (e.g. Roslyn analyzers)
 
 steps:
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
   displayName: 'Run Roslyn Analyzers'
+  userProvideBuildInfo: autoMsBuildInfo
   continueOnError: true
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -6,6 +6,8 @@ steps:
   displayName: 'Run Roslyn Analyzers'
   inputs:
     userProvideBuildInfo: auto
+  env:
+    system_accesstoken: $(System.AccessToken)
   continueOnError: true
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2

--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -4,7 +4,8 @@
 steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
   displayName: 'Run Roslyn Analyzers'
-  userProvideBuildInfo: autoMsBuildInfo
+  inputs:
+    userProvideBuildInfo: auto
   continueOnError: true
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2

--- a/build/template-publish-analysis-and-cleanup.yaml
+++ b/build/template-publish-analysis-and-cleanup.yaml
@@ -9,7 +9,6 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
   displayName: 'TSA upload to Codebase: Unified .NET Core Stamp: Azure'
   inputs:
-    GdnPublishTsaOnboard: true
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/tsaConfig.json'
   continueOnError: true
 

--- a/build/template-publish-analysis-and-cleanup.yaml
+++ b/build/template-publish-analysis-and-cleanup.yaml
@@ -6,24 +6,11 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
   displayName: 'Publish Security Analysis Logs'
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
   displayName: 'TSA upload to Codebase: Unified .NET Core Stamp: Azure'
   inputs:
-    tsaVersion: TsaV2
-    codebase: NewOrUpdate
-    codeBaseName: 'Unified .NET Core'
-    notificationAlias: 'IdentityDevExDotnet@microsoft.com'
-    codeBaseAdmins: 'EUROPE\\aadidagt'
-    instanceUrlForTsaV2: IDENTITYDIVISION
-    projectNameIDENTITYDIVISION: IDDP
-    areaPath: 'IDDP\DevEx-Client-SDK\DotNet'
-    iterationPath: 'IDDP\Unscheduled'
-    uploadAPIScan: false
-    uploadFortifySCA: false
-    uploadFxCop: false
-    uploadModernCop: false
-    uploadPREfast: false
-    uploadTSLint: false
+    GdnPublishTsaOnboard: true
+    GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/tsaConfig.json'
   continueOnError: true
 
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3

--- a/build/template-publish-analysis-and-cleanup.yaml
+++ b/build/template-publish-analysis-and-cleanup.yaml
@@ -9,6 +9,7 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
   displayName: 'TSA upload to Codebase: Unified .NET Core Stamp: Azure'
   inputs:
+    GdnPublishTsaOnboard: false
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/tsaConfig.json'
   continueOnError: true
 

--- a/build/tsaConfig.json
+++ b/build/tsaConfig.json
@@ -11,9 +11,9 @@
     "areaPath": "IDDP\\DevEx-Client-SDK\\DotNet",
     "iterationPath": "IDDP\\Unscheduled",
     "tools": [
-        "BinSkim",
-        "CredScan",
-        "PoliCheck",
-        "Roslyn"
+        "binskim",
+        "credscan",
+        "policheck",
+        "roslynanalyzers"
     ]
 }

--- a/build/tsaConfig.json
+++ b/build/tsaConfig.json
@@ -1,0 +1,19 @@
+{
+    "codebaseName": "Unified .NET Core",
+    "notificationAliases": [
+        "IdentityDevExDotnet@microsoft.com"
+    ],
+    "codebaseAdmins": [
+        "EUROPE\\aadidagt"
+    ],
+    "instanceUrl": "IDENTITYDIVISION",
+    "projectName": "IDDP",
+    "areaPath": "IDDP\\DevEx-Client-SDK\\DotNet",
+    "iterationPath": "IDDP\\Unscheduled",
+    "tools": [
+        "BinSkim",
+        "CredScan",
+        "PoliCheck",
+        "Roslyn"
+    ]
+}

--- a/build/tsaConfig.json
+++ b/build/tsaConfig.json
@@ -6,7 +6,7 @@
     "codebaseAdmins": [
         "EUROPE\\aadidagt"
     ],
-    "instanceUrl": "IDENTITYDIVISION",
+    "instanceUrl": "https://identitydivision.visualstudio.com",
     "projectName": "IDDP",
     "areaPath": "IDDP\\DevEx-Client-SDK\\DotNet",
     "iterationPath": "IDDP\\Unscheduled",


### PR DESCRIPTION
**Changes proposed in this request**
- Update Roslyn analyzers task version and input
- Update TSA upload task version and use config file (required) instead of input parameters

All of the compliance tasks need to be on the latest version to be able to work together. The newer and older versions don't seem to be backwards compatible.