### PR TITLE
Remove INCLUDE_MOBILE_AND_LEGACY_TFM from Perf builds

### DIFF
--- a/build/pipeline-perf-tests-automation.yaml
+++ b/build/pipeline-perf-tests-automation.yaml
@@ -16,7 +16,6 @@ pool:
 variables:
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'release'
-  INCLUDE_MOBILE_AND_LEGACY_TFM: 'true' # skips building mobile and legacy targets
 
 jobs:
   - job: 'BuildJob'
@@ -49,7 +48,7 @@ jobs:
         msbuildArchitecture: x64
         platform: '$(BuildPlatform)'
         configuration: '$(BuildConfiguration)'
-        msbuildArguments: '/p:RunCodeAnalysis=false /p:INCLUDE_MOBILE_AND_LEGACY_TFM =$(INCLUDE_MOBILE_AND_LEGACY_TFM )'
+        msbuildArguments: '/p:RunCodeAnalysis=false'
         clean: true
 
     # The parameters currently are not used, but can be uploaded into the reporting system in the future.

--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
-    <TargetFrameworkNetDesktop Condition="$([MSBuild]::IsOsPlatform('Windows')) and '$(INCLUDE_MOBILE_AND_LEGACY_TFM)' == ''">net461</TargetFrameworkNetDesktop>
+    <TargetFrameworkNetDesktop Condition="$([MSBuild]::IsOsPlatform('Windows'))">net461</TargetFrameworkNetDesktop>
 
     <LangVersion>8.0</LangVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
-  <!--Add MAUI_SUPPORT variable to environment when you compile MAUI. esp for.\tests\devapps\MauiApps\MauiApps.sln-->
-
   <PropertyGroup Label="Targets required for unit tests to run">
     <TargetFrameworkNetDesktop461>net461</TargetFrameworkNetDesktop461>
     <TargetFrameworkNetCore>netcoreapp2.1</TargetFrameworkNetCore>
@@ -297,7 +295,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.RulesetToEditorconfigConverter" Version="3.3.3" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNet6Android)' And '$(MAUI_SUPPORT)' != ''">
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNet6Android)'">
     <Compile Include="$(PathToMsalSources)\Platforms\Android\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
     <PackageReference Include="System.Security.SecureString" Version="4.3.0" />

--- a/tests/devapps/WAM/UWPWam/MainPage.xaml.cs
+++ b/tests/devapps/WAM/UWPWam/MainPage.xaml.cs
@@ -17,7 +17,6 @@ using System.Text;
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 namespace UWP_standalone
 {
-#pragma warning disable CS0618 // Type or member is obsolete
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>


### PR DESCRIPTION
INCLUDE_MOBILE_AND_LEGACY_TFM is triggering the Mobile workloads, hence removing it 