### PR TITLE
Bump MSALRuntime Native Interop version to 0.13.12

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <!-- Projects must set this individually -->
     <IsPackable>false</IsPackable>
     <!-- Version of the Microsoft.Identity.Client.NativeInterop package. -->
-    <MSALRuntimeNativeInteropVersion>0.13.8</MSALRuntimeNativeInteropVersion>
+    <MSALRuntimeNativeInteropVersion>0.13.12</MSALRuntimeNativeInteropVersion>
     
     <!-- Version of MSAL if not defined by the CI-->
     <MsalInternalVersion>4.51.0</MsalInternalVersion>


### PR DESCRIPTION
Bug [2468329](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2468329)

Bump MSALRuntime Native Interop version to 0.13.12

Bumping Interop version for this fix, [Add check for user canceled in GetTransferToken flow #3710](https://github.com/AzureAD/microsoft-authentication-library-for-cpp/pull/3710) in msalruntime. 