### PR TITLE
Bypass the Accounts Control when there is an account hint

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -15,6 +15,7 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.Utils;
 using static Microsoft.Identity.Client.Broker.RuntimeBroker;
 
@@ -240,6 +241,10 @@ namespace Microsoft.Identity.Client.Broker
             NativeInterop.AuthParameters authParams,
             ILoggerAdapter logger)
         {
+            //Set MSAL Identity Provider only for AcquireTokenInteractive API
+            if (authenticationRequestParameters.ApiId != ApiEvent.ApiIds.AcquireTokenInteractive)
+                return;
+
             //Set MsalIdentityProvider Based on Tenant ID
             if (authenticationRequestParameters?.Account?.HomeAccountId != null)
             {

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Identity.Client.Broker
         //MSA-PT Auth Params
         private const string NativeInteropMsalRequestType = "msal_request_type";
         private const string ConsumersPassthroughRequest = "consumer_passthrough";
+        private const string MsaMsalIdentityProvider = "msal_identity_provider";
+        private const string IdentityProviderTypeMSA = "msa";
         private const string WamHeaderTitle = "msal_accounts_control_title";
 
         //MSAL Runtime Error Response 
@@ -178,6 +180,7 @@ namespace Microsoft.Identity.Client.Broker
             if (brokerOptions.MsaPassthrough)
             {
                 authParams.Properties[NativeInteropMsalRequestType] = ConsumersPassthroughRequest;
+                authParams.Properties[MsaMsalIdentityProvider] = IdentityProviderTypeMSA;
             }
 
             //WAM Header Title

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -27,8 +27,9 @@ namespace Microsoft.Identity.Client.Broker
         //MSA-PT Auth Params
         private const string NativeInteropMsalRequestType = "msal_request_type";
         private const string ConsumersPassthroughRequest = "consumer_passthrough";
-        private const string MsaMsalIdentityProvider = "msal_identity_provider";
+        private const string MsalIdentityProvider = "msal_identity_provider";
         private const string IdentityProviderTypeMSA = "msa";
+        private const string IdentityProviderTypeAAD = "aad";
         private const string WamHeaderTitle = "msal_accounts_control_title";
 
         //MSAL Runtime Error Response 
@@ -176,11 +177,13 @@ namespace Microsoft.Identity.Client.Broker
             //this is used internally by the interop to fallback to the browser 
             authParams.RedirectUri = authenticationRequestParameters.RedirectUri.ToString();
 
+            //MSAL Identity Provider
+            SetMSALIdentityProvider(authenticationRequestParameters, authParams, logger);
+
             //MSA-PT
             if (brokerOptions.MsaPassthrough)
             {
                 authParams.Properties[NativeInteropMsalRequestType] = ConsumersPassthroughRequest;
-                authParams.Properties[MsaMsalIdentityProvider] = IdentityProviderTypeMSA;
             }
 
             //WAM Header Title
@@ -229,6 +232,36 @@ namespace Microsoft.Identity.Client.Broker
                 authParams.PopParams.UriHost = authenticationRequestParameters.PopAuthenticationConfiguration.HttpHost;
                 authParams.PopParams.UriPath = authenticationRequestParameters.PopAuthenticationConfiguration.HttpPath;
                 authParams.PopParams.Nonce = authenticationRequestParameters.PopAuthenticationConfiguration.Nonce;
+            }
+        }
+
+        private static void SetMSALIdentityProvider(
+            AuthenticationRequestParameters authenticationRequestParameters, 
+            NativeInterop.AuthParameters authParams,
+            ILoggerAdapter logger)
+        {
+            //Set MsalIdentityProvider Based on Tenant ID
+            if (authenticationRequestParameters?.Account?.HomeAccountId != null)
+            {
+                if (!string.IsNullOrEmpty(authenticationRequestParameters.Account.HomeAccountId.TenantId))
+                {
+                    var tenantObjectId = authenticationRequestParameters.Account.HomeAccountId.TenantId;
+
+                    if (tenantObjectId.Equals(Constants.MsaTenantId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        logger.Verbose($"[WamBroker] MSALRuntime Identity provider set to " +
+                            $"{ IdentityProviderTypeMSA }.");
+
+                        authParams.Properties[MsalIdentityProvider] = IdentityProviderTypeMSA;
+                    }
+                    else
+                    {
+                        logger.Verbose($"[WamBroker] MSALRuntime Identity provider set to " +
+                            $"{ IdentityProviderTypeAAD }.");
+
+                        authParams.Properties[MsalIdentityProvider] = IdentityProviderTypeAAD;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #3301

**Changes proposed in this request**
In majority of cases, MSALRuntime will know which identity provider to invoke based on the authority. However, in the consumer pass through scenario where the authority is /organizations or /<tanent_id> but the application accepts MSA, passing the account_hint itself will not able to disambiguate the identity provider. 
Hence, if there is an account_hint in the SignInInteractively, MSAL need to pass this additional key value pair if the identity provider is MSA:
````
{"msal_identity_provider":"msa"}
````
If this key value is missing or the value is not msa, the account_hint will be treated as AAD by default.  
If the account was signed in before and has an account object in MSAL C++ (By calling ReadAccountById), the token acquisition path should be to re-hydrated the account and then call acquireToken* with the account object instead of using SignInInteractively with the account_hint.

[Adding link to the design](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3301#issuecomment-1399941331) 


**Testing**
Dev App with MSA-PT

**Performance impact**
None

**Documentation**
- [ ] All relevant documentation is updated.
