### PR TITLE
Fix for WAM Runtime error logs duplicated info

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Features/RuntimeBroker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/RuntimeBroker/RuntimeBroker.cs
@@ -200,7 +200,6 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenInteractiveParameters acquireTokenInteractiveParameters)
         {
-            using LogEventWrapper logEventWrapper = new LogEventWrapper(this);
             MsalTokenResponse msalTokenResponse = null;
             var cancellationToken = authenticationRequestParameters.RequestContext.UserCancellationToken;
             Debug.Assert(s_lazyCore.Value != null, "Should not call this API if MSAL runtime init failed");
@@ -235,7 +234,6 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenInteractiveParameters acquireTokenInteractiveParameters)
         {
-            using LogEventWrapper logEventWrapper = new LogEventWrapper(this);
             Debug.Assert(s_lazyCore.Value != null, "Should not call this API if MSAL runtime init failed");
 
             MsalTokenResponse msalTokenResponse = null;

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/RuntimeBroker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/RuntimeBroker/RuntimeBroker.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
             return msalTokenResponse;
         }
 
-        public async Task<MsalTokenResponse> SignInInteractivelyAsync(
+        private async Task<MsalTokenResponse> SignInInteractivelyAsync(
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenInteractiveParameters acquireTokenInteractiveParameters)
         {
@@ -230,7 +230,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
             return msalTokenResponse;
         }
 
-        public async Task<MsalTokenResponse> AcquireTokenInteractiveDefaultUserAsync(
+        private async Task<MsalTokenResponse> AcquireTokenInteractiveDefaultUserAsync(
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenInteractiveParameters acquireTokenInteractiveParameters)
         {


### PR DESCRIPTION
Fixes #4353 

**Changes proposed in this request**

**Background :** LogEventWrapper helps setting up an event handler for log events from MSALRuntime.

**Fix :** Removing LogEventWrapper call from Interactive methods that gets called from the main `AcquireTokenInteractiveAsync` API call. Since `AcquireTokenInteractiveAsync` API method gets executed first every time when an Interactive request is made, Runtime logger gets invoked once, but then it (LogEventWrapper ) gets invoked again in the subsequent interactive methods. Removing the LogEventWrapper from the subsequent calls fixes the dupe issue. 

**Testing**
Dev App

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
