### PR TITLE
Disable CodeQL

### DIFF
--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -24,8 +24,7 @@ jobs: #Build and stage projects
       - msbuild
       - visualstudio
   variables:
-      Codeql.Enabled: true
-      Codeql.Language: csharp
+      Codeql.SkipTaskAutoInjection: true
 
   steps:
   # Bootstrap the build


### PR DESCRIPTION
Disable CodeQL in the classic pipeline, since it runs in the other one. Make sure to skip the auto-injected task, since it's unnecessary.