### PR TITLE
Deprecate extended expiry API

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -195,6 +195,7 @@ namespace Microsoft.Identity.Client
         /// Client applications accept extended life time tokens only if
         /// the ExtendedLifeTimeEnabled Boolean is set to true on ClientApplicationBase.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)] // deprecated, this feature is not in use
         public bool IsExtendedLifeTimeToken { get; }
 
         /// <summary>
@@ -214,6 +215,7 @@ namespace Microsoft.Identity.Client
         /// Gets the point in time in which the Access Token returned in the AccessToken property ceases to be valid in MSAL's extended LifeTime.
         /// This value is calculated based on current UTC time measured locally and the value ext_expiresIn received from the service.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)] // deprecated, this feature is not in use
         public DateTimeOffset ExtendedExpiresOn { get; }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -57,10 +57,12 @@ namespace Microsoft.Identity.Client
             string spaAuthCode = null)
         {
             AccessToken = accessToken;
+#pragma warning disable CS0618 // Type or member is obsolete
             IsExtendedLifeTimeToken = isExtendedLifeTimeToken;
+            ExtendedExpiresOn = extendedExpiresOn;
+#pragma warning restore CS0618 // Type or member is obsolete
             UniqueId = uniqueId;
             ExpiresOn = expiresOn;
-            ExtendedExpiresOn = extendedExpiresOn;
             TenantId = tenantId;
             Account = account;
             IdToken = idToken;
@@ -165,9 +167,13 @@ namespace Microsoft.Identity.Client
             {
                 AccessToken = authenticationScheme.FormatAccessToken(msalAccessTokenCacheItem);
                 ExpiresOn = msalAccessTokenCacheItem.ExpiresOn;
-                ExtendedExpiresOn = msalAccessTokenCacheItem.ExtendedExpiresOn;
                 Scopes = msalAccessTokenCacheItem.ScopeSet;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                ExtendedExpiresOn = msalAccessTokenCacheItem.ExtendedExpiresOn;
                 IsExtendedLifeTimeToken = msalAccessTokenCacheItem.IsExtendedLifeTimeToken;
+#pragma warning restore CS0618 // Type or member is obsolete
+
                 TokenType = msalAccessTokenCacheItem.TokenType;
 
                 if (msalAccessTokenCacheItem.RefreshOn.HasValue)
@@ -195,7 +201,9 @@ namespace Microsoft.Identity.Client
         /// Client applications accept extended life time tokens only if
         /// the ExtendedLifeTimeEnabled Boolean is set to true on ClientApplicationBase.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)] // deprecated, this feature is not in use
+        /// <remarks>This feature is not in use</remarks>
+        [Obsolete("This feature has been deprecated", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)] // deprecated, this feature is not in use        
         public bool IsExtendedLifeTimeToken { get; }
 
         /// <summary>
@@ -216,6 +224,7 @@ namespace Microsoft.Identity.Client
         /// This value is calculated based on current UTC time measured locally and the value ext_expiresIn received from the service.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)] // deprecated, this feature is not in use
+        [Obsolete("This feature has been deprecated", false)]
         public DateTimeOffset ExtendedExpiresOn { get; }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 .GetProperties()
                 .Where(p => p.GetCustomAttribute(typeof(ObsoleteAttribute)) == null);
 
-            Assert.AreEqual(ctorParameters.Length, classProperties.Count(), "The <for test> constructor should include all properties of AuthenticationObject"); ;
+            // +2 because of the obsolete ExtendedExpires properties
+            Assert.AreEqual(ctorParameters.Length, classProperties.Count() + 2, "The <for test> constructor should include all properties of AuthenticationObject"); ;
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTestsWithB2C.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTestsWithB2C.cs
@@ -282,7 +282,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.IsNull(result.AccessToken);
             Assert.IsNull(result.Scopes);
             Assert.IsTrue(result.ExpiresOn == default);
-            Assert.IsTrue(result.ExtendedExpiresOn == default);
         }
 
         private static void ValidateB2CLoginAuthority(MockHttpAndServiceBundle harness, string authority)

--- a/tests/devapps/KerberosConsole/Program.cs
+++ b/tests/devapps/KerberosConsole/Program.cs
@@ -455,8 +455,6 @@ namespace KerberosConsole
             AADKerberosLogger.Save("           Correlation Id: " + result.CorrelationId);
             AADKerberosLogger.Save("                Unique Id:" + result.UniqueId);
             AADKerberosLogger.Save("                Expres On: " + result.ExpiresOn);
-            AADKerberosLogger.Save("  IsExtendedLifeTimeToken: " + result.IsExtendedLifeTimeToken);
-            AADKerberosLogger.Save("       Extended Expres On: " + result.ExtendedExpiresOn);
             AADKerberosLogger.Save("             Access Token:\n" + result.AccessToken);
             AADKerberosLogger.Save("                 Id Token:\n" + result.IdToken);
 


### PR DESCRIPTION
Fixes #1377
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

Not used. Funny how the comments mention that app developer must configure this via `ClientApplicationBase` but no such config exists.
