### PR TITLE
Cache level should be L1 in case of default in memory cache.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -177,6 +177,9 @@ namespace Microsoft.Identity.Client.Cache
                         RequestContext.ApiEvent.CacheLevel = telemetryData.CacheLevel;
                     }
                 }
+            } else
+            {
+                RequestContext.ApiEvent.CacheLevel = CacheLevel.L1Cache;
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TelemetryClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TelemetryClientTests.cs
@@ -135,13 +135,13 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     AssertionType.Secret,
                     TestConstants.AuthorityUtidTenant,
                     TokenType.Bearer,
-                    CacheLevel.Unknown,
+                    CacheLevel.L1Cache,
                     TestConstants.s_scope.AsSingleString(),
                     null);
 
                 _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
 
-                // Acquire token forclient with resource
+                // Acquire token for client with resource
                 result = await _cca.AcquireTokenForClient(new[] { TestConstants.DefaultGraphScope })
                     .WithTenantId(TestConstants.Utid)
                     .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #4414 

**Changes proposed in this request**
Fix the cache level, when in memory cache is used cache level will be L1Cache.

**Testing**
Updated tests to verify

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
