### PR TITLE
Fix WAM exception thrown during sign out for the new preview broker 

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Identity.Client.Broker
                     }
                     else
                     {
-                        _logger?.ErrorPii(
+                        _logger?.WarningPii(
                             $"[WamBroker] Could not find a WAM account for the selected user {account.Username} - error: {readAccountResult.Error}",
                             $"[WamBroker] Could not find a WAM account for the selected user, error: {readAccountResult.Error}");
                     }
@@ -428,7 +428,7 @@ namespace Microsoft.Identity.Client.Broker
                         }
                         else
                         {
-                            _logger?.ErrorPii(
+                            _logger?.WarningPii(
                             $"[WamBroker] Could not sign out user {account.Username} - error: {result.Error}",
                             $"[WamBroker] Could not sign out user, error: {result.Error}");
                         }

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -412,12 +412,9 @@ namespace Microsoft.Identity.Client.Broker
                     }
                     else
                     {
-                        _logger?.WarningPii(
+                        _logger?.ErrorPii(
                             $"[WamBroker] Could not find a WAM account for the selected user {account.Username} - error: {readAccountResult.Error}",
                             $"[WamBroker] Could not find a WAM account for the selected user, error: {readAccountResult.Error}");
-
-                        string errorMessage = $"{readAccountResult.Error} (error code : {readAccountResult.Error.ErrorCode})";
-                        throw new MsalServiceException("wam_no_account_found", errorMessage);
                     }
 
                     using (NativeInterop.SignOutResult result = await s_lazyCore.Value.SignOutSilentlyAsync(
@@ -431,12 +428,9 @@ namespace Microsoft.Identity.Client.Broker
                         }
                         else
                         {
-                            _logger?.WarningPii(
+                            _logger?.ErrorPii(
                             $"[WamBroker] Could not sign out user {account.Username} - error: {result.Error}",
                             $"[WamBroker] Could not sign out user, error: {result.Error}");
-
-                            string errorMessage = $"{result.Error} (error code : {result.Error.ErrorCode})";
-                            throw new MsalServiceException("wam_sign_out_failed", errorMessage);
                         }
                     }
                 }

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -431,7 +431,12 @@ namespace Microsoft.Identity.Client.Broker
                         }
                         else
                         {
-                            WamAdapters.ThrowExceptionFromWamError(result, _logger);
+                            _logger?.WarningPii(
+                            $"[WamBroker] Could not sign out user {account.Username} - error: {result.Error}",
+                            $"[WamBroker] Could not sign out user, error: {result.Error}");
+
+                            string errorMessage = $"{result.Error} (error code : {result.Error.ErrorCode})";
+                            throw new MsalServiceException("wam_sign_out_failed", errorMessage);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #3685 

**Changes proposed in this request**
- Was wrongly passing SignOutResult object to ThrowExceptionFromWamError(), the exception handler only accepts authResult object
- Fixes the APIContractViolation error during signout 

**Testing**
Dev App

**Performance impact**
None

**Documentation**
- [ ] All relevant documentation is updated.
