### PR TITLE
[Suggestion] Fix two issues with dSTS authority, one when using WithTenantId, and …

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -274,11 +274,23 @@ namespace Microsoft.Identity.Client
                     MsalErrorMessage.TenantOverrideNonAad);
             }
 
-            AadAuthority aadAuthority = (AadAuthority)ServiceBundle.Config.Authority;
-            string tenantedAuthority = aadAuthority.GetTenantedAuthority(tenantId, true);
-            var newAuthorityInfo = AuthorityInfo.FromAadAuthority(
-                tenantedAuthority,
-                ServiceBundle.Config.Authority.AuthorityInfo.ValidateAuthority);
+            AuthorityInfo newAuthorityInfo;
+            if (ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType == AuthorityType.Dsts)
+            {
+                DstsAuthority dSTSAuthority = (DstsAuthority)ServiceBundle.Config.Authority;
+                string tenantedAuthority = dSTSAuthority.GetTenantedAuthority(tenantId, true);
+                newAuthorityInfo = AuthorityInfo.FromDstsAuthority(
+                    tenantedAuthority,
+                    ServiceBundle.Config.Authority.AuthorityInfo.ValidateAuthority);
+            }
+            else
+            {
+                AadAuthority aadAuthority = (AadAuthority)ServiceBundle.Config.Authority;
+                string tenantedAuthority = aadAuthority.GetTenantedAuthority(tenantId, true);
+                newAuthorityInfo = AuthorityInfo.FromAadAuthority(
+                    tenantedAuthority,
+                    ServiceBundle.Config.Authority.AuthorityInfo.ValidateAuthority);
+            }
 
             CommonParameters.AuthorityOverride = newAuthorityInfo;
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -274,23 +274,13 @@ namespace Microsoft.Identity.Client
                     MsalErrorMessage.TenantOverrideNonAad);
             }
 
-            AuthorityInfo newAuthorityInfo;
-            if (ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType == AuthorityType.Dsts)
-            {
-                DstsAuthority dSTSAuthority = (DstsAuthority)ServiceBundle.Config.Authority;
-                string tenantedAuthority = dSTSAuthority.GetTenantedAuthority(tenantId, true);
-                newAuthorityInfo = AuthorityInfo.FromDstsAuthority(
-                    tenantedAuthority,
-                    ServiceBundle.Config.Authority.AuthorityInfo.ValidateAuthority);
-            }
-            else
-            {
-                AadAuthority aadAuthority = (AadAuthority)ServiceBundle.Config.Authority;
-                string tenantedAuthority = aadAuthority.GetTenantedAuthority(tenantId, true);
-                newAuthorityInfo = AuthorityInfo.FromAadAuthority(
-                    tenantedAuthority,
-                    ServiceBundle.Config.Authority.AuthorityInfo.ValidateAuthority);
-            }
+            Authority originalAuthority = ServiceBundle.Config.Authority;
+            string tenantedAuthority = originalAuthority.GetTenantedAuthority(tenantId, true);
+
+            var newAuthorityInfo = new AuthorityInfo(
+                originalAuthority.AuthorityInfo.AuthorityType,
+                tenantedAuthority,
+                originalAuthority.AuthorityInfo.ValidateAuthority);
 
             CommonParameters.AuthorityOverride = newAuthorityInfo;
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Identity.Client
 
         internal bool IsUserAssertionSupported => AuthorityType != AuthorityType.Adfs && AuthorityType != AuthorityType.B2C;
 
-        internal bool IsTenantOverrideSupported => AuthorityType == AuthorityType.Aad;
+        internal bool IsTenantOverrideSupported => AuthorityType == AuthorityType.Aad || AuthorityType == AuthorityType.Dsts;
         internal bool IsMultiTenantSupported => AuthorityType != AuthorityType.Adfs;
         internal bool IsClientInfoSupported => AuthorityType == AuthorityType.Aad || AuthorityType == AuthorityType.Dsts || AuthorityType == AuthorityType.B2C;
 
@@ -236,6 +236,11 @@ namespace Microsoft.Identity.Client
         internal static AuthorityInfo FromAdfsAuthority(string authorityUri, bool validateAuthority)
         {
             return new AuthorityInfo(AuthorityType.Adfs, authorityUri, validateAuthority);
+        }
+
+        internal static AuthorityInfo FromDstsAuthority(string authorityUri, bool validateAuthority)
+        {
+            return new AuthorityInfo(AuthorityType.Dsts, authorityUri, validateAuthority);
         }
 
         internal static AuthorityInfo FromB2CAuthority(string authorityUri)

--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -136,11 +136,25 @@ namespace Microsoft.Identity.Client
 
         internal bool IsInstanceDiscoverySupported => AuthorityType == AuthorityType.Aad;
 
-        internal bool IsUserAssertionSupported => AuthorityType != AuthorityType.Adfs && AuthorityType != AuthorityType.B2C;
+        internal bool IsUserAssertionSupported => 
+            AuthorityType != AuthorityType.Adfs && 
+            AuthorityType != AuthorityType.B2C;
 
-        internal bool IsTenantOverrideSupported => AuthorityType == AuthorityType.Aad || AuthorityType == AuthorityType.Dsts;
-        internal bool IsMultiTenantSupported => AuthorityType != AuthorityType.Adfs;
-        internal bool IsClientInfoSupported => AuthorityType == AuthorityType.Aad || AuthorityType == AuthorityType.Dsts || AuthorityType == AuthorityType.B2C;
+        internal bool IsTenantOverrideSupported => 
+            AuthorityType == AuthorityType.Aad || 
+            AuthorityType == AuthorityType.Dsts;
+
+        internal bool IsMultiTenantSupported => 
+            AuthorityType == AuthorityType.Aad  ||
+            AuthorityType == AuthorityType.Dsts ||
+            AuthorityType == AuthorityType.B2C  ||
+            AuthorityType == AuthorityType.Ciam;
+
+        internal bool IsClientInfoSupported =>
+            AuthorityType == AuthorityType.Aad ||
+            AuthorityType == AuthorityType.Dsts ||
+            AuthorityType == AuthorityType.B2C ||
+            AuthorityType == AuthorityType.Ciam;
 
         #region Builders
         internal static AuthorityInfo FromAuthorityUri(string authorityUri, bool validateAuthority)
@@ -228,19 +242,9 @@ namespace Microsoft.Identity.Client
             return new AuthorityInfo(AuthorityType.Aad, authorityUri, validateAuthority);
         }
 
-        internal static AuthorityInfo FromAadAuthority(string authorityUri, bool validateAuthority)
-        {
-            return new AuthorityInfo(AuthorityType.Aad, authorityUri, validateAuthority);
-        }
-
         internal static AuthorityInfo FromAdfsAuthority(string authorityUri, bool validateAuthority)
         {
             return new AuthorityInfo(AuthorityType.Adfs, authorityUri, validateAuthority);
-        }
-
-        internal static AuthorityInfo FromDstsAuthority(string authorityUri, bool validateAuthority)
-        {
-            return new AuthorityInfo(AuthorityType.Dsts, authorityUri, validateAuthority);
         }
 
         internal static AuthorityInfo FromB2CAuthority(string authorityUri)

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -104,8 +104,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string ADFSAuthority2 = "https://someAdfs.com/adfs/";
 
         public const string DstsAuthorityTenantless = "https://some.url.dsts.core.azure-test.net/dstsv2/";
-        public const string DstsAuthorityTenanted = "https://some.url.dsts.core.azure-test.net/dstsv2/" + TenantId;
-        public const string DstsAuthorityCommon = "https://some.url.dsts.core.azure-test.net/dstsv2/" + Common;
+        public const string DstsAuthorityTenanted = "https://some.url.dsts.core.azure-test.net/dstsv2/" + TenantId + "/";
+        public const string DstsAuthorityCommon = "https://some.url.dsts.core.azure-test.net/dstsv2/" + Common + "/";
 
         public const string B2CLoginGlobal = ".b2clogin.com";
         public const string B2CLoginUSGov = ".b2clogin.us";

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string ADFSAuthority2 = "https://someAdfs.com/adfs/";
 
         public const string DstsAuthorityTenantless = "https://some.url.dsts.core.azure-test.net/dstsv2/";
-        public const string DstsAuthorityTenanted = "https://some.url.dsts.core.azure-test.net/dstsv2/" + TenantIdString;
+        public const string DstsAuthorityTenanted = "https://some.url.dsts.core.azure-test.net/dstsv2/" + TenantId;
         public const string DstsAuthorityCommon = "https://some.url.dsts.core.azure-test.net/dstsv2/" + Common;
 
         public const string B2CLoginGlobal = ".b2clogin.com";

--- a/tests/Microsoft.Identity.Test.Common/TestData.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestData.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Test.Common
             yield return new AuthorityWithExpectedTenantId { Authority = new Uri(TestConstants.AuthorityTestTenant), ExpectedTenantId = TestConstants.Utid }.ToObjectArray();
             yield return new AuthorityWithExpectedTenantId { Authority = new Uri(TestConstants.AadAuthorityWithTestTenantId), ExpectedTenantId = TestConstants.AadTenantId }.ToObjectArray();
             yield return new AuthorityWithExpectedTenantId { Authority = new Uri(TestConstants.AuthorityWindowsNet), ExpectedTenantId = TestConstants.Utid }.ToObjectArray();
-            yield return new AuthorityWithExpectedTenantId { Authority = new Uri(TestConstants.DstsAuthorityTenanted), ExpectedTenantId = TestConstants.TenantIdString }.ToObjectArray();
+            yield return new AuthorityWithExpectedTenantId { Authority = new Uri(TestConstants.DstsAuthorityTenanted), ExpectedTenantId = TestConstants.TenantId }.ToObjectArray();
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -76,25 +76,7 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
             Assert.AreEqual(ex1.ErrorCode, MsalError.TenantOverrideNonAad);
             Assert.AreEqual(ex2.ErrorCode, MsalError.TenantOverrideNonAad);
         }
-
-        [TestMethod]
-        public void DstsAuthority_WithTenantId_Success()
-        {
-            var app = ConfidentialClientApplicationBuilder
-                .Create(TestConstants.ClientId)
-                .WithAuthority(TestConstants.DstsAuthorityTenanted)
-                .WithClientSecret("secret")
-                .Build();
-
-            var parameterBuilder = app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, "code")
-                    .WithTenantId(TestConstants.TenantId);
-
-            // Verify Host still matches the original Authority
-            Assert.AreEqual(new Uri(TestConstants.DstsAuthorityTenanted).Host, parameterBuilder.CommonParameters.AuthorityOverride.Host);
-
-            // Verify the Tenant Id matches
-            Assert.AreEqual(TestConstants.TenantId, AuthorityHelpers.GetTenantId(parameterBuilder.CommonParameters.AuthorityOverride.CanonicalAuthority));
-        }
+       
 
         [DataTestMethod]
         [DynamicData(nameof(TestData.GetAuthorityWithExpectedTenantId), typeof(TestData), DynamicDataSourceType.Method)]

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSubstitute.ReceivedExtensions;
 
 namespace Microsoft.Identity.Test.Unit.ApiConfigTests
 {
@@ -76,6 +75,25 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
 
             Assert.AreEqual(ex1.ErrorCode, MsalError.TenantOverrideNonAad);
             Assert.AreEqual(ex2.ErrorCode, MsalError.TenantOverrideNonAad);
+        }
+
+        [TestMethod]
+        public void DstsAuthority_WithTenantId_Success()
+        {
+            var app = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithAuthority(TestConstants.DstsAuthorityTenanted)
+                .WithClientSecret("secret")
+                .Build();
+
+            var parameterBuilder = app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, "code")
+                    .WithTenantId(TestConstants.TenantId);
+
+            // Verify Host still matches the original Authority
+            Assert.AreEqual(new Uri(TestConstants.DstsAuthorityTenanted).Host, parameterBuilder.CommonParameters.AuthorityOverride.Host);
+
+            // Verify the Tenant Id matches
+            Assert.AreEqual(TestConstants.TenantId, AuthorityHelpers.GetTenantId(parameterBuilder.CommonParameters.AuthorityOverride.CanonicalAuthority));
         }
 
         [DataTestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/DstsAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/DstsAuthorityTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 {
@@ -81,6 +82,46 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
             }
+        }
+
+        [TestMethod]
+        public void DstsAuthorityFlags()
+        {
+            var app = ConfidentialClientApplicationBuilder
+               .Create(TestConstants.ClientId)
+               .WithAuthority(TestConstants.DstsAuthorityTenanted)
+               .WithClientSecret("secret")
+               .Build();
+
+            Assert.AreEqual(AuthorityType.Dsts, (app.AppConfig as ApplicationConfiguration).Authority.AuthorityInfo.AuthorityType);
+
+            Assert.IsTrue((app.AppConfig as ApplicationConfiguration).Authority.AuthorityInfo.IsMultiTenantSupported);
+            Assert.IsTrue((app.AppConfig as ApplicationConfiguration).Authority.AuthorityInfo.IsClientInfoSupported);
+            Assert.IsFalse((app.AppConfig as ApplicationConfiguration).Authority.AuthorityInfo.IsInstanceDiscoverySupported);
+            Assert.IsTrue((app.AppConfig as ApplicationConfiguration).Authority.AuthorityInfo.IsTenantOverrideSupported);
+            Assert.IsTrue((app.AppConfig as ApplicationConfiguration).Authority.AuthorityInfo.IsUserAssertionSupported);
+        }
+
+        [TestMethod]
+        public void DstsAuthority_WithTenantId_Success()
+        {
+            var app = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithAuthority(TestConstants.DstsAuthorityTenanted)
+                .WithClientSecret("secret")
+                .Build();
+
+            Assert.AreEqual(TestConstants.DstsAuthorityTenanted, app.Authority);
+
+            // change the tenant id
+            var parameterBuilder = app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, "code")
+                    .WithTenantId(TestConstants.TenantId2);
+
+            // Verify Host still matches the original Authority
+            Assert.AreEqual(new Uri(TestConstants.DstsAuthorityTenanted).Host, parameterBuilder.CommonParameters.AuthorityOverride.Host);
+
+            // Verify the Tenant Id matches
+            Assert.AreEqual(TestConstants.TenantId2, AuthorityHelpers.GetTenantId(parameterBuilder.CommonParameters.AuthorityOverride.CanonicalAuthority));
         }
 
         [DataTestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/DstsAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/DstsAuthorityTests.cs
@@ -118,10 +118,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 
         [TestMethod]
         public void CreateAuthorityFromTenantedWithTenantTest()
-        {
-            
+        {            
             Authority authority = AuthorityTestHelper.CreateAuthorityFromUrl(TestConstants.DstsAuthorityTenanted);
-            Assert.AreEqual("tenantid", authority.TenantId);
+            Assert.AreEqual(TestConstants.TenantId, authority.TenantId);
             
             string updatedAuthority = authority.GetTenantedAuthority("tenant2");            
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/DstsAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/DstsAuthorityTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 
             return new MockHttpMessageHandler()
             {
-                ExpectedUrl = $"{authority}/oauth2/v2.0/token",
+                ExpectedUrl = $"{authority}oauth2/v2.0/token",
                 ExpectedMethod = HttpMethod.Post,
                 ExpectedPostData = expectedRequestBody,
                 ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage(MockHelpers.CreateClientInfo(TestConstants.Uid, TestConstants.Utid))
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .Build();
 
-                Assert.AreEqual(authority + "/", app.Authority);
+                Assert.AreEqual(authority, app.Authority);
                 var confidentailClientApp = (ConfidentialClientApplication)app;
                 Assert.AreEqual(AuthorityType.Dsts, confidentailClientApp.AuthorityInfo.AuthorityType);
 
@@ -135,9 +135,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 _harness.ServiceBundle,
                 Guid.NewGuid());
 
-            Assert.AreEqual($"{authority}/oauth2/v2.0/token", instance.GetTokenEndpointAsync(_testRequestContext).Result);
-            Assert.AreEqual($"{authority}/oauth2/v2.0/authorize", instance.GetAuthorizationEndpointAsync(_testRequestContext).Result);
-            Assert.AreEqual($"{authority}/oauth2/v2.0/devicecode", instance.GetDeviceCodeEndpointAsync(_testRequestContext).Result);
+            Assert.AreEqual($"{authority}oauth2/v2.0/token", instance.GetTokenEndpointAsync(_testRequestContext).Result);
+            Assert.AreEqual($"{authority}oauth2/v2.0/authorize", instance.GetAuthorizationEndpointAsync(_testRequestContext).Result);
+            Assert.AreEqual($"{authority}oauth2/v2.0/devicecode", instance.GetDeviceCodeEndpointAsync(_testRequestContext).Result);
             Assert.AreEqual($"https://some.url.dsts.core.azure-test.net/dstsv2/common/userrealm/", instance.AuthorityInfo.UserRealmUriPrefix);
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 
             Assert.AreEqual(
                 TestConstants.DstsAuthorityTenanted,
-                updatedAuthority.TrimEnd('/'),
+                updatedAuthority,
                 "Not changed, original authority already has tenant id");
 
             string updatedAuthority2 = authority.GetTenantedAuthority("tenant2", true);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TenantIdTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TenantIdTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [DataRow(TestConstants.B2CLoginAuthorityMoonCake, TestConstants.SomeTenantId, DisplayName = "B2C MoonCake Tenant Id")]
         [DataRow(TestConstants.AuthoritySovereignCNTenant, TestConstants.TenantId, DisplayName = "Sovereign Tenant Id")]
         [DataRow(TestConstants.AuthoritySovereignDETenant, TestConstants.TenantId, DisplayName = "Sovereign Tenant Id")]
-        [DataRow(TestConstants.DstsAuthorityTenanted, "tenantid", DisplayName = "DSTS Tenant Id")]
+        [DataRow(TestConstants.DstsAuthorityTenanted, TestConstants.TenantId, DisplayName = "DSTS Tenant Id")]
         [DataRow(TestConstants.DstsAuthorityCommon, TestConstants.Common, DisplayName = "DSTS Common Tenant Id")]
         public void ParseTest_Success(string authorityUrl, string expectedTenantId)
         {


### PR DESCRIPTION
…adding dSTS as a supported tenant override. Add a test

Fixes #4144, fixes #4145 

Just a suggestion. I'm having issues running the MSAL tests, so assuming this would work. have tested E2E with Id Web and seems to be working.