### PR TITLE
Add one retry to assertion signing.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netcore/NetCorePlatformProxy.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -15,12 +14,10 @@ using Microsoft.Identity.Client.AuthScheme.PoP;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.Internal.Broker;
 using Microsoft.Identity.Client.Platforms.Features.DesktopOs;
 using Microsoft.Identity.Client.Platforms.Shared.NetStdCore;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;
-using Microsoft.Identity.Client.TelemetryCore.Internal;
 using Microsoft.Identity.Client.UI;
 
 namespace Microsoft.Identity.Client.Platforms.netcore
@@ -140,7 +137,7 @@ namespace Microsoft.Identity.Client.Platforms.netcore
         }
 
         protected override IWebUIFactory CreateWebUiFactory() => new NetCoreWebUIFactory();
-        protected override ICryptographyManager InternalGetCryptographyManager() => new CommonCryptographyManager();
+        protected override ICryptographyManager InternalGetCryptographyManager() => new CommonCryptographyManager(Logger);
         protected override IPlatformLogger InternalGetPlatformLogger() => new EventSourcePlatformLogger();
 
         protected override IFeatureFlags CreateFeatureFlags() => new NetCoreFeatureFlags();

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopCryptographyManager.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopCryptographyManager.cs
@@ -3,18 +3,13 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Globalization;
 using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Permissions;
-using System.Text;
-using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.Internal.ClientCredential;
+using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Platforms.net45.Native;
-using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;
-using Microsoft.Identity.Client.Utils;
 using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.Identity.Client.Platforms.net45
@@ -27,6 +22,10 @@ namespace Microsoft.Identity.Client.Platforms.net45
     {
         private static readonly ConcurrentDictionary<string, RSACryptoServiceProvider> s_certificateToRsaCspMap = new ConcurrentDictionary<string, RSACryptoServiceProvider>();
         private static readonly int s_maximumMapSize = 1000;
+
+#if !NET45
+        public NetDesktopCryptographyManager(ILoggerAdapter logger = null) : base(logger) { }
+#endif
 #if NET45
         public string CreateBase64UrlEncodedSha256Hash(string input)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopCryptographyManager.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopCryptographyManager.cs
@@ -7,9 +7,13 @@ using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Permissions;
+using System.Text;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Platforms.net45.Native;
+using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;
+using Microsoft.Identity.Client.Utils;
 using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.Identity.Client.Platforms.net45
@@ -23,7 +27,9 @@ namespace Microsoft.Identity.Client.Platforms.net45
         private static readonly ConcurrentDictionary<string, RSACryptoServiceProvider> s_certificateToRsaCspMap = new ConcurrentDictionary<string, RSACryptoServiceProvider>();
         private static readonly int s_maximumMapSize = 1000;
 
-#if !NET45
+#if NET45
+        public NetDesktopCryptographyManager(ILoggerAdapter logger = null) { }
+#else
         public NetDesktopCryptographyManager(ILoggerAdapter logger = null) : base(logger) { }
 #endif
 #if NET45

--- a/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netdesktop/NetDesktopPlatformProxy.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Identity.Client.Platforms.net45
         }
 
         /// <inheritdoc/>
-        protected override ICryptographyManager InternalGetCryptographyManager() => new NetDesktopCryptographyManager();
+        protected override ICryptographyManager InternalGetCryptographyManager() => new NetDesktopCryptographyManager(Logger);
 
         protected override IPlatformLogger InternalGetPlatformLogger() => new EventSourcePlatformLogger();
 


### PR DESCRIPTION
Fixes #4366

**Changes proposed in this request**
Adds one retry when an `RSA.SignData` operation fails. Recreates the RSA key, in case the old one is faulted, try signing again.

**Testing**
Manual tests with multi-threaded requests.
Can't really add unit tests since the code can't be mocked.

**Performance impact**
Negligible during a successful operation.

**Documentation**
- [x] All relevant documentation is updated.
