### PR TITLE
Audit all info and verbose logs and use lambdas to generate strings

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Identity.Client.Broker
                 {
                     if (readAccountResult.IsSuccess)
                     {
-                        _logger?.Verbose(() => "[WamBroker] WAM Account exist and can be removed.");
+                        _logger?.Verbose(() => "[WamBroker] WAM Account exists and can be removed.");
 
                     }
                     else

--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Identity.Client.Broker
 
             var cancellationToken = authenticationRequestParameters.RequestContext.UserCancellationToken;
 
-            _logger?.Verbose("[WamBroker] Using Windows account picker.");
+            _logger?.Verbose(() => "[WamBroker] Using Windows account picker.");
 
             if (authenticationRequestParameters?.Account?.HomeAccountId?.ObjectId != null)
             {
@@ -215,7 +215,7 @@ namespace Microsoft.Identity.Client.Broker
             {
                 //Login Hint
                 string loginHint = authenticationRequestParameters.LoginHint ?? authenticationRequestParameters?.Account?.Username;
-                _logger?.Verbose("[WamBroker] AcquireTokenInteractive - login hint provided? " + !string.IsNullOrEmpty(loginHint));
+                _logger?.Verbose(() => "[WamBroker] AcquireTokenInteractive - login hint provided? " + !string.IsNullOrEmpty(loginHint));
 
                 using (var result = await s_lazyCore.Value.SignInInteractivelyAsync(
                     _parentHandle,
@@ -242,7 +242,7 @@ namespace Microsoft.Identity.Client.Broker
             MsalTokenResponse msalTokenResponse = null;
             var cancellationToken = authenticationRequestParameters.RequestContext.UserCancellationToken;
 
-            _logger?.Verbose("[WamBroker] Signing in with the default user account.");
+            _logger?.Verbose(() => "[WamBroker] Signing in with the default user account.");
 
             using (var authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
@@ -283,7 +283,7 @@ namespace Microsoft.Identity.Client.Broker
             var cancellationToken = authenticationRequestParameters.RequestContext.UserCancellationToken;
             MsalTokenResponse msalTokenResponse = null;
 
-            _logger?.Verbose("[WamBroker] Acquiring token silently.");
+            _logger?.Verbose(() => "[WamBroker] Acquiring token silently.");
 
             using (var authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
@@ -331,7 +331,7 @@ namespace Microsoft.Identity.Client.Broker
             var cancellationToken = authenticationRequestParameters.RequestContext.UserCancellationToken;
             MsalTokenResponse msalTokenResponse = null;
 
-            _logger?.Verbose("[WamBroker] Acquiring token silently for default account.");
+            _logger?.Verbose(() => "[WamBroker] Acquiring token silently for default account.");
 
             using (var authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
@@ -361,7 +361,7 @@ namespace Microsoft.Identity.Client.Broker
             var cancellationToken = authenticationRequestParameters.RequestContext.UserCancellationToken;
             MsalTokenResponse msalTokenResponse = null;
 
-            _logger?.Verbose("[WamBroker] Acquiring token with Username Password flow.");
+            _logger?.Verbose(() => "[WamBroker] Acquiring token with Username Password flow.");
 
             using (AuthParameters authParams = WamAdapters.GetCommonAuthParameters(
                 authenticationRequestParameters, 
@@ -391,7 +391,7 @@ namespace Microsoft.Identity.Client.Broker
             
             if (account == null)
             {
-                _logger?.Verbose("[WamBroker] No valid account was passed to RemoveAccountAsync. ");
+                _logger?.Verbose(() => "[WamBroker] No valid account was passed to RemoveAccountAsync. ");
                 throw new MsalClientException("wam_remove_account_failed", "No valid account was passed.");
             }
 
@@ -400,11 +400,11 @@ namespace Microsoft.Identity.Client.Broker
             //if OperatingSystemAccount is passed then we use the user signed -in on the machine
             if (PublicClientApplication.IsOperatingSystemAccount(account))
             {
-                _logger?.Verbose("[WamBroker] Default Operating System Account cannot be removed. ");
+                _logger?.Verbose(() => "[WamBroker] Default Operating System Account cannot be removed. ");
                 throw new MsalClientException("wam_remove_account_failed", "Default Operating System account cannot be removed.");
             }
 
-            _logger?.Info($"Removing WAM Account. Correlation ID : {correlationId} ");
+            _logger?.Info(() => $"Removing WAM Account. Correlation ID : {correlationId} ");
 
             {
                 using (var readAccountResult = await s_lazyCore.Value.ReadAccountByIdAsync(
@@ -414,7 +414,7 @@ namespace Microsoft.Identity.Client.Broker
                 {
                     if (readAccountResult.IsSuccess)
                     {
-                        _logger?.Verbose("[WamBroker] WAM Account exist and can be removed.");
+                        _logger?.Verbose(() => "[WamBroker] WAM Account exist and can be removed.");
 
                     }
                     else
@@ -431,7 +431,7 @@ namespace Microsoft.Identity.Client.Broker
                     {
                         if (result.IsSuccess)
                         {
-                            _logger?.Verbose("[WamBroker] Account signed out successfully. ");
+                            _logger?.Verbose(() => "[WamBroker] Account signed out successfully. ");
                         }
                         else
                         {
@@ -470,7 +470,7 @@ namespace Microsoft.Identity.Client.Broker
                 {
                     List<NativeInterop.Account> wamAccounts = discoverAccountsResult.Accounts;
 
-                    _logger.Info($"[WamBroker] Broker returned {wamAccounts.Count} account(s).");
+                    _logger.Info(() => $"[WamBroker] Broker returned {wamAccounts.Count} account(s).");
 
                     if (wamAccounts.Count == 0)
                     {
@@ -487,11 +487,11 @@ namespace Microsoft.Identity.Client.Broker
                                 environmentList,
                                 requestContext).ConfigureAwait(false);
 
-                        _logger.Verbose($"[WamBroker] Filtering WAM accounts based on Environment.");
+                        _logger.Verbose(() => $"[WamBroker] Filtering WAM accounts based on Environment.");
 
                         wamAccounts.RemoveAll(acc => !instanceMetadata.Aliases.ContainsOrdinalIgnoreCase(acc.Environment));
 
-                        _logger.Verbose($"[WamBroker] {wamAccounts.Count} account(s) returned after filtering.");
+                        _logger.Verbose(() => $"[WamBroker] {wamAccounts.Count} account(s) returned after filtering.");
                     }
 
                     List<IAccount> msalAccounts = new List<IAccount>();
@@ -504,7 +504,7 @@ namespace Microsoft.Identity.Client.Broker
                         }
                     }
 
-                    _logger.Verbose($"[WamBroker] Converted {msalAccounts.Count} WAM account(s) to MSAL Account(s).");
+                    _logger.Verbose(() => $"[WamBroker] Converted {msalAccounts.Count} WAM account(s) to MSAL Account(s).");
 
                     return msalAccounts;
                 }
@@ -549,12 +549,12 @@ namespace Microsoft.Identity.Client.Broker
 
             if (s_lazyCore.Value == null)
             {
-                _logger?.Info("[WAM Broker] MsalRuntime initialization failed. See https://aka.ms/msal-net-wam#wam-limitations");
+                _logger?.Info(() => "[WAM Broker] MsalRuntime initialization failed. See https://aka.ms/msal-net-wam#wam-limitations");
                 _logger?.InfoPii(s_initException);
                 return false;
             }
 
-            _logger?.Verbose($"[WAM Broker] MsalRuntime initialization successful.");
+            _logger?.Verbose(() => "[WAM Broker] MsalRuntime initialization successful.");
             return true;
         }
 

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -241,16 +241,12 @@ namespace Microsoft.Identity.Client.Broker
 
                     if (tenantObjectId.Equals(Constants.MsaTenantId, StringComparison.OrdinalIgnoreCase))
                     {
-                        logger.Verbose(() => $"[WamBroker] MSALRuntime Identity provider set to " +
-                            $"{ IdentityProviderTypeMSA }.");
-
+                        logger.Verbose(() => $"[WamBroker] MSALRuntime Identity provider set to MSA.");
                         authParams.Properties[MsalIdentityProvider] = IdentityProviderTypeMSA;
                     }
                     else
                     {
-                        logger.Verbose(() => $"[WamBroker] MSALRuntime Identity provider set to " +
-                            $"{ IdentityProviderTypeAAD }.");
-
+                        logger.Verbose(() => "[WamBroker] MSALRuntime Identity provider set to AAD");
                         authParams.Properties[MsalIdentityProvider] = IdentityProviderTypeAAD;
                     }
                 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/EmbeddedWebViewOptions.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/EmbeddedWebViewOptions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Client
         {
             logger.Info("WebView2Options configured");
 
-            logger.Info($"Title: {Title}");
+            logger.Info(() => $"Title: {Title}");
         }
 
         internal static void ValidatePlatformAvailability()

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/AbstractExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/AbstractExecutor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
             var requestContext = new RequestContext(ServiceBundle, correlationId, userCancellationToken);
 
             requestContext.Logger.Info(
-                string.Format(
+                () => string.Format(
                     CultureInfo.InvariantCulture,
                     "MSAL {0} with assembly version '{1}'. CorrelationId({2})",
                     ServiceBundle.PlatformProxy.GetProductName(),

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ClientApplicationBaseExecutor.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
                 requestContext,
                 _clientApplicationBase.UserTokenCacheInternal).ConfigureAwait(false);
 
-            requestContext.Logger.Info(LogMessages.UsingXScopesForRefreshTokenRequest(commonParameters.Scopes.Count()));
+            requestContext.Logger.Info(() => LogMessages.UsingXScopesForRefreshTokenRequest(commonParameters.Scopes.Count()));
 
             requestParameters.SendX5C = refreshTokenParameters.SendX5C ?? false;
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
@@ -15,11 +15,14 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         /// <inheritdoc />
         public void LogParameters(ILoggerAdapter logger)
         {
-            var builder = new StringBuilder();
-            builder.AppendLine("=== AcquireTokenForClientParameters ===");
-            builder.AppendLine("SendX5C: " + SendX5C);
-            builder.AppendLine("ForceRefresh: " + ForceRefresh);
-            logger.Info(builder.ToString());
+            if (logger.IsLoggingEnabled(LogLevel.Info))
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("=== AcquireTokenForClientParameters ===");
+                builder.AppendLine("SendX5C: " + SendX5C);
+                builder.AppendLine("ForceRefresh: " + ForceRefresh);
+                logger.Info(builder.ToString());
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenInteractiveParameters.cs
@@ -30,16 +30,19 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         public void LogParameters(ILoggerAdapter logger)
         {
-            var builder = new StringBuilder();
-            builder.AppendLine("=== InteractiveParameters Data ===");
-            builder.AppendLine("LoginHint provided: " + !string.IsNullOrEmpty(LoginHint));
-            builder.AppendLine("User provided: " + (Account != null));
-            builder.AppendLine("UseEmbeddedWebView: " + UseEmbeddedWebView);
-            builder.AppendLine("ExtraScopesToConsent: " + string.Join(";", ExtraScopesToConsent ?? CollectionHelpers.GetEmptyReadOnlyList<string>()));
-            builder.AppendLine("Prompt: " + Prompt.PromptValue);
-            builder.AppendLine("HasCustomWebUi: " + (CustomWebUi != null));
-            UiParent.SystemWebViewOptions?.LogParameters(logger);
-            logger.Info(builder.ToString());
+            if (logger.IsLoggingEnabled(LogLevel.Info))
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine("=== InteractiveParameters Data ===");
+                builder.AppendLine("LoginHint provided: " + !string.IsNullOrEmpty(LoginHint));
+                builder.AppendLine("User provided: " + (Account != null));
+                builder.AppendLine("UseEmbeddedWebView: " + UseEmbeddedWebView);
+                builder.AppendLine("ExtraScopesToConsent: " + string.Join(";", ExtraScopesToConsent ?? CollectionHelpers.GetEmptyReadOnlyList<string>()));
+                builder.AppendLine("Prompt: " + Prompt.PromptValue);
+                builder.AppendLine("HasCustomWebUi: " + (CustomWebUi != null));
+                UiParent.SystemWebViewOptions?.LogParameters(logger);
+                logger.Info(builder.ToString());
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
@@ -21,21 +21,24 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         /// <inheritdoc />
         public void LogParameters(ILoggerAdapter logger)
         {
-            var builder = new StringBuilder();
-            builder.AppendLine("=== OnBehalfOfParameters ===");
-            builder.AppendLine("SendX5C: " + SendX5C);
-            builder.AppendLine("ForceRefresh: " + ForceRefresh);
-            builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
-            builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
-            if (UserAssertion != null && !string.IsNullOrWhiteSpace(LongRunningOboCacheKey))
+            if (logger.IsLoggingEnabled(LogLevel.Info))
             {
-                builder.AppendLine("InitiateLongRunningProcessInWebApi called: True");
+                var builder = new StringBuilder();
+                builder.AppendLine("=== OnBehalfOfParameters ===");
+                builder.AppendLine("SendX5C: " + SendX5C);
+                builder.AppendLine("ForceRefresh: " + ForceRefresh);
+                builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
+                builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
+                if (UserAssertion != null && !string.IsNullOrWhiteSpace(LongRunningOboCacheKey))
+                {
+                    builder.AppendLine("InitiateLongRunningProcessInWebApi called: True");
+                }
+                else if (UserAssertion == null && !string.IsNullOrWhiteSpace(LongRunningOboCacheKey))
+                {
+                    builder.AppendLine("AcquireTokenInLongRunningProcess called: True");
+                }
+                logger.Info(builder.ToString());
             }
-            else if (UserAssertion == null && !string.IsNullOrWhiteSpace(LongRunningOboCacheKey))
-            {
-                builder.AppendLine("AcquireTokenInLongRunningProcess called: True");
-            }
-            logger.Info(builder.ToString());
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenSilentParameters.cs
@@ -10,17 +10,20 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public bool ForceRefresh { get; set; }
         public string LoginHint { get; set; }
         public IAccount Account { get; set; }
-        public bool? SendX5C { get; set; } 
+        public bool? SendX5C { get; set; }
 
         /// <inheritdoc />
         public void LogParameters(ILoggerAdapter logger)
         {
-            logger.Info("=== AcquireTokenSilent Parameters ===");
-            logger.Info("LoginHint provided: " + !string.IsNullOrEmpty(LoginHint));
-            logger.InfoPii(
-                "Account provided: " + ((Account != null) ? Account.ToString() : "false"),
-                "Account provided: " + (Account != null));
-            logger.Info("ForceRefresh: " + ForceRefresh);
+            if (logger.IsLoggingEnabled(LogLevel.Info))
+            {
+                logger.Info("=== AcquireTokenSilent Parameters ===");
+                logger.Info("LoginHint provided: " + !string.IsNullOrEmpty(LoginHint));
+                logger.InfoPii(
+                    "Account provided: " + ((Account != null) ? Account.ToString() : "false"),
+                    "Account provided: " + (Account != null));
+                logger.Info("ForceRefresh: " + ForceRefresh);
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/SystemWebViewOptions.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/SystemWebViewOptions.cs
@@ -74,15 +74,20 @@ namespace Microsoft.Identity.Client
         {
             logger.Info("DefaultBrowserOptions configured");
 
-            logger.InfoPii("HtmlMessageSuccess " + HtmlMessageSuccess,
-                "HtmlMessageSuccess? " + !String.IsNullOrEmpty(HtmlMessageSuccess));
-            logger.InfoPii("HtmlMessageError " + HtmlMessageError,
-               "HtmlMessageError? " + !String.IsNullOrEmpty(HtmlMessageError));
-            logger.InfoPii("BrowserRedirectSuccess " + BrowserRedirectSuccess,
-               "BrowserRedirectSuccess? " + (BrowserRedirectSuccess != null));
-            logger.InfoPii("BrowserRedirectError " + BrowserRedirectError,
-               "BrowserRedirectError? " + (BrowserRedirectError != null));
-            logger.Info($"HidePrivacyPrompt {iOSHidePrivacyPrompt}");
+            logger.InfoPii(
+                () => "HtmlMessageSuccess " + HtmlMessageSuccess,
+                () => "HtmlMessageSuccess? " + !String.IsNullOrEmpty(HtmlMessageSuccess));
+            logger.InfoPii(
+                () => "HtmlMessageError " + HtmlMessageError,
+                () => "HtmlMessageError? " + !String.IsNullOrEmpty(HtmlMessageError));
+            logger.InfoPii(
+                () => "BrowserRedirectSuccess " + BrowserRedirectSuccess,
+                () => "BrowserRedirectSuccess? " + (BrowserRedirectSuccess != null));
+            logger.InfoPii(
+                () => "BrowserRedirectError " + BrowserRedirectError,
+                () => "BrowserRedirectError? " + (BrowserRedirectError != null));
+            
+            logger.Info(() => $"HidePrivacyPrompt {iOSHidePrivacyPrompt}");
         }
 
         internal static void ValidatePlatformAvailability()

--- a/src/client/Microsoft.Identity.Client/ApiConfig/SystemWebViewOptions.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/SystemWebViewOptions.cs
@@ -72,22 +72,25 @@ namespace Microsoft.Identity.Client
 
         internal void LogParameters(ILoggerAdapter logger)
         {
-            logger.Info("DefaultBrowserOptions configured");
+            if (logger.IsLoggingEnabled(LogLevel.Info))
+            {
+                logger.Info("DefaultBrowserOptions configured");
 
-            logger.InfoPii(
-                () => "HtmlMessageSuccess " + HtmlMessageSuccess,
-                () => "HtmlMessageSuccess? " + !String.IsNullOrEmpty(HtmlMessageSuccess));
-            logger.InfoPii(
-                () => "HtmlMessageError " + HtmlMessageError,
-                () => "HtmlMessageError? " + !String.IsNullOrEmpty(HtmlMessageError));
-            logger.InfoPii(
-                () => "BrowserRedirectSuccess " + BrowserRedirectSuccess,
-                () => "BrowserRedirectSuccess? " + (BrowserRedirectSuccess != null));
-            logger.InfoPii(
-                () => "BrowserRedirectError " + BrowserRedirectError,
-                () => "BrowserRedirectError? " + (BrowserRedirectError != null));
-            
-            logger.Info(() => $"HidePrivacyPrompt {iOSHidePrivacyPrompt}");
+                logger.InfoPii(
+                    () => "HtmlMessageSuccess " + HtmlMessageSuccess,
+                    () => "HtmlMessageSuccess? " + !String.IsNullOrEmpty(HtmlMessageSuccess));
+                logger.InfoPii(
+                    () => "HtmlMessageError " + HtmlMessageError,
+                    () => "HtmlMessageError? " + !String.IsNullOrEmpty(HtmlMessageError));
+                logger.InfoPii(
+                    () => "BrowserRedirectSuccess " + BrowserRedirectSuccess,
+                    () => "BrowserRedirectSuccess? " + (BrowserRedirectSuccess != null));
+                logger.InfoPii(
+                    () => "BrowserRedirectError " + BrowserRedirectError,
+                    () => "BrowserRedirectError? " + (BrowserRedirectError != null));
+
+                logger.Info(() => $"HidePrivacyPrompt {iOSHidePrivacyPrompt}");
+            }
         }
 
         internal static void ValidatePlatformAvailability()

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Identity.Client
         /// </param>
         /// <returns>The builder to chain the .With methods</returns>
         /// <exception cref="InvalidOperationException"/> is thrown if the loggingCallback
-        /// was already set on the application builder
+        /// was already set on the application builder        
         public T WithLogging(
             LogCallback loggingCallback,
             LogLevel? logLevel = null,

--- a/src/client/Microsoft.Identity.Client/Cache/AdalCacheOperations.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/AdalCacheOperations.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Client.Cache
             {
                 BinaryWriter writer = new BinaryWriter(stream);
                 writer.Write(SchemaVersion);
-                logger.Info($"[AdalCacheOperations] Serializing token cache with {tokenCacheDictionary.Count} items. ");
+                logger.Info(() => $"[AdalCacheOperations] Serializing token cache with {tokenCacheDictionary.Count} items. ");
 
                 writer.Write(tokenCacheDictionary.Count);
                 foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> kvp in tokenCacheDictionary)
@@ -76,7 +76,7 @@ namespace Microsoft.Identity.Client.Cache
                     dictionary[key] = resultEx;
                 }
 
-                logger.Info($"[AdalCacheOperations] Deserialized {dictionary.Count} items to ADAL token cache. ");
+                logger.Info(() => $"[AdalCacheOperations] Deserialized {dictionary.Count} items to ADAL token cache. ");
             }
 
             return dictionary;

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -102,9 +102,9 @@ namespace Microsoft.Identity.Client.Cache
             {
                 if (!_cacheRefreshedForRead)
                 {
-                    _requestParams.RequestContext.Logger.Verbose($"[Cache Session Manager] Entering the cache semaphore. { TokenCacheInternal.Semaphore.GetCurrentCountLogMessage()}");
+                    _requestParams.RequestContext.Logger.Verbose(()=>$"[Cache Session Manager] Entering the cache semaphore. { TokenCacheInternal.Semaphore.GetCurrentCountLogMessage()}");
                     await TokenCacheInternal.Semaphore.WaitAsync(_requestParams.RequestContext.UserCancellationToken).ConfigureAwait(false);
-                    _requestParams.RequestContext.Logger.Verbose("[Cache Session Manager] Entered cache semaphore");
+                    _requestParams.RequestContext.Logger.Verbose(()=>"[Cache Session Manager] Entered cache semaphore");
 
                     Stopwatch stopwatch = new Stopwatch();
                     try
@@ -169,7 +169,7 @@ namespace Microsoft.Identity.Client.Cache
                     finally
                     {
                         TokenCacheInternal.Semaphore.Release();
-                        _requestParams.RequestContext.Logger.Verbose("[Cache Session Manager] Released cache semaphore");
+                        _requestParams.RequestContext.Logger.Verbose(()=>"[Cache Session Manager] Released cache semaphore");
                     }
                 }
             }

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Identity.Client
         // Not all brokers return the accounts only for the given env
         private async Task<IEnumerable<IAccount>> FilterBrokerAccountsByEnvAsync(IEnumerable<IAccount> brokerAccounts, CancellationToken cancellationToken)
         {
-            ServiceBundle.ApplicationLogger.Verbose(()=>$"Filtering broker accounts by env. Before filtering: " + brokerAccounts.Count());
+            ServiceBundle.ApplicationLogger.Verbose(()=>$"Filtering broker accounts by environment. Before filtering: " + brokerAccounts.Count());
 
             ISet<string> allEnvs = new HashSet<string>(
                 brokerAccounts.Select(aci => aci.Environment),
@@ -335,7 +335,7 @@ namespace Microsoft.Identity.Client
                 else
                 {
                     ServiceBundle.ApplicationLogger.InfoPii(
-                        () => "Account merge eliminated broker account with id: " + account.HomeAccountId,
+                        () => "Account merge eliminated broker account with ID: " + account.HomeAccountId,
                         () => "Account merge eliminated an account");
                 }
             }

--- a/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -257,10 +257,10 @@ namespace Microsoft.Identity.Client
             accountsFromCache = accountsFromCache ?? Enumerable.Empty<IAccount>();
             accountsFromBroker = accountsFromBroker ?? Enumerable.Empty<IAccount>();
 
-            ServiceBundle.ApplicationLogger.Info($"Found {accountsFromCache.Count()} cache accounts and {accountsFromBroker.Count()} broker accounts");
+            ServiceBundle.ApplicationLogger.Info(() => $"Found {accountsFromCache.Count()} cache accounts and {accountsFromBroker.Count()} broker accounts");
             IEnumerable<IAccount> cacheAndBrokerAccounts = MergeAccounts(accountsFromCache, accountsFromBroker);
 
-            ServiceBundle.ApplicationLogger.Info($"Returning {cacheAndBrokerAccounts.Count()} accounts");
+            ServiceBundle.ApplicationLogger.Info(() => $"Returning {cacheAndBrokerAccounts.Count()} accounts");
             return cacheAndBrokerAccounts;
         }
 
@@ -302,7 +302,7 @@ namespace Microsoft.Identity.Client
         // Not all brokers return the accounts only for the given env
         private async Task<IEnumerable<IAccount>> FilterBrokerAccountsByEnvAsync(IEnumerable<IAccount> brokerAccounts, CancellationToken cancellationToken)
         {
-            ServiceBundle.ApplicationLogger.Verbose($"Filtering broker accounts by env. Before filtering: " + brokerAccounts.Count());
+            ServiceBundle.ApplicationLogger.Verbose(()=>$"Filtering broker accounts by env. Before filtering: " + brokerAccounts.Count());
 
             ISet<string> allEnvs = new HashSet<string>(
                 brokerAccounts.Select(aci => aci.Environment),
@@ -315,7 +315,7 @@ namespace Microsoft.Identity.Client
 
             brokerAccounts = brokerAccounts.Where(acc => instanceMetadata.Aliases.ContainsOrdinalIgnoreCase(acc.Environment));
 
-            ServiceBundle.ApplicationLogger.Verbose($"After filtering: " + brokerAccounts.Count());
+            ServiceBundle.ApplicationLogger.Verbose(()=>$"After filtering: " + brokerAccounts.Count());
 
             return brokerAccounts;
         }
@@ -335,8 +335,8 @@ namespace Microsoft.Identity.Client
                 else
                 {
                     ServiceBundle.ApplicationLogger.InfoPii(
-                        "Account merge eliminated broker account with id: " + account.HomeAccountId,
-                        "Account merge eliminated an account");
+                        () => "Account merge eliminated broker account with id: " + account.HomeAccountId,
+                        () => "Account merge eliminated an account");
                 }
             }
 

--- a/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client
             AppTokenCacheInternal = configuration.AppTokenCacheInternalForTest ?? new TokenCache(ServiceBundle, true);
             Certificate = configuration.ClientCredentialCertificate;
 
-            this.ServiceBundle.ApplicationLogger.Verbose($"ConfidentialClientApplication {configuration.GetHashCode()} created");
+            this.ServiceBundle.ApplicationLogger.Verbose(()=>$"ConfidentialClientApplication {configuration.GetHashCode()} created");
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Identity.Client.Http
                     return response;
                 }
 
-                logger.Info(string.Format(CultureInfo.InvariantCulture,
+                logger.Info(() => string.Format(CultureInfo.InvariantCulture,
                     MsalErrorMessage.HttpRequestUnsuccessful,
                     (int)response.StatusCode, response.StatusCode));
 
@@ -251,8 +251,8 @@ namespace Microsoft.Identity.Client.Http
                 requestMessage.Content = body;
 
                 logger.VerbosePii(
-                    $"[HttpManager] Sending request. Method: {method}. URI: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}{endpoint.AbsolutePath}")}. ",
-                    $"[HttpManager] Sending request. Method: {method}. Host: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}")}. ");
+                    () => $"[HttpManager] Sending request. Method: {method}. URI: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}{endpoint.AbsolutePath}")}. ",
+                    () => $"[HttpManager] Sending request. Method: {method}. Host: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}")}. ");
 
                 Stopwatch sw = Stopwatch.StartNew();
 
@@ -262,7 +262,7 @@ namespace Microsoft.Identity.Client.Http
                     await client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false))
                 {
                     LastRequestDurationInMs = sw.ElapsedMilliseconds;
-                    logger.Verbose($"[HttpManager] Received response. Status code: {responseMessage.StatusCode}. ");
+                    logger.Verbose(()=>$"[HttpManager] Received response. Status code: {responseMessage.StatusCode}. ");
 
                     HttpResponse returnValue = await CreateResponseAsync(responseMessage).ConfigureAwait(false);
                     returnValue.UserAgent = requestMessage.Headers.UserAgent.ToString();

--- a/src/client/Microsoft.Identity.Client/Http/RedirectUriHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Http/RedirectUriHelper.cs
@@ -53,14 +53,14 @@ namespace Microsoft.Identity.Client.Http
             // MSAL style redirect URI - case sensitive
             if (string.Equals(expectedRedirectUri, actualRedirectUriString.TrimEnd('/'), StringComparison.Ordinal))
             {
-                logger.Verbose("Valid MSAL style redirect Uri detected. ");
+                logger.Verbose(() => "Valid MSAL style redirect Uri detected. ");
                 return;
             }
 
             // ADAL style redirect URI - my_scheme://{bundleID} 
             if (redirectUri.Authority.Equals(bundleId, StringComparison.OrdinalIgnoreCase))
             {
-                logger.Verbose("Valid ADAL style redirect Uri detected. ");
+                logger.Verbose(() => "Valid ADAL style redirect Uri detected. ");
                 return;
             }
 

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 }
                 if (entry == null)
                 {
-                    requestContext.Logger.Info($"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because is not enabled.");
+                    requestContext.Logger.Info(() => $"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because is not enabled.");
                     entry = CreateEntryForSingleAuthority(authorityInfo.CanonicalAuthority);
                 }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             }
             else
             {
-                requestContext.Logger.Info($"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because is not supported.");
+                requestContext.Logger.Info(() => $"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because is not supported.");
                 return await GetMetadataEntryAsync(authorityInfo, requestContext).ConfigureAwait(false);
             }
         }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 }
                 if (entry == null)
                 {
-                    requestContext.Logger.Info(() => $"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because is not enabled.");
+                    requestContext.Logger.Info(() => $"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because it is not enabled.");
                     entry = CreateEntryForSingleAuthority(authorityInfo.CanonicalAuthority);
                 }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             }
             else
             {
-                requestContext.Logger.Info(() => $"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because is not supported.");
+                requestContext.Logger.Info(() => $"Skipping Instance discovery for {authorityInfo.AuthorityType} authority because it is not supported.");
                 return await GetMetadataEntryAsync(authorityInfo, requestContext).ConfigureAwait(false);
             }
         }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -108,14 +108,14 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             if (canUseProvider)
             {
                 s_knownEntries.TryGetValue(environment, out InstanceDiscoveryMetadataEntry entry);
-                logger.Verbose($"[Instance Discovery] Tried to use known metadata provider for {environment}. Success? {entry != null}. ");
+                logger.Verbose(()=>$"[Instance Discovery] Tried to use known metadata provider for {environment}. Success? {entry != null}. ");
 
                 return entry;
             }
 
             logger.VerbosePii(
-                $"[Instance Discovery] Could not use known metadata provider because at least one environment in the cache is not known. Environments in cache: {string.Join(" ", existingEnvironmentsInCache)} ",
-                $"[Instance Discovery] Could not use known metadata provider because at least one environment in the cache is not known. ");
+                () => $"[Instance Discovery] Could not use known metadata provider because at least one environment in the cache is not known. Environments in cache: {string.Join(" ", existingEnvironmentsInCache)} ",
+                () => $"[Instance Discovery] Could not use known metadata provider because at least one environment in the cache is not known. ");
             return null;
         }
 

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkCacheMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkCacheMetadataProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         public InstanceDiscoveryMetadataEntry GetMetadata(string environment, ILoggerAdapter logger)
         {
             s_cache.TryGetValue(environment, out InstanceDiscoveryMetadataEntry entry);
-            logger.Verbose($"[Instance Discovery] Tried to use network cache provider for {environment}. Success? {entry != null}. ");
+            logger.Verbose(() => $"[Instance Discovery] Tried to use network cache provider for {environment}. Success? {entry != null}. ");
 
             return entry;
         }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             var cachedEntry = _networkCacheMetadataProvider.GetMetadata(environment, logger);
             if (cachedEntry != null)
             {
-                logger.Verbose($"[Instance Discovery] The network provider found an entry for {environment}. ");
+                logger.Verbose(() => $"[Instance Discovery] The network provider found an entry for {environment}. ");
                 return cachedEntry;
             }
 
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             CacheInstanceDiscoveryMetadata(discoveryResponse);
 
             cachedEntry = _networkCacheMetadataProvider.GetMetadata(environment, logger);
-            logger.Verbose($"[Instance Discovery] After hitting the discovery endpoint, the network provider found an entry for {environment} ? {cachedEntry != null}. ");
+            logger.Verbose(() => $"[Instance Discovery] After hitting the discovery endpoint, the network provider found an entry for {environment} ? {cachedEntry != null}. ");
 
             return cachedEntry;
         }
@@ -109,8 +109,8 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 authority.Port);
 
             requestContext.Logger.InfoPii(
-                $"Fetching instance discovery from the network from host {discoveryHost}. Endpoint {instanceDiscoveryEndpoint}. ",
-                $"Fetching instance discovery from the network from host {discoveryHost}. ");
+                () => $"Fetching instance discovery from the network from host {discoveryHost}. Endpoint {instanceDiscoveryEndpoint}. ",
+                () => $"Fetching instance discovery from the network from host {discoveryHost}. ");
 
             return new Uri(instanceDiscoveryEndpoint);
         }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionDiscoveryProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Client.Region
 
             if (KnownMetadataProvider.IsPublicEnvironment(host))
             {
-                requestContext.Logger.Info($"[Region discovery] Regionalized Environment is : {region}.{PublicEnvForRegional}. ");
+                requestContext.Logger.Info(() => $"[Region discovery] Regionalized Environment is : {region}.{PublicEnvForRegional}. ");
                 return $"{region}.{PublicEnvForRegional}";
             }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client.Region
                 host = preferredNetworkEnv;
             }
 
-            requestContext.Logger.Info($"[Region discovery] Regionalized Environment is : {region}.{host}. ");
+            requestContext.Logger.Info(() => $"[Region discovery] Regionalized Environment is : {region}.{host}. ");
             return $"{region}.{host}";
         }
     }

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/UserMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/UserMetadataProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         {
             _entries.TryGetValue(environment ?? "", out InstanceDiscoveryMetadataEntry entry);
 
-            logger.Verbose($"[Instance Discovery] Tried to use user metadata provider for {environment}. Success? {entry != null}. ");
+            logger.Verbose(() => $"[Instance Discovery] Tried to use user metadata provider for {environment}. Success? {entry != null}. ");
 
             if (entry == null)
             {

--- a/src/client/Microsoft.Identity.Client/Instance/Region/RegionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Region/RegionManager.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Identity.Client.Region
             var logger = requestContext.Logger;
             if (string.IsNullOrEmpty(azureRegionConfig))
             {
-                logger.Verbose($"[Region discovery] WithAzureRegion not configured. ");
+                logger.Verbose(() => $"[Region discovery] WithAzureRegion not configured. ");
                 return null;
             }
 
@@ -85,20 +85,20 @@ namespace Microsoft.Identity.Client.Region
             {
                 if (discoveredRegion.RegionSource != RegionAutodetectionSource.FailedAutoDiscovery)
                 {
-                    logger.Verbose($"[Region discovery] Discovered Region {discoveredRegion.Region}");
+                    logger.Verbose(() => $"[Region discovery] Discovered Region {discoveredRegion.Region}");
                     requestContext.ApiEvent.RegionUsed = discoveredRegion.Region;
                     requestContext.ApiEvent.AutoDetectedRegion = discoveredRegion.Region;
                     return discoveredRegion.Region;
                 }
                 else
                 {
-                    logger.Verbose($"[Region discovery] {s_regionDiscoveryDetails}");
+                    logger.Verbose(() => $"[Region discovery] {s_regionDiscoveryDetails}");
                     requestContext.ApiEvent.RegionDiscoveryFailureReason = s_regionDiscoveryDetails;
                     return null;
                 }
             }
 
-            logger.Info($"[Region discovery] Returning user provided region: {azureRegionConfig}.");
+            logger.Info(() => $"[Region discovery] Returning user provided region: {azureRegionConfig}.");
             return azureRegionConfig;
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Identity.Client.Region
 
                         if (ValidateRegion(region, "REGION_NAME env variable", logger)) // this is just to validate the region string
                         {
-                            logger.Info($"[Region discovery] Region found in environment variable: {region}.");
+                            logger.Info(() => $"[Region discovery] Region found in environment variable: {region}.");
                             result = new RegionInfo(region, RegionAutodetectionSource.EnvVariable, null);
                         }
                         else
@@ -215,7 +215,7 @@ namespace Microsoft.Identity.Client.Region
 
                                 if (ValidateRegion(region, $"IMDS call to {imdsUri.AbsoluteUri}", logger))
                                 {
-                                    logger.Info($"[Region discovery] Call to local IMDS succeeded. Region: {region}. {DateTime.UtcNow}");
+                                    logger.Info(() => $"[Region discovery] Call to local IMDS succeeded. Region: {region}. {DateTime.UtcNow}");
                                     result = new RegionInfo(region, RegionAutodetectionSource.Imds, null);
                                 }
                             }
@@ -263,18 +263,18 @@ namespace Microsoft.Identity.Client.Region
             if (s_failedAutoDiscovery)
             {
                 var autoDiscoveryError = $"[Region discovery] Auto-discovery failed in the past. Not trying again. {s_regionDiscoveryDetails}. {DateTime.UtcNow}";
-                logger.Verbose(autoDiscoveryError);
+                logger.Verbose(() => autoDiscoveryError);
                 return new RegionInfo(null, RegionAutodetectionSource.FailedAutoDiscovery, autoDiscoveryError);
             }
 
             if (s_failedAutoDiscovery == false &&
                 !string.IsNullOrEmpty(s_autoDiscoveredRegion))
             {
-                logger.Info($"[Region discovery] Auto-discovery already ran and found {s_autoDiscoveredRegion}.");
+                logger.Info(() => $"[Region discovery] Auto-discovery already ran and found {s_autoDiscoveredRegion}.");
                 return new RegionInfo(s_autoDiscoveredRegion, RegionAutodetectionSource.Cache, null);
             }
 
-            logger.Verbose($"[Region discovery] Auto-discovery did not run yet.");
+            logger.Verbose(() => $"[Region discovery] Auto-discovery did not run yet.");
             return null;
         }
 
@@ -282,7 +282,7 @@ namespace Microsoft.Identity.Client.Region
         {
             if (string.IsNullOrEmpty(region))
             {
-                logger.Verbose($"[Region discovery] Region from {source} not detected. {DateTime.UtcNow}");
+                logger.Verbose(() => $"[Region discovery] Region from {source} not detected. {DateTime.UtcNow}");
                 return false;
             }
 
@@ -308,14 +308,14 @@ namespace Microsoft.Identity.Client.Region
 
                 if (errorResponse != null && !errorResponse.NewestVersions.IsNullOrEmpty())
                 {
-                    logger.Info($"[Region discovery] Updated the version for IMDS endpoint to: {errorResponse.NewestVersions[0]}.");
+                    logger.Info(() => $"[Region discovery] Updated the version for IMDS endpoint to: {errorResponse.NewestVersions[0]}.");
                     return errorResponse.NewestVersions[0];
                 }
 
-                logger.Info($"[Region discovery] The response is empty or does not contain the newest versions. {DateTime.UtcNow}");
+                logger.Info(() => $"[Region discovery] The response is empty or does not contain the newest versions. {DateTime.UtcNow}");
             }
 
-            logger.Info($"[Region discovery] Failed to get the updated version for IMDS endpoint. HttpStatusCode: {response.StatusCode}. {DateTime.UtcNow}");
+            logger.Info(() => $"[Region discovery] Failed to get the updated version for IMDS endpoint. HttpStatusCode: {response.StatusCode}. {DateTime.UtcNow}");
 
             throw MsalServiceExceptionFactory.FromImdsResponse(
             MsalError.RegionDiscoveryFailed,

--- a/src/client/Microsoft.Identity.Client/Instance/Validation/AadAuthorityValidator.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Validation/AadAuthorityValidator.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Identity.Client.Instance.Validation
             var authorityUri = authorityInfo.CanonicalAuthority;
             bool isKnownEnv = KnownMetadataProvider.IsKnownEnvironment(authorityUri.Host);
 
-            _requestContext.Logger.Info($"Authority validation enabled? {authorityInfo.ValidateAuthority}. ");
-            _requestContext.Logger.Info($"Authority validation - is known env? {isKnownEnv}. ");
+            _requestContext.Logger.Info(() => $"Authority validation enabled? {authorityInfo.ValidateAuthority}. ");
+            _requestContext.Logger.Info(() => $"Authority validation - is known env? {isKnownEnv}. ");
 
             if (authorityInfo.ValidateAuthority && !isKnownEnv)
             {
-                _requestContext.Logger.Info($"Authority validation is being performed. ");
+                _requestContext.Logger.Info("Authority validation is being performed. ");
 
                 // MSAL will throw if the instance discovery URI does not respond with a valid json
                 await _requestContext.ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAsync(

--- a/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Broker/BrokerInteractiveRequestComponent.cs
@@ -70,8 +70,7 @@ namespace Microsoft.Identity.Client.Internal.Broker
             _logger.Info(LogMessages.CheckMsalTokenResponseReturnedFromBroker);
             if (!string.IsNullOrEmpty(msalTokenResponse.AccessToken))
             {
-                _logger.Info(
-                    "Success. Broker response contains an access token. ");
+                _logger.Info("Success. Broker response contains an access token. ");
                 return;
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Logger/MsalLoggerExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Logger/MsalLoggerExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.Tracing;
 using Microsoft.Identity.Client.Internal.Logger;
+using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Core
 {
@@ -67,29 +68,55 @@ namespace Microsoft.Identity.Client.Core
             logger.Log(LogLevel.Info, string.Empty, message);
         }
 
+        /// <summary>
+        /// This method is used to avoid string concatenation when the log level is not enabled.
+        /// </summary>
+        public static void Info(this ILoggerAdapter logger, Func<string> messageProducer)
+        {
+            if (logger.IsLoggingEnabled(LogLevel.Info))
+            {
+                logger.Log(LogLevel.Info, string.Empty, messageProducer());
+            }
+        }
+
         public static void InfoPii(this ILoggerAdapter logger, string messageWithPii, string messageScrubbed)
         {
             logger.Log(LogLevel.Info, messageWithPii, messageScrubbed);
+        }
+
+        /// <summary>
+        /// This method is used to avoid string concatenation when the log level is not enabled.
+        /// </summary>
+        public static void InfoPii(this ILoggerAdapter logger, Func<string> messageWithPiiProducer, Func<string> messageScrubbedProducer)
+        {
+            if (logger.IsLoggingEnabled(LogLevel.Info))
+            {
+                logger.Log(LogLevel.Info, messageWithPiiProducer(), messageScrubbedProducer());
+            }
         }
 
         public static void InfoPii(this ILoggerAdapter logger, Exception exWithPii)
         {
             logger.Log(LogLevel.Info, exWithPii?.ToString(), LoggerHelper.GetPiiScrubbedExceptionDetails(exWithPii));
         }
-
-        public static void InfoPiiWithPrefix(this ILoggerAdapter logger, Exception exWithPii, string prefix)
+       
+        public static void Verbose(this ILoggerAdapter logger, Func<string> messageProducer)
         {
-            logger.Log(LogLevel.Info, prefix + exWithPii.ToString(), prefix + LoggerHelper.GetPiiScrubbedExceptionDetails(exWithPii));
+            if (logger.IsLoggingEnabled(LogLevel.Verbose))
+            {
+                logger.Log(LogLevel.Verbose, string.Empty, messageProducer());
+            }
         }
 
-        public static void Verbose(this ILoggerAdapter logger, string message)
+        public static void VerbosePii(
+            this ILoggerAdapter logger, 
+            Func<string> messageWithPiiProducer, 
+            Func<string> messageScrubbedProducer)
         {
-            logger.Log(LogLevel.Verbose, string.Empty, message);
-        }
-
-        public static void VerbosePii(this ILoggerAdapter logger, string messageWithPii, string messageScrubbed)
-        {
-            logger.Log(LogLevel.Verbose, messageWithPii, messageScrubbed);
+            if (logger.IsLoggingEnabled(LogLevel.Verbose))
+            {
+                logger.Log(LogLevel.Verbose, messageWithPiiProducer(), messageScrubbedProducer());
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -167,48 +167,52 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             var logger = RequestContext.Logger;
 
-            // Create PII enabled string builder
-            var builder = new StringBuilder(
-                Environment.NewLine + "=== Request Data ===" + Environment.NewLine + "Authority Provided? - " +
-                (Authority != null) + Environment.NewLine);
-            builder.AppendLine("Client Id - " + AppConfig.ClientId);
-            builder.AppendLine("Scopes - " + Scope?.AsSingleString());
-            builder.AppendLine("Redirect Uri - " + RedirectUri?.OriginalString);
-            builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
-            builder.AppendLine("ClaimsAndClientCapabilities - " + ClaimsAndClientCapabilities);
-            builder.AppendLine("Authority - " + AuthorityInfo?.CanonicalAuthority);
-            builder.AppendLine("ApiId - " + ApiId);
-            builder.AppendLine("IsConfidentialClient - " + AppConfig.IsConfidentialClient);
-            builder.AppendLine("SendX5C - " + SendX5C);
-            builder.AppendLine("LoginHint - " + LoginHint);
-            builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
-            builder.AppendLine("HomeAccountId - " + HomeAccountId);
-            builder.AppendLine("CorrelationId - " + CorrelationId);
-            builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
-            builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
-            builder.AppendLine("Region configured: " + AppConfig.AzureRegion);
+            if (logger.IsLoggingEnabled(LogLevel.Info))
+            {
 
-            string messageWithPii = builder.ToString();
+                // Create PII enabled string builder
+                var builder = new StringBuilder(
+                    Environment.NewLine + "=== Request Data ===" + Environment.NewLine + "Authority Provided? - " +
+                    (Authority != null) + Environment.NewLine);
+                builder.AppendLine("Client Id - " + AppConfig.ClientId);
+                builder.AppendLine("Scopes - " + Scope?.AsSingleString());
+                builder.AppendLine("Redirect Uri - " + RedirectUri?.OriginalString);
+                builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
+                builder.AppendLine("ClaimsAndClientCapabilities - " + ClaimsAndClientCapabilities);
+                builder.AppendLine("Authority - " + AuthorityInfo?.CanonicalAuthority);
+                builder.AppendLine("ApiId - " + ApiId);
+                builder.AppendLine("IsConfidentialClient - " + AppConfig.IsConfidentialClient);
+                builder.AppendLine("SendX5C - " + SendX5C);
+                builder.AppendLine("LoginHint - " + LoginHint);
+                builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
+                builder.AppendLine("HomeAccountId - " + HomeAccountId);
+                builder.AppendLine("CorrelationId - " + CorrelationId);
+                builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
+                builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
+                builder.AppendLine("Region configured: " + AppConfig.AzureRegion);
 
-            // Create no PII enabled string builder
-            builder = new StringBuilder(
-                Environment.NewLine + "=== Request Data ===" +
-                Environment.NewLine + "Authority Provided? - " + (Authority != null) +
-                Environment.NewLine);
-            builder.AppendLine("Scopes - " + Scope?.AsSingleString());
-            builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
-            builder.AppendLine("ApiId - " + ApiId);
-            builder.AppendLine("IsConfidentialClient - " + AppConfig.IsConfidentialClient);
-            builder.AppendLine("SendX5C - " + SendX5C);
-            builder.AppendLine("LoginHint ? " + !string.IsNullOrEmpty(LoginHint));
-            builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
-            builder.AppendLine("HomeAccountId - " + !string.IsNullOrEmpty(HomeAccountId));
-            builder.AppendLine("CorrelationId - " + CorrelationId);
-            builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
-            builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
-            builder.AppendLine("Region configured: " + AppConfig.AzureRegion);
+                string messageWithPii = builder.ToString();
 
-            logger.InfoPii(messageWithPii, builder.ToString());
+                // Create no PII enabled string builder
+                builder = new StringBuilder(
+                    Environment.NewLine + "=== Request Data ===" +
+                    Environment.NewLine + "Authority Provided? - " + (Authority != null) +
+                    Environment.NewLine);
+                builder.AppendLine("Scopes - " + Scope?.AsSingleString());
+                builder.AppendLine("Extra Query Params Keys (space separated) - " + ExtraQueryParameters.Keys.AsSingleString());
+                builder.AppendLine("ApiId - " + ApiId);
+                builder.AppendLine("IsConfidentialClient - " + AppConfig.IsConfidentialClient);
+                builder.AppendLine("SendX5C - " + SendX5C);
+                builder.AppendLine("LoginHint ? " + !string.IsNullOrEmpty(LoginHint));
+                builder.AppendLine("IsBrokerConfigured - " + AppConfig.IsBrokerEnabled);
+                builder.AppendLine("HomeAccountId - " + !string.IsNullOrEmpty(HomeAccountId));
+                builder.AppendLine("CorrelationId - " + CorrelationId);
+                builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
+                builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
+                builder.AppendLine("Region configured: " + AppConfig.AzureRegion);
+
+                logger.InfoPii(messageWithPii, builder.ToString());
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ByRefreshTokenRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ByRefreshTokenRequest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         protected override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            AuthenticationRequestParameters.RequestContext.Logger.Verbose(LogMessages.BeginningAcquireByRefreshToken);
+            AuthenticationRequestParameters.RequestContext.Logger.Verbose(()=>LogMessages.BeginningAcquireByRefreshToken);
             await ResolveAuthorityAsync().ConfigureAwait(false);
             var msalTokenResponse = await SendTokenRequestAsync(
                                         GetBodyParameters(_refreshTokenParameters.RefreshToken),

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/InteractiveRequest.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private async Task<MsalTokenResponse> RunBrokerWithInstallUriAsync(string brokerInstallUri, CancellationToken cancellationToken)
         {
-            _logger.Info("Based on the auth code, the broker flow is required. " +
+            _logger.Info(() => "Based on the auth code, the broker flow is required. " +
                 "Starting broker flow knowing the broker installation app link. ");
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -182,7 +182,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 brokerInstallUri,
                 cancellationToken).ConfigureAwait(false);
 
-            _logger.Info("Broker attempt completed successfully " + (tokenResponse != null));
+            _logger.Info(() => "Broker attempt completed successfully " + (tokenResponse != null));
             Metrics.IncrementTotalAccessTokensFromBroker();
             return tokenResponse;
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     var account = await CacheManager.GetAccountAssociatedWithAccessTokenAsync(cachedAccessToken).ConfigureAwait(false);
 
                     logger.Info(
-                        "[OBO Request] Found a valid access token in the cache. ID token also found? " + (cachedIdToken != null));
+                        () => "[OBO Request] Found a valid access token in the cache. ID token also found? " + (cachedIdToken != null));
 
                     AuthenticationRequestParameters.RequestContext.ApiEvent.IsAccessTokenCacheHit = true;
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -147,19 +147,22 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private static void LogMetricsFromAuthResult(AuthenticationResult authenticationResult, ILoggerAdapter logger)
         {
-            var sb = new StringBuilder(250);
-            sb.AppendLine();
-            sb.Append("[LogMetricsFromAuthResult] Cache Refresh Reason: ");
-            sb.AppendLine(authenticationResult.AuthenticationResultMetadata.CacheRefreshReason.ToString());
-            sb.Append("[LogMetricsFromAuthResult] DurationInCacheInMs: ");
-            sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationInCacheInMs.ToString());
-            sb.Append("[LogMetricsFromAuthResult] DurationTotalInMs: ");
-            sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationTotalInMs.ToString());
-            sb.Append("[LogMetricsFromAuthResult] DurationInHttpInMs: ");
-            sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationInHttpInMs.ToString());
-            logger.Always(sb.ToString());
-            logger.AlwaysPii($"[LogMetricsFromAuthResult] TokenEndpoint: {authenticationResult.AuthenticationResultMetadata.TokenEndpoint ?? ""}",
-                                "TokenEndpoint: ****");
+            if (logger.IsLoggingEnabled(LogLevel.Always))
+            {
+                var sb = new StringBuilder(250);
+                sb.AppendLine();
+                sb.Append("[LogMetricsFromAuthResult] Cache Refresh Reason: ");
+                sb.AppendLine(authenticationResult.AuthenticationResultMetadata.CacheRefreshReason.ToString());
+                sb.Append("[LogMetricsFromAuthResult] DurationInCacheInMs: ");
+                sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationInCacheInMs.ToString());
+                sb.Append("[LogMetricsFromAuthResult] DurationTotalInMs: ");
+                sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationTotalInMs.ToString());
+                sb.Append("[LogMetricsFromAuthResult] DurationInHttpInMs: ");
+                sb.AppendLine(authenticationResult.AuthenticationResultMetadata.DurationInHttpInMs.ToString());
+                logger.Always(sb.ToString());
+                logger.AlwaysPii($"[LogMetricsFromAuthResult] TokenEndpoint: {authenticationResult.AuthenticationResultMetadata.TokenEndpoint ?? ""}",
+                                    "TokenEndpoint: ****");
+            }
         }
 
         private static void UpdateTelemetry(Stopwatch sw, ApiEvent apiEvent, AuthenticationResult authenticationResult)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -408,9 +408,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 
                 AuthenticationRequestParameters.RequestContext.Logger.Info("\n\t=== Token Acquisition finished successfully:");
                 AuthenticationRequestParameters.RequestContext.Logger.InfoPii(
-                        $" AT expiration time: {result.ExpiresOn}, scopes: {scopes}. " +
+                       () => $" AT expiration time: {result.ExpiresOn}, scopes: {scopes}. " +
                             $"source: {result.AuthenticationResultMetadata.TokenSource}",
-                        $" AT expiration time: {result.ExpiresOn}, scopes: {scopes}. " +
+                       () => $" AT expiration time: {result.ExpiresOn}, scopes: {scopes}. " +
                             $"source: {result.AuthenticationResultMetadata.TokenSource}");
 
                 if (result.AuthenticationResultMetadata.TokenSource != TokenSource.Cache)
@@ -418,8 +418,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     Uri canonicalAuthority = AuthenticationRequestParameters.AuthorityInfo.CanonicalAuthority;
 
                     AuthenticationRequestParameters.RequestContext.Logger.InfoPii(
-                        $"Fetched access token from host {canonicalAuthority.Host}. Endpoint: {canonicalAuthority}. ",
-                        $"Fetched access token from host {canonicalAuthority.Host}. ");
+                        () => $"Fetched access token from host {canonicalAuthority.Host}. Endpoint: {canonicalAuthority}. ",
+                        () => $"Fetched access token from host {canonicalAuthority.Host}. ");
                 }
             }
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/BrokerSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/BrokerSilentStrategy.cs
@@ -94,8 +94,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             if (msalTokenResponse.Error != null)
             {
-                _logger.Info(
-                    LogMessages.ErrorReturnedInBrokerResponse(msalTokenResponse.Error));
+                _logger.Info(() => LogMessages.ErrorReturnedInBrokerResponse(msalTokenResponse.Error));
 
                 if (msalTokenResponse.Error == BrokerResponseConst.AndroidNoTokenFound ||
                     msalTokenResponse.Error == BrokerResponseConst.AndroidNoAccountFound ||

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
         {
             if (PublicClientApplication.IsOperatingSystemAccount(AuthenticationRequestParameters.Account))
             {
-                AuthenticationRequestParameters.RequestContext.Logger.Verbose(
+                AuthenticationRequestParameters.RequestContext.Logger.Verbose(()=>
                     "OperatingSystemAccount is only supported by some brokers");
 
                 throw new MsalUiRequiredException(
@@ -178,15 +178,15 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
 
             if (isFamilyMember.HasValue && !isFamilyMember.Value)
             {
-                AuthenticationRequestParameters.RequestContext.Logger.Verbose(
+                AuthenticationRequestParameters.RequestContext.Logger.Verbose(()=>
                     "[FOCI] App is not part of the family, skipping FOCI. ");
 
                 return null;
             }
 
-            logger.Verbose("[FOCI] App is part of the family or unknown, looking for FRT. ");
+            logger.Verbose(()=>"[FOCI] App is part of the family or unknown, looking for FRT. ");
             var familyRefreshToken = await CacheManager.FindFamilyRefreshTokenAsync(TheOnlyFamilyId).ConfigureAwait(false);
-            logger.Verbose("[FOCI] FRT found? " + (familyRefreshToken != null));
+            logger.Verbose(()=>"[FOCI] FRT found? " + (familyRefreshToken != null));
 
             if (familyRefreshToken != null)
             {
@@ -195,7 +195,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                     MsalTokenResponse frtTokenResponse = await SilentRequestHelper.RefreshAccessTokenAsync(familyRefreshToken, _silentRequest, AuthenticationRequestParameters, cancellationToken)
                         .ConfigureAwait(false);
 
-                    logger.Verbose("[FOCI] FRT refresh succeeded. ");
+                    logger.Verbose(()=>"[FOCI] FRT refresh succeeded. ");
                     return frtTokenResponse;
                 }
                 catch (MsalServiceException ex)
@@ -230,7 +230,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             var msalRefreshTokenItem = await CacheManager.FindRefreshTokenAsync().ConfigureAwait(false);
             if (msalRefreshTokenItem == null)
             {
-                AuthenticationRequestParameters.RequestContext.Logger.Verbose("No Refresh Token was found in the cache. ");
+                AuthenticationRequestParameters.RequestContext.Logger.Verbose(()=>"No Refresh Token was found in the cache. ");
 
                 throw new MsalUiRequiredException(
                     MsalError.NoTokensFoundError,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             {
                 if (AuthenticationRequestParameters.Account == null)
                 {
-                    _logger.Verbose("No account passed to AcquireTokenSilent.");
+                    _logger.Verbose(()=>"No account passed to AcquireTokenSilent. ");
                     throw new MsalUiRequiredException(
                        MsalError.UserNullError,
                        MsalErrorMessage.MsalUiRequiredMessage,
@@ -67,12 +67,12 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
 
                     if (brokerResult != null)
                     {
-                        _logger.Verbose("Broker responded to silent request.");
+                        _logger.Verbose(() => "Broker responded to silent request.");
                         return brokerResult;
                     }
                     else
                     {
-                        _logger.Verbose("Broker could not satisfy the silent request.");
+                        _logger.Verbose(() => "Broker could not satisfy the silent request.");
                         throw new MsalUiRequiredException(
                            MsalError.FailedToAcquireTokenSilentlyFromBroker,
                            "Broker could not satisfy the silent request.",
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                     }
                 }
 
-                _logger.Verbose("Attempting to acquire token using local cache.");
+                _logger.Verbose(() => "Attempting to acquire token using local cache.");
 
                 return await _clientStrategy.ExecuteAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             }
             catch (MsalException ex)
             {
-                _logger.Verbose(isBrokerConfigured ? $"Broker could not satisfy silent request." : $"Token cache could not satisfy silent request.");
+                _logger.Verbose(() => isBrokerConfigured ? $"Broker could not satisfy silent request." : $"Token cache could not satisfy silent request.");
                 throw ex;
             }
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Client.Internal
 
         internal static async Task<MsalTokenResponse> RefreshAccessTokenAsync(MsalRefreshTokenCacheItem msalRefreshTokenItem, RequestBase request, AuthenticationRequestParameters authenticationRequestParameters, CancellationToken cancellationToken)
         {
-            authenticationRequestParameters.RequestContext.Logger.Verbose("Refreshing access token...");
+            authenticationRequestParameters.RequestContext.Logger.Verbose(() => "Refreshing access token...");
             await authenticationRequestParameters.AuthorityManager.RunInstanceDiscoveryAndValidationAsync().ConfigureAwait(false);
 
             var dict = GetBodyParameters(msalRefreshTokenItem.Secret);

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AppServiceManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AppServiceManagedIdentitySource.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             // if BOTH the env vars endpoint and secret values are null, this MSI provider is unavailable.
             if (string.IsNullOrEmpty(msiEndpoint) || string.IsNullOrEmpty(secret))
             {
-                logger.Verbose("[Managed Identity] App service managed identity is unavailable.");
+                logger.Verbose(()=>"[Managed Identity] App service managed identity is unavailable.");
                 return false;
             }
 
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     CultureInfo.InvariantCulture, MsalErrorMessage.ManagedIdentityEndpointInvalidUriError, "IDENTITY_ENDPOINT", msiEndpoint, "App Service"), ex);
             }
 
-            logger.Info($"[Managed Identity] Environment variables validation passed for app service managed identity. Endpoint URI: {endpointUri}. Creating App Service managed identity.");
+            logger.Info(() => $"[Managed Identity] Environment variables validation passed for app service managed identity. Endpoint URI: {endpointUri}. Creating App Service managed identity.");
             return true;
         }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AppServiceManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AppServiceManagedIdentitySource.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     CultureInfo.InvariantCulture, MsalErrorMessage.ManagedIdentityEndpointInvalidUriError, "IDENTITY_ENDPOINT", msiEndpoint, "App Service"), ex);
             }
 
-            logger.Info(() => $"[Managed Identity] Environment variables validation passed for app service managed identity. Endpoint URI: {endpointUri}. Creating App Service managed identity.");
+            logger.Info($"[Managed Identity] Environment variables validation passed for app service managed identity. Endpoint URI: {endpointUri}. Creating App Service managed identity.");
             return true;
         }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AzureArcManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AzureArcManagedIdentitySource.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             // if BOTH the env vars IDENTITY_ENDPOINT and IMDS_ENDPOINT are set the MsiType is Azure Arc
             if (string.IsNullOrEmpty(identityEndpoint) || string.IsNullOrEmpty(imdsEndpoint))
             {
-                requestContext.Logger.Verbose("[Managed Identity] Azure Arc managed identity is unavailable.");
+                requestContext.Logger.Verbose(()=>"[Managed Identity] Azure Arc managed identity is unavailable.");
                 return null;
             }
 
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     CultureInfo.InvariantCulture, MsalErrorMessage.ManagedIdentityEndpointInvalidUriError, "IDENTITY_ENDPOINT", identityEndpoint, AzureArc));
             }
 
-            requestContext.Logger.Verbose("[Managed Identity] Creating Azure Arc managed identity. Endpoint URI: " + endpointUri);
+            requestContext.Logger.Verbose(()=>"[Managed Identity] Creating Azure Arc managed identity. Endpoint URI: " + endpointUri);
             return new AzureArcManagedIdentitySource(endpointUri, requestContext);
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             HttpResponse response,
             CancellationToken cancellationToken)
         {
-            _requestContext.Logger.Verbose($"[Managed Identity] Response received. Status code: {response.StatusCode}");
+            _requestContext.Logger.Verbose(()=>$"[Managed Identity] Response received. Status code: {response.StatusCode}");
 
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
                 ManagedIdentityRequest request = CreateRequest(ScopeHelper.ScopesToResource(parameters.Scopes.ToArray()));
 
-                _requestContext.Logger.Verbose("[Managed Identity] Adding authorization header to the request.");
+                _requestContext.Logger.Verbose(()=>"[Managed Identity] Adding authorization header to the request.");
                 request.Headers.Add("Authorization", authHeaderValue);
 
                 response = await _requestContext.ServiceBundle.HttpManager.SendGetAsync(request.ComputeUri(), request.Headers, _requestContext.Logger, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/CloudShellManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/CloudShellManagedIdentitySource.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             // if ONLY the env var MSI_ENDPOINT is set the MsiType is CloudShell
             if (string.IsNullOrEmpty(msiEndpoint))
             {
-                requestContext.Logger.Verbose("[Managed Identity] Cloud shell managed identity is unavailable.");
+                requestContext.Logger.Verbose(()=>"[Managed Identity] Cloud shell managed identity is unavailable.");
                 return null;
             }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     CultureInfo.InvariantCulture, MsalErrorMessage.ManagedIdentityEndpointInvalidUriError, "MSI_ENDPOINT", msiEndpoint, CloudShell), ex);
             }
 
-            requestContext.Logger.Verbose("[Managed Identity] Creating cloud shell managed identity. Endpoint URI: " + msiEndpoint);
+            requestContext.Logger.Verbose(()=>"[Managed Identity] Creating cloud shell managed identity. Endpoint URI: " + msiEndpoint);
             return new CloudShellManagedIdentitySource(endpointUri, requestContext);
         }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         {
             if (!string.IsNullOrEmpty(EnvironmentVariables.PodIdentityEndpoint))
 			{
-                requestContext.Logger.Verbose("[Managed Identity] Environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST for IMDS returned endpoint: " + EnvironmentVariables.PodIdentityEndpoint);
+                requestContext.Logger.Verbose(() => "[Managed Identity] Environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST for IMDS returned endpoint: " + EnvironmentVariables.PodIdentityEndpoint);
                 var builder = new UriBuilder(EnvironmentVariables.PodIdentityEndpoint)
                 {
                     Path = ImdsTokenPath
@@ -45,13 +45,13 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 			}
 			else
 			{
-                requestContext.Logger.Verbose("[Managed Identity] Unable to find AZURE_POD_IDENTITY_AUTHORITY_HOST environment variable for IMDS, using the default endpoint.");
+                requestContext.Logger.Verbose(() => "[Managed Identity] Unable to find AZURE_POD_IDENTITY_AUTHORITY_HOST environment variable for IMDS, using the default endpoint.");
             	_imdsEndpoint = s_imdsEndpoint;
 			}
 
             _userAssignedId = requestContext.ServiceBundle.Config.ManagedIdentityUserAssignedId;
 
-            requestContext.Logger.Verbose("[Managed Identity] Creating IMDS managed identity source. Endpoint URI: " + _imdsEndpoint);
+            requestContext.Logger.Verbose(() => "[Managed Identity] Creating IMDS managed identity source. Endpoint URI: " + _imdsEndpoint);
         }
 
         protected override ManagedIdentityRequest CreateRequest(string resource)

--- a/src/client/Microsoft.Identity.Client/MigrationAid/TokenCache.MigrationAid.cs
+++ b/src/client/Microsoft.Identity.Client/MigrationAid/TokenCache.MigrationAid.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Client
         public CacheData SerializeUnifiedAndAdalCache()
         {
             Validate();
-            this.ServiceBundle.ApplicationLogger.Info($"[ADAL Caching] Legacy SerializeUnifiedAndAdalCache being called. {_semaphoreSlim.GetCurrentCountLogMessage()}.");
+            this.ServiceBundle.ApplicationLogger.Info(() => $"[ADAL Caching] Legacy SerializeUnifiedAndAdalCache being called. {_semaphoreSlim.GetCurrentCountLogMessage()}.");
             // reads the underlying in-memory dictionary and dumps out the content as a JSON
             _semaphoreSlim.Wait();
             this.ServiceBundle.ApplicationLogger.Info("[ADAL Caching] Acquired semaphore");

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Identity.Client.OAuth2
 
             if (response.StatusCode != HttpStatusCode.OK || expectErrorsOn200OK)
             {
-                requestContext.Logger.Verbose("[Oauth2Client] Processing error response ");
+                requestContext.Logger.Verbose(() => "[Oauth2Client] Processing error response ");
 
                 try
                 {

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/HttpStatusProvider.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/HttpStatusProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
                 // if a retry-after header is present, another provider will take care of this
                 !RetryAfterProvider.TryGetRetryAfterValue(ex.Headers, out _)) 
             {
-                logger.Info($"[Throttling] HTTP status code {ex.StatusCode} encountered - " +
+                logger.Info(() => $"[Throttling] HTTP status code {ex.StatusCode} encountered - " +
                     $"throttling for {s_throttleDuration.TotalSeconds} seconds. ");
 
                 var thumbprint = ThrottleCommon.GetRequestStrictThumbprint(bodyParams,

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/RetryAfterProvider.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/RetryAfterProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
                 retryAfterTimespan = GetSafeValue(retryAfterTimespan);
 
                 var logger = requestParams.RequestContext.Logger;
-                logger.Info($"[Throttling] Retry-After header detected, " +
+                logger.Info(() => $"[Throttling] Retry-After header detected, " +
                     $"value: {retryAfterTimespan.TotalSeconds} seconds");
 
                 string thumbprint = ThrottleCommon.GetRequestStrictThumbprint(

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCache.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCache.cs
@@ -49,15 +49,15 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
             ex = null;
             if (_cache.TryGetValue(key, out var entry))
             {
-                logger.Info($"[Throttling] Entry found. Creation: {entry.CreationTime} Expiration: {entry.ExpirationTime} ");
+                logger.Info(() => $"[Throttling] Entry found. Creation: {entry.CreationTime} Expiration: {entry.ExpirationTime} ");
                 if (entry.IsExpired)
                 {
-                    logger.Info($"[Throttling] Removing entry because it is expired");
+                    logger.Info(() => $"[Throttling] Removing entry because it is expired");
                     _cache.TryRemove(key, out _);
                     return false;
                 }
 
-                logger.InfoPii($"[Throttling] Returning valid entry for key {key}", "[Throttling] Returning valid entry.");
+                logger.InfoPii(() => $"[Throttling] Returning valid entry for key {key}", () => "[Throttling] Returning valid entry.");
                 ex = entry.Exception;
                 return true;
             }
@@ -82,20 +82,20 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
             if (_lastCleanupTime + s_cleanupCacheInterval < DateTimeOffset.UtcNow &&
                 !_cleanupInProgress)
             {
-                logger.Verbose($"[Throttling] Acquiring lock to cleanup throttling state");
+                logger.Verbose(() => "[Throttling] Acquiring lock to cleanup throttling state");
 
                 lock (_padlock)
                 {
                     if (!_cleanupInProgress)
                     {
-                        logger.Verbose($"[Throttling] Cache size before cleaning up {_cache.Count}");
+                        logger.Verbose(() => $"[Throttling] Cache size before cleaning up {_cache.Count}");
 
                         _cleanupInProgress = true;
                         CleanupCacheNoLocks();
                         _lastCleanupTime = DateTimeOffset.UtcNow;
                         _cleanupInProgress = false;
 
-                        logger.Verbose($"[Throttling] Cache size after cleaning up {_cache.Count}");
+                        logger.Verbose(() => $"[Throttling] Cache size after cleaning up {_cache.Count}");
                     }
                 }
             }

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCache.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottlingCache.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
                 logger.Info(() => $"[Throttling] Entry found. Creation: {entry.CreationTime} Expiration: {entry.ExpirationTime} ");
                 if (entry.IsExpired)
                 {
-                    logger.Info(() => $"[Throttling] Removing entry because it is expired");
+                    logger.Info(() => "[Throttling] Removing entry because it is expired");
                     _cache.TryRemove(key, out _);
                     return false;
                 }

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/UiRequiredProvider.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/UiRequiredProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
             {
                 var logger = requestParams.RequestContext.Logger;
 
-                logger.Info($"[Throttling] MsalUiRequiredException encountered - " +
+                logger.Info(() => $"[Throttling] MsalUiRequiredException encountered - " +
                     $"throttling for {s_uiRequiredExpiration.TotalSeconds} seconds. ");
 
                 var thumbprint = GetRequestStrictThumbprint(bodyParams,

--- a/src/client/Microsoft.Identity.Client/OAuth2/TokenClient.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/TokenClient.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Client.OAuth2
             if (_serviceBundle.Config.ClientCredential != null)
             {
                 _requestParams.RequestContext.Logger.Verbose(
-                    "[TokenClient] Before adding the client assertion / secret");
+                    () => "[TokenClient] Before adding the client assertion / secret");
 
                 await _serviceBundle.Config.ClientCredential.AddConfidentialClientParametersAsync(
                     _oAuth2Client,
@@ -143,7 +143,7 @@ namespace Microsoft.Identity.Client.OAuth2
                     cancellationToken).ConfigureAwait(false);
 
                 _requestParams.RequestContext.Logger.Verbose(
-                    "[TokenClient] After adding the client assertion / secret");
+                    () => "[TokenClient] After adding the client assertion / secret");
             }
 
             _oAuth2Client.AddBodyParameter(OAuth2Parameter.Scope, scopes);
@@ -208,13 +208,13 @@ namespace Microsoft.Identity.Client.OAuth2
 
                     resolvedClaims = JsonHelper.JsonObjectToString(mergedClaims);
                     _requestParams.RequestContext.Logger.Verbose(
-                        $"Adding kerberos claim + Claims/ClientCapabilities to request: {resolvedClaims}");
+                        () => $"Adding kerberos claim + Claims/ClientCapabilities to request: {resolvedClaims}");
                 }
                 else
                 {
                     resolvedClaims = kerberosClaim;
                     _requestParams.RequestContext.Logger.Verbose(
-                        $"Adding kerberos claim to request: {resolvedClaims}");
+                        () => $"Adding kerberos claim to request: {resolvedClaims}");
                 }
             }
 
@@ -249,7 +249,7 @@ namespace Microsoft.Identity.Client.OAuth2
 
             try
             {
-                logger.Verbose("[Token Client] Fetching MsalTokenResponse .... ");
+                logger.Verbose(() => "[Token Client] Fetching MsalTokenResponse .... ");
                 MsalTokenResponse msalTokenResponse =
                     await _oAuth2Client
                         .GetTokenAsync(tokenEndpointWithQueryParams,

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/AuthenticationContinuationHelper.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client
         [CLSCompliant(false)]
         public static void SetAuthenticationContinuationEventArgs(int requestCode, Result resultCode, Intent data)
         {
-            LastRequestLogger?.Info($"SetAuthenticationContinuationEventArgs - resultCode: {(int)resultCode} requestCode: {requestCode}");
+            LastRequestLogger?.Info(() => $"SetAuthenticationContinuationEventArgs - resultCode: {(int)resultCode} requestCode: {requestCode}");
 
             AuthorizationResult authorizationResult;
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidAccountManagerBroker.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
                 // onActivityResult will receive the response for this activity.
                 // Launching this activity will switch to the broker app.
 
-                _logger.Verbose("[Android broker] Starting Android Broker interactive authentication. ");
+                _logger.Verbose(()=>"[Android broker] Starting Android Broker interactive authentication. ");
                 Intent brokerIntent = await GetIntentForInteractiveBrokerRequestAsync(brokerRequest).ConfigureAwait(false);
 
                 if (brokerIntent != null)
@@ -177,7 +177,9 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             _brokerHelper.ValidateBrokerRedirectUri(brokerRequest);
             string brokerRequestJson = JsonHelper.SerializeToJson(brokerRequest);
-            _logger.InfoPii("[Android broker] GetInteractiveBrokerIntent: " + brokerRequestJson, "Enable PII to see the broker request. ");
+            _logger.InfoPii(
+                () => "[Android broker] GetInteractiveBrokerIntent: " + brokerRequestJson, 
+                () => "Enable PII to see the broker request. ");
             brokerIntent.PutExtra(BrokerConstants.BrokerRequestV2, brokerRequestJson);
 
             return brokerIntent;
@@ -188,7 +190,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             // Don't send silent background request if account information is not provided
             using (_logger.LogMethodDuration())
             {
-                _logger.Verbose("[Android broker] User is specified for silent token request. Starting silent Android broker request. ");
+                _logger.Verbose(()=>"[Android broker] User is specified for silent token request. Starting silent Android broker request. ");
                 string silentResult = await GetBrokerAuthTokenSilentlyAsync(brokerRequest).ConfigureAwait(false);
                 return _brokerHelper.HandleSilentAuthenticationResult(silentResult, brokerRequest.CorrelationId);
             }
@@ -319,12 +321,12 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             var myLooper = Looper.MyLooper();
             if (myLooper != null && callerActivity != null && callerActivity.MainLooper != myLooper)
             {
-                _logger.Info("[Android broker] myLooper returned. Calling thread is associated with a Looper: " + myLooper.ToString());
+                _logger.Info(() => "[Android broker] myLooper returned. Calling thread is associated with a Looper: " + myLooper.ToString());
                 return new Handler(myLooper);
             }
             else
             {
-                _logger.Info("[Android broker] Looper.MainLooper returned: " + Looper.MainLooper.ToString());
+                _logger.Info(() => "[Android broker] Looper.MainLooper returned: " + Looper.MainLooper.ToString());
                 return new Handler(Looper.MainLooper);
             }
         }
@@ -346,7 +348,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
 
                         if (!string.IsNullOrEmpty(bpKey))
                         {
-                            _logger.Info("[Android broker] Using broker protocol version: " + bpKey);
+                            _logger.Info(() => "[Android broker] Using broker protocol version: " + bpKey);
                             return;
                         }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidBrokerHelper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             _androidContext = androidContext ?? throw new ArgumentNullException(nameof(androidContext));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            _logger.Verbose("[Android broker] Getting the Android context for broker request. ");
+            _logger.Verbose(()=>"[Android broker] Getting the Android context for broker request. ");
             AndroidAccountManager = AccountManager.Get(_androidContext);
         }
 
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             using (_logger.LogMethodDuration())
             {
                 bool canInvoke = CanSwitchToBroker();
-                _logger.Verbose("[Android broker] Can invoke broker? " + canInvoke);
+                _logger.Verbose(()=>"[Android broker] Can invoke broker? " + canInvoke);
 
                 return canInvoke;
             }
@@ -99,7 +99,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             string responseJson = bundleResult.GetString(BrokerConstants.BrokerResultV2);
 
             bool success = bundleResult.GetBoolean(BrokerConstants.BrokerRequestV2Success);
-            _logger.Info($"[Android broker] Silent call result - success? {success}. ");
+            _logger.Info(() => $"[Android broker] Silent call result - success? {success}. ");
 
             if (!success)
             {
@@ -178,7 +178,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
                 }
             }
 
-            _logger.Info("[Android broker] Found " + brokerAccounts.Count + " accounts in the account manager. ");
+            _logger.Info(() => "[Android broker] Found " + brokerAccounts.Count + " accounts in the account manager. ");
 
             return brokerAccounts;
         }
@@ -250,7 +250,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             ValidateBrokerRedirectUri(brokerRequest);
             Bundle bundle = new Bundle();
             string brokerRequestJson = JsonHelper.SerializeToJson(brokerRequest);
-            _logger.InfoPii("[Android broker] CreateSilentBrokerBundle: " + brokerRequestJson, "Enable PII to see the silent broker request. ");
+            _logger.InfoPii(() => "[Android broker] CreateSilentBrokerBundle: " + brokerRequestJson, () => "Enable PII to see the silent broker request. ");
             bundle.PutString(BrokerConstants.BrokerRequestV2, brokerRequestJson);
             bundle.PutInt(BrokerConstants.CallerInfoUID, Binder.CallingUid);
 
@@ -259,7 +259,9 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
 
         public Bundle CreateBrokerAccountBundle(BrokerRequest brokerRequest)
         {
-            _logger.InfoPii("[Android broker] CreateBrokerAccountBundle: " + JsonHelper.SerializeToJson(brokerRequest), "Enable PII to see the broker account bundle request. ");
+            _logger.InfoPii(
+                () => "[Android broker] CreateBrokerAccountBundle: " + JsonHelper.SerializeToJson(brokerRequest), 
+                () => "Enable PII to see the broker account bundle request. ");
             Bundle bundle = new Bundle();
 
             bundle.PutString(BrokerConstants.AccountClientIdKey, brokerRequest.ClientId);
@@ -385,7 +387,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
                     if (authenticator.Type.Equals(BrokerConstants.BrokerAccountType, StringComparison.OrdinalIgnoreCase)
                         && VerifySignature(authenticator.PackageName))
                     {
-                        _logger.Verbose("[Android broker] Found the Authenticator on the device. ");
+                        _logger.Verbose(()=>"[Android broker] Found the Authenticator on the device. ");
                         return authenticator;
                     }
                 }
@@ -415,7 +417,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             try
             {
                 _logger.Info(
-                    "[Android broker] Calling activity pid:" + Process.MyPid()
+                    () => "[Android broker] Calling activity pid:" + Process.MyPid()
                     + " tid:" + Process.MyTid() + "uid:"
                     + Process.MyUid());
 
@@ -453,7 +455,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
 
         public void HandleInstallUrl(string appLink, Activity activity)
         {
-            _logger.Info("[Android broker] Starting ActionView activity to " + appLink);
+            _logger.Info(() => "[Android broker] Starting ActionView activity to " + appLink);
             activity.StartActivity(new Intent(Intent.ActionView, AndroidNative.Net.Uri.Parse(appLink)));
 
             throw new MsalClientException(

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/Broker/AndroidContentProviderBroker.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
 
             if (!string.IsNullOrEmpty(negotiatedBrokerProtocalKey))
             {
-                _logger.Info("[Android broker] Using broker protocol version: " + negotiatedBrokerProtocalKey);
+                _logger.Info(() => "[Android broker] Using broker protocol version: " + negotiatedBrokerProtocalKey);
                 return negotiatedBrokerProtocalKey;
             }
 
@@ -134,7 +134,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             using (_logger.LogMethodDuration())
             {
-                _logger.Verbose("[Android broker] Starting interactive authentication. ");
+                _logger.Verbose(()=>"[Android broker] Starting interactive authentication. ");
 
                 Bundle bundleResult = await PerformContentResolverOperationAsync(ContentResolverOperation.acquireTokenInteractive, null).ConfigureAwait(false);
 
@@ -173,7 +173,9 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             string brokerRequestJson = JsonHelper.SerializeToJson(brokerRequest);
             bundle.PutString(BrokerConstants.BrokerRequestV2, brokerRequestJson);
             bundle.PutInt(BrokerConstants.CallerInfoUID, Binder.CallingUid);
-            _logger.InfoPii("[Android broker] GetInteractiveBrokerBundle: " + brokerRequestJson, "Enable PII to see the broker request. ");
+            _logger.InfoPii(
+                () => "[Android broker] GetInteractiveBrokerBundle: " + brokerRequestJson, 
+                () => "Enable PII to see the broker request. ");
             return bundle;
         }
 
@@ -207,7 +209,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
         {
             using (_logger.LogMethodDuration())
             {
-                _logger.Verbose("[Android broker] User is specified for silent token request. Starting silent request. ");
+                _logger.Verbose(()=>"[Android broker] User is specified for silent token request. Starting silent request. ");
 
                 var accountData = await GetBrokerAccountDataAsync(brokerRequest).ConfigureAwait(false);
 
@@ -316,7 +318,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
             ContentResolver resolver = GetContentResolver();
 
             var contentResolverUri = GetContentProviderUriForOperation(Enum.GetName(typeof(ContentResolverOperation), operation));
-            _logger.Info($"[Android broker] Executing content resolver operation: {operation} URI: {contentResolverUri}");
+            _logger.Info(() => $"[Android broker] Executing content resolver operation: {operation} URI: {contentResolverUri}");
 
             ICursor resultCursor = null;
 
@@ -340,7 +342,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.Broker
 
             if (resultBundle != null)
             {
-                _logger.Verbose($"[Android broker] Content resolver operation completed successfully. Operation: {operation} URI: {contentResolverUri}");
+                _logger.Verbose(()=>$"[Android broker] Content resolver operation completed successfully. Operation: {operation} URI: {contentResolverUri}");
             }
 
             return resultBundle;

--- a/src/client/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/SystemWebview/AuthenticationActivity.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.SystemWebview
             }
             else
             {
-                RequestContext.Logger.Info(
+                RequestContext.Logger.Info(() =>
                     string.Format(
                     CultureInfo.CurrentCulture,
                     "Browser with custom tabs package available. Using {0}. ",

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/DefaultOSBrowser/HttpListenerInterceptor.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/DefaultOSBrowser/HttpListenerInterceptor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Platforms.Shared.DefaultOSBrowser
                 TestBeforeStart?.Invoke(urlToListenTo);
 
                 httpListener.Start();
-                _logger.Info("Listening for authorization code on " + urlToListenTo);
+                _logger.Info(() => "Listening for authorization code on " + urlToListenTo);
 
                 using (cancellationToken.Register(() =>
                 {
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client.Platforms.Shared.DefaultOSBrowser
                     cancellationToken.ThrowIfCancellationRequested();
 
                     Respond(responseProducer, context);
-                    _logger.Verbose("HttpListner received a message on " + urlToListenTo);
+                    _logger.Verbose(()=>"HttpListner received a message on " + urlToListenTo);
 
                     // the request URL should now contain the auth code and pkce
                     return context.Request.Url;
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Client.Platforms.Shared.DefaultOSBrowser
             // But this is just cancellation...
             catch (Exception ex) when (ex is HttpListenerException || ex is ObjectDisposedException)
             {
-                _logger.Info("HttpListenerException - cancellation requested? " + cancellationToken.IsCancellationRequested);
+                _logger.Info(() => "HttpListenerException - cancellation requested? " + cancellationToken.IsCancellationRequested);
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (ex is HttpListenerException)
@@ -121,7 +121,7 @@ namespace Microsoft.Identity.Client.Platforms.Shared.DefaultOSBrowser
         private void Respond(Func<Uri, MessageAndHttpCode> responseProducer, HttpListenerContext context)
         {
             MessageAndHttpCode messageAndCode = responseProducer(context.Request.Url);
-            _logger.Info("Processing a response message to the browser. HttpStatus:" + messageAndCode.HttpCode);
+            _logger.Info(() => "Processing a response message to the browser. HttpStatus:" + messageAndCode.HttpCode);
 
             switch (messageAndCode.HttpCode)
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AadPlugin.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AadPlugin.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             if (!envMetadata.Aliases.ContainsOrdinalIgnoreCase(accountEnv))
             {
                 _logger.InfoPii(
-                $"[WAM AAD Provider] Account {webAccount.UserName} environment {accountEnv} does not match input authority environment {envMetadata.PreferredNetwork} or an alias",
-                $"[WAM AAD Provider] Account environment {accountEnv} does not match input authority environment {envMetadata.PreferredNetwork}");
+                () => $"[WAM AAD Provider] Account {webAccount.UserName} environment {accountEnv} does not match input authority environment {envMetadata.PreferredNetwork} or an alias",
+                () => $"[WAM AAD Provider] Account environment {accountEnv} does not match input authority environment {envMetadata.PreferredNetwork}");
 
                 return null;
             }
@@ -136,8 +136,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             if (MatchCacheAccount(webAccount, accountsFromCache, out AccountId homeAccountId))
             {
                 _logger.VerbosePii(
-                    $"[WAM AAD Provider] ConvertToMsalAccountOrNullAsync account {webAccount.UserName} matched a cached account",
-                    $"[WAM AAD Provider] Account matched a cache account");
+                    () => $"[WAM AAD Provider] ConvertToMsalAccountOrNullAsync account {webAccount.UserName} matched a cached account",
+                    () => $"[WAM AAD Provider] Account matched a cache account");
 
                 return new Account(
                     homeAccountId.Identifier,
@@ -160,8 +160,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                 var tuple = await cacheManager.SaveTokenResponseAsync(response).ConfigureAwait(false);
 
                 _logger.InfoPii(
-                      $"[WAM AAD Provider] ConvertToMsalAccountOrNullAsync resolved account {webAccount.UserName} via web call? {tuple?.Item3 != null}",
-                      $"[WAM AAD Provider] ConvertToMsalAccountOrNullAsync resolved account via web call? {tuple?.Item3 != null}");
+                      () => $"[WAM AAD Provider] ConvertToMsalAccountOrNullAsync resolved account {webAccount.UserName} via web call? {tuple?.Item3 != null}",
+                      () => $"[WAM AAD Provider] ConvertToMsalAccountOrNullAsync resolved account via web call? {tuple?.Item3 != null}");
 
                 return tuple?.Item3; // Account
             }
@@ -341,8 +341,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             _logger.Info("Result from WAM has client info? " + hasClientInfo);
 
             bool hasScopes = webTokenResponse.Properties.TryGetValue("wamcompat_scopes", out string scopes);
-            _logger.InfoPii("Result from WAM scopes: " + scopes,
-                "Result from WAM has scopes? " + hasScopes);
+            _logger.InfoPii(() => "Result from WAM scopes: " + scopes,
+                () => "Result from WAM has scopes? " + hasScopes);
 
             foreach (var kvp in webTokenResponse.Properties)
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/AccountPicker.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             _authority = authority;
             _isMsaPassthrough = isMsaPassthrough;
             _optionalHeaderText = optionalHeaderText;
-            _logger.Verbose("Is MSA passthrough? " + _isMsaPassthrough);
+            _logger.Verbose(()=>"Is MSA passthrough? " + _isMsaPassthrough);
         }
 
         public async Task<WebAccountProvider> DetermineAccountInteractivelyAsync()
@@ -256,7 +256,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
 
                 if (string.Equals("common", _authority.TenantId))
                 {
-                    _logger.Verbose("Displaying selector for common");
+                    _logger.Verbose(()=>"Displaying selector for common");
                     await AddSelectorsAsync(
                         args,
                         addOrgAccounts: true,
@@ -264,7 +264,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                 }
                 else if (string.Equals("organizations", _authority.TenantId))
                 {
-                    _logger.Verbose("Displaying selector for organizations");
+                    _logger.Verbose(()=>"Displaying selector for organizations");
                     await AddSelectorsAsync(
                         args,
                         addOrgAccounts: true,
@@ -272,7 +272,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                 }
                 else if (string.Equals("consumers", _authority.TenantId))
                 {
-                    _logger.Verbose("Displaying selector for consumers");
+                    _logger.Verbose(() => "Displaying selector for consumers");
                     await AddSelectorsAsync(
                         args,
                         addOrgAccounts: false,
@@ -280,7 +280,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                 }
                 else
                 {
-                    _logger.Verbose("Displaying selector for tenanted authority");
+                    _logger.Verbose(()=>"Displaying selector for tenanted authority");
                     await AddSelectorsAsync(
                         args,
                         addOrgAccounts: true,

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/MsaPassthroughHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/MsaPassthroughHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         public async Task<string> TryFetchTransferTokenInteractiveAsync(AuthenticationRequestParameters authenticationRequestParameters, WebAccountProvider accountProvider)
         {
             // First party apps can have MSA-PT enabled and can configured to allow MSA users
-            _logger.Verbose("WAM MSA-PT - fetching transfer token for interactive flow");
+            _logger.Verbose(() => "WAM MSA-PT - fetching transfer token for interactive flow");
 
             var webTokenRequestMsa = await _msaPlugin.CreateWebTokenRequestAsync(
                 accountProvider,
@@ -68,7 +68,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         public async Task<string> TryFetchTransferTokenSilentDefaultAccountAsync(AuthenticationRequestParameters authenticationRequestParameters, WebAccountProvider accountProvider)
         {
             // First party apps can have MSA-PT enabled and can configured to allow MSA users
-            _logger.Verbose("WAM MSA-PT - fetching transfer token for silent flow with default OS account");
+            _logger.Verbose(() => "WAM MSA-PT - fetching transfer token for silent flow with default OS account");
 
             var webTokenRequestMsa = await _msaPlugin.CreateWebTokenRequestAsync(
                 accountProvider,
@@ -103,7 +103,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
 
         public async Task<string> TryFetchTransferTokenSilentAsync(AuthenticationRequestParameters authenticationRequestParameters, WebAccount account)
         {
-            _logger.Verbose("WAM MSA-PT - fetching transfer token for silent flow");
+            _logger.Verbose(() => "WAM MSA-PT - fetching transfer token for silent flow");
 
             var webTokenRequestMsa = await _msaPlugin.CreateWebTokenRequestAsync(
                 account.WebAccountProvider,
@@ -161,7 +161,9 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
 
             // Important: cannot use this WebAccount with the AAD provider
             WebAccount msaPtWebAccount = transferResponse.ResponseData[0].WebAccount;
-            _logger.InfoPii($"Obtained a transfer token for {msaPtWebAccount.UserName} ?  {code != null}", $"Obtained a transfer token? {code != null}");
+            _logger.InfoPii(
+                () => $"Obtained a transfer token for {msaPtWebAccount.UserName} ?  {code != null}",
+                () => $"Obtained a transfer token? {code != null}");
 
             return code;
         }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamBroker.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             if (authenticationRequestParameters.Account != null ||
                 !string.IsNullOrEmpty(authenticationRequestParameters.LoginHint))
             {
-                _logger.Verbose("[WamBroker] AcquireTokenIntractive - account information provided. Trying to find a Windows account that matches.");
+                _logger.Verbose(() => "[WamBroker] AcquireTokenIntractive - account information provided. Trying to find a Windows account that matches.");
 
                 bool isMsaPassthrough = _wamOptions.MsaPassthrough;
                 bool isMsa = await IsMsaRequestAsync(
@@ -179,19 +179,19 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
                         isInteractive: true);
                 }
 
-                _logger.Verbose("[WamBroker] AcquireTokenIntractive - account information provided but no matching account was found ");
+                _logger.Verbose(() => "[WamBroker] AcquireTokenIntractive - account information provided but no matching account was found ");
             }
 
             // no account information available, need an account picker
             if (CanSkipAccountPicker(authenticationRequestParameters.Authority))
             {
-                _logger.Verbose("[WamBroker] Using AAD plugin account picker");
+                _logger.Verbose(() => "[WamBroker] Using AAD plugin account picker");
                 return await AcquireInteractiveWithAadBrowserAsync(
                     authenticationRequestParameters,
                     acquireTokenInteractiveParameters.Prompt).ConfigureAwait(false);
             }
 
-            _logger.Verbose("[WamBroker] Using Windows account picker (AccountsSettingsPane)");
+            _logger.Verbose(() => "[WamBroker] Using Windows account picker (AccountsSettingsPane)");
             return await AcquireInteractiveWithPickerAsync(
                 authenticationRequestParameters,
                 acquireTokenInteractiveParameters.Prompt)
@@ -898,7 +898,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
 
                 var webAccount = await FindWamAccountForMsalAccountAsync(provider, wamPlugin, account, null, appConfig.ClientId)
                     .ConfigureAwait(false);
-                _logger.Info("Found a webAccount? " + (webAccount != null));
+                _logger.Info(() => "Found a webAccount? " + (webAccount != null));
 
                 if (webAccount != null)
                 {
@@ -912,7 +912,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
             if (!string.IsNullOrEmpty(homeTenantId))
             {
                 bool result = IsConsumerTenantId(homeTenantId);
-                _logger.Info("[WAM Broker] Deciding plugin based on home tenant Id ... MSA? " + result);
+                _logger.Info(() => "[WAM Broker] Deciding plugin based on home tenant Id ... MSA? " + result);
                 return result;
             }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WamBroker/WamProxy.cs
@@ -37,11 +37,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         {
             using (_logger.LogBlockDuration("WAM:GetTokenSilentlyAsync:webAccount"))
             {
-                if (_logger.IsLoggingEnabled(LogLevel.Verbose))
-                {
-                    _logger.VerbosePii(webTokenRequest.ToLogString(true), webTokenRequest.ToLogString(false));
-                    _logger.VerbosePii(webAccount.ToLogString(true), webAccount.ToLogString(false));
-                }
+                _logger.VerbosePii(() => webTokenRequest.ToLogString(true), () => webTokenRequest.ToLogString(false));
+                _logger.VerbosePii(() => webAccount.ToLogString(true), () => webAccount.ToLogString(false));
 
                 var wamResult = await WebAuthenticationCoreManager.GetTokenSilentlyAsync(webTokenRequest, webAccount);
                 return new WebTokenRequestResultWrapper(wamResult);
@@ -52,10 +49,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         {
             using (_logger.LogBlockDuration("WAM:GetTokenSilentlyAsync:"))
             {
-                if (_logger.IsLoggingEnabled(LogLevel.Verbose))
-                {
-                    _logger.VerbosePii(webTokenRequest.ToLogString(true), webTokenRequest.ToLogString(false));
-                }
+                _logger.VerbosePii(() => webTokenRequest.ToLogString(true), () => webTokenRequest.ToLogString(false));
 
                 var wamResult = await WebAuthenticationCoreManager.GetTokenSilentlyAsync(webTokenRequest);
                 return new WebTokenRequestResultWrapper(wamResult);
@@ -68,10 +62,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         {
             using (_logger.LogBlockDuration("WAM:RequestTokenForWindowAsync:"))
             {
-                if (_logger.IsLoggingEnabled(LogLevel.Verbose))
-                {
-                    _logger.VerbosePii(webTokenRequest.ToLogString(true), webTokenRequest.ToLogString(false));
-                }
+                _logger.VerbosePii(() => webTokenRequest.ToLogString(true), () => webTokenRequest.ToLogString(false));
 #if WINDOWS_APP
                 // UWP requires being on the UI thread
                 await _synchronizationContext;
@@ -93,11 +84,10 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         {
             using (_logger.LogBlockDuration("WAM:RequestTokenForWindowAsync:"))
             {
-                if (_logger.IsLoggingEnabled(LogLevel.Verbose))
-                {
-                    _logger.VerbosePii(webTokenRequest.ToLogString(true), webTokenRequest.ToLogString(false));
-                    _logger.VerbosePii(wamAccount.ToLogString(true), wamAccount.ToLogString(false));
-                }
+
+                _logger.VerbosePii(() => webTokenRequest.ToLogString(true), () => webTokenRequest.ToLogString(false));
+                _logger.VerbosePii(() => wamAccount.ToLogString(true), () => wamAccount.ToLogString(false));
+
 #if WINDOWS_APP
 
                 // UWP requires being on the UI thread
@@ -119,11 +109,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         {
             using (_logger.LogBlockDuration("WAM:FindAccountAsync:"))
             {
-                if (_logger.IsLoggingEnabled(LogLevel.Verbose))
-                {
-                    _logger.VerbosePii(provider.ToLogString(true), provider.ToLogString(false));
-                }
-
+                _logger.VerbosePii(() => provider.ToLogString(true), () => provider.ToLogString(false));
                 return await WebAuthenticationCoreManager.FindAccountAsync(provider, wamAccountId);
             }
         }
@@ -132,10 +118,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WamBroker
         {
             using (_logger.LogBlockDuration("WAM:FindAllWebAccountsAsync:"))
             {
-                if (_logger.IsLoggingEnabled(LogLevel.Verbose))
-                {
-                    _logger.VerbosePii(provider.ToLogString(true), provider.ToLogString(false));
-                }
+                _logger.VerbosePii(() => provider.ToLogString(true), () => provider.ToLogString(false));
 
                 // Win 10 RS3 release and above
                 if (!ApiInformation.IsMethodPresent(

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WebView2WebUi/WinFormsPanelWithWebView2.cs
@@ -220,12 +220,12 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
         {
             if (CheckForEndUrl(new Uri(e.Uri)))
             {
-                _logger.Verbose("[WebView2Control] Redirect URI reached. Stopping the interactive view");
+                _logger.Verbose(() => "[WebView2Control] Redirect URI reached. Stopping the interactive view");
                 e.Cancel = true;
             }
             else
             {
-                _logger.Verbose("[WebView2Control] Navigating to " + e.Uri);
+                _logger.Verbose(() => "[WebView2Control] Navigating to " + e.Uri);
             }
         }
 
@@ -264,7 +264,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WebView2WebUi
 
         private void WebView2Control_CoreWebView2InitializationCompleted(object sender, CoreWebView2InitializationCompletedEventArgs e)
         {
-            _logger.Verbose("[WebView2Control] CoreWebView2InitializationCompleted ");
+            _logger.Verbose(() => "[WebView2Control] CoreWebView2InitializationCompleted ");
             _webView2.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
             _webView2.CoreWebView2.Settings.AreDevToolsEnabled = false;
             _webView2.CoreWebView2.Settings.AreHostObjectsAllowed = false;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/WinFormsLegacyWebUi/WindowsFormsWebAuthenticationDialogBase.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 
             if (string.IsNullOrEmpty(e.Url))
             {
-                RequestContext.Logger.Verbose("[Legacy WebView] URL in BeforeNavigate is null or empty.");
+                RequestContext.Logger.Verbose(()=>"[Legacy WebView] URL in BeforeNavigate is null or empty.");
                 e.Cancel = true;
                 return;
             }
@@ -145,8 +145,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
             {
                 string urlDecode = CoreHelpers.UrlDecode(e.Url.ToString());
                 RequestContext.Logger.VerbosePii(
-                    string.Format(CultureInfo.InvariantCulture, "[Legacy WebView] Navigating to '{0}'.", urlDecode),
-                    string.Empty);
+                    () => string.Format(CultureInfo.InvariantCulture, "[Legacy WebView] Navigating to '{0}'.", urlDecode),
+                    () => string.Empty);
             }
         }
 
@@ -160,8 +160,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
 
             string urlDecode = CoreHelpers.UrlDecode(e.Url.ToString());
             RequestContext.Logger.VerbosePii(
-                string.Format(CultureInfo.InvariantCulture, "[Legacy WebView] Navigated to '{0}'.", urlDecode),
-                string.Empty);
+                () => string.Format(CultureInfo.InvariantCulture, "[Legacy WebView] Navigated to '{0}'.", urlDecode),
+                () => string.Empty);
         }
 
         /// <summary>
@@ -242,14 +242,14 @@ namespace Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi
                     return;
                 }
 
-                RequestContext.Logger.Verbose(string.Format(CultureInfo.InvariantCulture,
+                RequestContext.Logger.Verbose(()=>string.Format(CultureInfo.InvariantCulture,
                     "[Legacy WebView] WebBrowser state: IsBusy: {0}, ReadyState: {1}, Created: {2}, Disposing: {3}, IsDisposed: {4}, IsOffline: {5}",
                     _webBrowser.IsBusy, _webBrowser.ReadyState, _webBrowser.Created,
                     _webBrowser.Disposing, _webBrowser.IsDisposed, _webBrowser.IsOffline));
 
                 _webBrowser.Stop();
 
-                RequestContext.Logger.Verbose(string.Format(CultureInfo.InvariantCulture,
+                RequestContext.Logger.Verbose(()=>string.Format(CultureInfo.InvariantCulture,
                     "[Legacy WebView] WebBrowser state (after Stop): IsBusy: {0}, ReadyState: {1}, Created: {2}, Disposing: {3}, IsDisposed: {4}, IsOffline: {5}",
                     _webBrowser.IsBusy, _webBrowser.ReadyState, _webBrowser.Created,
                     _webBrowser.Disposing, _webBrowser.IsDisposed, _webBrowser.IsOffline));

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Identity.Client
         public static bool SetAuthenticationContinuationEventArgs(NSUrl url)
         {
             LastRequestLogger?.InfoPii(
-                "AuthenticationContinuationHelper - SetAuthenticationContinuationEventArgs url: " + url,
-                "AuthenticationContinuationHelper - SetAuthenticationContinuationEventArgs ");            
+                () => "AuthenticationContinuationHelper - SetAuthenticationContinuationEventArgs url: " + url,
+                () => "AuthenticationContinuationHelper - SetAuthenticationContinuationEventArgs ");            
 
             return WebviewBase.ContinueAuthentication(url.AbsoluteString, LastRequestLogger);
         }
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client
         /// <returns>True if the response is from broker, False otherwise.</returns>
         public static bool IsBrokerResponse(string sourceApplication)
         {
-            LastRequestLogger?.Info("IsBrokerResponse called with sourceApplication " + sourceApplication);
+            LastRequestLogger?.Info(() => "IsBrokerResponse called with sourceApplication " + sourceApplication);
 
             if (string.Equals("com.microsoft.azureauthenticator", sourceApplication, StringComparison.OrdinalIgnoreCase))
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client
         /// <param name="url"></param>
         public static void SetBrokerContinuationEventArgs(NSUrl url)
         {
-            LastRequestLogger?.Info("SetBrokercontinuationEventArgs Called with Url " + url);
+            LastRequestLogger?.Info(() => "SetBrokercontinuationEventArgs Called with Url " + url);
 
             string urlString = url.AbsoluteString;
             

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/BrokerKeyHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/BrokerKeyHelper.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Identity.Client.Platforms.iOS
                 };
 
                 var removeResult = SecKeyChain.Remove(recordToRemove);
-                logger.Info("Broker key removal result: " + removeResult);
+                logger.Info(() => "Broker key removal result: " + removeResult);
 
                 result = SecKeyChain.Add(recordToAdd);
-                logger.Info("Broker key re-adding result: " + result);
+                logger.Info(() => "Broker key re-adding result: " + result);
             }
 
             if (result != SecStatusCode.Success)

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -212,12 +212,12 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             s_brokerResponseReady = new SemaphoreSlim(0);
 
             string paramsAsQuery = brokerPayload.ToQueryParameter();
-            _logger.Info(iOSBrokerConstants.InvokeTheIosBroker);
+            _logger.Info(() => iOSBrokerConstants.InvokeTheIosBroker);
             NSUrl url = new NSUrl(iOSBrokerConstants.InvokeV2Broker + paramsAsQuery);
 
             _logger.VerbosePii(
-                iOSBrokerConstants.BrokerPayloadPii + paramsAsQuery,
-                iOSBrokerConstants.BrokerPayloadNoPii + brokerPayload.Count);
+                () => iOSBrokerConstants.BrokerPayloadPii + paramsAsQuery,
+                () => iOSBrokerConstants.BrokerPayloadNoPii + brokerPayload.Count);
 
             DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.OpenUrl(url));
 
@@ -244,12 +244,13 @@ namespace Microsoft.Identity.Client.Platforms.iOS
                     {
                         responseDictionary[iOSBrokerConstants.Error] = iOSBrokerConstants.BrokerError;
 
-                        _logger.VerbosePii(iOSBrokerConstants.BrokerResponseValuesPii + keyValue.ToString(),
-                        iOSBrokerConstants.BrokerResponseContainsError);
+                        _logger.VerbosePii(
+                            () => iOSBrokerConstants.BrokerResponseValuesPii + keyValue.ToString(),
+                            () => iOSBrokerConstants.BrokerResponseContainsError);
                     }
                 }
 
-                _logger.Verbose(iOSBrokerConstants.ProcessBrokerResponse + responseDictionary.Count);
+                _logger.Verbose(() => iOSBrokerConstants.ProcessBrokerResponse + responseDictionary.Count);
 
                 return ResultFromBrokerResponse(responseDictionary);
             }
@@ -349,7 +350,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             {
                 SecStatusCode secStatusCode = iOSTokenCacheAccessor.SaveBrokerApplicationToken(clientId, applicationToken);
 
-                _logger.Info(string.Format(
+                _logger.Info(() => string.Format(
                     CultureInfo.CurrentCulture,
                     iOSBrokerConstants.AttemptToSaveBrokerApplicationToken + "SecStatusCode: {0}",
                     secStatusCode));
@@ -370,7 +371,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             {
                 SecStatusCode secStatusCode = iOSTokenCacheAccessor.TryGetBrokerApplicationToken(brokerPayload[BrokerParameter.ClientId], out string appToken);
 
-                _logger.Info(string.Format(
+                _logger.Info(() => string.Format(
                     CultureInfo.CurrentCulture,
                     iOSBrokerConstants.SecStatusCodeFromTryGetBrokerApplicationToken + "SecStatusCode: {0}",
                     secStatusCode));

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
         {
             AuthenticationContinuationHelper.LastRequestLogger = requestContext.Logger;
             requestContext.Logger.InfoPii(
-                $"Starting the iOS embedded webui. Start Uri: {authorizationUri} Redirect URI:{redirectUri} ",
-                $"Starting the iOS embedded webui. Redirect URI: {redirectUri}"); 
+                () => $"Starting the iOS embedded webui. Start Uri: {authorizationUri} Redirect URI:{redirectUri} ",
+                () => $"Starting the iOS embedded webui. Redirect URI: {redirectUri}"); 
                 
             s_returnedUriReady = new SemaphoreSlim(0);
             Authenticate(authorizationUri, redirectUri, requestContext);

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/SystemWebview/SystemWebUI.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Identity.Client.Platforms.iOS.SystemWebview
         {
             AuthenticationContinuationHelper.LastRequestLogger = requestContext.Logger;
             requestContext.Logger.InfoPii(
-              $"Starting the iOS system webui. Start Uri: {authorizationUri} Redirect URI:{redirectUri} ",
-              $"Starting the iOS system webui. Redirect URI: {redirectUri}");
+              () => $"Starting the iOS system webui. Start Uri: {authorizationUri} Redirect URI:{redirectUri} ",
+              () => $"Starting the iOS system webui. Redirect URI: {redirectUri}");
 
             s_viewController = null;
             InvokeOnMainThread(() =>

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/WebviewBase.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/WebviewBase.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             }
 
             s_authorizationResult = AuthorizationResult.FromUri(url);
-            logger?.Verbose("Response url parsed and the result is " + s_authorizationResult.Status);
+            logger?.Verbose(() => "Response url parsed and the result is " + s_authorizationResult.Status);
 
             s_returnedUriReady.Release();
 

--- a/src/client/Microsoft.Identity.Client/Platforms/uap/SynchronizedAndEncryptedFileProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/uap/SynchronizedAndEncryptedFileProvider.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Identity.Client.Platforms.uap
 
         private async Task OnBeforeAccessAsync(TokenCacheNotificationArgs args)
         {
-            _logger.Verbose($"OnBeforeAccessAsync - before getting the lock " + _semaphoreSlim.CurrentCount);
+            _logger.Verbose(() => $"OnBeforeAccessAsync - before getting the lock " + _semaphoreSlim.CurrentCount);
 
             // prevent other threads / background tasks from reading the file            
             await _semaphoreSlim.WaitAsync().ConfigureAwait(true);
 
-            _logger.Verbose($"OnBeforeAccessAsync - acquired the lock");
+            _logger.Verbose(() => $"OnBeforeAccessAsync - acquired the lock");
 
             IStorageFile cacheFile = await ApplicationData.Current.LocalFolder.TryGetItemAsync(CacheFileName) as IStorageFile;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Identity.Client.Platforms.uap
             }
             finally
             {
-                _logger.Verbose($"{DateTime.UtcNow} OnAfterAccessAsync - released the lock");
+                _logger.Verbose(() => "OnAfterAccessAsync - released the lock");
                 _semaphoreSlim.Release();
             }
         }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
@@ -133,8 +133,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             if (partition == null || !partition.TryRemove(item.CacheKey, out _))
             {
                 _logger.InfoPii(
-                    $"[Internal cache] Cannot delete access token because it was not found in the cache. Key {item.CacheKey}.",
-                    "[Internal cache] Cannot delete access token because it was not found in the cache.");
+                    () => $"[Internal cache] Cannot delete access token because it was not found in the cache. Key {item.CacheKey}.",
+                    () => "[Internal cache] Cannot delete access token because it was not found in the cache.");
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
@@ -155,8 +155,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             if (partition == null || !partition.TryRemove(item.CacheKey, out _))
             {
                 _logger.InfoPii(
-                    $"[Internal cache] Cannot delete access token because it was not found in the cache. Key {item.CacheKey}.",
-                    "[Internal cache] Cannot delete access token because it was not found in the cache.");
+                    () => $"[Internal cache] Cannot delete access token because it was not found in the cache. Key {item.CacheKey}.",
+                    () => "[Internal cache] Cannot delete access token because it was not found in the cache.");
             }
         }
 
@@ -168,8 +168,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             if (partition == null || !partition.TryRemove(item.CacheKey, out _))
             {
                 _logger.InfoPii(
-                    $"[Internal cache] Cannot delete refresh token because it was not found in the cache. Key {item.CacheKey}.",
-                    "[Internal cache] Cannot delete refresh token because it was not found in the cache.");
+                    () => $"[Internal cache] Cannot delete refresh token because it was not found in the cache. Key {item.CacheKey}.",
+                    () => "[Internal cache] Cannot delete refresh token because it was not found in the cache.");
             }
         }
 
@@ -181,8 +181,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             if (partition == null || !partition.TryRemove(item.CacheKey, out _))
             {
                 _logger.InfoPii(
-                    $"[Internal cache] Cannot delete ID token because it was not found in the cache. Key {item.CacheKey}.",
-                    "[Internal cache] Cannot delete ID token because it was not found in the cache.");
+                    () => $"[Internal cache] Cannot delete ID token because it was not found in the cache. Key {item.CacheKey}.",
+                    () => "[Internal cache] Cannot delete ID token because it was not found in the cache.");
             }
         }
 
@@ -194,8 +194,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             if (partition == null || !partition.TryRemove(item.CacheKey, out _))
             {
                 _logger.InfoPii(
-                    $"[Internal cache] Cannot delete account because it was not found in the cache. Key {item.CacheKey}.",
-                    "[Internal cache] Cannot delete account because it was not found in the cache");
+                    () => $"[Internal cache] Cannot delete account because it was not found in the cache. Key {item.CacheKey}.",
+                    () => "[Internal cache] Cannot delete account because it was not found in the cache");
             }
         }
         #endregion

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -148,9 +148,9 @@ namespace Microsoft.Identity.Client
 
             #endregion
 
-            logger.Verbose($"[SaveTokenResponseAsync] Entering token cache semaphore. Count {_semaphoreSlim.GetCurrentCountLogMessage()}.");
+            logger.Verbose(() => $"[SaveTokenResponseAsync] Entering token cache semaphore. Count {_semaphoreSlim.GetCurrentCountLogMessage()}.");
             await _semaphoreSlim.WaitAsync(requestParams.RequestContext.UserCancellationToken).ConfigureAwait(false);
-            logger.Verbose("[SaveTokenResponseAsync] Entered token cache semaphore. ");
+            logger.Verbose(() => "[SaveTokenResponseAsync] Entered token cache semaphore. ");
             ITokenCacheInternal tokenCacheInternal = this;
 
             try
@@ -268,7 +268,7 @@ namespace Microsoft.Identity.Client
             finally
             {
                 _semaphoreSlim.Release();
-                logger.Verbose("[SaveTokenResponseAsync] Released token cache semaphore. ");
+                logger.Verbose(() => "[SaveTokenResponseAsync] Released token cache semaphore. ");
             }
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.Identity.Client
                     tokenCacheKeyDump.AppendLine($"AT Cache Key: {cacheItem.ToLogString(requestParameters.RequestContext.Logger.PiiLoggingEnabled)}");
                 }
 
-                requestParameters.RequestContext.Logger.Verbose(tokenCacheKeyDump.ToString());
+                requestParameters.RequestContext.Logger.Verbose(() => tokenCacheKeyDump.ToString());
             }
         }
 
@@ -367,7 +367,7 @@ namespace Microsoft.Identity.Client
             }
             else
             {
-                requestParams.RequestContext.Logger.Verbose("Not saving to ADAL legacy cache. ");
+                requestParams.RequestContext.Logger.Verbose(() => "Not saving to ADAL legacy cache. ");
             }
         }
 
@@ -443,7 +443,7 @@ namespace Microsoft.Identity.Client
             if (accessTokens.Count == 0)
             {
 
-                logger.Verbose("[FindAccessTokenAsync] No access tokens found in the cache. Skipping filtering. ");
+                logger.Verbose(() => "[FindAccessTokenAsync] No access tokens found in the cache. Skipping filtering. ");
                 requestParams.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.NoCachedAccessToken;
 
                 return null;
@@ -460,7 +460,7 @@ namespace Microsoft.Identity.Client
             // no match
             if (accessTokens.Count == 0)
             {
-                logger.Verbose("[FindAccessTokenAsync] No tokens found for matching authority, client_id, user and scopes. ");
+                logger.Verbose(() => "[FindAccessTokenAsync] No tokens found for matching authority, client_id, user and scopes. ");
                 return null;
             }
 
@@ -485,7 +485,7 @@ namespace Microsoft.Identity.Client
             var logger = requestParams.RequestContext.Logger;
             if (tokenCacheItems.Count == 0)
             {
-                logger.Verbose("Not filtering by scopes, because there are no candidates");
+                logger.Verbose(() => "Not filtering by scopes, because there are no candidates");
                 return;
             }
 
@@ -499,8 +499,7 @@ namespace Microsoft.Identity.Client
 
                     if (logger.IsLoggingEnabled(LogLevel.Verbose))
                     {
-                        logger.Verbose($"Access token with scopes {string.Join(" ", item.ScopeSet)} " +
-                            $"passes scope filter? {accepted} ");
+                        logger.Verbose(() => $"Access token with scopes {string.Join(" ", item.ScopeSet)} " + $"passes scope filter? {accepted} ");
                     }
                     return accepted;
                 },
@@ -592,12 +591,9 @@ namespace Microsoft.Identity.Client
                         return null;
                     }
 
-                    if (logger.IsLoggingEnabled(LogLevel.Info))
-                    {
-                        logger.Info(
-                            "Access token is not expired. Returning the found cache entry. " +
-                            GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
-                    }
+                    logger.Info(
+                        () => "Access token is not expired. Returning the found cache entry. " +
+                        GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
 
                     return msalAccessTokenCacheItem;
                 }
@@ -605,23 +601,18 @@ namespace Microsoft.Identity.Client
                 if (ServiceBundle.Config.IsExtendedTokenLifetimeEnabled &&
                     msalAccessTokenCacheItem.ExtendedExpiresOn > DateTime.UtcNow + Constants.AccessTokenExpirationBuffer)
                 {
-                    if (logger.IsLoggingEnabled(LogLevel.Info))
-                    {
-                        logger.Info(
-                            "Access token is expired.  IsExtendedLifeTimeEnabled=TRUE and ExtendedExpiresOn is not exceeded.  Returning the found cache entry. " +
-                            GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
-                    }
+
+                    logger.Info(() =>
+                        "Access token is expired.  IsExtendedLifeTimeEnabled=TRUE and ExtendedExpiresOn is not exceeded.  Returning the found cache entry. " +
+                        GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
 
                     msalAccessTokenCacheItem.IsExtendedLifeTimeToken = true;
                     return msalAccessTokenCacheItem;
                 }
 
-                if (logger.IsLoggingEnabled(LogLevel.Info))
-                {
-                    logger.Info(
-                        "Access token has expired or about to expire. " +
-                        GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
-                }
+                logger.Info(() =>
+                    "Access token has expired or about to expire. " +
+                    GetAccessTokenExpireLogMessageContent(msalAccessTokenCacheItem));
             }
 
             return null;
@@ -651,7 +642,7 @@ namespace Microsoft.Identity.Client
 
             if (tokenCacheItems.Count == 0)
             {
-                logger.Verbose("Not filtering AT by environment, because there are no candidates");
+                logger.Verbose(() => "Not filtering AT by environment, because there are no candidates");
                 return tokenCacheItems;
             }
 
@@ -675,7 +666,7 @@ namespace Microsoft.Identity.Client
             {
                 if (logger.IsLoggingEnabled(LogLevel.Verbose))
                 {
-                    logger.Verbose($"Filtered AT by preferred alias returning {itemsFilteredByAlias.Count} tokens.");
+                    logger.Verbose(() => $"Filtered AT by preferred alias returning {itemsFilteredByAlias.Count} tokens.");
                 }
 
                 return itemsFilteredByAlias;
@@ -697,18 +688,18 @@ namespace Microsoft.Identity.Client
             string requestKid = authenticationRequest.AuthenticationScheme.KeyId;
             if (string.IsNullOrEmpty(item.KeyId) && string.IsNullOrEmpty(requestKid))
             {
-                authenticationRequest.RequestContext.Logger.Verbose("Bearer token found");
+                authenticationRequest.RequestContext.Logger.Verbose(() => "Bearer token found");
                 return item;
             }
 
             if (string.Equals(item.KeyId, requestKid, StringComparison.OrdinalIgnoreCase))
             {
-                authenticationRequest.RequestContext.Logger.Verbose("Keyed token found");
+                authenticationRequest.RequestContext.Logger.Verbose(() => "Keyed token found");
                 return item;
             }
 
             authenticationRequest.RequestContext.Logger.Info(
-                    string.Format(
+                    () => string.Format(
                         CultureInfo.InvariantCulture,
                         "A token bound to the wrong key was found. Token key id: {0} Request key id: {1}",
                         item.KeyId,
@@ -789,7 +780,7 @@ namespace Microsoft.Identity.Client
                         item => !aliases.ContainsOrdinalIgnoreCase(item.Environment));
                 }
 
-                requestParams.RequestContext.Logger.Info("[FindRefreshTokenAsync] Refresh token found in the cache? - " + (refreshTokens.Count != 0));
+                requestParams.RequestContext.Logger.Info(() => "[FindRefreshTokenAsync] Refresh token found in the cache? - " + (refreshTokens.Count != 0));
 
                 if (refreshTokens.Count > 0)
                 {
@@ -798,10 +789,10 @@ namespace Microsoft.Identity.Client
             }
             else
             {
-                requestParams.RequestContext.Logger.Verbose("[FindRefreshTokenAsync] No RTs found in the MSAL cache ");
+                requestParams.RequestContext.Logger.Verbose(() => "[FindRefreshTokenAsync] No RTs found in the MSAL cache ");
             }
 
-            requestParams.RequestContext.Logger.Verbose("[FindRefreshTokenAsync] Checking ADAL cache for matching RT. ");
+            requestParams.RequestContext.Logger.Verbose(() => "[FindRefreshTokenAsync] Checking ADAL cache for matching RT. ");
 
             if (IsLegacyAdalCacheEnabled(requestParams) &&
                 requestParams.Account != null &&
@@ -927,7 +918,7 @@ namespace Microsoft.Identity.Client
 
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
             {
-                logger.Verbose($"[GetAccounts] Found {refreshTokenCacheItems.Count} RTs and {accountCacheItems.Count} accounts in MSAL cache. ");
+                logger.Verbose(() => $"[GetAccounts] Found {refreshTokenCacheItems.Count} RTs and {accountCacheItems.Count} accounts in MSAL cache. ");
             }
 
             // Multi-cloud support - must filter by environment.
@@ -962,7 +953,7 @@ namespace Microsoft.Identity.Client
 
             if (logger.IsLoggingEnabled(LogLevel.Verbose))
             {
-                logger.Verbose($"[GetAccounts] Found {refreshTokenCacheItems.Count} RTs and {accountCacheItems.Count} accounts in MSAL cache after environment filtering. ");
+                logger.Verbose(() => $"[GetAccounts] Found {refreshTokenCacheItems.Count} RTs and {accountCacheItems.Count} accounts in MSAL cache after environment filtering. ");
             }
 
             IDictionary<string, Account> clientInfoToAccountMap = new Dictionary<string, Account>();
@@ -1038,7 +1029,7 @@ namespace Microsoft.Identity.Client
 
                 if (logger.IsLoggingEnabled(LogLevel.Verbose))
                 {
-                    logger.Verbose($"Filtered by home account id. Remaining accounts {accounts.Count()} ");
+                    logger.Verbose(() => $"Filtered by home account id. Remaining accounts {accounts.Count()} ");
                 }
             }
 
@@ -1157,9 +1148,9 @@ namespace Microsoft.Identity.Client
 
         async Task ITokenCacheInternal.RemoveAccountAsync(IAccount account, AuthenticationRequestParameters requestParameters)
         {
-            requestParameters.RequestContext.Logger.Verbose($"[RemoveAccountAsync] Entering token cache semaphore. Count {_semaphoreSlim.GetCurrentCountLogMessage()}");
+            requestParameters.RequestContext.Logger.Verbose(() => $"[RemoveAccountAsync] Entering token cache semaphore. Count {_semaphoreSlim.GetCurrentCountLogMessage()}");
             await _semaphoreSlim.WaitAsync(requestParameters.RequestContext.UserCancellationToken).ConfigureAwait(false);
-            requestParameters.RequestContext.Logger.Verbose("[RemoveAccountAsync] Entered token cache semaphore");
+            requestParameters.RequestContext.Logger.Verbose(() => "[RemoveAccountAsync] Entered token cache semaphore");
 
             try
             {
@@ -1269,7 +1260,7 @@ namespace Microsoft.Identity.Client
                 Accessor.DeleteRefreshToken(refreshTokenCacheItem);
             }
 
-            requestContext.Logger.Info($"[RemoveAccountAsync] Deleted {refreshTokens.Count} refresh tokens.");
+            requestContext.Logger.Info(() => $"[RemoveAccountAsync] Deleted {refreshTokens.Count} refresh tokens.");
 
             var accessTokens = Accessor.GetAllAccessTokens(partitionKey);
             accessTokens.RemoveAll(item => !item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase));
@@ -1283,7 +1274,7 @@ namespace Microsoft.Identity.Client
                 Accessor.DeleteAccessToken(accessTokenCacheItem);
             }
 
-            requestContext.Logger.Info($"[RemoveAccountAsync] Deleted {accessTokens.Count} access tokens.");
+            requestContext.Logger.Info(() => $"[RemoveAccountAsync] Deleted {accessTokens.Count} access tokens.");
 
             var idTokens = Accessor.GetAllIdTokens(partitionKey);
             idTokens.RemoveAll(item => !item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase));
@@ -1297,7 +1288,7 @@ namespace Microsoft.Identity.Client
                 Accessor.DeleteIdToken(idTokenCacheItem);
             }
 
-            requestContext.Logger.Info($"[RemoveAccountAsync] Deleted {idTokens.Count} ID tokens.");
+            requestContext.Logger.Info(() => $"[RemoveAccountAsync] Deleted {idTokens.Count} ID tokens.");
 
             var accounts = Accessor.GetAllAccounts(partitionKey);
             accounts.RemoveAll(item => !(item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Identity.Client
             if (requestParams.RequestContext.Logger.IsLoggingEnabled(LogLevel.Info))
             {
                 requestParams.RequestContext.Logger.Info(
-                    "Looking for scopes for the authority in the cache which intersect with " +
+                    () => "Looking for scopes for the authority in the cache which intersect with " +
                     requestParams.Scope.AsSingleString());
             }
 
@@ -159,19 +159,19 @@ namespace Microsoft.Identity.Client
                     string.Equals(accessToken.TenantId, tenantId, StringComparison.OrdinalIgnoreCase) &&
                     accessToken.ScopeSet.Overlaps(scopeSet))
                 {
-                    requestParams.RequestContext.Logger.Verbose("Intersecting scopes found");
+                    requestParams.RequestContext.Logger.Verbose(() => $"Intersecting scopes found: {scopeSet}");
                     accessTokensToDelete.Add(accessToken);
                 }
             }
 
-            requestParams.RequestContext.Logger.Info("Intersecting scope entries count - " + accessTokensToDelete.Count);
+            requestParams.RequestContext.Logger.Info(() => "Intersecting scope entries count - " + accessTokensToDelete.Count);
 
             if (!requestParams.IsClientCredentialRequest)
             {
                 // filter by identifier of the user instead
                 accessTokensToDelete.RemoveAll(
                             item => !item.HomeAccountId.Equals(homeAccountId, StringComparison.OrdinalIgnoreCase));
-                requestParams.RequestContext.Logger.Info("Matching entries after filtering by user - " + accessTokensToDelete.Count);
+                requestParams.RequestContext.Logger.Info(() => "Matching entries after filtering by user - " + accessTokensToDelete.Count);
             }
 
             foreach (var cacheItem in accessTokensToDelete)

--- a/src/client/Microsoft.Identity.Client/UI/CustomWebUiHandler.cs
+++ b/src/client/Microsoft.Identity.Client/UI/CustomWebUiHandler.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Identity.Client.UI
 
             try
             {
-                requestContext.Logger.InfoPii(LogMessages.CustomWebUiCallingAcquireAuthorizationCodePii(authorizationUri, redirectUri),
-                                              LogMessages.CustomWebUiCallingAcquireAuthorizationCodeNoPii);
+                requestContext.Logger.InfoPii(
+                    () => LogMessages.CustomWebUiCallingAcquireAuthorizationCodePii(authorizationUri, redirectUri),
+                    () => LogMessages.CustomWebUiCallingAcquireAuthorizationCodeNoPii);
                 var uri = await _customWebUi.AcquireAuthorizationCodeAsync(authorizationUri, redirectUri, cancellationToken)
                                             .ConfigureAwait(false);
                 if (uri == null || String.IsNullOrWhiteSpace(uri.Query))

--- a/src/client/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/EnumerableExtensions.cs
@@ -37,10 +37,9 @@ namespace Microsoft.Identity.Client.Utils
             string logPrefix,
             bool updateOriginalCollection = true)
         {
-            if (logger.IsLoggingEnabled(LogLevel.Verbose))
-            {
-                logger.Verbose($"{logPrefix} - item count before: {list.Count} ");
-            }
+
+            logger.Verbose(() => $"{logPrefix} - item count before: {list.Count} ");
+
             if (updateOriginalCollection)
             {
                 list.RemoveAll(e => !predicate(e));
@@ -50,10 +49,9 @@ namespace Microsoft.Identity.Client.Utils
                 list = list.Where(predicate).ToList();
             }
 
-            if (logger.IsLoggingEnabled(LogLevel.Verbose))
-            {
-                logger.Verbose($"{logPrefix} - item count after: {list.Count} ");
-            }
+
+            logger.Verbose(() => $"{logPrefix} - item count after: {list.Count} ");
+
 
             return list;
         }

--- a/src/client/Microsoft.Identity.Client/WsTrust/CommonNonInteractiveHandler.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/CommonNonInteractiveHandler.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Identity.Client.WsTrust
                     MsalErrorMessage.UnknownUser);
             }
 
-            _requestContext.Logger.InfoPii($"Logged in user detected with user name '{platformUsername}'", "Logged in user detected. ");
+            _requestContext.Logger.InfoPii(
+                () => $"Logged in user detected with user name '{platformUsername}'",
+                () => "Logged in user detected. ");
             return platformUsername;
         }
 
@@ -58,8 +60,8 @@ namespace Microsoft.Identity.Client.WsTrust
             }
 
             _requestContext.Logger.InfoPii(
-                $"User with user name '{username}' detected as '{userRealmResponse.AccountType}'. ",
-                string.Empty);
+                () => $"User with user name '{username}' detected as '{userRealmResponse.AccountType}'. ",
+                () => $"User detected as '{userRealmResponse.AccountType}'. ",);
 
             return userRealmResponse;
         }
@@ -95,9 +97,9 @@ namespace Microsoft.Identity.Client.WsTrust
                   MsalErrorMessage.WsTrustEndpointNotFoundInMetadataDocument);
             }
 
-            _requestContext.Logger.InfoPii(
-                string.Format(CultureInfo.InvariantCulture, "WS-Trust endpoint '{0}' being used from MEX at '{1}'", wsTrustEndpoint.Uri, federationMetadataUrl),
-                "Fetched and parsed MEX. ");
+            _requestContext.Logger.VerbosePii(
+                () => string.Format(CultureInfo.InvariantCulture, "WS-Trust endpoint '{0}' being used from MEX at '{1}'", wsTrustEndpoint.Uri, federationMetadataUrl),
+                () => "Fetched and parsed MEX. ");
 
             WsTrustResponse wsTrustResponse = await GetWsTrustResponseAsync(
                 userAuthType,
@@ -106,7 +108,7 @@ namespace Microsoft.Identity.Client.WsTrust
                 username,
                 password).ConfigureAwait(false);
 
-            _requestContext.Logger.Info($"Token of type '{wsTrustResponse.TokenType}' acquired from WS-Trust endpoint. ");
+            _requestContext.Logger.Info(() => $"Token of type '{wsTrustResponse.TokenType}' acquired from WS-Trust endpoint. ");
 
             return wsTrustResponse;
         }
@@ -130,7 +132,7 @@ namespace Microsoft.Identity.Client.WsTrust
                 WsTrustResponse wsTrustResponse = await _serviceBundle.WsTrustWebRequestManager.GetWsTrustResponseAsync(
                     endpoint, wsTrustRequestMessage, _requestContext).ConfigureAwait(false);
 
-                _requestContext.Logger.Info($"Token of type '{wsTrustResponse.TokenType}' acquired from WS-Trust endpoint. ");
+                _requestContext.Logger.Info(() => $"Token of type '{wsTrustResponse.TokenType}' acquired from WS-Trust endpoint. ");
                 return wsTrustResponse;
             }
             catch (Exception ex) when (ex is not MsalClientException)

--- a/src/client/Microsoft.Identity.Client/WsTrust/CommonNonInteractiveHandler.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/CommonNonInteractiveHandler.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Client.WsTrust
 
             _requestContext.Logger.InfoPii(
                 () => $"User with user name '{username}' detected as '{userRealmResponse.AccountType}'. ",
-                () => $"User detected as '{userRealmResponse.AccountType}'. ",);
+                () => $"User detected as '{userRealmResponse.AccountType}'. ");
 
             return userRealmResponse;
         }

--- a/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -35,8 +35,7 @@ namespace Microsoft.Identity.Client.WsTrust
             if (!string.IsNullOrEmpty(federationMetadata))
             {
                 mexDoc = new MexDocument(federationMetadata);
-                requestContext.Logger.Info(
-                    $"MEX document fetched and parsed from provided federation metadata");
+                requestContext.Logger.Info(() => $"MEX document fetched and parsed from provided federation metadata");
                 return mexDoc;
             }
 
@@ -71,8 +70,8 @@ namespace Microsoft.Identity.Client.WsTrust
             mexDoc = new MexDocument(httpResponse.Body);
 
             requestContext.Logger.InfoPii(
-                $"MEX document fetched and parsed from '{federationMetadataUrl}'",
-                "Fetched and parsed MEX");
+                () => $"MEX document fetched and parsed from '{federationMetadataUrl}'",
+                () => "Fetched and parsed MEX");
 
             return mexDoc;
         }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/LoggerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/LoggerTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             incrementCounter.Invoke();
 
             _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
-            logger.Verbose(TestConstants.TestMessage);
+            logger.Verbose(()=>TestConstants.TestMessage);
             Assert.AreEqual(validationCounter, counter);
         }
 
@@ -168,8 +168,61 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             incrementCounter.Invoke();
 
             _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
-            logger.VerbosePii(TestConstants.TestMessage, string.Empty);
+            logger.VerbosePii(() => TestConstants.TestMessage,()=> string.Empty);
             Assert.AreEqual(validationCounter, counter);
+        }
+
+        [TestMethod]
+        public void LogApiWithProducerDoesNotConcatenateStrings()
+        {
+            ILoggerAdapter logger = CreateLogger(LogLevel.Warning, true, false);
+
+            logger.Verbose(() =>
+            {
+                Assert.Fail("Not expecting this function pointer to execute");
+                return "";
+            });
+
+            logger.VerbosePii(() =>
+            {
+                Assert.Fail("Not expecting this function pointer to execute");
+                return "";
+            },
+            () =>
+            {
+                Assert.Fail("Not expecting this function pointer to execute");
+                return "";
+            }
+            );
+            logger.Info(() =>
+            {
+                Assert.Fail("Not expecting this function pointer to execute");
+                return "";
+            });
+
+            logger.InfoPii(() =>
+            {
+                Assert.Fail("Not expecting this function pointer to execute");
+                return "";
+            },
+            () =>
+            {
+                Assert.Fail("Not expecting this function pointer to execute");
+                return "";
+            }
+            );
+
+            ILoggerAdapter logger2 = CreateLogger(LogLevel.Verbose, true, false);
+
+            bool executed = false;
+            logger2.Verbose(() =>
+            {
+                executed = true;
+                return "";
+            });
+
+            Assert.IsTrue(executed, "Expected the string generator to execute because the log is set to verbose");
+
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #3901 
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
- add logging methods that use lambdas, which do not execute unless the log level is met (this is inspired by high-performance logging from https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-7.0)
- for verbose logging, i removed the overloads with strings. Use only Func<string>
- for info it's a mix bag - strings and Func<string>, since info is ON by default and the Func<string> introduces an extra check.


**Testing** 
unit

**Performance impact**
|                                                Method |        Mean |     Error |    StdDev |      Median |         Min |         Max |   Gen0 | Allocated |
|------------------------------------------------------ |------------:|----------:|----------:|------------:|------------:|------------:|-------:|----------:|
|  'Compute and log expensive string via direct string' | 1,292.38 ns | 35.423 ns | 33.135 ns | 1,287.09 ns | 1,253.46 ns | 1,371.78 ns | 0.1488 |     944 B |
|           'Compute and log expensive string via Func' | 1,369.27 ns | 41.625 ns | 34.759 ns | 1,362.51 ns | 1,296.23 ns | 1,436.84 ns | 0.1678 |    1056 B |
|           'Compute and skip logging expensive string' |   628.37 ns | 10.844 ns | 10.143 ns |   626.69 ns |   611.36 ns |   650.44 ns | 0.0591 |     376 B |
| 'No compute (Func) and skip logging expensive string' |    14.14 ns |  0.286 ns |  0.239 ns |    14.14 ns |    13.72 ns |    14.66 ns | 0.0153 |      96 B |

** AcquireTokenForClient perf tests **

These were modified to run with `WithLogging(Console.WriteLine(msg), LogLevel.Info)`

|                Method |   CacheSize | EnableCacheSerialization |      Mean |       Min |       Max |      Gen0 |      Gen1 |     Gen2 |   Allocated |
|---------------------- |------------ |------------------------- |----------:|----------:|----------:|----------:|----------:|---------:|------------:|
| AcquireTokenForClient |     (1, 10) |                    False |  3.114 ms |  3.057 ms |  3.204 ms |    7.8125 |         - |        - |    51.26 KB |
| AcquireTokenForClient |     (1, 10) |                     True |  3.204 ms |  3.163 ms |  3.280 ms |   46.8750 |   15.6250 |        - |   287.65 KB |
| AcquireTokenForClient |   (1, 1000) |                    False |  3.121 ms |  3.059 ms |  3.160 ms |   27.3438 |         - |        - |   190.96 KB |
| AcquireTokenForClient |   (1, 1000) |                     True | 30.336 ms | 29.677 ms | 31.857 ms | 2687.5000 | 1312.5000 | 625.0000 | 17010.89 KB |
| AcquireTokenForClient | (10000, 10) |                    False |  3.116 ms |  3.030 ms |  3.184 ms |    7.8125 |         - |        - |    51.28 KB |
| AcquireTokenForClient | (10000, 10) |                     True |  4.117 ms |  3.383 ms |  4.852 ms |   46.8750 |   15.6250 |        - |   287.65 KB 



|                Method |   CacheSize | EnableCacheSerialization |      Mean |       Min |       Max |      Gen0 |      Gen1 |     Gen2 |   Allocated |
|---------------------- |------------ |------------------------- |----------:|----------:|----------:|----------:|----------:|---------:|------------:|
| AcquireTokenForClient |     (1, 10) |                    False |  2.990 ms |  2.907 ms |  3.063 ms |    7.8125 |         - |        - |    50.23 KB |
| AcquireTokenForClient |     (1, 10) |                     True |  3.092 ms |  3.024 ms |  3.180 ms |   42.9688 |   11.7188 |        - |   287.06 KB |
| AcquireTokenForClient |   (1, 1000) |                    False |  3.012 ms |  2.932 ms |  3.064 ms |   23.4375 |         - |        - |   158.98 KB |
| AcquireTokenForClient |   (1, 1000) |                     True | 29.365 ms | 27.786 ms | 31.487 ms | 2625.0000 | 1250.0000 | 625.0000 | 17065.87 KB |
| AcquireTokenForClient | (10000, 10) |                    False |  2.966 ms |  2.916 ms |  3.019 ms |    7.8125 |         - |        - |    50.24 KB |
| AcquireTokenForClient | (10000, 10) |                     True |  3.080 ms |  3.010 ms |  3.147 ms |   42.9688 |   11.7188 |        - |   287.03 KB |

**Documentation**
n/a
