### PR TITLE
Add dotnet task for prebuild compliance tasks.

### DIFF
--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -16,9 +16,6 @@ jobs: #Build and stage projects
   container: mcr.microsoft.com/windows/servercore:ltsc2022-KB5017316
 
   steps:
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '16.x'
   #Pre build analysis
     - template: template-prebuild-code-analysis.yaml
 

--- a/build/template-prebuild-code-analysis.yaml
+++ b/build/template-prebuild-code-analysis.yaml
@@ -2,6 +2,15 @@
 # Run pre-build code analysis (e.g. credscan, policheck)
 
 steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '16.x'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 6.x'
+  inputs:
+    version: 6.x
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
   displayName: 'Run PoliCheck'
   inputs:

--- a/build/template-prebuild-code-analysis.yaml
+++ b/build/template-prebuild-code-analysis.yaml
@@ -3,6 +3,7 @@
 
 steps:
 - task: NodeTool@0
+  displayName: 'Install NPM'
   inputs:
     versionSpec: '16.x'
 


### PR DESCRIPTION
**Changes proposed in this request**
The latest version of compliance tool was updated, and it looks and tries to install .NET 6 instead of .NET Core 3.1. After installing it can't find dotnet path. So adding this install task explicitly fixes the issue.