### PR TITLE
Updated tests after migrating test subscription to new Dogfood tenant

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OnBehalfOfServicePrincipalTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OnBehalfOfServicePrincipalTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private const string OBOClientPpeClientID = "9793041b-9078-4942-b1d2-babdc472cc0c";
         private const string OBOServicePpeClientID = "c84e9c32-0bc9-4a73-af05-9efe9982a322";
         private const string OBOServiceDownStreamApiPpeClientID = "23d08a1e-1249-4f7c-b5a5-cb11f29b6923";
-        private const string PPEAuthenticationAuthority = "https://login.windows-ppe.net/f686d426-8d16-42db-81b7-ab578e110ccd";
+        private const string PPEAuthenticationAuthority = "https://login.windows-ppe.net/94430a9c-83e9-4f08-bbb0-64fccd0661fc";
 
         /// <summary>
         /// Client -> Middletier -> RP

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OnBehalfOfServicePrincipalTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OnBehalfOfServicePrincipalTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private const string OBOClientPpeClientID = "9793041b-9078-4942-b1d2-babdc472cc0c";
         private const string OBOServicePpeClientID = "c84e9c32-0bc9-4a73-af05-9efe9982a322";
         private const string OBOServiceDownStreamApiPpeClientID = "23d08a1e-1249-4f7c-b5a5-cb11f29b6923";
-        private const string PPEAuthenticationAuthority = "https://login.windows-ppe.net/94430a9c-83e9-4f08-bbb0-64fccd0661fc";
+        private const string PPEAuthenticationAuthority = "https://login.windows-ppe.net/f686d426-8d16-42db-81b7-ab578e110ccd";
 
         /// <summary>
         /// Client -> Middletier -> RP

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/WwwAuthenticateParametersIntegrationTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         [TestMethod]
         public async Task CreateWwwAuthenticateResponseFromKeyVaultUrlAsync()
         {
-
             var authParams = await WwwAuthenticateParameters.CreateFromResourceResponseAsync("https://buildautomation.vault.azure.net/secrets/CertName/CertVersion").ConfigureAwait(false);
 
             Assert.AreEqual("login.microsoftonline.com", new Uri(authParams.Authority).Host);
@@ -61,7 +60,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         /// <param name="tenantId">Expected Tenant ID</param>
         [TestMethod]
         [DataRow("management.azure.com", "c1686c51-b717-4fe0-9af3-24a20a41fb0c", "login.windows.net", "72f988bf-86f1-41af-91ab-2d7cd011db47")]
-        [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "f686d426-8d16-42db-81b7-ab578e110ccd")]
+        [DataRow("api-dogfood.resources.windows-int.net", "1835ad3d-4585-4c5f-b55a-b0c3cbda1103", "login.windows-ppe.net", "94430a9c-83e9-4f08-bbb0-64fccd0661fc")]
         public async Task CreateWwwAuthenticateResponseFromAzureResourceManagerUrlAsync(string hostName, string subscriptionId, string authority, string tenantId)
         {
             const string apiVersion = "2020-08-01"; // current latest API version for /subscriptions/get

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Infrastructure/ConfidentialAppSettings.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
             public Cloud Cloud => Cloud.Public;
 
             public bool UseAppIdUri { get; set; }
+
             public bool InstanceDiscoveryEndpoint { get; set; } = true;
 
             public X509Certificate2 GetCertificate()
@@ -104,7 +105,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
         {
             public string ClientId => UseAppIdUri? "api://microsoft.identity.9793041b-9078-4942-b1d2-babdc472cc0c" : "9793041b-9078-4942-b1d2-babdc472cc0c";
 
-            public string TenantId => "f686d426-8d16-42db-81b7-ab578e110ccd";
+            public string TenantId => "94430a9c-83e9-4f08-bbb0-64fccd0661fc";
 
             public string Environment => "login.windows-ppe.net";
 
@@ -159,10 +160,13 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
 
         private static Lazy<IConfidentialAppSettings> s_publicCloudSettings =
             new Lazy<IConfidentialAppSettings>(() => new PublicCloudConfidentialAppSettings());
+        
         private static Lazy<IConfidentialAppSettings> s_ppeCloudSettings =
             new Lazy<IConfidentialAppSettings>(() => new PpeConfidentialAppSettings());
+        
         private static Lazy<IConfidentialAppSettings> s_arlingtonCloudSettings =
             new Lazy<IConfidentialAppSettings>(() => new ArlingtonConfidentialAppSettings());
+        
         private static Lazy<IConfidentialAppSettings> s_adfsCloudSettings =
           new Lazy<IConfidentialAppSettings>(() => new AdfsConfidentialAppSettings());
 


### PR DESCRIPTION
Fixes #4281.

**Changes proposed in this request**

Updated some of the tests to replace the old tenant (Azure Dogfood) with the new tenant (Azure Control Plane Dogfood).

Ping _alexbat_ for invitation and/or permissions.

**What's not included**

The [OBO tests ](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/main/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/OnBehalfOfServicePrincipalTests.cs) as they rely on a special configuration of the SPN.

**Testing**

The change touches the tests only.

**Performance impact**

N/A

**Documentation**

N/A
