### PR TITLE
Update a service principal long running OBO test. Rename StopLR API. Update analyzers. Fix comments.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,6 @@
          For clarity, without PrivateAssets marked here, anyone consuming Microsoft.Identity.Client
          would also be forced to install these dependencies.  PrivateAssets avoids this problem. -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="All" />
   </ItemGroup>
 </Project> 

--- a/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ConfidentialClientApplication.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Identity.Client
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Returns true if tokens are removed from the cache. False otherwise.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="longRunningProcessSessionKey"/> is not set.</exception>
-        public async Task<bool> StopLongRunningWebApiAsync(string longRunningProcessSessionKey, CancellationToken cancellationToken = default)
+        public async Task<bool> StopLongRunningProcessInWebApiAsync(string longRunningProcessSessionKey, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(longRunningProcessSessionKey))
             {

--- a/src/client/Microsoft.Identity.Client/Extensibility/ConfidentialClientApplicationExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/ConfidentialClientApplicationExtensions.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Returns true if tokens are removed from the cache. False otherwise.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="longRunningProcessSessionKey"/> is not set.</exception>
-        public static async Task<bool> StopLongRunningProcessWebApiAsync(this ILongRunningWebApi clientApp, string longRunningProcessSessionKey, CancellationToken cancellationToken = default)
+        public static async Task<bool> StopLongRunningProcessInWebApiAsync(this ILongRunningWebApi clientApp, string longRunningProcessSessionKey, CancellationToken cancellationToken = default)
         {
-            return await (clientApp as ConfidentialClientApplication).StopLongRunningWebApiAsync(longRunningProcessSessionKey, cancellationToken).ConfigureAwait(false);
+            return await (clientApp as ConfidentialClientApplication).StopLongRunningProcessInWebApiAsync(longRunningProcessSessionKey, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Extensibility/ConfidentialClientApplicationExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/ConfidentialClientApplicationExtensions.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,14 +14,14 @@ namespace Microsoft.Identity.Client.Extensibility
     {
         /// <summary>
         /// Stops an in progress long running OBO session by removing the tokens associated with the provided cache key.
-        /// See https://aka.ms/msal-net-on-behalf-of.
+        /// See https://aka.ms/msal-net-long-running-obo.
         /// </summary>
         /// <param name="clientApp">Client app to remove tokens from</param>
         /// <param name="longRunningProcessSessionKey">OBO cache key used to remove the tokens</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Returns true if tokens are removed from the cache. False otherwise.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="longRunningProcessSessionKey"/> is not set.</exception>
-        public static async Task<bool> StopLongRunningWebApiAsync(this ILongRunningWebApi clientApp, string longRunningProcessSessionKey, CancellationToken cancellationToken = default)
+        public static async Task<bool> StopLongRunningProcessWebApiAsync(this ILongRunningWebApi clientApp, string longRunningProcessSessionKey, CancellationToken cancellationToken = default)
         {
             return await (clientApp as ConfidentialClientApplication).StopLongRunningWebApiAsync(longRunningProcessSessionKey, cancellationToken).ConfigureAwait(false);
         }

--- a/src/client/Microsoft.Identity.Client/ILongRunningWebApi.cs
+++ b/src/client/Microsoft.Identity.Client/ILongRunningWebApi.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Microsoft.Identity.Client.Extensibility;
 
 namespace Microsoft.Identity.Client
 {
@@ -16,7 +17,7 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-long-running-obo .
         /// This confidential client application was itself called with a token which will be provided in the
         /// <paramref name="userToken">userToken</paramref> parameter.
-        /// <seealso cref="ILongRunningWebApi.StopLongRunningWebApiAsync"/> to stop the long running process.
+        /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessWebApiAsync"/> to stop the long running process.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
         /// <param name="userToken">A JSON Web Token which was used to call the web API and contains the credential information
@@ -30,7 +31,7 @@ namespace Microsoft.Identity.Client
         /// Retrieves an access token from the cache using the provided cache key that can be used to
         /// access another downstream protected web API on behalf of a user using the OAuth 2.0 On-Behalf-Of flow.
         /// See https://aka.ms/msal-net-long-running-obo.
-        /// <seealso cref="ILongRunningWebApi.StopLongRunningWebApiAsync"/> to stop the long running process.
+        /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessWebApiAsync"/> to stop the long running process.
         /// </summary>
         /// <remarks>
         /// This method is intended to be used in the long running processes inside of web APIs.

--- a/src/client/Microsoft.Identity.Client/ILongRunningWebApi.cs
+++ b/src/client/Microsoft.Identity.Client/ILongRunningWebApi.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-long-running-obo .
         /// This confidential client application was itself called with a token which will be provided in the
         /// <paramref name="userToken">userToken</paramref> parameter.
-        /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessWebApiAsync"/> to stop the long running process.
+        /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync"/> to stop the long running process.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
         /// <param name="userToken">A JSON Web Token which was used to call the web API and contains the credential information
@@ -31,7 +31,7 @@ namespace Microsoft.Identity.Client
         /// Retrieves an access token from the cache using the provided cache key that can be used to
         /// access another downstream protected web API on behalf of a user using the OAuth 2.0 On-Behalf-Of flow.
         /// See https://aka.ms/msal-net-long-running-obo.
-        /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessWebApiAsync"/> to stop the long running process.
+        /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync"/> to stop the long running process.
         /// </summary>
         /// <remarks>
         /// This method is intended to be used in the long running processes inside of web APIs.

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests2.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OboTests2.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -126,7 +127,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .ConfigureAwait(false);
            
             Assert.IsNotNull(authenticationResult.AccessToken);
-            Assert.IsTrue(!userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
+            Assert.IsFalse(userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
             Assert.IsTrue(userCacheRecorder.LastAfterAccessNotificationArgs.HasTokens);
             Assert.AreEqual(atHash, userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheKey);
             Assert.AreEqual(TokenSource.Cache, authenticationResult.AuthenticationResultMetadata.TokenSource);
@@ -135,6 +136,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 "The cache expiry is not set because the node did not change");
         }
 
+        // Will need to be updated.
+        // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3913
         [RunOn(TargetFrameworks.NetCore)]
         public async Task ServicePrincipal_OBO_LongRunningProcess_PPE_Async()
         {
@@ -158,7 +161,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                                     .Create(OBOServicePpeClientID)
                                     .WithAuthority(PPEAuthenticationAuthority)
                                     .WithCertificate(cert)
-                                    .Build();
+                                    .BuildConcrete();
             var userCacheRecorder = middletierServiceApp.UserTokenCache.RecordAccess();
 
             Trace.WriteLine("1. Upstream client gets an app token");            
@@ -170,21 +173,25 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             Trace.WriteLine("2. MidTier kicks off the long running process by getting an OBO token");            
             string cacheKey = null;
-            authenticationResult = await (middletierServiceApp as ILongRunningWebApi).
+            authenticationResult = await middletierServiceApp.
                 InitiateLongRunningProcessInWebApi(downstreamApiScopes, clientToken, ref cacheKey)
                 .ExecuteAsync().ConfigureAwait(false);
 
             Assert.IsNotNull(authenticationResult.AccessToken);
-            Assert.IsTrue(!userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
+            Assert.IsFalse(userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
             Assert.IsTrue(userCacheRecorder.LastAfterAccessNotificationArgs.HasTokens);
             Assert.AreEqual(cacheKey, userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheKey);
             Assert.AreEqual(TokenSource.IdentityProvider, authenticationResult.AuthenticationResultMetadata.TokenSource);
             Assert.IsNull(
                 userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheExpiry,
                 "The cache expiry is not set because there is an RT in the cache");
+            Assert.AreEqual(1, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count);
+            Assert.AreEqual(1, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Count);
+            Assert.AreEqual(1, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllIdTokens().Count);
+            Assert.AreEqual(1, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllAccounts().Count);
 
             Trace.WriteLine("3. Later, mid-tier needs the token again, and one is in the cache");
-            authenticationResult = await (middletierServiceApp as ILongRunningWebApi)
+            authenticationResult = await middletierServiceApp
                 .AcquireTokenInLongRunningProcess(downstreamApiScopes, cacheKey)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
@@ -194,19 +201,32 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Trace.WriteLine("4. After the original token expires, the mid-tier needs a token again. RT will be used.");
             TokenCacheHelper.ExpireAllAccessTokens(middletierServiceApp.UserTokenCache as ITokenCacheInternal);
 
-            authenticationResult = await (middletierServiceApp as ILongRunningWebApi)
+            authenticationResult = await middletierServiceApp
                .AcquireTokenInLongRunningProcess(downstreamApiScopes, cacheKey)
                .ExecuteAsync()
                .ConfigureAwait(false);
 
             Assert.IsNotNull(authenticationResult.AccessToken);
-            Assert.IsTrue(!userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
+            Assert.IsFalse(userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
             Assert.IsTrue(userCacheRecorder.LastAfterAccessNotificationArgs.HasTokens);
             Assert.AreEqual(cacheKey, userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheKey);
             Assert.AreEqual(TokenSource.IdentityProvider, authenticationResult.AuthenticationResultMetadata.TokenSource);
             Assert.IsNull(
                 userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheExpiry,
                 "The cache expiry is not set because there is an RT in the cache");
+            Assert.AreEqual(2, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Count);
+            Assert.AreEqual(2, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Count);
+            Assert.AreEqual(1, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllIdTokens().Count);
+            Assert.AreEqual(1, middletierServiceApp.UserTokenCacheInternal.Accessor.GetAllAccounts().Count);
+
+            Trace.WriteLine("5. Subsequent acquire token calls should return cached token. Throws error for now.");
+            var ex = await Assert.ThrowsExceptionAsync<MsalClientException>(async () =>
+                await middletierServiceApp
+                   .AcquireTokenInLongRunningProcess(downstreamApiScopes, cacheKey)
+                   .ExecuteAsync()
+                   .ConfigureAwait(false)
+                ).ConfigureAwait(false);
+            Assert.AreEqual(MsalError.MultipleTokensMatchedError, ex.ErrorCode);
         }
 
         [RunOn(TargetFrameworks.NetCore)]
@@ -297,7 +317,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.IsNotNull(authResult);
             Assert.IsNotNull(authResult.AccessToken);
             Assert.IsNotNull(authResult.IdToken);
-            Assert.IsTrue(!userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
+            Assert.IsFalse(userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
             Assert.IsTrue(userCacheRecorder.LastAfterAccessNotificationArgs.HasTokens);
             Assert.AreEqual(atHash, userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheKey);
             Assert.AreEqual(TokenSource.Cache, authResult.AuthenticationResultMetadata.TokenSource);
@@ -313,7 +333,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.IsNotNull(authResult);
             Assert.IsNotNull(authResult.AccessToken);
             Assert.IsNotNull(authResult.IdToken);
-            Assert.IsTrue(!userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
+            Assert.IsFalse(userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
             Assert.IsTrue(userCacheRecorder.LastAfterAccessNotificationArgs.HasTokens);
             Assert.AreEqual(atHash, userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheKey);
             Assert.AreEqual(TokenSource.IdentityProvider, authResult.AuthenticationResultMetadata.TokenSource);
@@ -339,7 +359,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.IsNotNull(authResult);
             Assert.IsNotNull(authResult.AccessToken);
             Assert.IsNotNull(authResult.IdToken);
-            Assert.IsTrue(!userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
+            Assert.IsFalse(userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
             Assert.IsTrue(userCacheRecorder.LastAfterAccessNotificationArgs.HasTokens);
             Assert.AreEqual(atHash, userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheKey);
             Assert.AreEqual(TokenSource.IdentityProvider, authResult.AuthenticationResultMetadata.TokenSource);
@@ -356,7 +376,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.IsNotNull(authResult);
             Assert.IsNotNull(authResult.AccessToken);
             Assert.IsNotNull(authResult.IdToken);
-            Assert.IsTrue(!userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
+            Assert.IsFalse(userCacheRecorder.LastAfterAccessNotificationArgs.IsApplicationCache);
             Assert.IsTrue(userCacheRecorder.LastAfterAccessNotificationArgs.HasTokens);
             Assert.AreEqual(atHash, userCacheRecorder.LastAfterAccessNotificationArgs.SuggestedCacheKey);
             Assert.AreEqual(TokenSource.IdentityProvider, authResult.AuthenticationResultMetadata.TokenSource);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
@@ -918,7 +918,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 //remove tokens
                 validateCacheProperties = true;
-                var tokensRemoved = await oboCca.StopLongRunningProcessWebApiAsync(oboCacheKey).ConfigureAwait(false);
+                var tokensRemoved = await oboCca.StopLongRunningProcessInWebApiAsync(oboCacheKey).ConfigureAwait(false);
 
                 var cachedAccessTokens = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
                 var cachedRefreshTokens = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();
@@ -928,7 +928,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.IsTrue(tokensRemoved);
 
                 //validate that no more tokens are removed
-                tokensRemoved = await oboCca.StopLongRunningProcessWebApiAsync(oboCacheKey).ConfigureAwait(false);
+                tokensRemoved = await oboCca.StopLongRunningProcessInWebApiAsync(oboCacheKey).ConfigureAwait(false);
 
                 cachedAccessTokens = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
                 cachedRefreshTokens = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
@@ -918,7 +918,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
                 //remove tokens
                 validateCacheProperties = true;
-                var tokensRemoved = await oboCca.StopLongRunningWebApiAsync(oboCacheKey).ConfigureAwait(false);
+                var tokensRemoved = await oboCca.StopLongRunningProcessWebApiAsync(oboCacheKey).ConfigureAwait(false);
 
                 var cachedAccessTokens = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
                 var cachedRefreshTokens = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();
@@ -928,7 +928,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 Assert.IsTrue(tokensRemoved);
 
                 //validate that no more tokens are removed
-                tokensRemoved = await oboCca.StopLongRunningWebApiAsync(oboCacheKey).ConfigureAwait(false);
+                tokensRemoved = await oboCca.StopLongRunningProcessWebApiAsync(oboCacheKey).ConfigureAwait(false);
 
                 cachedAccessTokens = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
                 cachedRefreshTokens = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();


### PR DESCRIPTION
Related to #3913, #3973

**Changes proposed in this request**
- Suggestion to rename `StopLongRunningWebApiAsync` to `StopLongRunningProcessInWebApiAsync` to match `InitiateLongRunningProcessInWebApi` and `AcquireTokenInLongRunningProcess`.
- Update service principal long-running OBO test.
- Fix comments.
- Set analyzers version to wildcard, so latest one is always used.