### PR TITLE
Add API and logic for ignoring cached OBO assertion for Initiate long OBO

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -163,6 +163,19 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+        /// <summary>
+        /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
+        /// When enabled, mimics MSAL 4.50.0 and below behavior - does not check cached tokens based on OBO assertions.
+        /// When disabled (default behavior), cached tokens will only be returned if the OBO assertion in the request matched the assertion of the cached token.
+        /// </summary>
+        /// <param name="ignoreCachedAssertion">Whether to match on cached OBO assertion hash.</param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public AcquireTokenOnBehalfOfParameterBuilder WithIgnoreCachedAssertion(bool ignoreCachedAssertion = true)
+        {
+            Parameters.IgnoreCachedOboAssertion = ignoreCachedAssertion;
+            return this;
+        }
+
         /// <inheritdoc />
         internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Text;
 using Microsoft.Identity.Client.Core;
 
@@ -9,13 +10,21 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     internal class AcquireTokenOnBehalfOfParameters : AbstractAcquireTokenConfidentialClientParameters, IAcquireTokenParameters
     {
         /// <remarks>
-        /// User assertion is null when <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess"/> is called.
+        /// User assertion is null when <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/> is called.
         /// </remarks>
         public UserAssertion UserAssertion { get; set; }
         /// <summary>
         /// User-provided cache key for long-running OBO flow.
         /// </summary>
         public string LongRunningOboCacheKey { get; set; }
+
+        /// <summary>
+        /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
+        /// When enabled, mimics MSAL 4.50.0 and below behavior - does not check cached tokens based on OBO assertions.
+        /// When disabled (default behavior), cached tokens will only be returned if the OBO assertion in the request matched the assertion of the cached token.
+        /// </summary>
+        public bool IgnoreCachedOboAssertion { get; set; }
+
         public bool ForceRefresh { get; set; }
 
         /// <inheritdoc />
@@ -28,6 +37,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 builder.AppendLine("SendX5C: " + SendX5C);
                 builder.AppendLine("ForceRefresh: " + ForceRefresh);
                 builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
+                builder.AppendLine("IgnoreCachedOboAssertion: " + IgnoreCachedOboAssertion);
                 builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
                 if (UserAssertion != null && !string.IsNullOrWhiteSpace(LongRunningOboCacheKey))
                 {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -56,7 +56,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     cachedAccessToken = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
                 }
 
-                if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.InitiateLongRunningObo && cachedAccessToken != null &&
+                if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.InitiateLongRunningObo &&
+                    !_onBehalfOfParameters.IgnoreCachedOboAssertion &&
+                    cachedAccessToken != null &&
                     !AuthenticationRequestParameters.UserAssertion.AssertionHash.Equals(cachedAccessToken.OboAssertionHash, System.StringComparison.Ordinal))
                 {
                     logger.Info("[OBO request] InitiateLongRunningProcessInWebApi found cached access token with a different assertion; fetching new tokens.");
@@ -145,7 +147,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // Look for a refresh token
                 MsalRefreshTokenCacheItem cachedRefreshToken = await CacheManager.FindRefreshTokenAsync().ConfigureAwait(false);
 
-                if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.InitiateLongRunningObo && cachedRefreshToken != null &&
+                if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.InitiateLongRunningObo &&
+                    !_onBehalfOfParameters.IgnoreCachedOboAssertion &&
+                    cachedRefreshToken != null &&
                     !AuthenticationRequestParameters.UserAssertion.AssertionHash.Equals(cachedRefreshToken.OboAssertionHash, System.StringComparison.Ordinal))
                 {
                     logger.Info("[OBO request] InitiateLongRunningProcessInWebApi found cached refresh token with a different assertion; fetching new tokens.");

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1597,7 +1597,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             var longRunningOboBuilder = ((ILongRunningWebApi)app).InitiateLongRunningProcessInWebApi(
                                TestConstants.s_scope.ToArray(),
                                TestConstants.DefaultClientAssertion,
-                               ref oboCacheKey);
+                               ref oboCacheKey)
+                .WithIgnoreCachedAssertion();
             PublicClientApplicationTests.CheckBuilderCommonMethods(longRunningOboBuilder);
 
             longRunningOboBuilder = ((ILongRunningWebApi)app).AcquireTokenInLongRunningProcess(

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
@@ -343,6 +343,68 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
+        public async Task InitiateLongRunningObo_WithIgnoreCachedAssertion_TestAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                AddMockHandlerAadSuccess(httpManager);
+
+                var cca = BuildCCA(httpManager);
+
+                var userCacheAccess = cca.UserTokenCache.RecordAccess();
+
+                string oboCacheKey = null;
+
+                // Token's not in the cache, searched by user assertion hash, retrieved from IdP, saved with the provided OBO cache key
+                var result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, TestConstants.DefaultAccessToken, ref oboCacheKey)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TestConstants.ATSecret, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                MsalAccessTokenCacheItem cachedAccessToken = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
+                MsalRefreshTokenCacheItem cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
+                Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
+                Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
+                Assert.AreEqual(CacheRefreshReason.NoCachedAccessToken, result.AuthenticationResultMetadata.CacheRefreshReason);
+                userCacheAccess.AssertAccessCounts(1, 1);
+
+                // Initiate with different user assertion and IgnoreCachedAssertion flag
+                // MSAL will not match on the assertion and return cached token
+                result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, $"{TestConstants.DefaultAccessToken}2", ref oboCacheKey)
+                    .WithIgnoreCachedAssertion()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
+                userCacheAccess.AssertAccessCounts(2, 1);
+
+                AddMockHandlerAadSuccess(httpManager,
+                    responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(accessToken: TestConstants.ATSecret2, refreshToken: TestConstants.RTSecret2),
+                    expectedPostData: new Dictionary<string, string> { { OAuth2Parameter.GrantType, OAuth2GrantType.RefreshToken } });
+                TokenCacheHelper.ExpireAllAccessTokens(cca.UserTokenCacheInternal);
+
+                // Initiate with different user assertion and IgnoreCachedAssertion flag
+                // MSAL will not match on the assertion, find expired cached token, and use cached refresh token
+                result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, $"{TestConstants.DefaultAccessToken}2", ref oboCacheKey)
+                    .WithIgnoreCachedAssertion()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TestConstants.ATSecret2, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                cachedAccessToken = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
+                cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
+                Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
+                Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
+                Assert.AreEqual(TestConstants.ATSecret2, cachedAccessToken.Secret);
+                Assert.AreEqual(TestConstants.RTSecret2, cachedRefreshToken.Secret);
+                Assert.AreEqual(CacheRefreshReason.Expired, result.AuthenticationResultMetadata.CacheRefreshReason);
+                userCacheAccess.AssertAccessCounts(3, 2);
+            }
+        }
+
+        [TestMethod]
         public async Task InitiateLongRunningObo_WithNullCachedAssertionHash_TestAsync()
         {
             using (var httpManager = new MockHttpManager())


### PR DESCRIPTION
Fixes #4124

**Changes proposed in this request**
Adds new API `WithIgnoreCachedAssertion`.
Only affects `InitiateLongRunningProcessInWebApi`.
When enabled, mimics MSAL 4.50.0 and below behavior - does not check cached tokens based on OBO assertions.
When disabled (default behavior), cached tokens will only be returned if the OBO assertion in the request matched the assertion of the cached token.

**Testing**
Adding.

**Performance impact**
None.

**Documentation**
- [ ] All relevant documentation is updated. - After release
