### PR TITLE
[Prototype] Add partition-aware cache serializer

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/TokenCacheJsonSerializer.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/TokenCacheJsonSerializer.cs
@@ -24,23 +24,28 @@ namespace Microsoft.Identity.Client.Cache
 
         public byte[] Serialize(IDictionary<string, JToken> unknownNodes)
         {
+            return Serialize(null, unknownNodes);
+        }
+
+        public byte[] Serialize(string cacheKey, IDictionary<string, JToken> unknownNodes)
+        {
             var cache = new CacheSerializationContract(unknownNodes);
-            foreach (var token in _accessor.GetAllAccessTokens())
+            foreach (var token in _accessor.GetAllAccessTokens(cacheKey))
             {
                 cache.AccessTokens[token.CacheKey] = token;
             }
 
-            foreach (var token in _accessor.GetAllRefreshTokens())
+            foreach (var token in _accessor.GetAllRefreshTokens(cacheKey))
             {
                 cache.RefreshTokens[token.CacheKey] = token;
             }
 
-            foreach (var token in _accessor.GetAllIdTokens())
+            foreach (var token in _accessor.GetAllIdTokens(cacheKey))
             {
                 cache.IdTokens[token.CacheKey] = token;
             }
 
-            foreach (var accountItem in _accessor.GetAllAccounts())
+            foreach (var accountItem in _accessor.GetAllAccounts(cacheKey))
             {
                 cache.Accounts[accountItem.CacheKey] = accountItem;
             }

--- a/src/client/Microsoft.Identity.Client/ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/ITokenCacheInternal.cs
@@ -12,7 +12,7 @@ using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client
 {
-    internal interface ITokenCacheInternal : ITokenCache, ITokenCacheSerializer
+    internal interface ITokenCacheInternal : ITokenCache, ITokenCacheSerializer, IPartitionedTokenCacheSerializer
     {
         OptionalSemaphoreSlim Semaphore { get; }
         ILegacyCachePersistence LegacyPersistence { get; }

--- a/src/client/Microsoft.Identity.Client/ITokenCacheSerializer.cs
+++ b/src/client/Microsoft.Identity.Client/ITokenCacheSerializer.cs
@@ -110,4 +110,23 @@ namespace Microsoft.Identity.Client
         [EditorBrowsable(EditorBrowsableState.Never)]
         void DeserializeMsalV2(byte[] msalV2State);
     }
+
+    /// <summary>
+    /// Similar to <see cref="ITokenCacheSerializer"/> except accepts a cache partition to serialize into.
+    /// </summary>
+    public interface IPartitionedTokenCacheSerializer
+    {
+        /// <summary>
+        /// Similar to <see cref="ITokenCacheSerializer.SerializeMsalV3"/> except serializes only the specified partition.
+        /// </summary>
+        /// <param name="cacheKey"></param>
+        byte[] SerializeMsal(string cacheKey);
+
+        /// <summary>
+        /// Similar to <see cref="ITokenCacheSerializer.DeserializeMsalV3(byte[], bool)"/> except doesn't clear the existing cache data.
+        /// </summary>
+        /// <param name="msalState"></param>
+
+        void DeserializeMsal(byte[] msalState);
+    }
 }

--- a/src/client/Microsoft.Identity.Client/TokenCache.Serialization.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.Serialization.cs
@@ -53,5 +53,19 @@ namespace Microsoft.Identity.Client
             }
             _unknownNodes = new TokenCacheJsonSerializer(Accessor).Deserialize(msalV3State, shouldClearExistingCache);
         }
+
+        byte[] IPartitionedTokenCacheSerializer.SerializeMsal(string cacheKey)
+        {
+            return new TokenCacheJsonSerializer(Accessor).Serialize(cacheKey, _unknownNodes);
+        }
+
+        void IPartitionedTokenCacheSerializer.DeserializeMsal(byte[] msalState)
+        {
+            if (msalState == null || msalState.Length == 0)
+            {
+                return;
+            }
+            _unknownNodes = new TokenCacheJsonSerializer(Accessor).Deserialize(msalState, false);
+        }
     }
 }


### PR DESCRIPTION
Related to #3285, #3439.

Adds a token cache serializer that accepts a cache partition key which allows to serialize only that specific partition and not the whole internal cache dictionary.

Example usage:
```csharp
        public void BeforeAccessNotification(TokenCacheNotificationArgs args)
        {
            if (!string.IsNullOrEmpty(args.SuggestedCacheKey))
            {
                byte[] tokenCacheBytes = ReadCacheBytes(args.SuggestedCacheKey);
                ((IPartitionedTokenCacheSerializer)args.TokenCache).DeserializeMsal(tokenCacheBytes);
            }
        }

        public void AfterAccessNotification(TokenCacheNotificationArgs args)
        {
            if (args.HasStateChanged)
            {
                if (args.HasTokens)
                {
                    var key = string.IsNullOrEmpty(args.SuggestedCacheKey) ? args.Account.HomeAccountId.Identifier : args.SuggestedCacheKey;
                    WriteCacheBytes(key, ((IPartitionedTokenCacheSerializer)args.TokenCache).SerializeMsal(key));
                }
                else
                {
                    // No token in the cache. we can remove the cache entry
                    RemoveKey(args.SuggestedCacheKey);
                }
            }
        }
```