### PR TITLE
Fall back to local cache if broker fails to return result for silent token call 

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -66,19 +66,11 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                     _logger.Info("Broker is configured and enabled, attempting to use broker instead.");
                     var brokerResult = await _brokerStrategyLazy.Value.ExecuteAsync(cancellationToken).ConfigureAwait(false);
 
+                    // fallback to local cache if broker fails
                     if (brokerResult != null)
                     {
                         _logger.Verbose(() => "Broker responded to silent request.");
                         return brokerResult;
-                    }
-                    else
-                    {
-                        _logger.Verbose(() => "Broker could not satisfy the silent request.");
-                        throw new MsalUiRequiredException(
-                           MsalError.FailedToAcquireTokenSilentlyFromBroker,
-                           "Broker could not satisfy the silent request.",
-                           null,
-                           UiRequiredExceptionClassification.AcquireTokenSilentFailed);
                     }
                 }
 

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 }
                 catch (MsalUiRequiredException e)
                 {
-                    Assert.AreEqual("failed_to_acquire_token_silently_from_broker", e.ErrorCode);
+                    Assert.AreEqual("no_tokens_found", e.ErrorCode);
 
                     harness.HttpManager.AddInstanceDiscoveryMockHandler();
                     harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();


### PR DESCRIPTION
Fixes #4209

**Changes proposed in this request**
WithBroker = true, interactive token call falls back correctly to browser and completes the flow. With silent token call for the same account, currently there is no fallback to local cache if broker fails to return result. BrokerStrategy can fail for example if the broker is not available in the machine. The fix is to fall back to local cache for silent token call as well similar to interactive call. 

**Testing**
The existing unit tests were modified to account for the new bahavior
Ran through the scenario manually in the WinForms test app and verified its working as expected

**Performance impact**
None

**Documentation**
None
