### PR TITLE
Roslyn : Do Not Use Plain Password in PKIs

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string MobileDefaultRedirectUri = "msal4a1aa1d5-c567-49d0-ad0b-cd957a47f842://auth"; // in msidentity-samples-testing tenant -> PublicClientSample
         public const string ClientSecret = "client_secret";
         public const string DefaultPassword = "password";
+        public const string TestCertPassword = "passw0rd!";
         public const string AuthorityTestTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + Utid + "/";
         public const string DiscoveryEndPoint = "discovery/instance";
         public const string DefaultAuthorizationCode = "DefaultAuthorizationCode";

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
             };
 
             var cert = new X509Certificate2(
-               ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
+               ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestCertPassword);
 
             var app = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(options)
                                                           .WithCertificate(cert)
@@ -340,7 +340,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_WithCertificate_X509Certificate2()
         {
             var cert = new X509Certificate2(
-                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
+                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestCertPassword);
 
             var cca = ConfidentialClientApplicationBuilder
                       .Create(TestConstants.ClientId)
@@ -375,7 +375,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         public void TestConstructor_WithCertificate_SendX5C()
         {
             var cert = new X509Certificate2(
-                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
+                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestCertPassword);
 
             var app = ConfidentialClientApplicationBuilder
                       .Create(TestConstants.ClientId)

--- a/tests/Microsoft.Identity.Test.Unit/CryptographyTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CryptographyTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Identity.Test.Unit
             var serviceBundle = TestCommon.CreateDefaultServiceBundle();
             // Tests the cryptography libraries used by MSAL to sign with certificates
             var cert = new X509Certificate2(
-                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
+                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestCertPassword);
             var crypto = serviceBundle.PlatformProxy.CryptographyManager;
             byte[] result = crypto.SignWithCertificate("TEST", cert);
             string value = Base64UrlHelpers.Encode(result);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -443,7 +443,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CheckJWTHeaderWithCertTrueTest()
         {
             var cert = new X509Certificate2(
-                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
+                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestCertPassword);
 
             var header = new JWTHeaderWithCertificate(cert, Base64UrlHelpers.Encode(cert.GetCertHash()), true);
 
@@ -456,7 +456,7 @@ namespace Microsoft.Identity.Test.Unit
         public void CheckJWTHeaderWithCertFalseTest()
         {
             var cert = new X509Certificate2(
-                 ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), "passw0rd!");
+                 ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestCertPassword);
 
             var header = new JWTHeaderWithCertificate(cert, Base64UrlHelpers.Encode(cert.GetCertHash()), false);
 


### PR DESCRIPTION
Fixes ##[error]1. RoslynAnalyzers Error IA5352 - File: [tests/Microsoft.Identity.Test.Unit/CryptographyTests.cs](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1051408&view=logs&j=9906ff93-67e4-5c55-442d-8f18d4fd3348&t=dd131459-e75d-50d9-3ace-869ae72cdd79&l=94). Line: 29. Column 81.

**Changes proposed in this request**
RoslynAnalyzers: Rule: IA5352 (Do Not Misuse Cryptographic APIs ). http://aka.ms/IA5352-   Do Not Use Plain Password in PKIs

**Testing**
Build

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
