### PR TITLE
Add serialization of broker error data in exceptions

### DIFF
--- a/src/client/Microsoft.Identity.Client/MsalException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalException.cs
@@ -168,10 +168,7 @@ namespace Microsoft.Identity.Client
                 innerExceptionContents);
         }
 
-        #region SERIALIZATION
-
-        // DEPRECATE / OBSOLETE - this functionality is not used and should be removed in a next major version
-
+        #region Serialization
         private class ExceptionSerializationKey
         {
             internal const string ExceptionTypeKey = "type";
@@ -191,6 +188,7 @@ namespace Microsoft.Identity.Client
             jObject[ExceptionSerializationKey.ErrorCodeKey] = ErrorCode;
             jObject[ExceptionSerializationKey.ErrorDescriptionKey] = Message;
 
+            // Populate JSON string with broker exception data
             var exceptionData = new JObject();
 
             if (AdditionalExceptionData.TryGetValue(BrokerErrorContext, out string brokerErrorContext))
@@ -219,6 +217,7 @@ namespace Microsoft.Identity.Client
 
         internal virtual void PopulateObjectFromJson(JObject jObject)
         {
+            // Populate this exception instance with broker exception data from JSON
             var exceptionData = JsonHelper.ExtractInnerJsonAsDictionary(jObject, ExceptionSerializationKey.AdditionalExceptionData);
 
             if (exceptionData.TryGetValue(ExceptionSerializationKey.BrokerErrorContext, out string brokerErrorContext))
@@ -299,6 +298,6 @@ namespace Microsoft.Identity.Client
             return ex;
         }
 
-        #endregion // SERIALIZATION
+        #endregion
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -254,9 +254,6 @@ namespace Microsoft.Identity.Client
         }
 
         #region Serialization
-
-        // DEPRECATE / OBSOLETE - this functionality is not used and should be removed in a next major version
-
         internal override void PopulateJson(JObject jObject)
         {
             base.PopulateJson(jObject);

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -257,24 +257,24 @@ namespace Microsoft.Identity.Client
 
         // DEPRECATE / OBSOLETE - this functionality is not used and should be removed in a next major version
 
-        internal override void PopulateJson(JObject jobj)
+        internal override void PopulateJson(JObject jObject)
         {
-            base.PopulateJson(jobj);
+            base.PopulateJson(jObject);
 
-            jobj[ClaimsKey] = Claims;
-            jobj[ResponseBodyKey] = ResponseBody;
-            jobj[CorrelationIdKey] = CorrelationId;
-            jobj[SubErrorKey] = SubError;
+            jObject[ClaimsKey] = Claims;
+            jObject[ResponseBodyKey] = ResponseBody;
+            jObject[CorrelationIdKey] = CorrelationId;
+            jObject[SubErrorKey] = SubError;
         }
 
-        internal override void PopulateObjectFromJson(JObject jobj)
+        internal override void PopulateObjectFromJson(JObject jObject)
         {
-            base.PopulateObjectFromJson(jobj);
+            base.PopulateObjectFromJson(jObject);
 
-            Claims = JsonHelper.GetExistingOrEmptyString(jobj, ClaimsKey);
-            ResponseBody = JsonHelper.GetExistingOrEmptyString(jobj, ResponseBodyKey);
-            CorrelationId = JsonHelper.GetExistingOrEmptyString(jobj, CorrelationIdKey);
-            SubError = JsonHelper.GetExistingOrEmptyString(jobj, SubErrorKey);
+            Claims = JsonHelper.GetExistingOrEmptyString(jObject, ClaimsKey);
+            ResponseBody = JsonHelper.GetExistingOrEmptyString(jObject, ResponseBodyKey);
+            CorrelationId = JsonHelper.GetExistingOrEmptyString(jObject, CorrelationIdKey);
+            SubError = JsonHelper.GetExistingOrEmptyString(jObject, SubErrorKey);
         }
         #endregion
     }

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         private const string BrokerErrorTag = "0x123456";
         private const string BrokerErrorStatus = "broker error status";
         private const string BrokerErrorCode = "broker error code";
-        private const string BrokerTelemetry = "broker telemetry";
+        private const string BrokerTelemetry = "{\"error-property1\": \"0\",\"error-property2\": \"abc\"}";
 
         [DataTestMethod]
         [DataRow(false)]

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Identity.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -18,36 +19,43 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         private const string SomeResponseBody = "the response body";
         private const string SomeSubError = "the_sub_error";
 
-        private void SerializeDeserializeAndValidate(MsalException ex, Type expectedType, bool isServiceExceptionDerived)
-        {
-            string json = ex.ToJsonString();
+        private const string BrokerErrorContext = "broker error context";
+        private const string BrokerErrorTag = "0x123456";
+        private const string BrokerErrorStatus = "broker error status";
+        private const string BrokerErrorCode = "broker error code";
+        private const string BrokerTelemetry = "broker telemetry";
 
-            var exDeserialized = MsalException.FromJsonString(json);
-
-            Assert.AreEqual(expectedType, exDeserialized.GetType());
-            Assert.AreEqual(ex.ErrorCode, exDeserialized.ErrorCode);
-            Assert.AreEqual(ex.Message, exDeserialized.Message);
-
-            if (isServiceExceptionDerived)
-            {
-                var svcEx = (MsalServiceException)exDeserialized;
-
-                Assert.AreEqual(SomeClaims, svcEx.Claims);
-                Assert.AreEqual(SomeResponseBody, svcEx.ResponseBody);
-                Assert.AreEqual(SomeCorrelationId, svcEx.CorrelationId);
-                Assert.AreEqual(SomeSubError, svcEx.SubError);
-            }
-        }
-
-        [TestMethod]
-        public void MsalExceptionCanSerializeAndDeserializeRoundTrip()
+        [DataTestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void MsalException_CanSerializeAndDeserializeRoundTrip(bool includeAdditionalData)
         {
             var ex = new MsalException(SomeErrorCode, SomeErrorMessage);
-            SerializeDeserializeAndValidate(ex, typeof(MsalException), false);
+
+            if (includeAdditionalData)
+            {
+                ex.AdditionalExceptionData = new Dictionary<string, string>()
+                {
+                    { MsalException.BrokerErrorContext, BrokerErrorContext },
+                    { MsalException.BrokerErrorTag, BrokerErrorTag },
+                    { MsalException.BrokerErrorStatus, BrokerErrorStatus },
+                    { MsalException.BrokerErrorCode, BrokerErrorCode },
+                    { MsalException.BrokerTelemetry, BrokerTelemetry },
+                };
+            }
+
+            SerializeDeserializeAndValidate(ex, typeof(MsalException), false, includeAdditionalData);
         }
 
         [TestMethod]
-        public void MsalServiceExceptionCanSerializeAndDeserializeRoundTrip()
+        public void MsalClientException_CanSerializeAndDeserializeRoundTrip()
+        {
+            var ex = new MsalClientException(SomeErrorCode, SomeErrorMessage);
+            SerializeDeserializeAndValidate(ex, typeof(MsalClientException), false);
+        }
+
+        [TestMethod]
+        public void MsalServiceException_CanSerializeAndDeserializeRoundTrip()
         {
             var ex = new MsalServiceException(SomeErrorCode, SomeErrorMessage)
             {
@@ -61,14 +69,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         }
 
         [TestMethod]
-        public void MsalClientExceptionCanSerializeAndDeserializeRoundTrip()
-        {
-            var ex = new MsalClientException(SomeErrorCode, SomeErrorMessage);
-            SerializeDeserializeAndValidate(ex, typeof(MsalClientException), false);
-        }
-
-        [TestMethod]
-        public void MsalUiRequiredExceptionCanSerializeAndDeserializeRoundTrip()
+        public void MsalUiRequiredException_CanSerializeAndDeserializeRoundTrip()
         {
             var ex = new MsalUiRequiredException(SomeErrorCode, SomeErrorMessage)
             {
@@ -79,6 +80,36 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
             };
 
             SerializeDeserializeAndValidate(ex, typeof(MsalUiRequiredException), true);
+        }
+
+        private void SerializeDeserializeAndValidate(MsalException ex, Type expectedType, bool isServiceExceptionDerived, bool includesAdditionalData = false)
+        {
+            string json = ex.ToJsonString();
+
+            var exDeserialized = MsalException.FromJsonString(json);
+
+            Assert.AreEqual(expectedType, exDeserialized.GetType());
+            Assert.AreEqual(ex.ErrorCode, exDeserialized.ErrorCode);
+            Assert.AreEqual(ex.Message, exDeserialized.Message);
+
+            if (includesAdditionalData)
+            {
+                Assert.AreEqual(ex.AdditionalExceptionData[MsalException.BrokerErrorContext], exDeserialized.AdditionalExceptionData[MsalException.BrokerErrorContext]);
+                Assert.AreEqual(ex.AdditionalExceptionData[MsalException.BrokerErrorTag], exDeserialized.AdditionalExceptionData[MsalException.BrokerErrorTag]);
+                Assert.AreEqual(ex.AdditionalExceptionData[MsalException.BrokerErrorStatus], exDeserialized.AdditionalExceptionData[MsalException.BrokerErrorStatus]);
+                Assert.AreEqual(ex.AdditionalExceptionData[MsalException.BrokerErrorCode], exDeserialized.AdditionalExceptionData[MsalException.BrokerErrorCode]);
+                Assert.AreEqual(ex.AdditionalExceptionData[MsalException.BrokerTelemetry], exDeserialized.AdditionalExceptionData[MsalException.BrokerTelemetry]);
+            }
+
+            if (isServiceExceptionDerived)
+            {
+                var serviceEx = (MsalServiceException)exDeserialized;
+
+                Assert.AreEqual(SomeClaims, serviceEx.Claims);
+                Assert.AreEqual(SomeResponseBody, serviceEx.ResponseBody);
+                Assert.AreEqual(SomeCorrelationId, serviceEx.CorrelationId);
+                Assert.AreEqual(SomeSubError, serviceEx.SubError);
+            }
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         [DataTestMethod]
         [DataRow(false)]
         [DataRow(true)]
-        public void MsalException_CanSerializeAndDeserializeRoundTrip(bool includeAdditionalData)
+        public void MsalException_CanSerializeAndDeserializeRoundTrip(bool includeAdditionalExceptionData)
         {
             var ex = new MsalException(SomeErrorCode, SomeErrorMessage);
 
-            if (includeAdditionalData)
+            if (includeAdditionalExceptionData)
             {
                 ex.AdditionalExceptionData = new Dictionary<string, string>()
                 {
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
                 };
             }
 
-            SerializeDeserializeAndValidate(ex, typeof(MsalException), false, includeAdditionalData);
+            SerializeDeserializeAndValidate(ex, typeof(MsalException), false, includeAdditionalExceptionData);
         }
 
         [TestMethod]
@@ -82,7 +82,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
             SerializeDeserializeAndValidate(ex, typeof(MsalUiRequiredException), true);
         }
 
-        private void SerializeDeserializeAndValidate(MsalException ex, Type expectedType, bool isServiceExceptionDerived, bool includesAdditionalData = false)
+        private void SerializeDeserializeAndValidate(MsalException ex, Type expectedType, bool isServiceExceptionDerived, bool includeAdditionalExceptionData = false)
         {
             string json = ex.ToJsonString();
 
@@ -92,7 +92,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
             Assert.AreEqual(ex.ErrorCode, exDeserialized.ErrorCode);
             Assert.AreEqual(ex.Message, exDeserialized.Message);
 
-            if (includesAdditionalData)
+            if (includeAdditionalExceptionData)
             {
                 Assert.AreEqual(ex.AdditionalExceptionData[MsalException.BrokerErrorContext], exDeserialized.AdditionalExceptionData[MsalException.BrokerErrorContext]);
                 Assert.AreEqual(ex.AdditionalExceptionData[MsalException.BrokerErrorTag], exDeserialized.AdditionalExceptionData[MsalException.BrokerErrorTag]);


### PR DESCRIPTION
Fixes #4371

**Changes proposed in this request**
- Adds additional broker exception data to exception de/serialization.
- Added a flag for less escaping in STJ.
   - System.Text.Json, by default, escapes more characters than Newtonsoft. This makes broker telemetry, which is a JSON string, less readable (see [doc](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/migrate-from-newtonsoft?pivots=dotnet-7-0#minimal-character-escaping) and [doc](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/character-encoding#serialize-all-characters)). Something like: 
```text
"broker_telemetry": "{\u0022additional_query_parameters_count\u0022:\u00220\u0022,\u0022all_error_tags\u0022:\u00229zdfv\u0022,\u0022api_error_code\u0022:\u00220\u0022,\u0022api_error_context\u0022:\u0022
```
- When serializing broker data, using snake case for property names for consistency. Like this:
```json
{
  "type": "MsalException",
  "error_code": "some_error_code",
  "error_description": "Some error message.",
  "additional_exception_data": {
    "broker_error_context": "broker error context",
    "broker_error_tag": "0x123456",
    "broker_error_status": "broker error status",
    "broker_error_code": "broker error code",
    "broker_telemetry": "broker telemetry"
  }
}
```
Otherwise, if using property name from the `AdditionalExceptionData` dictionary, JSON would look like this:
```json
{
	"type": "MsalException",
	"error_code": "some_error_code",
	"error_description": "Some error message.",
	"AdditionalExceptionData": {
	  "BrokerErrorContext": "broker error context",
	  "BrokerErrorTag": "0x123456",
	  "BrokerErrorStatus": "broker error status",
	  "BrokerErrorCode": "broker error code",
	  "BrokerTelemetry": "broker telemetry"
	}
```


**Testing**
Manual + unit tests.

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
