### PR TITLE
Update to Microsoft.Identity.Client.NativeInterop version 0.13.7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsPackable>false</IsPackable>
     <!-- Version of the Microsoft.Identity.Client.NativeInterop package. -->
-    <MSALRuntimeNativeInteropVersion>0.13.6</MSALRuntimeNativeInteropVersion>
+    <MSALRuntimeNativeInteropVersion>0.13.7</MSALRuntimeNativeInteropVersion>
     
     <!-- Version of MSAL if not defined by the CI-->
     <MsalInternalVersion>4.51.0</MsalInternalVersion>


### PR DESCRIPTION
Update to Microsoft.Identity.Client.NativeInterop version 0.13.7

- fixes packaging issue with arch targeted specific projects 
- this version of the interop loads msalruntime from default search order in addition to the custom search 
- this version re-introduces the build.props file 