### PR TITLE
Trigger OneBranch CI when github main gets updated

### DIFF
--- a/.github/workflows/trigger_onebranch_ci.yml
+++ b/.github/workflows/trigger_onebranch_ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+# Run this workflow every time a commit gets pushed to main
+# This triggers the ADO OneBranch CI Pipeline
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+    build:
+        name: Call OneBranch ADO Pipeline (CI)
+        runs-on: ubuntu-latest
+        steps:
+        - name: Azure Pipelines Action
+          uses: Azure/pipelines@v1
+          with:
+            azure-devops-project-url: https://identitydivision.visualstudio.com/IDDP
+            azure-pipeline-name: 'MSAL.NET-OneBranch-Release-Official'
+            azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}


### PR DESCRIPTION
Trigger OneBranch CI when github main gets updated. this uses the `AZURE_DEVOPS_TOKEN` variable. `AZURE_DEVOPS_TOKEN` holds the ADO PAT

Reference : https://learn.microsoft.com/en-us/azure/devops/pipelines/ecosystems/github-actions?view=azure-devops