### PR TITLE
LongRunning OBO cache fix for different user assertions

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -128,9 +128,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private bool IsCachedAssertionTheSame(string userAssertion)
         {
+            //User assertion is null when ILongRunningWebApi.AcquireTokenInLongRunningProcess is called.
+            //In this scenario the cached token should be used.
             if (string.IsNullOrWhiteSpace(userAssertion))
             { 
-                return false;
+                return true;
             }
 
             return AuthenticationRequestParameters.UserAssertion.Assertion.Equals(userAssertion);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             //User assertion is null when ILongRunningWebApi.AcquireTokenInLongRunningProcess is called.
             //In this scenario the cached token should be used.
-            if (string.IsNullOrWhiteSpace(userAssertion))
+            if (string.IsNullOrWhiteSpace(AuthenticationRequestParameters?.UserAssertion?.Assertion))
             { 
                 return true;
             }
 
-            return AuthenticationRequestParameters.UserAssertion.Assertion.Equals(userAssertion);
+            return userAssertion.Equals(AuthenticationRequestParameters?.UserAssertion?.Assertion);
         }
 
         private async Task<AuthenticationResult> RefreshRtOrFetchNewAccessTokenAsync(CancellationToken cancellationToken)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             CacheRefreshReason cacheInfoTelemetry = CacheRefreshReason.NotApplicable;
 
             //Check if initiating a long running process
-            if (AuthenticationRequestParameters.UserAssertion != null && !string.IsNullOrEmpty(AuthenticationRequestParameters.LongRunningOboCacheKey))
+            if (IsLongOboInitialize())
             {
                 //Long running process should not use cached tokens
                 logger.Info("[OBO Request] Initiating long running process. Fetching OBO token from ESTS.");
@@ -131,6 +131,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 return await HandleTokenRefreshErrorAsync(e, cachedAccessToken).ConfigureAwait(false);
             }
+        }
+
+        private bool IsLongOboInitialize()
+        {
+            return AuthenticationRequestParameters.UserAssertion != null && !string.IsNullOrEmpty(AuthenticationRequestParameters.LongRunningOboCacheKey);
         }
 
         private async Task<AuthenticationResult> RefreshRtOrFetchNewAccessTokenAsync(CancellationToken cancellationToken)

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -53,11 +53,11 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                                         "\"trace_id\":\"dd25f4fb-3e8d-458e-90e7-179524ce0000\",\"correlation_id\":" +
                                         "\"f11508ab-067f-40d4-83cb-ccc67bf57e45\"}";
 
-        public static string GetDefaultTokenResponse()
+        public static string GetDefaultTokenResponse(string accessToken = TestConstants.ATSecret)
         {
               return
             "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"refresh_in\":\"2400\",\"scope\":" +
-            "\"r1/scope1 r1/scope2\",\"access_token\":\"" + TestConstants.ATSecret + "\"" +
+            "\"r1/scope1 r1/scope2\",\"access_token\":\"" + accessToken + "\"" +
             ",\"refresh_token\":\"" + Guid.NewGuid() + "\",\"client_info\"" +
             ":\"" + CreateClientInfo() + "\",\"id_token\"" +
             ":\"" + CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId) +
@@ -181,10 +181,10 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 scopes, idToken, clientInfo));
         }
 
-        public static HttpResponseMessage CreateSuccessTokenResponseMessage(bool foci = false)
+        public static HttpResponseMessage CreateSuccessTokenResponseMessage(bool foci = false, string accessToken = TestConstants.ATSecret)
         {
             return CreateSuccessResponseMessage(
-                foci ? GetFociTokenResponse() : GetDefaultTokenResponse());
+                foci ? GetFociTokenResponse() : GetDefaultTokenResponse(accessToken));
         }
 
         public static HttpResponseMessage CreateSuccessTokenResponseMessageWithUid(

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string ATSecret = "some-access-token";
         public const string RTSecret2 = "someRT2";
         public const string ATSecret2 = "some-access-token2";
+        public const string RTSecret3 = "someRT3";
+        public const string ATSecret3 = "some-access-token3";
 
         public const string HomeAccountId = Uid + "." + Utid;
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests.cs
@@ -452,11 +452,11 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.AreEqual(1, cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count);
             Assert.AreEqual(0, cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Count);
 
-            // InitiateLR - AT from cache
+            // InitiateLR - AT from IdentityProvider
             result = await cca.InitiateLongRunningProcessInWebApi(s_scopes, userAuthResult.AccessToken, ref oboCacheKey)
                 .ExecuteAsync().ConfigureAwait(false);
 
-            Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
 
             // Expire AT
             TokenCacheHelper.ExpireAllAccessTokens(cca.UserTokenCacheInternal);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
-        public async Task InitiateLongRunningProcessWithExistingKey_TestAsync()
+        public async Task InitiateLongRunningProcessWithExistingKeyAndToken_TestAsync()
         {
             using (var httpManager = new MockHttpManager())
             {
@@ -250,8 +250,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
                 Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
                 userCacheAccess.AssertAccessCounts(0, 1);
-
-                //AddMockHandlerAadSuccess(httpManager);
 
                 AddMockHandlerAadSuccess(httpManager,
                     responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(accessToken: TestConstants.ATSecret2));
@@ -303,20 +301,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
                 Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
                 Assert.AreEqual(TestConstants.RTSecret, cachedRefreshToken.Secret);
-                userCacheAccess.AssertAccessCounts(1, 1);
-
-                // Token with the same scopes, OBO cache key, etc. exists in the cache -> AT is retrieved from the cache
-                result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, TestConstants.DefaultAccessToken, ref oboCacheKey)
-                    .ExecuteAsync().ConfigureAwait(false);
-
-                Assert.AreEqual(TestConstants.ATSecret, result.AccessToken);
-                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
-                cachedAccessToken = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
-                cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
-                Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
-                Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
-                Assert.AreEqual(TestConstants.RTSecret, cachedRefreshToken.Secret);
-                userCacheAccess.AssertAccessCounts(2, 1);
+                userCacheAccess.AssertAccessCounts(0, 1);
 
                 AddMockHandlerAadSuccess(httpManager,
                     responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(
@@ -340,7 +325,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
                 Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
                 Assert.AreEqual(TestConstants.RTSecret2, cachedRefreshToken.Secret);
-                userCacheAccess.AssertAccessCounts(3, 2);
+                userCacheAccess.AssertAccessCounts(0, 2);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
@@ -197,14 +197,14 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 MsalRefreshTokenCacheItem cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
                 Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
                 Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
-                userCacheAccess.AssertAccessCounts(1, 1);
+                userCacheAccess.AssertAccessCounts(0, 1);
 
                 result = await cca.AcquireTokenInLongRunningProcess(TestConstants.s_scope, oboCacheKey).ExecuteAsync().ConfigureAwait(false);
 
                 // Token is in the cache, retrieved by the provided OBO cache key
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
                 Assert.AreEqual(TestConstants.ATSecret, result.AccessToken);
-                userCacheAccess.AssertAccessCounts(2, 1);
+                userCacheAccess.AssertAccessCounts(1, 1);
 
                 TokenCacheHelper.ExpireAllAccessTokens(cca.UserTokenCacheInternal);
                 AddMockHandlerAadSuccess(httpManager,
@@ -221,7 +221,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 // Cached AT is expired, RT used to retrieve new AT
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
                 Assert.AreEqual(TestConstants.ATSecret2, result.AccessToken);
-                userCacheAccess.AssertAccessCounts(3, 2);
+                userCacheAccess.AssertAccessCounts(2, 2);
             }
         }
 
@@ -267,6 +267,23 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
                 Assert.AreEqual(TestConstants.ATSecret2, cachedAccessToken.Secret);
                 userCacheAccess.AssertAccessCounts(0, 2);
+
+                AddMockHandlerAadSuccess(httpManager,
+                    responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(accessToken: TestConstants.ATSecret3));
+
+                //Initiate another process using the same cache key but a different user assertion
+                //MSAL should ignore the token in the cache, fetch a new token.
+                result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, $"{TestConstants.DefaultAccessToken}2", ref oboCacheKey)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TestConstants.ATSecret3, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                cachedAccessToken = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
+                cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
+                Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
+                Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
+                Assert.AreEqual(TestConstants.ATSecret3, cachedAccessToken.Secret);
+                userCacheAccess.AssertAccessCounts(0, 3);
             }
         }
 
@@ -548,7 +565,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                         utid: TestConstants.Utid,
                         accessToken: "access-token-2",
                         refreshToken: "refresh-token-2"),
-                    expectedPostData: new Dictionary<string, string> { { OAuth2Parameter.GrantType, OAuth2GrantType.RefreshToken } });
+                    expectedPostData: new Dictionary<string, string> { { OAuth2Parameter.GrantType, OAuth2GrantType.JwtBearer } });
 
                 // InitiateLR - AT from IdP via RT flow(new AT, RT cached)
                 result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, userToken, ref oboCacheKey)
@@ -763,11 +780,21 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.AreEqual("access-token-1", result.AccessToken);
                 Assert.AreEqual("access-token-1", cachedAccessToken.Secret);
 
+                AddMockHandlerAadSuccess(httpManager,
+                    responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(
+                        TestConstants.Uid,
+                        TestConstants.DisplayableId,
+                        TestConstants.s_scope.ToArray(),
+                        utid: TestConstants.Utid,
+                        accessToken: "access-token-1",
+                        refreshToken: "refresh-token-1"),
+                    expectedPostData: new Dictionary<string, string> { { OAuth2Parameter.GrantType, OAuth2GrantType.JwtBearer } });
+
                 // InitiateLR - AT from cache
                 result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, userToken, ref oboCacheKey)
                     .ExecuteAsync().ConfigureAwait(false);
 
-                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
                 Assert.AreEqual("access-token-1", result.AccessToken);
 
                 // Expire AT


### PR DESCRIPTION
Fixes #
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3825

**Changes proposed in this request**
Enabling obo request to acquire new token if user cached assertion is different from the one provided.
This is done by ensuring `InitiateLongRunningProcessInWebApi` always goes to get a new token rather than using what is already in the cache for a specified cache key.

**Testing**
Unit

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
