### PR TITLE
Remove container from build

### DIFF
--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -12,9 +12,6 @@ jobs: #Build and stage projects
   variables:
       runCodesignValidationInjection: false
 
-  #Specified container image to use for build. See: https://hub.docker.com/_/microsoft-windows-servercore
-  container: mcr.microsoft.com/windows/servercore:ltsc2022-KB5017316
-
   steps:
     - task: NodeTool@0
       inputs:


### PR DESCRIPTION
Container was added as an experiment (per Travis); can be removed, as it adds like 5 min to build time. We only have it for the PreBuild stage and the compliance tasks there don't use it.