### PR TITLE
Check for null and empty scopes in managed identity

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -30,13 +30,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         protected override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(_managedIdentityParameters.Resource))
-            {
-                throw new MsalClientException(
-                    MsalError.ScopesRequired,
-                    MsalErrorMessage.ScopesRequired);
-            }
-
             AuthenticationResult authResult = null;
             ILoggerAdapter logger = AuthenticationRequestParameters.RequestContext.Logger;
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -47,9 +47,7 @@ namespace Microsoft.Identity.Client
         {
             if (string.IsNullOrEmpty(resource))
             {
-                throw new MsalClientException(
-                    MsalError.ManagedIdentityScopesRequired,
-                    MsalErrorMessage.ScopesRequired);
+                throw new ArgumentNullException(nameof(resource));
             }
 
             return AcquireTokenForManagedIdentityParameterBuilder.Create(

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Identity.Client
         /// <inheritdoc/>
         public AcquireTokenForManagedIdentityParameterBuilder AcquireTokenForManagedIdentity(string resource)
         {
+            if (string.IsNullOrEmpty(resource))
+            {
+                throw new MsalClientException(
+                    MsalError.ManagedIdentityScopesRequired,
+                    MsalErrorMessage.ScopesRequired);
+            }
+
             return AcquireTokenForManagedIdentityParameterBuilder.Create(
                 ClientExecutorFactory.CreateManagedIdentityExecutor(this),
                 resource);

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -855,12 +855,6 @@ namespace Microsoft.Identity.Client
         public const string ScopesRequired = "scopes_required_client_credentials";
 
         /// <summary>
-        /// <para>What happens?</para>No scopes have been requested
-        /// <para>Mitigation</para>At least one scope must be specified for this authentication flow
-        /// </summary>
-        public const string ManagedIdentityScopesRequired = "scopes_required_managed_identity";
-
-        /// <summary>
         /// <para>What happens?</para>The certificate provided does not have a private key.
         /// <para>Mitigation</para>Ensure the certificate has a private key.
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -855,6 +855,12 @@ namespace Microsoft.Identity.Client
         public const string ScopesRequired = "scopes_required_client_credentials";
 
         /// <summary>
+        /// <para>What happens?</para>No scopes have been requested
+        /// <para>Mitigation</para>At least one scope must be specified for this authentication flow
+        /// </summary>
+        public const string ManagedIdentityScopesRequired = "scopes_required_managed_identity";
+
+        /// <summary>
         /// <para>What happens?</para>The certificate provided does not have a private key.
         /// <para>Mitigation</para>Ensure the certificate has a private key.
         /// </summary>

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -303,6 +303,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataTestMethod]
         [DataRow("", ManagedIdentitySource.AppService, AppServiceEndpoint)]
         [DataRow(null, ManagedIdentitySource.AppService, AppServiceEndpoint)]
+        [ExpectedException(typeof(ArgumentNullException))]
         public async Task ManagedIdentityTestNullOrEmptyScopeAsync(string resource, ManagedIdentitySource managedIdentitySource, string endpoint)
         {
             using (new EnvVariableContext())
@@ -310,16 +311,11 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             {
                 SetEnvironmentVariables(managedIdentitySource, endpoint);
 
-                var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
-                    .WithHttpManager(httpManager);
+                var mi = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager).Build();
 
-                var mi = miBuilder.Build();
-
-                ArgumentNullException ex = await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
-                    await mi.AcquireTokenForManagedIdentity(resource)
-                    .ExecuteAsync().ConfigureAwait(false)).ConfigureAwait(false);
-
-                Assert.IsNotNull(ex);
+                await mi.AcquireTokenForManagedIdentity(resource)
+                    .ExecuteAsync().ConfigureAwait(false);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -305,8 +305,6 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(null, ManagedIdentitySource.AppService, AppServiceEndpoint)]
         public async Task ManagedIdentityTestNullOrEmptyScopeAsync(string resource, ManagedIdentitySource managedIdentitySource, string endpoint)
         {
-            string expectedError = "Value cannot be null. (Parameter 'resource')";
-
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager(isManagedIdentity: true))
             {
@@ -322,8 +320,6 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .ExecuteAsync().ConfigureAwait(false)).ConfigureAwait(false);
 
                 Assert.IsNotNull(ex);
-                Assert.AreEqual(ex.Message, expectedError);
-
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -305,6 +305,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(null, ManagedIdentitySource.AppService, AppServiceEndpoint)]
         public async Task ManagedIdentityTestNullOrEmptyScopeAsync(string resource, ManagedIdentitySource managedIdentitySource, string endpoint)
         {
+            string expectedError = "Value cannot be null. (Parameter 'resource')";
+
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager(isManagedIdentity: true))
             {
@@ -315,12 +317,13 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
-                MsalClientException ex = await Assert.ThrowsExceptionAsync<MsalClientException>(async () =>
+                ArgumentNullException ex = await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
                     await mi.AcquireTokenForManagedIdentity(resource)
                     .ExecuteAsync().ConfigureAwait(false)).ConfigureAwait(false);
 
                 Assert.IsNotNull(ex);
-                Assert.AreEqual(MsalError.ManagedIdentityScopesRequired, ex.ErrorCode);
+                Assert.AreEqual(ex.Message, expectedError);
+
             }
         }
 


### PR DESCRIPTION
Fixes #4332.
Check for null and empty scopes in managed identity