### PR TITLE
Add back netcore tests.

### DIFF
--- a/build/template-run-integration-tests.yaml
+++ b/build/template-run-integration-tests.yaml
@@ -19,6 +19,20 @@ steps:
     pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to mess something up
 
 - task: VSTest@2
+  displayName: 'Run integration tests (.NET Core)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netcore\bin\**\Microsoft.Identity.Test.Integration.NetCore.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    rerunFailedTests: true
+    rerunMaxAttempts: '3'
+    runInParallel: false
+    codeCoverageEnabled: true
+    failOnMinTestsNotRun: true
+    minimumExpectedTests: '1'
+
+- task: VSTest@2
   displayName: 'Run integration tests (.NET Standard)'
   condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:

--- a/build/template-run-unit-tests.yaml
+++ b/build/template-run-unit-tests.yaml
@@ -20,6 +20,18 @@ steps:
     pathtoCustomTestAdapters: 'C:\temp' # Workaround for test failure, as NUnit Test Adapter that gets detected seems to mess something up
 
 - task: VSTest@2
+  displayName: 'Run unit tests (.NET CORE 3.1)'
+  condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\netcoreapp3.1\Microsoft.Identity.Test.Unit.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    runInParallel: true
+    codeCoverageEnabled: true
+    failOnMinTestsNotRun: true
+    minimumExpectedTests: '1'
+
+- task: VSTest@2
   displayName: 'Run unit tests (NET6-WIN)'
   condition: and(succeeded(), eq(variables['RunTests'], 'true'))
   inputs:

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/PoPTests.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                .Create(labResponse.App.AppId)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
                .WithLogging(wastestLogger)
-               .WithBroker()
+               .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
                .Build();
 
             Assert.IsTrue(pca.IsProofOfPossessionSupportedByClient(), "Either the broker is not configured or it does not support POP.");

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
         [DllImport("user32.dll")]
         static extern IntPtr GetForegroundWindow();
 
+        // This test should fail locally but succeed in a CI build.
         [RunOn(TargetFrameworks.NetCore)]
         public async Task WamSilentAuthUserInteractionRequiredAsync()
         {
@@ -47,7 +48,9 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Create("04f0c124-f2bc-4f59-8241-bf6df9866bbd")
                .WithAuthority("https://login.microsoftonline.com/organizations");
 
-            IPublicClientApplication pca = pcaBuilder.WithBroker().Build();
+            IPublicClientApplication pca = pcaBuilder
+                .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
+                .Build();
 
             // Act
             try
@@ -78,7 +81,9 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Create("04f0c124-f2bc-4f59-8241-bf6df9866bbd")
                .WithAuthority("https://login.microsoftonline.com/organizations");
 
-            IPublicClientApplication pca = pcaBuilder.WithBroker().Build();
+            IPublicClientApplication pca = pcaBuilder
+               .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
+               .Build();
 
             // Act
             try
@@ -112,7 +117,8 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .WithParentActivityOrWindow(windowHandleProvider)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
                .WithLogging(testLogger)
-               .WithBroker().Build();
+               .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
+               .Build();
 
             // Acquire token using username password
             var result = await pca.AcquireTokenByUsernamePassword(scopes, labResponse.User.Upn, labResponse.User.GetOrFetchPassword()).ExecuteAsync().ConfigureAwait(false);
@@ -165,7 +171,8 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .WithParentActivityOrWindow(windowHandleProvider)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
                .WithLogging(testLogger, enablePiiLogging: true)
-               .WithBroker().Build();
+               .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
+               .Build();
 
             // Acquire token using username password
             var result = await pca.AcquireTokenByUsernamePassword(scopes, labResponse.User.Upn, labResponse.User.GetOrFetchPassword()).ExecuteAsync().ConfigureAwait(false);
@@ -212,9 +219,9 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .WithParentActivityOrWindow(windowHandleProvider)
                .WithAuthority(labResponse.Lab.Authority, "organizations")
                .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows)
-                {
-                    ListOperatingSystemAccounts = true,
-                })
+               {
+                   ListOperatingSystemAccounts = true,
+               })
                .Build();
 
 
@@ -246,7 +253,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Create("43dfbb29-3683-4673-a66f-baba91798bd2")
                .WithAuthority("https://login.microsoftonline.com/organizations")
                .WithParentActivityOrWindow(windowHandleProvider)
-               .WithBroker()
+               .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
                .Build();
 
             // Act

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworkNetCore>netcoreapp3.1</TargetFrameworkNetCore>
     <TargetFrameworkNet6Win>net6.0-windows</TargetFrameworkNet6Win>
 
-    <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNet6Win)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNetCore);$(TargetFrameworkNet6Win)</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <LangVersion>latest</LangVersion>

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -2,20 +2,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworkNetDesktop461>net48</TargetFrameworkNetDesktop461>
+    <TargetFrameworkNetCore>netcoreapp3.1</TargetFrameworkNetCore>
     <TargetFrameworkNet6Win>net6.0-windows</TargetFrameworkNet6Win>
-    
+
     <TargetFrameworks>$(TargetFrameworkNetDesktop461);$(TargetFrameworkNet6Win)</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    
+
     <LangVersion>latest</LangVersion>
-    
+
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
 
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client.Broker\Microsoft.Identity.Client.Broker.csproj" Condition="'$(TargetFramework)' != '$(TargetFrameworkNet6Win)'"/> 
+    <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client.Broker\Microsoft.Identity.Client.Broker.csproj" Condition="'$(TargetFramework)' != '$(TargetFrameworkNet6Win)'"/>
     <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj">
       <Project>{3433eb33-114a-4db7-bc57-14f17f55da3c}</Project>
       <Name>Microsoft.Identity.Client</Name>
@@ -60,10 +61,13 @@
     <PackageReference Include="System.Windows.Forms" Version="4.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)'">
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)' or '$(TargetFramework)' == '$(TargetFrameworkNetCore)'">
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
     <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetCore)'">
+    <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop461)' ">
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
**Changes proposed in this request**
Adds back running netcore3.1 unit and integration tests.
Fixed some broker tests to call the correct Msal Runtime broker API.

Created issue #4052 as a follow up improvement to this.