### PR TITLE
[WAM] Token protection validation with CA Policy

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -296,13 +296,20 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
                .Build();
 
-            // Acquire token using username password
-            var result = await pca.AcquireTokenByUsernamePassword(scopes, popUser, labResponse.User.GetOrFetchPassword())
-                .WithProofOfPossession("some_nonce", System.Net.Http.HttpMethod.Get, new Uri(pca.Authority))
-                .ExecuteAsync()
-                .ConfigureAwait(false);
-
-            MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);
+            try
+            {
+                // Acquire token using username password
+                var result = await pca.AcquireTokenByUsernamePassword(scopes, popUser, labResponse.User.GetOrFetchPassword())
+                    .WithProofOfPossession("some_nonce", System.Net.Http.HttpMethod.Get, new Uri(pca.Authority))
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.AreEqual(ex.Message,"checking the message");
+            }
+            
+            //MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);
         }
 
     }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
 
         [RunOn(TargetFrameworks.NetStandard | TargetFrameworks.NetCore)]
         [ExpectedException(typeof(MsalUiRequiredException))]
-        public async Task WamUsernamePasswordPopTokenEnforcedWithCaInOnValidResourceAsync()
+        public async Task WamUsernamePasswordPopTokenEnforcedWithCaOnInValidResourceAsync()
         {
             //Arrange
             var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -303,27 +303,12 @@ namespace Microsoft.Identity.Test.Integration.Broker
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
-                MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);
-            }
-            catch (MsalUiRequiredException ex)
-            {
-                Assert.AreEqual(ex.Message,"checking the message");
-                Assert.AreEqual(ex.InnerException, "checking the message");
-            }
-            catch (MsalServiceException ex)
-            {
-                Assert.AreEqual(ex.Message, "checking the message");
-                Assert.AreEqual(ex.InnerException, "checking the message");
+                Assert.IsNotNull(result.Account);
+                Assert.IsNotNull(result.Account.Username);
             }
             catch (MsalException ex)
             {
-                Assert.AreEqual(ex.Message, "checking the message");
-                Assert.AreEqual(ex.InnerException, "checking the message");
-            }
-            catch (Exception ex)
-            {
-                Assert.AreEqual(ex.Message, "checking the message");
-                Assert.AreEqual(ex.InnerException, "checking the message");
+                Assert.IsNull(ex.Message);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -304,9 +304,10 @@ namespace Microsoft.Identity.Test.Integration.Broker
                     .ExecuteAsync()
                     .ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (MsalUiRequiredException ex)
             {
                 Assert.AreEqual(ex.Message,"checking the message");
+                Assert.AreEqual(ex.InnerException, "checking the message");
             }
             
             //MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -267,7 +267,6 @@ namespace Microsoft.Identity.Test.Integration.Broker
         }
 
         [RunOn(TargetFrameworks.NetStandard | TargetFrameworks.NetCore)]
-        [ExpectedException(typeof(MsalUiRequiredException))]
         public async Task WamUsernamePasswordPopTokenAsync()
         {
             var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
@@ -303,14 +302,29 @@ namespace Microsoft.Identity.Test.Integration.Broker
                     .WithProofOfPossession("some_nonce", System.Net.Http.HttpMethod.Get, new Uri(pca.Authority))
                     .ExecuteAsync()
                     .ConfigureAwait(false);
+
+                MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);
             }
             catch (MsalUiRequiredException ex)
             {
                 Assert.AreEqual(ex.Message,"checking the message");
                 Assert.AreEqual(ex.InnerException, "checking the message");
             }
-            
-            //MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);
+            catch (MsalServiceException ex)
+            {
+                Assert.AreEqual(ex.Message, "checking the message");
+                Assert.AreEqual(ex.InnerException, "checking the message");
+            }
+            catch (MsalException ex)
+            {
+                Assert.AreEqual(ex.Message, "checking the message");
+                Assert.AreEqual(ex.InnerException, "checking the message");
+            }
+            catch (Exception ex)
+            {
+                Assert.AreEqual(ex.Message, "checking the message");
+                Assert.AreEqual(ex.InnerException, "checking the message");
+            }
         }
 
     }

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -297,7 +297,10 @@ namespace Microsoft.Identity.Test.Integration.Broker
                .Build();
 
             // Acquire token using username password
-            var result = await pca.AcquireTokenByUsernamePassword(scopes, popUser, labResponse.User.GetOrFetchPassword()).ExecuteAsync().ConfigureAwait(false);
+            var result = await pca.AcquireTokenByUsernamePassword(scopes, popUser, labResponse.User.GetOrFetchPassword())
+                .WithProofOfPossession("some_nonce", System.Net.Http.HttpMethod.Get, new Uri(pca.Authority))
+                .ExecuteAsync()
+                .ConfigureAwait(false);
 
             MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);
         }


### PR DESCRIPTION
Token protection (sometimes referred to as token binding in the industry) attempts to reduce attacks using token theft by ensuring a token is usable only from the intended device. When an attacker is able to steal a token, by hijacking or replay, they can impersonate their victim until the token expires or is revoked. Token theft is thought to be a relatively rare event, but the damage from it can be significant.

learn more : [https://learn.microsoft.com/en-us/azure/active-directory/conditional-access/concept-token-protection](https://learn.microsoft.com/en-us/azure/active-directory/conditional-access/concept-token-protection)

In msidlab4 lab, we now have a valid resource (SPO) to test for POP tokens and also a CA Policy for token issuance. AAD will only get a token back for the popUser when requested with a valid resource (i.e. https://msidlab4.sharepoint.com in this case) using the WAM Broker + WithProofOfPossession API.  

**CA Policy in msidlab4.com :**

![image](https://user-images.githubusercontent.com/90415114/229379226-e85ec747-6c32-4229-b317-b3e9e5e4a75b.png)

  