### PR TITLE
Add public API to search in cache for Initiate long-running OBO

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Client
     public sealed class AcquireTokenOnBehalfOfParameterBuilder :
         AbstractConfidentialClientAcquireTokenParameterBuilder<AcquireTokenOnBehalfOfParameterBuilder>
     {
-        private AcquireTokenOnBehalfOfParameters Parameters { get; } = new AcquireTokenOnBehalfOfParameters();
+        internal AcquireTokenOnBehalfOfParameters Parameters { get; } = new AcquireTokenOnBehalfOfParameters();
 
         /// <inheritdoc />
         internal AcquireTokenOnBehalfOfParameterBuilder(IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor)
@@ -160,20 +160,6 @@ namespace Microsoft.Identity.Client
             };
 
             this.WithExtraHttpHeaders(ccsRoutingHeader);
-            return this;
-        }
-
-        /// <summary>
-        /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
-        /// When enabled, mimics MSAL 4.50.0 and below behavior - checks in cache for cached tokens first, 
-        /// and if not found, then uses user assertion to request new tokens from AAD.
-        /// When disabled (default behavior), doesn't search in cache, but uses the user assertion to retrieve tokens from AAD.
-        /// </summary>
-        /// <param name="searchInCache">Whether to match on cached OBO assertion hash.</param>
-        /// <returns>The builder to chain the .With methods</returns>
-        public AcquireTokenOnBehalfOfParameterBuilder WithSearchInCacheForLongRunningProcess(bool searchInCache = true)
-        {
-            Parameters.SearchInCacheForLongRunningObo = searchInCache;
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -163,6 +163,19 @@ namespace Microsoft.Identity.Client
             return this;
         }
 
+        /// <summary>
+        /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
+        /// When enabled, mimics MSAL 4.50.0 and below behavior - checks in cache for cached tokens.
+        /// When disabled (default behavior), doesn't search in cache, but uses the user assertion to retrieve tokens from AAD.
+        /// </summary>
+        /// <param name="searchInCache">Whether to match on cached OBO assertion hash.</param>
+        /// <returns>The builder to chain the .With methods</returns>
+        public AcquireTokenOnBehalfOfParameterBuilder WithSearchInCache(bool searchInCache = true)
+        {
+            Parameters.SearchInCacheForLongRunningObo = searchInCache;
+            return this;
+        }
+
         /// <inheritdoc />
         internal override Task<AuthenticationResult> ExecuteInternalAsync(CancellationToken cancellationToken)
         {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenOnBehalfOfParameterBuilder.cs
@@ -165,12 +165,13 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
-        /// When enabled, mimics MSAL 4.50.0 and below behavior - checks in cache for cached tokens.
+        /// When enabled, mimics MSAL 4.50.0 and below behavior - checks in cache for cached tokens first, 
+        /// and if not found, then uses user assertion to request new tokens from AAD.
         /// When disabled (default behavior), doesn't search in cache, but uses the user assertion to retrieve tokens from AAD.
         /// </summary>
         /// <param name="searchInCache">Whether to match on cached OBO assertion hash.</param>
         /// <returns>The builder to chain the .With methods</returns>
-        public AcquireTokenOnBehalfOfParameterBuilder WithSearchInCache(bool searchInCache = true)
+        public AcquireTokenOnBehalfOfParameterBuilder WithSearchInCacheForLongRunningProcess(bool searchInCache = true)
         {
             Parameters.SearchInCacheForLongRunningObo = searchInCache;
             return this;

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Text;
 using Microsoft.Identity.Client.Core;
 
@@ -9,13 +10,21 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
     internal class AcquireTokenOnBehalfOfParameters : AbstractAcquireTokenConfidentialClientParameters, IAcquireTokenParameters
     {
         /// <remarks>
-        /// User assertion is null when <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess"/> is called.
+        /// User assertion is null when <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/> is called.
         /// </remarks>
         public UserAssertion UserAssertion { get; set; }
         /// <summary>
         /// User-provided cache key for long-running OBO flow.
         /// </summary>
         public string LongRunningOboCacheKey { get; set; }
+
+        /// <summary>
+        /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
+        /// When enabled, mimics MSAL 4.50.0 and below behavior - does not check cached tokens based on OBO assertions.
+        /// When disabled (default behavior), cached tokens will only be returned if the OBO assertion in the request matched the assertion of the cached token.
+        /// </summary>
+        public bool SearchInCacheForLongRunningObo { get; set; }
+
         public bool ForceRefresh { get; set; }
 
         /// <inheritdoc />
@@ -28,6 +37,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 builder.AppendLine("SendX5C: " + SendX5C);
                 builder.AppendLine("ForceRefresh: " + ForceRefresh);
                 builder.AppendLine("UserAssertion set: " + (UserAssertion != null));
+                builder.AppendLine("SearchInCacheForLongRunningObo: " + SearchInCacheForLongRunningObo);
                 builder.AppendLine("LongRunningOboCacheKey set: " + !string.IsNullOrWhiteSpace(LongRunningOboCacheKey));
                 if (UserAssertion != null && !string.IsNullOrWhiteSpace(LongRunningOboCacheKey))
                 {

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenOnBehalfOfParameters.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         /// <summary>
         /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
-        /// When enabled, mimics MSAL 4.50.0 and below behavior - does not check cached tokens based on OBO assertions.
-        /// When disabled (default behavior), cached tokens will only be returned if the OBO assertion in the request matched the assertion of the cached token.
+        /// When enabled, mimics MSAL 4.50.0 and below behavior - checks in cache for cached tokens first, 
+        /// and if not found, then uses user assertion to request new tokens from AAD.
+        /// When disabled (default behavior), doesn't search in cache, but uses the user assertion to retrieve tokens from AAD.
         /// </summary>
         public bool SearchInCacheForLongRunningObo { get; set; }
 

--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenOnBehalfOfParameterBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenOnBehalfOfParameterBuilderExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Microsoft.Identity.Client.Extensibility
+{
+    /// <summary>
+    /// Extension methods for the <see cref="AcquireTokenOnBehalfOfParameterBuilder" />
+    /// </summary>
+    public static class AcquireTokenOnBehalfOfParameterBuilderExtensions
+    {
+        /// <summary>
+        /// Only affects <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/>.
+        /// When enabled, mimics MSAL 4.50.0 and below behavior - checks in cache for cached tokens first, 
+        /// and if not found, then uses user assertion to request new tokens from AAD.
+        /// When disabled (default behavior), doesn't search in cache, but uses the user assertion to retrieve tokens from AAD.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be used in specific cases for backwards compatibility. For most cases, rely on the default behavior
+        /// of <see cref="ILongRunningWebApi.InitiateLongRunningProcessInWebApi(IEnumerable{string}, string, ref string)"/> and
+        /// <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess(IEnumerable{string}, string)"/> described in https://aka.ms/msal-net-long-running-obo .
+        /// </remarks>
+        /// <param name="builder"></param>
+        /// <param name="searchInCache">Whether to search in cache.</param>
+        /// <returns>The builder to chain the .With methods</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static AcquireTokenOnBehalfOfParameterBuilder WithSearchInCacheForLongRunningProcess(this AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = true)
+        {
+            builder.Parameters.SearchInCacheForLongRunningObo = searchInCache;
+            return builder;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ILongRunningWebApi.cs
+++ b/src/client/Microsoft.Identity.Client/ILongRunningWebApi.cs
@@ -14,11 +14,14 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Acquires an access token for this web API from the authority configured in the application,
         /// in order to access another downstream protected web API on behalf of a user using the OAuth 2.0 On-Behalf-Of flow.
-        /// See https://aka.ms/msal-net-long-running-obo .
+        /// See https://aka.ms/msal-net-long-running-obo.
         /// This confidential client application was itself called with a token which will be provided in the
         /// <paramref name="userToken">userToken</paramref> parameter.
         /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync"/> to stop the long running process.
         /// </summary>
+        /// <remarks>
+        /// This method should be called once when the long running session is started.
+        /// </remarks>
         /// <param name="scopes">Scopes requested to access a protected API</param>
         /// <param name="userToken">A JSON Web Token which was used to call the web API and contains the credential information
         /// about the user on behalf of whom to get a token.</param>
@@ -34,7 +37,7 @@ namespace Microsoft.Identity.Client
         /// Use <seealso cref="ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync"/> to stop the long running process.
         /// </summary>
         /// <remarks>
-        /// This method is intended to be used in the long running processes inside of web APIs.
+        /// This method should be called during the long running session to retrieve the token from the cache
         /// </remarks>
         /// <param name="scopes">Scopes requested to access a protected API</param>
         /// <param name="longRunningProcessSessionKey">Key by which to look up the token in the cache</param>

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -175,11 +175,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     throw new MsalClientException(MsalError.OboCacheKeyNotInCacheError, MsalErrorMessage.OboCacheKeyNotInCache);
                 }
 
-                AuthenticationRequestParameters.RequestContext.Logger.Info("[OBO request] No Refresh Token was found in the cache. Fetching OBO token from ESTS");
+                AuthenticationRequestParameters.RequestContext.Logger.Info("[OBO request] No refresh token was found in the cache. Fetching OBO tokens from ESTS.");
             }
             else
             {
-                logger.Info("[OBO request] Normal OBO flow, skipping to fetching access token via OBO flow.");
+                logger.Info("[OBO request] Fetching tokens via normal OBO flow.");
             }
 
             return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             CacheRefreshReason cacheInfoTelemetry = CacheRefreshReason.NotApplicable;
 
             //Check if initiating a long running process
-            if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.InitiateLongRunningObo)
+            if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.InitiateLongRunningObo && !_onBehalfOfParameters.SearchInCacheForLongRunningObo)
             {
-                //Long running process should not use cached tokens
+                //Long running OBO doesn't search in cache by default
                 logger.Info("[OBO Request] Initiating long running process. Fetching OBO token from ESTS.");
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -142,7 +142,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (ApiEvent.IsLongRunningObo(AuthenticationRequestParameters.ApiId))
             {
                 AuthenticationRequestParameters.RequestContext.Logger.Info("[OBO request] Long-running OBO flow, trying to refresh using a refresh token flow.");
-
 
                 // Look for a refresh token
                 MsalRefreshTokenCacheItem cachedRefreshToken = await CacheManager.FindRefreshTokenAsync().ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -54,7 +53,7 @@ namespace Microsoft.Identity.Client
 
             string suggestedWebCacheKey = CacheKeyFactory.GetExternalCacheKeyFromResponse(requestParams, homeAccountId);
 
-            // token could be comming from a different cloud than the one configured
+            // token could be coming from a different cloud than the one configured
             if (requestParams.AppConfig.MultiCloudSupportEnabled && !string.IsNullOrEmpty(response.AuthorityUrl))
             {
                 var url = new Uri(response.AuthorityUrl);

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -54,12 +54,12 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                                         "\"trace_id\":\"dd25f4fb-3e8d-458e-90e7-179524ce0000\",\"correlation_id\":" +
                                         "\"f11508ab-067f-40d4-83cb-ccc67bf57e45\"}";
 
-        public static string GetDefaultTokenResponse(string accessToken = TestConstants.ATSecret)
+        public static string GetDefaultTokenResponse(string accessToken = TestConstants.ATSecret, string refreshToken = TestConstants.RTSecret)
         {
               return
             "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"refresh_in\":\"2400\",\"scope\":" +
             "\"r1/scope1 r1/scope2\",\"access_token\":\"" + accessToken + "\"" +
-            ",\"refresh_token\":\"" + Guid.NewGuid() + "\",\"client_info\"" +
+            ",\"refresh_token\":\"" + refreshToken + "\",\"client_info\"" +
             ":\"" + CreateClientInfo() + "\",\"id_token\"" +
             ":\"" + CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId) + "\"}";
         }
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return
           "{\"token_type\":\"pop\",\"expires_in\":\"3599\",\"scope\":" +
           "\"r1/scope1 r1/scope2\",\"access_token\":\"" + TestConstants.ATSecret + "\"" +
-          ",\"refresh_token\":\"" + Guid.NewGuid() + "\",\"client_info\"" +
+          ",\"refresh_token\":\"" + TestConstants.RTSecret + "\",\"client_info\"" +
           ":\"" + CreateClientInfo() + "\",\"id_token\"" +
           ":\"" + CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId) +
           "\",\"id_token_expires_in\":\"3600\"}";
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return
             "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"refresh_in\":\"2400\",\"scope\":" +
             "\"r1/scope1 r1/scope2\",\"access_token\":\"" + TestConstants.ATSecret + "\"" +
-            ",\"refresh_token\":\"" + Guid.NewGuid() + "\",\"client_info\"" +
+            ",\"refresh_token\":\"" + TestConstants.RTSecret + "\",\"client_info\"" +
             ":\"" + CreateClientInfo() + "\",\"id_token\"" +
             ":\"" + CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId) +
             "\",\"spa_code\":\"" + spaCode + "\"" +
@@ -92,7 +92,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return
             "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"refresh_in\":\"2400\",\"scope\":" +
             "\"r1/scope1 r1/scope2\",\"access_token\":\"" + TestConstants.ATSecret + "\"" +
-            ",\"refresh_token\":\"" + Guid.NewGuid() + "\",\"client_info\"" +
+            ",\"refresh_token\":\"" + TestConstants.RTSecret + "\",\"client_info\"" +
             ":\"" + CreateClientInfo() + "\",\"id_token\"" +
             ":\"" + CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId) +
             "\",\"spa_accountId\":\"" + spaAccountId + "\"" +
@@ -193,10 +193,10 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 scopes, idToken, clientInfo));
         }
 
-        public static HttpResponseMessage CreateSuccessTokenResponseMessage(bool foci = false, string accessToken = TestConstants.ATSecret)
+        public static HttpResponseMessage CreateSuccessTokenResponseMessage(bool foci = false, string accessToken = TestConstants.ATSecret, string refreshToken = TestConstants.RTSecret)
         {
             return CreateSuccessResponseMessage(
-                foci ? GetFociTokenResponse() : GetDefaultTokenResponse(accessToken));
+                foci ? GetFociTokenResponse() : GetDefaultTokenResponse(accessToken, refreshToken));
         }
 
         public static HttpResponseMessage CreateSuccessTokenResponseMessageWithUid(

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/CacheSerializationTests.cs
@@ -608,18 +608,20 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public void TestSerializeContainsNoNulls()
         {
+            var prefix = $"_SOMERANDOMPREFIX";
             var accessor = CreateTokenCacheAccessor();
 
             // Create a refresh token with a null family id in it
             var item = CreateRefreshTokenItem();
             item.FamilyId = null;
-            item.Environment += $"_SOMERANDOMPREFIX"; // ensure we get unique cache keys
+            item.Environment += prefix; // ensure we get unique cache keys
             accessor.SaveRefreshToken(item);
 
             var s1 = new TokenCacheJsonSerializer(accessor);
             byte[] bytes = s1.Serialize(null);
             string json = CoreHelpers.ByteArrayToString(bytes);
-            Console.WriteLine(json);
+
+            Assert.IsTrue(json.Contains(prefix));
             Assert.IsFalse(json.ToLowerInvariant().Contains("null"));
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1597,7 +1597,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             var longRunningOboBuilder = ((ILongRunningWebApi)app).InitiateLongRunningProcessInWebApi(
                                TestConstants.s_scope.ToArray(),
                                TestConstants.DefaultClientAssertion,
-                               ref oboCacheKey);
+                               ref oboCacheKey)
+                .WithSearchInCache();
             PublicClientApplicationTests.CheckBuilderCommonMethods(longRunningOboBuilder);
 
             longRunningOboBuilder = ((ILongRunningWebApi)app).AcquireTokenInLongRunningProcess(

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1598,7 +1598,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                TestConstants.s_scope.ToArray(),
                                TestConstants.DefaultClientAssertion,
                                ref oboCacheKey)
-                .WithSearchInCache();
+                .WithSearchInCacheForLongRunningProcess();
             PublicClientApplicationTests.CheckBuilderCommonMethods(longRunningOboBuilder);
 
             longRunningOboBuilder = ((ILongRunningWebApi)app).AcquireTokenInLongRunningProcess(

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
@@ -347,6 +347,7 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             }
         }
 
+        // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4124
         [TestMethod]
         public async Task InitiateLongRunningObo_WithIgnoreCachedAssertion_TestAsync()
         {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/OBOTests.cs
@@ -366,24 +366,19 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 var result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, TestConstants.DefaultAccessToken, ref oboCacheKey)
                     .ExecuteAsync().ConfigureAwait(false);
 
-                Assert.AreEqual(TestConstants.ATSecret, result.AccessToken);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-                MsalAccessTokenCacheItem cachedAccessToken = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
-                MsalRefreshTokenCacheItem cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
-                Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
-                Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
-                Assert.AreEqual(CacheRefreshReason.NoCachedAccessToken, result.AuthenticationResultMetadata.CacheRefreshReason);
-                userCacheAccess.AssertAccessCounts(1, 1);
+                Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
+                userCacheAccess.AssertAccessCounts(0, 1);
 
                 // Initiate with different user assertion and IgnoreCachedAssertion flag
                 // MSAL will not match on the assertion and return cached token
                 result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, $"{TestConstants.DefaultAccessToken}2", ref oboCacheKey)
-                    .WithSearchInCache()
+                    .WithSearchInCacheForLongRunningProcess()
                     .ExecuteAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
-                userCacheAccess.AssertAccessCounts(2, 1);
+                userCacheAccess.AssertAccessCounts(1, 1);
 
                 AddMockHandlerAadSuccess(httpManager,
                     responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(accessToken: TestConstants.ATSecret2, refreshToken: TestConstants.RTSecret2),
@@ -393,19 +388,59 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
                 // Initiate with different user assertion and IgnoreCachedAssertion flag
                 // MSAL will not match on the assertion, find expired cached token, and use cached refresh token
                 result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, $"{TestConstants.DefaultAccessToken}2", ref oboCacheKey)
-                    .WithSearchInCache()
+                    .WithSearchInCacheForLongRunningProcess()
                     .ExecuteAsync().ConfigureAwait(false);
 
                 Assert.AreEqual(TestConstants.ATSecret2, result.AccessToken);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-                cachedAccessToken = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
-                cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
+                MsalAccessTokenCacheItem cachedAccessToken = cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
+                MsalRefreshTokenCacheItem cachedRefreshToken = cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Single();
                 Assert.AreEqual(oboCacheKey, cachedAccessToken.OboCacheKey);
                 Assert.AreEqual(oboCacheKey, cachedRefreshToken.OboCacheKey);
                 Assert.AreEqual(TestConstants.ATSecret2, cachedAccessToken.Secret);
                 Assert.AreEqual(TestConstants.RTSecret2, cachedRefreshToken.Secret);
                 Assert.AreEqual(CacheRefreshReason.Expired, result.AuthenticationResultMetadata.CacheRefreshReason);
-                userCacheAccess.AssertAccessCounts(3, 2);
+                userCacheAccess.AssertAccessCounts(2, 2);
+            }
+        }
+
+        [TestMethod]
+        public async Task InitiateLongRunningObo_WithIgnoreCachedAssertionAndWithForceRefresh_TestAsync()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                AddMockHandlerAadSuccess(httpManager);
+
+                var cca = BuildCCA(httpManager);
+
+                var userCacheAccess = cca.UserTokenCache.RecordAccess();
+
+                string oboCacheKey = null;
+
+                // Token's not in the cache, searched by user assertion hash, retrieved from IdP, saved with the provided OBO cache key
+                var result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, TestConstants.DefaultAccessToken, ref oboCacheKey)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
+                userCacheAccess.AssertAccessCounts(0, 1);
+
+                AddMockHandlerAadSuccess(httpManager,
+                    responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(accessToken: TestConstants.ATSecret2, refreshToken: TestConstants.RTSecret2),
+                    expectedPostData: new Dictionary<string, string> { { OAuth2Parameter.GrantType, OAuth2GrantType.RefreshToken } });
+
+                // Initiate with different user assertion; and IgnoreCachedAssertion and ForceRefresh flags
+                // MSAL will not return a cached AT, but use RT to refresh
+                result = await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, $"{TestConstants.DefaultAccessToken}2", ref oboCacheKey)
+                    .WithSearchInCacheForLongRunningProcess()
+                    .WithForceRefresh(true)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(CacheRefreshReason.ForceRefreshOrClaims, result.AuthenticationResultMetadata.CacheRefreshReason);
+                userCacheAccess.AssertAccessCounts(1, 2);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
@@ -599,7 +599,8 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                 case AcquireTokenSilentOutcome.SuccessViaRefreshGrant:
                     // let's remove the AT so that they can't be used 
                     _app.UserTokenCacheInternal.Accessor.ClearAccessTokens();
-                    tokenRequest = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityUtidTenant);
+                    tokenRequest = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityUtidTenant,
+                        responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(refreshToken: Guid.NewGuid().ToString()));
                     authResult = await request
                       .ExecuteAsync()
                       .ConfigureAwait(false);
@@ -607,7 +608,8 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
 
                     break;
                 case AcquireTokenSilentOutcome.SuccessViaCacheRefresh:
-                    tokenRequest = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityUtidTenant);
+                    tokenRequest = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityUtidTenant,
+                        responseMessage: MockHelpers.CreateSuccessTokenResponseMessage(refreshToken: Guid.NewGuid().ToString()));
                     authResult = await request
                       .ExecuteAsync()
                       .ConfigureAwait(false);


### PR DESCRIPTION
Fixes #4124
Related to #4111

**Changes proposed in this request**
Adds new API `WithSearchInCacheForLongRunningProcess`.
Only affects `InitiateLongRunningProcessInWebApi`.
When enabled, mimics MSAL 4.50.0 and below behavior - checks in cache for cached tokens.
When disabled (default behavior), doesn't search in cache, but uses the user assertion to retrieve tokens from AAD.

**Testing**
Unit test. Manual.

**Performance impact**

**Documentation**
- [x] All relevant documentation is updated.
