### PR TITLE
Remove Managed Identity Test that checks response when no env variables are set 

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ManagedIdentityTests.cs
@@ -50,27 +50,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         //non existent Resource ID of the User Assigned Identity 
         private const string Non_Existent_UamiResourceId = "/subscriptions/userAssignedIdentities/NO_ID";
 
-        [TestMethod]
-        public async Task ManagedIdentity_WithoutEnvironmentVariables_ThrowsAsync()
-        {
-            //Arrange
-            ManagedIdentityApplicationBuilder builder = ManagedIdentityApplicationBuilder
-            .Create()
-            .WithExperimentalFeatures();
-
-            IManagedIdentityApplication mia = builder.Build();
-
-            //Act and Assert
-            MsalServiceException ex = await AssertException
-                .TaskThrowsAsync<MsalServiceException>(async () =>
-            {
-                await mia
-                .AcquireTokenForManagedIdentity(s_msi_scopes)
-                .ExecuteAsync()
-                .ConfigureAwait(false);
-            }).ConfigureAwait(false);
-        }
-
         [DataTestMethod]
         [DataRow(MsiAzureResource.WebApp, "", DisplayName = "System Identity Web App")]
         [DataRow(MsiAzureResource.Function, "", DisplayName = "System Identity Function App")]


### PR DESCRIPTION
This test runs on the Build Machine but returns a `MSALServiceException` because build machines have IMDS endpoints enabled 

![image](https://user-images.githubusercontent.com/90415114/225606381-efd72ccc-09db-4d7f-b2aa-a3e3fffd6abb.png)

But on the local machine it fails with `HttpRequestException`. We already have unit test coverage so deleting this as it could be a flaky test in the future. 

Or open for ideas on how to deal with this. 