### PR TITLE
Revert "RuntimeBroker is now default broker for non-UWP (#3976)"

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/BrokerExtension.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/BrokerExtension.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;
@@ -24,25 +23,6 @@ namespace Microsoft.Identity.Client.Broker
         /// If a broker does not exist or cannot be used, MSAL will fallback to a browser.
         /// Make sure browser auth is enabled (e.g. if using system browser, register the "http://localhost" redirect URI, etc.)
         /// </remarks>
-        public static PublicClientApplicationBuilder WithWindowsBroker(this PublicClientApplicationBuilder builder, bool enableBroker = true)
-        {
-            builder.Config.IsBrokerEnabled = enableBroker;
-            AddRuntimeSupportForWam(builder);
-            return builder;
-        }
-
-        /// <summary>
-        /// Enables MSAL to use Broker flows, which are more secure than browsers. 
-        /// For details about Windows broker, see https://aka.ms/msal-net-wam
-        /// </summary>
-        /// <remarks>
-        /// No broker integration exists on Mac and Linux yet.
-        /// Windows broker does not work on Win 8, Win Server 2016 and lower.
-        /// This implementation is not supported on UWP, use <c>WithBroker()</c> from Microsoft.Identity.Client package instead.
-        /// If a broker does not exist or cannot be used, MSAL will fallback to a browser.
-        /// Make sure browser auth is enabled (e.g. if using system browser, register the "http://localhost" redirect URI, etc.)
-        /// </remarks>
-        [Obsolete("Use WithWindowsBroker instead.", false)]
         public static PublicClientApplicationBuilder WithBrokerPreview(this PublicClientApplicationBuilder builder, bool enableBroker = true)
         {
             builder.Config.IsBrokerEnabled = enableBroker;
@@ -57,7 +37,7 @@ namespace Microsoft.Identity.Client.Broker
                 builder.Config.BrokerCreatorFunc =
                      (uiParent, appConfig, logger) =>
                      {
-                         logger.Info("[RuntimeBroker] WAM supported OS.");
+                         logger.Info("[WamBroker] WAM supported OS.");
                          return new RuntimeBroker(uiParent, appConfig, logger);
                      };
             }
@@ -66,7 +46,7 @@ namespace Microsoft.Identity.Client.Broker
                 builder.Config.BrokerCreatorFunc =
                    (uiParent, appConfig, logger) =>
                    {
-                       logger.Info("[RuntimeBroker] Not a Windows 10 or Server equivalent machine. WAM is not available.");
+                       logger.Info("[WamBroker] Not a Windows 10 or Server equivalent machine. WAM is not available.");
                        return new NullBroker(logger);
                    };
             }

--- a/src/client/Microsoft.Identity.Client.Desktop/DesktopExtensions.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/DesktopExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Identity.Client.Platforms.Features.WebView2WebUi;
 
 namespace Microsoft.Identity.Client.Desktop
@@ -20,25 +19,7 @@ namespace Microsoft.Identity.Client.Desktop
         /// - WebView2 embedded web view, based on Microsoft Edge - https://aka.ms/msal-net-webview2
         /// </summary>
         /// <remarks>These extensions live in a separate package to avoid adding dependencies to MSAL</remarks>
-        [Obsolete("This method has been deprecated. Use WithWindowsDesktopFeatures. For Windows Broker support only, use WithWindowsBroker API from Microsoft.Identity.Client.Broker package.", false)]
         public static PublicClientApplicationBuilder WithDesktopFeatures(this PublicClientApplicationBuilder builder)
-        {
-            WamExtension.AddSupportForWam(builder);
-            AddSupportForWebView2(builder);
-
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds enhanced support for desktop applications, e.g. CLI, WinForms, WPF apps.
-        /// 
-        /// Support added is around: 
-        /// 
-        /// - Windows Authentication Manager (WAM) broker, the recommended authentication mechanism on Windows 10 - https://aka.ms/msal-net-wam
-        /// - Embedded web view. AAD applications use the older WebBrowser control. B2C applications use WebView2, an embedded browser based on Microsoft Edge - https://aka.ms/msal-net-webview2
-        /// </summary>
-        /// <remarks>These extensions live in a separate package to avoid adding dependencies to MSAL</remarks>
-        public static PublicClientApplicationBuilder WithWindowsDesktopFeatures(this PublicClientApplicationBuilder builder)
         {
             WamExtension.AddSupportForWam(builder);
             AddSupportForWebView2(builder);

--- a/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
@@ -73,7 +73,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Identity.Client.Broker\Microsoft.Identity.Client.Broker.csproj" />
     <ProjectReference Include="..\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
   </ItemGroup>
 

--- a/src/client/Microsoft.Identity.Client.Desktop/WamExtension.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop/WamExtension.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Client.Broker;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;
@@ -19,11 +18,11 @@ namespace Microsoft.Identity.Client.Desktop
         /// </summary>
         public static PublicClientApplicationBuilder WithWindowsBroker(this PublicClientApplicationBuilder builder, bool enableBroker = true)
         {
-            builder.Config.IdentityLogger?.Log(new IdentityModel.Abstractions.LogEntry() { EventLogLevel = IdentityModel.Abstractions.EventLogLevel.Informational, Message = "Desktop WAM Broker extension calling RuntimeBroker extension" });
-            return BrokerExtension.WithWindowsBroker(builder, enableBroker);
+            builder.Config.IsBrokerEnabled = enableBroker;
+            AddSupportForWam(builder);
+            return builder;
         }
 
-        // this is for legacy WAM
         internal static void AddSupportForWam(PublicClientApplicationBuilder builder)
         {
             if (DesktopOsHelper.IsWin10OrServerEquivalent())

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
@@ -464,9 +464,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             IPublicClientApplication pca = PublicClientApplicationBuilder
                .Create(labResponse.App.AppId)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
+               .WithExperimentalFeatures()
                .WithLogging(wastestLogger)
-               .WithWindowsBroker()
-               .Build();
+               .WithBrokerPreview().Build();
 
             Assert.IsTrue(pca.IsProofOfPossessionSupportedByClient(), "Either the broker is not configured or it does not support POP.");
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Create("04f0c124-f2bc-4f59-8241-bf6df9866bbd")
                .WithAuthority("https://login.microsoftonline.com/organizations");
 
-            IPublicClientApplication pca = pcaBuilder.WithWindowsBroker().Build();
+            IPublicClientApplication pca = pcaBuilder.WithBrokerPreview().Build();
 
             // Act
             try
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Create("04f0c124-f2bc-4f59-8241-bf6df9866bbd")
                .WithAuthority("https://login.microsoftonline.com/organizations");
 
-            IPublicClientApplication pca = pcaBuilder.WithWindowsBroker().Build();
+            IPublicClientApplication pca = pcaBuilder.WithBrokerPreview().Build();
 
             // Act
             try
@@ -110,7 +110,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .WithParentActivityOrWindow(windowHandleProvider)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
                .WithLogging(testLogger)
-               .WithWindowsBroker().Build();
+               .WithBrokerPreview().Build();
 
             // Acquire token using username password
             var result = await pca.AcquireTokenByUsernamePassword(scopes, labResponse.User.Upn, labResponse.User.GetOrFetchPassword()).ExecuteAsync().ConfigureAwait(false);
@@ -168,7 +168,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .WithParentActivityOrWindow(windowHandleProvider)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
                .WithLogging(testLogger, enablePiiLogging: true)
-               .WithWindowsBroker().Build();
+               .WithBrokerPreview().Build();
 
             // Acquire token using username password
             var result = await pca.AcquireTokenByUsernamePassword(scopes, labResponse.User.Upn, labResponse.User.GetOrFetchPassword()).ExecuteAsync().ConfigureAwait(false);
@@ -219,7 +219,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Create(labResponse.App.AppId)
                .WithParentActivityOrWindow(windowHandleProvider)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
-               .WithWindowsBroker()
+               .WithBrokerPreview()
                .WithWindowsBrokerOptions(
                 new WindowsBrokerOptions() 
                 {
@@ -255,7 +255,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Create("43dfbb29-3683-4673-a66f-baba91798bd2")
                .WithAuthority("https://login.microsoftonline.com/organizations")
                .WithParentActivityOrWindow(windowHandleProvider)
-               .WithWindowsBroker()
+               .WithBrokerPreview()
                .Build();
 
             // Act

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             IPublicClientApplication pca = PublicClientApplicationBuilder
                .Create(labResponse.App.AppId)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
-               .WithWindowsBroker().Build();
+               .WithBrokerPreview().Build();
 
             Assert.IsTrue(pca.IsProofOfPossessionSupportedByClient(), "Either the broker is not configured or it does not support POP.");
 

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -649,7 +649,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             var builder2 = PublicClientApplicationBuilder
                    .Create(TestConstants.ClientId)
-                   .WithWindowsDesktopFeatures()
+                   .WithDesktopFeatures()
                    .WithAuthority(TestConstants.AuthorityTenant);
 
             // broker is not available out of the box
@@ -668,7 +668,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             var builder2 = PublicClientApplicationBuilder
                    .Create(TestConstants.ClientId)
-                   .WithWindowsDesktopFeatures()
+                   .WithDesktopFeatures()
                    .WithAuthority(TestConstants.ADFSAuthority);
 
             // broker is not available on ADFS
@@ -676,7 +676,7 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
 
             var builder3 = PublicClientApplicationBuilder
                    .Create(TestConstants.ClientId)
-                   .WithWindowsDesktopFeatures()
+                   .WithDesktopFeatures()
                    .WithAdfsAuthority(TestConstants.ADFSAuthority);
 
             // broker is not available on ADFS

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/RuntimeBrokerTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                .Create("d3adb33f-c0de-ed0c-c0de-deadb33fc0d3")
                .WithAuthority(TestConstants.AuthorityTenant);
 
-            pcaBuilder = pcaBuilder.WithWindowsBroker();
+            pcaBuilder = pcaBuilder.WithBrokerPreview();
             Assert.IsTrue(pcaBuilder.IsBrokerAvailable());
 
         }
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                .Create("d3adb33f-c0de-ed0c-c0de-deadb33fc0d3")
                .WithAdfsAuthority(TestConstants.ADFSAuthority);
 
-            pcaBuilder = pcaBuilder.WithWindowsBroker();
+            pcaBuilder = pcaBuilder.WithBrokerPreview();
 
             Assert.IsFalse(pcaBuilder.IsBrokerAvailable());
 
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             var pca = PublicClientApplicationBuilder
                .Create(TestConstants.ClientId)
-               .WithWindowsBroker()
+               .WithBrokerPreview()
                .Build();
 
             // no window handle - throw

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamTests.cs
@@ -88,8 +88,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                .WithAuthority(TestConstants.AuthorityTenant);
 
 #if !NET6_WIN
-            // this ensures that legacy broker is called
-            DesktopExtensions.WithWindowsDesktopFeatures(pcaBuilder);
+            pcaBuilder = pcaBuilder.WithWindowsBroker();
 #endif
 
             Assert.IsTrue(pcaBuilder.IsBrokerAvailable());

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationSchemeTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationSchemeTests.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     Arg.Any<AcquireTokenSilentParameters>()).Returns(CreateMsalRunTimeBrokerTokenResponse(null, Constants.PoPAuthHeaderPrefix));
 
                 var pca = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                    .WithWindowsBroker()
+                    .WithExperimentalFeatures(true)
+                    .WithBrokerPreview()
                     .WithTestBroker(mockBroker)
                     .WithHttpManager(harness.HttpManager)
                     .BuildConcrete();

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/PublicClientApplicationTests.cs
@@ -1046,7 +1046,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 #if NET5_0_OR_GREATER
                 pcaBuilder.WithBroker();
 #else
-                WamExtension.WithWindowsBroker(pcaBuilder);
+                pcaBuilder.WithWindowsBroker();
 #endif
             }
 

--- a/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
             {
                 PublicClientApplication app =
                     PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                              .WithWindowsBroker()
+                                                              .WithBrokerPreview()
                                                               .WithHttpManager(httpManager)
                                                               .BuildConcrete();
 
@@ -285,7 +285,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 mockBroker.IsPopSupported.Returns(true);
 
                 var pca = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                    .WithWindowsBroker()
+                    .WithBrokerPreview()
                     .WithTestBroker(mockBroker)
                     .WithHttpManager(harness.HttpManager)
                     .BuildConcrete();
@@ -317,7 +317,8 @@ namespace Microsoft.Identity.Test.Unit.Pop
             mockBroker.IsPopSupported.Returns(false);
 
             var pca = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                .WithWindowsBroker()
+                .WithExperimentalFeatures(true)
+                .WithBrokerPreview()
                 .WithTestBroker(mockBroker)
                 .BuildConcrete();
 
@@ -347,8 +348,9 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 mockBroker.AcquireTokenSilentAsync(Arg.Any<AuthenticationRequestParameters>(), Arg.Any<AcquireTokenSilentParameters>()).Returns(CreateMsalPopTokenResponse());
 
                 var pca = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithExperimentalFeatures(true)
                     .WithAdfsAuthority(TestConstants.ADFSAuthority, false)
-                    .WithWindowsBroker()
+                    .WithBrokerPreview()
                     .WithTestBroker(mockBroker)
                     .WithHttpManager(harness.HttpManager)
                     .BuildConcrete();
@@ -388,7 +390,8 @@ namespace Microsoft.Identity.Test.Unit.Pop
                     Arg.Any<AcquireTokenSilentParameters>()).Returns(CreateMsalRunTimeBrokerTokenResponse(null, Constants.PoPAuthHeaderPrefix));
 
                 var pca = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                    .WithWindowsBroker()
+                    .WithExperimentalFeatures(true)
+                    .WithBrokerPreview()
                     .WithTestBroker(mockBroker)
                     .WithHttpManager(harness.HttpManager)
                     .BuildConcrete();
@@ -426,7 +429,8 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 Arg.Any<AcquireTokenSilentParameters>()).Returns(CreateMsalPopTokenResponse(brokerAccessToken));
 
             var pca = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
-                .WithWindowsBroker()
+                .WithExperimentalFeatures(true)
+                .WithBrokerPreview()
                 .WithTestBroker(mockBroker)
                 .BuildConcrete();
 
@@ -494,7 +498,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
             //Broker enabled
             IPublicClientApplication app = PublicClientApplicationBuilder
                                             .Create(TestConstants.ClientId)
-                                            .WithWindowsBroker()
+                                            .WithBrokerPreview()
                                             .Build();
 
             Assert.IsTrue(app.IsProofOfPossessionSupportedByClient());
@@ -502,7 +506,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
             //Broker disabled
             app = PublicClientApplicationBuilder
                                 .Create(TestConstants.ClientId)
-                                .WithWindowsBroker(false)
+                                .WithBrokerPreview(false)
                                 .Build();
 
             Assert.IsFalse(app.IsProofOfPossessionSupportedByClient());

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -66,18 +66,14 @@ namespace NetCoreTestApp
             return $"https://login.microsoftonline.com/{tenant}";
         }
 
-        private static IPublicClientApplication CreatePca(bool withWamBroker = false)
+        private static IPublicClientApplication CreatePca()
         {
             var pcaBuilder = PublicClientApplicationBuilder
                             .Create(s_clientIdForPublicApp)
                             .WithAuthority(GetAuthority())
-                            .WithLogging(Log, LogLevel.Verbose, true);
-
-            if(withWamBroker)
-            {
-                pcaBuilder.WithWindowsDesktopFeatures()
-                            .WithBroker();
-            }
+                            .WithLogging(Log, LogLevel.Verbose, true)
+                            .WithExperimentalFeatures()
+                            .WithDesktopFeatures();
 
             Console.WriteLine($"IsBrokerAvailable: {pcaBuilder.IsBrokerAvailable()}");
 
@@ -129,7 +125,6 @@ namespace NetCoreTestApp
                         9. Rotate Tenant ID
                        10. Acquire Token Interactive with Chrome
                        11. AcquireTokenForClient with multiple threads
-                       12. Acquire Token Interactive with Legacy Broker
                         0. Exit App
                     Enter your Selection: ");
                 int.TryParse(Console.ReadLine(), out var selection);
@@ -240,6 +235,7 @@ namespace NetCoreTestApp
 
                             var optionsChrome = new SystemWebViewOptions()
                             {
+                                //BrowserRedirectSuccess = new Uri("https://www.bing.com?q=why+is+42+the+meaning+of+life")
                                 OpenBrowserAsync = SystemWebViewOptions.OpenWithChromeEdgeBrowserAsync
                             };
 
@@ -279,25 +275,6 @@ namespace NetCoreTestApp
                             }
 
                             break;
-
-                        case 12: // acquire token interactive with WamBroker
-                            {
-                                var optionsbroker = new SystemWebViewOptions()
-                                {
-                                    OpenBrowserAsync = SystemWebViewOptions.OpenWithEdgeBrowserAsync
-                                };
-
-                                var pcaBroker = CreatePca(true);
-
-                                var ctsBroker = new CancellationTokenSource();
-                                authTask = pcaBroker.AcquireTokenInteractive(s_scopes)
-                                    .WithSystemWebViewOptions(optionsbroker)
-                                    .ExecuteAsync(ctsBroker.Token);
-
-                                await FetchTokenAndCallGraphAsync(pcaBroker, authTask).ConfigureAwait(false);
-                            }
-                            break;
-
                         case 0:
                             return;
 

--- a/tests/devapps/WAM/MSIX/WPF/MainWindow.xaml.cs
+++ b/tests/devapps/WAM/MSIX/WPF/MainWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace WPF
             IPublicClientApplication pca = PublicClientApplicationBuilder
               .Create(clientId)
               .WithAuthority("https://login.microsoftonline.com/common")
-              .WithWindowsBroker(true)   // this method exists in Microsoft.Identity.Client.Broker package
+              .WithBrokerPreview(true)   // this method exists in Microsoft.Identity.Client.Broker package
               .Build();
 
             IEnumerable<IAccount> accounts = await pca.GetAccountsAsync().ConfigureAwait(true);

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -120,14 +120,14 @@ namespace NetDesktopWinForms
                     builder = ToggleOldBroker(builder, true);
                     break;
                 case AuthMethod.WAMRuntime:
-                    builder = BrokerExtension.WithWindowsBroker(builder);
+                    builder = builder.WithBrokerPreview().WithExperimentalFeatures();
                     break;
                 case AuthMethod.SystemBrowser:
-                    builder = BrokerExtension.WithWindowsBroker(builder, false);
+                    builder = builder.WithExperimentalFeatures().WithBrokerPreview(false);
                     builder = ToggleOldBroker(builder, false);
                     break;
                 case AuthMethod.EmbeddedBrowser:
-                    builder = BrokerExtension.WithWindowsBroker(builder, false);
+                    builder = builder.WithExperimentalFeatures().WithBrokerPreview(false);
                     builder = ToggleOldBroker(builder, false);
 
                     break;
@@ -152,7 +152,7 @@ namespace NetDesktopWinForms
         private static PublicClientApplicationBuilder ToggleOldBroker(PublicClientApplicationBuilder builder, bool enable)
         {
 #if NETCOREAPP3_1
-            builder = WamExtension.WithWindowsBroker(builder, enable);
+            builder = builder.WithWindowsBroker(enable);
 #else
             builder = builder.WithBroker(enable);
 #endif

--- a/tests/devapps/WAM/NetDesktopWpf/MainWindow.xaml.cs
+++ b/tests/devapps/WAM/NetDesktopWpf/MainWindow.xaml.cs
@@ -41,9 +41,9 @@ namespace NetDesktopWpf
 
         private IPublicClientApplication CreatePublicClient()
         {
-            var pca = WamExtension.WithWindowsBroker(PublicClientApplicationBuilder.Create(s_clientID)
+            var pca = PublicClientApplicationBuilder.Create(s_clientID)
                 .WithAuthority(s_authority)
-, true)
+                .WithWindowsBroker(true)
                 .WithLogging((x, y, z) => Debug.WriteLine($"{x} {y}"), LogLevel.Verbose, true)
                 .Build();
 
@@ -54,9 +54,9 @@ namespace NetDesktopWpf
 
         private IPublicClientApplication CreatePublicClientForRuntime()
         {
-            var pca = BrokerExtension.WithWindowsBroker(PublicClientApplicationBuilder.Create(s_clientID)
+            var pca = PublicClientApplicationBuilder.Create(s_clientID)
                 .WithAuthority(s_authority)
-, true)
+                .WithBrokerPreview(true)
                 .WithLogging((x, y, z) => Debug.WriteLine($"{x} {y}"), LogLevel.Verbose, true)
                 .Build();
 

--- a/tests/devapps/WAM/NetFrameworkWam/Form1.cs
+++ b/tests/devapps/WAM/NetFrameworkWam/Form1.cs
@@ -101,20 +101,20 @@ namespace NetDesktopWinForms
             switch (authMethod)
             {
                 case AuthMethod.WAM:
-                    builder = WamExtension.WithWindowsBroker(builder);
+                    builder = builder.WithWindowsBroker();
                     break;
                 case AuthMethod.WAMRuntime:
-                    builder = BrokerExtension.WithWindowsBroker(builder);
+                    builder = builder.WithBrokerPreview();
                     break;
                 case AuthMethod.SystemBrowser:
-                    builder = BrokerExtension.WithWindowsBroker(builder, false);
-                    builder = WamExtension.WithWindowsBroker(builder, false);
+                    builder = builder.WithBrokerPreview(false);
+                    builder = builder.WithWindowsBroker(false);
                     builder = builder.WithRedirectUri("http://localhost");
                     break;
                 case AuthMethod.EmbeddedBrowser:
                     builder = builder.WithRedirectUri($"ms-appx-web://microsoft.aad.brokerplugin/{clientId}");
-                    builder = BrokerExtension.WithWindowsBroker(builder, false);
-                    builder = WamExtension.WithWindowsBroker(builder, false);
+                    builder = builder.WithBrokerPreview(false);
+                    builder = builder.WithWindowsBroker(false);
                     break;
                 default:
                     throw new NotImplementedException();

--- a/tests/devapps/WAM/UWPWam/MainPage.xaml
+++ b/tests/devapps/WAM/UWPWam/MainPage.xaml
@@ -11,11 +11,10 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Button Content="ATI" Margin="615,105,0,0" VerticalAlignment="Top" Click="ATI_ClickAsync"/>
         <Button Content="ATS" Margin="661,105,0,0" VerticalAlignment="Top" Click="ATS_ClickAsync"/>
-        <Button Content="WIA" Margin="711,105,0,0" VerticalAlignment="Top" Click="AcquireTokenIWA_ClickAsync"/>
-        <Button Content="ATI Broker" Margin="800,105,0,0" VerticalAlignment="Top" Click="ATIDesktop_ClickAsync"/>
 
         <Button Content="Clear Cache" Margin="619,324,0,0" VerticalAlignment="Top" Click="ClearCacheAsync" Width="99"/>
 
+        <Button Content="WIA" Margin="711,105,0,0" VerticalAlignment="Top" Click="AcquireTokenIWA_ClickAsync"/>
         <TextBlock HorizontalAlignment="Left" Margin="354,381,0,0" Height="512" Width="800" TextWrapping="Wrap" Text="" VerticalAlignment="Top" TextAlignment="Center" Name="Log"/>
         <CheckBox Content="Use Broker (WAM)" Margin="615,250,0,0" VerticalAlignment="Top" IsChecked="True" x:Name="chkUseBroker"/>
         <Button Content="GetAccounts" Margin="619,287,0,0" VerticalAlignment="Top" Click="GetAccountsAsync"/>

--- a/tests/devapps/WAM/UWPWam/MainPage.xaml.cs
+++ b/tests/devapps/WAM/UWPWam/MainPage.xaml.cs
@@ -13,7 +13,6 @@ using Windows.Security.Authentication.Web;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-using Microsoft.Identity.Client.Broker;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 namespace UWP_standalone
@@ -169,40 +168,6 @@ namespace UWP_standalone
                 return;
             }
 
-        }
-
-        private async void ATIDesktop_ClickAsync(object sender, RoutedEventArgs e)
-        {
-            var pca = PublicClientApplicationBuilder.Create(s_clientID)
-                .WithAuthority(s_authority)
-                .WithBroker(chkUseBroker.IsChecked.Value)
-                .WithWindowsBroker() // should not affect
-                .WithLogging((x, y, z) => Debug.WriteLine($"{x} {y}"), LogLevel.Verbose, true)
-                .Build();
-
-            SynchronizedEncryptedFileMsalCache cache = new SynchronizedEncryptedFileMsalCache();
-            cache.Initialize(pca.UserTokenCache);
-
-            var upnPrefix = tbxUpn.Text;
-
-            IEnumerable<IAccount> accounts = await pca.GetAccountsAsync().ConfigureAwait(true); // stay on UI thread
-            var acc = accounts.SingleOrDefault(a => a.Username.StartsWith(upnPrefix));
-
-            try
-            {
-                var result = await pca.AcquireTokenInteractive(s_scopes)
-                    .WithAccount(acc)
-                    .ExecuteAsync(CancellationToken.None)
-                    .ConfigureAwait(false);
-
-                await DisplayResultAsync(result).ConfigureAwait(false);
-
-            }
-            catch (Exception ex)
-            {
-                await DisplayErrorAsync(ex).ConfigureAwait(false);
-                return;
-            }
         }
 
         private async Task DisplayErrorAsync(Exception ex)

--- a/tests/devapps/WAM/UWPWam/UWP standalone WAM.csproj
+++ b/tests/devapps/WAM/UWPWam/UWP standalone WAM.csproj
@@ -154,10 +154,6 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.12</Version>
     </PackageReference>
-    <ProjectReference Include="..\..\..\..\src\client\Microsoft.Identity.Client.Broker\Microsoft.Identity.Client.Broker.csproj">
-      <Project>{6839f934-45f0-4026-8af3-c3aefb7d48a9}</Project>
-      <Name>Microsoft.Identity.Client.Broker</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj">
       <Project>{3433eb33-114a-4db7-bc57-14f17f55da3c}</Project>
       <Name>Microsoft.Identity.Client</Name>


### PR DESCRIPTION
This reverts commit 3d20374e4bd9ed621119b917c51e4c1eb68d3032.

Fixes #
Revert broker changes

**Changes proposed in this request**
Revert the last

**Testing**
Automated tests

**Performance impact**
NA

**Documentation**
- [x] All relevant documentation is updated.
