### PR TITLE
WAM - Let user perform account switch

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/RuntimeBroker.cs
@@ -376,14 +376,8 @@ namespace Microsoft.Identity.Client.Broker
                         authenticationRequestParameters.CorrelationId.ToString("D"),
                         cancellationToken).ConfigureAwait(false))
                 {
-                    if (result.IsSuccess)
-                    {
-                        msalTokenResponse = WamAdapters.ParseRuntimeResponse(result, authenticationRequestParameters, _logger);
-                    }
-                    else
-                    {
-                        WamAdapters.ThrowExceptionFromWamError(result, authenticationRequestParameters, _logger);
-                    }
+                    var errorMessage = "Could not acquire token with username and password.";
+                    msalTokenResponse = WamAdapters.HandleResponse(result, authenticationRequestParameters, _logger, errorMessage);
                 }
             }
 

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -277,7 +277,8 @@ namespace Microsoft.Identity.Client.Broker
         {
             MsalTokenResponse msalTokenResponse = null;
 
-            if (authResult.IsSuccess)
+            if (authResult.IsSuccess ||  
+                (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
             {
                 msalTokenResponse = ParseRuntimeResponse(authResult, authenticationRequestParameters, logger);
                 logger.Verbose("[WamBroker] Successfully retrieved token.");

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -300,14 +300,17 @@ namespace Microsoft.Identity.Client.Broker
             NativeInterop.AuthResult authResult,
             ILoggerAdapter logger)
         {
-            if (authResult.IsSuccess)
+            if (authResult.Error != null 
+                && (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
             {
-                return true;
-            }
+                string internalErrorCode = authResult.Error.Tag.ToString(CultureInfo.InvariantCulture);
 
-            if (authResult.Error != null && (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
-            {
-                logger.Info($"[WamBroker] Account Switch : { authResult.Error.Context }.");
+                string message =
+                        $" Error Code: {authResult.Error.ErrorCode} \n" +
+                        $" Error Message: {authResult.Error.Context} \n" +
+                        $" Internal Error Code: {internalErrorCode} \n";
+
+                logger.Info($"[WamBroker] Account Switch : { message }.");
                 return true;
             }
 

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -277,8 +277,7 @@ namespace Microsoft.Identity.Client.Broker
         {
             MsalTokenResponse msalTokenResponse = null;
 
-            if (authResult.IsSuccess ||  
-                (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
+            if (TokenReceivedFromWam(authResult, logger))
             {
                 msalTokenResponse = ParseRuntimeResponse(authResult, authenticationRequestParameters, logger);
                 logger.Verbose("[WamBroker] Successfully retrieved token.");
@@ -290,6 +289,29 @@ namespace Microsoft.Identity.Client.Broker
             }
 
             return msalTokenResponse;
+        }
+        
+        /// <summary>
+        /// Token Received from WAM
+        /// </summary>
+        /// <param name="authResult"></param>
+        /// <param name="logger"></param>
+        private static bool TokenReceivedFromWam(
+            NativeInterop.AuthResult authResult,
+            ILoggerAdapter logger)
+        {
+            if (authResult.IsSuccess)
+            {
+                return true;
+            }
+
+            if (authResult.Error != null && (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
+            {
+                logger.Info($"[WamBroker] Account Switch : { authResult.Error.Tag }.");
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Client.Broker
         /// <exception cref="MsalClientException"></exception>
         /// <exception cref="MsalUiRequiredException"></exception>
         /// <exception cref="MsalServiceException"></exception>
-        internal static void ThrowExceptionFromWamError(
+        private static void ThrowExceptionFromWamError(
             NativeInterop.AuthResult authResult,
             AuthenticationRequestParameters authenticationRequestParameters,
             ILoggerAdapter logger)
@@ -130,27 +130,6 @@ namespace Microsoft.Identity.Client.Broker
                     logger.Verbose($"[WamBroker] {MsalError.UnknownBrokerError} {errorMessage}");
                     throw new MsalServiceException(MsalError.UnknownBrokerError, errorMessage);
             }
-        }
-
-        /// <summary>
-        /// Create WAM SignOutResult Error Response
-        /// </summary>
-        /// <param name="signoutResult"></param>
-        /// <param name="logger"></param>
-        /// <exception cref="MsalServiceException"></exception>
-        internal static void ThrowExceptionFromWamError(
-            NativeInterop.SignOutResult signoutResult,
-            ILoggerAdapter logger)
-        {
-            logger.Verbose("[WamBroker] Processing WAM exception");
-            logger.Verbose($"[WamBroker] TelemetryData: {signoutResult.TelemetryData}");
-
-            string internalErrorCode = signoutResult.Error.Tag.ToString(CultureInfo.InvariantCulture);
-            long errorCode = signoutResult.Error.ErrorCode;
-            string errorMessage = $"{signoutResult.Error} (error code {errorCode}) (internal error code {internalErrorCode})";
-
-            logger.Verbose($"[WamBroker] {MsalError.WamFailedToSignout} {errorMessage}");
-            throw new MsalServiceException(MsalError.WamFailedToSignout, errorMessage);
         }
 
         /// <summary>
@@ -304,18 +283,12 @@ namespace Microsoft.Identity.Client.Broker
             if (authResult.IsSuccess)
                 return true;
             
-            //user switch result is not success and a token is received from MSALRuntime with an Error Response status    
+            //user switch result is not success and a token is received
+            //from MSALRuntime with an Error Response status    
             if (authResult.Error != null 
                 && (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
             {
-                string internalErrorCode = authResult.Error.Tag.ToString(CultureInfo.InvariantCulture);
-
-                string message =
-                        $" Error Code: {authResult.Error.ErrorCode} \n" +
-                        $" Error Message: {authResult.Error.Context} \n" +
-                        $" Internal Error Code: {internalErrorCode} \n";
-
-                logger.Info($"[WamBroker] Account Switch : { message }.");
+                logger.Info("[WamBroker] WAM response status account switch. Treating as success");
                 return true;
             }
 
@@ -330,7 +303,7 @@ namespace Microsoft.Identity.Client.Broker
         /// <param name="authenticationRequestParameters"></param>
         /// <param name="logger"></param>
         /// <exception cref="MsalServiceException"></exception>
-        public static MsalTokenResponse ParseRuntimeResponse(
+        private static MsalTokenResponse ParseRuntimeResponse(
                 NativeInterop.AuthResult authResult, 
                 AuthenticationRequestParameters authenticationRequestParameters,
                 ILoggerAdapter logger)

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Identity.Client.Broker
 
             if (authResult.Error != null && (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
             {
-                logger.Info($"[WamBroker] Account Switch : { authResult.Error.Tag }.");
+                logger.Info($"[WamBroker] Account Switch : { authResult.Error.Context }.");
                 return true;
             }
 

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -300,6 +300,11 @@ namespace Microsoft.Identity.Client.Broker
             NativeInterop.AuthResult authResult,
             ILoggerAdapter logger)
         {
+            //success result from WAM
+            if (authResult.IsSuccess)
+                return true;
+            
+            //user switch result is not success and a token is received from MSALRuntime with an Error Response status    
             if (authResult.Error != null 
                 && (ResponseStatus)authResult.Error.Status == ResponseStatus.UserSwitch)
             {
@@ -314,6 +319,7 @@ namespace Microsoft.Identity.Client.Broker
                 return true;
             }
 
+            //for all other conditions return false and process the error response
             return false;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenInteractiveParameterBuilder.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="account">Account to use for the interactive token acquisition. See <see cref="IAccount"/> for ways to get an account</param>
         /// <returns>The builder to chain the .With methods</returns>
+        /// <remarks>An exception will be thrown If AAD returns a different account than the one that is being requested for.</remarks>
         public AcquireTokenInteractiveParameterBuilder WithAccount(IAccount account)
         {
             Parameters.Account = account;

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -50,6 +50,13 @@ namespace Microsoft.Identity.Client
             return new AcquireTokenSilentParameterBuilder(clientApplicationBaseExecutor).WithScopes(scopes).WithLoginHint(loginHint);
         }
 
+        /// <summary>
+        /// Sets the account for which the token will be retrieved. This method is mutually exclusive
+        /// with <see cref="WithLoginHint(string)"/>. If both are used, an exception will be thrown
+        /// </summary>
+        /// <param name="account">Account to use for the silent token acquisition. See <see cref="IAccount"/> for ways to get an account</param>
+        /// <returns>The builder to chain the .With methods</returns>
+        /// <remarks>An exception will be thrown If AAD returns a different account than the one that is being requested for.</remarks>
         private AcquireTokenSilentParameterBuilder WithAccount(IAccount account)
         {
             Parameters.Account = account;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             AuthenticationRequestParameters.RequestContext.Logger.ErrorPii(
                 string.Format(
                     CultureInfo.InvariantCulture,
-                    "Returned user identifiers (uid:{0} utid:{1}) does not match the sent user identifier (uid:{2} utid:{3})",
+                    "User identifier returned by AAD (uid:{0} utid:{1}) does not match the user identifier sent. (uid:{2} utid:{3})",
                     fromServer.UniqueObjectIdentifier,
                     fromServer.UniqueTenantIdentifier,
                     AuthenticationRequestParameters.Account.HomeAccountId.ObjectId,


### PR DESCRIPTION
Fixes #3929

**Changes proposed in this request**
- Account switch comes back as error from MSALRuntime but with a valid token for the new account
- Check account switch status and process the access token instead of throwing an unknown error 

**Testing**
Dev App. 

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
