### PR TITLE
Remove test name with spaces as it fails in re-run

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ManagedIdentityTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         [DataRow(MsiAzureResource.WebApp, UamiResourceId, DisplayName = "ResourceID Web App")]
         [DataRow(MsiAzureResource.Function, UamiResourceId, DisplayName = "ResourceID Function App")]
         [DataRow(MsiAzureResource.VM, UamiResourceId, DisplayName = "ResourceID Virtual Machine")]
-        [DataRow(MsiAzureResource.AzureArc, "", DisplayName = "System Identity Azure ARC")]
+        [DataRow(MsiAzureResource.AzureArc, "", DisplayName = "Azure ARC")]
         public async Task AcquireMSITokenAsync(MsiAzureResource azureResource, string userIdentity)
         {
             //Arrange

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/ManagedIdentityTests.cs
@@ -51,16 +51,16 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private const string Non_Existent_UamiResourceId = "/subscriptions/userAssignedIdentities/NO_ID";
 
         [DataTestMethod]
-        [DataRow(MsiAzureResource.WebApp, "", DisplayName = "System Identity Web App")]
-        [DataRow(MsiAzureResource.Function, "", DisplayName = "System Identity Function App")]
-        [DataRow(MsiAzureResource.VM, "", DisplayName = "System Identity Virtual Machine")]
-        [DataRow(MsiAzureResource.WebApp, UserAssignedClientID, DisplayName = "User Identity Web App")]
-        [DataRow(MsiAzureResource.Function, UserAssignedClientID, DisplayName = "User Identity Function App")]
-        [DataRow(MsiAzureResource.VM, UserAssignedClientID, DisplayName = "User Identity Virtual Machine")]
-        [DataRow(MsiAzureResource.WebApp, UamiResourceId, DisplayName = "ResourceID Web App")]
-        [DataRow(MsiAzureResource.Function, UamiResourceId, DisplayName = "ResourceID Function App")]
-        [DataRow(MsiAzureResource.VM, UamiResourceId, DisplayName = "ResourceID Virtual Machine")]
-        [DataRow(MsiAzureResource.AzureArc, "", DisplayName = "Azure ARC")]
+        [DataRow(MsiAzureResource.WebApp, "", DisplayName = "System_Identity_Web_App")]
+        [DataRow(MsiAzureResource.Function, "", DisplayName = "System_Identity_Function_App")]
+        [DataRow(MsiAzureResource.VM, "", DisplayName = "System_Identity_Virtual_Machine")]
+        [DataRow(MsiAzureResource.WebApp, UserAssignedClientID, DisplayName = "User_Identity_Web_App")]
+        [DataRow(MsiAzureResource.Function, UserAssignedClientID, DisplayName = "User_Identity_Function_App")]
+        [DataRow(MsiAzureResource.VM, UserAssignedClientID, DisplayName = "User_Identity_Virtual_Machine")]
+        [DataRow(MsiAzureResource.WebApp, UamiResourceId, DisplayName = "ResourceID_Web_App")]
+        [DataRow(MsiAzureResource.Function, UamiResourceId, DisplayName = "ResourceID_Function_App")]
+        [DataRow(MsiAzureResource.VM, UamiResourceId, DisplayName = "ResourceID_Virtual_Machine")]
+        [DataRow(MsiAzureResource.AzureArc, "", DisplayName = "Azure_ARC")]
         public async Task AcquireMSITokenAsync(MsiAzureResource azureResource, string userIdentity)
         {
             //Arrange


### PR DESCRIPTION
Rerun tests which contain spaces in their names does not work. 

Issue : https://github.com/microsoft/azure-pipelines-tasks/issues/10709