### PR TITLE
Add .WithForceRefresh support for silent broker flows

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Features/RuntimeBroker/RuntimeBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/RuntimeBroker/RuntimeBroker.cs
@@ -312,6 +312,21 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
                         var errorMessage = "Could not acquire token silently.";
                         msalTokenResponse = WamAdapters.HandleResponse(result, authenticationRequestParameters, _logger, errorMessage);
                     }
+
+                    if (acquireTokenSilentParameters.ForceRefresh && !string.IsNullOrEmpty(msalTokenResponse.AccessToken))
+                    {
+                        authParams.AccessTokenToRenew = msalTokenResponse.AccessToken;
+
+                        using (NativeInterop.AuthResult result = await s_lazyCore.Value.AcquireTokenSilentlyAsync(
+                        authParams,
+                        authenticationRequestParameters.CorrelationId.ToString("D"),
+                        readAccountResult.Account,
+                        cancellationToken).ConfigureAwait(false))
+                        {
+                            var errorMessage = "Could not acquire token silently with AccessTokenToRenew option.";
+                            msalTokenResponse = WamAdapters.HandleResponse(result, authenticationRequestParameters, _logger, errorMessage);
+                        }
+                    }
                 }
             }
 
@@ -343,6 +358,21 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
                     var errorMessage = "Could not acquire token silently for the default user.";
                     msalTokenResponse = WamAdapters.HandleResponse(result, authenticationRequestParameters, _logger, errorMessage);
                 }
+
+                if (acquireTokenSilentParameters.ForceRefresh && !string.IsNullOrEmpty(msalTokenResponse.AccessToken))
+                {
+                    authParams.AccessTokenToRenew = msalTokenResponse.AccessToken;
+
+                    using (NativeInterop.AuthResult result = await s_lazyCore.Value.SignInSilentlyAsync(
+                       authParams,
+                       authenticationRequestParameters.CorrelationId.ToString("D"),
+                       cancellationToken).ConfigureAwait(false))
+                    {
+                        var errorMessage = "Could not acquire token silently for the default user.";
+                        msalTokenResponse = WamAdapters.HandleResponse(result, authenticationRequestParameters, _logger, errorMessage);
+                    }
+                }
+
             }
 
             return msalTokenResponse;

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/RuntimeBrokerTests.cs
@@ -169,8 +169,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             }
         }
 
-        [RunOn(TargetFrameworks.NetCore)]
-        [ExpectedException(typeof(MsalUiRequiredException))]
+        [RunOn(TargetFrameworks.NetCore)]        
         public async Task WamUsernamePasswordRequestAsync()
         {
             var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
@@ -215,8 +214,59 @@ namespace Microsoft.Identity.Test.Integration.Broker
 
             Assert.IsNotNull(accounts);
 
-            // this should throw MsalUiRequiredException
-            result = await pca.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false);
+            await AssertException.TaskThrowsAsync<MsalUiRequiredException>(
+               () => pca.AcquireTokenSilent(scopes, account).ExecuteAsync())
+                .ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task WamUsernamePasswordWithForceRefreshAsync()
+        {
+            var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
+            string[] scopes = { "User.Read" };
+            string[] expectedScopes = { "email", "offline_access", "openid", "profile", "User.Read" };
+
+            IntPtr intPtr = GetForegroundWindow();
+            Func<IntPtr> windowHandleProvider = () => intPtr;
+
+            IPublicClientApplication pca = PublicClientApplicationBuilder
+               .Create(labResponse.App.AppId)
+               .WithParentActivityOrWindow(windowHandleProvider)
+               .WithAuthority(labResponse.Lab.Authority, "organizations")
+               .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
+               .Build();
+
+            // Acquire token using username password
+            var result = await pca.AcquireTokenByUsernamePassword(
+                scopes, 
+                labResponse.User.Upn, 
+                labResponse.User.GetOrFetchPassword())
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            DateTimeOffset ropcTokenExpiration = result.ExpiresOn;
+            string ropcToken = result.AccessToken;
+
+            MsalAssert.AssertAuthResult(result, TokenSource.Broker, labResponse.Lab.TenantId, expectedScopes);
+            Assert.IsNotNull(result.AuthenticationResultMetadata.Telemetry);
+
+            // Get Accounts
+            var accounts = await pca.GetAccountsAsync().ConfigureAwait(false);            
+            var account = accounts.FirstOrDefault();
+            Assert.IsNotNull(account);
+
+            result = await pca.AcquireTokenSilent(scopes, account)
+                .ExecuteAsync().ConfigureAwait(false);
+
+            // This proves the token is from the cache
+            Assert.AreEqual(ropcToken, result.AccessToken);
+
+            result = await pca.AcquireTokenSilent(scopes, account)
+                .WithForceRefresh(true)
+               .ExecuteAsync().ConfigureAwait(false);
+
+            // This proves the token is not from the cache
+            Assert.AreNotEqual(ropcToken, result.AccessToken);
         }
 
         [RunOn(TargetFrameworks.NetCore)]

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.Designer.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.Designer.cs
@@ -28,485 +28,461 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.resultTbx = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.authorityCbx = new System.Windows.Forms.ComboBox();
-            this.clientIdCbx = new System.Windows.Forms.ComboBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.loginHintTxt = new System.Windows.Forms.TextBox();
-            this.promptCbx = new System.Windows.Forms.ComboBox();
-            this.atsBtn = new System.Windows.Forms.Button();
-            this.atiBtn = new System.Windows.Forms.Button();
-            this.atsAtiBtn = new System.Windows.Forms.Button();
-            this.accBtn = new System.Windows.Forms.Button();
-            this.clearBtn = new System.Windows.Forms.Button();
-            this.btnClearCache = new System.Windows.Forms.Button();
-            this.cbxScopes = new System.Windows.Forms.ComboBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
-            this.cbxAccount = new System.Windows.Forms.ComboBox();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.cbxMsaPt = new System.Windows.Forms.CheckBox();
-            this.btnExpire = new System.Windows.Forms.Button();
-            this.btnRemoveAccount = new System.Windows.Forms.Button();
-            this.cbxBackgroundThread = new System.Windows.Forms.CheckBox();
-            this.cbxListOsAccounts = new System.Windows.Forms.CheckBox();
-            this.cbxUseWam = new System.Windows.Forms.ComboBox();
-            this.cbxPOP = new System.Windows.Forms.CheckBox();
-            this.UsernameTxt = new System.Windows.Forms.TextBox();
-            this.label7 = new System.Windows.Forms.Label();
-            this.label8 = new System.Windows.Forms.Label();
-            this.PasswordTxt = new System.Windows.Forms.TextBox();
-            this.atUsernamePwdBtn = new System.Windows.Forms.Button();
-            this.btnATSperf = new System.Windows.Forms.Button();
-            this.nudAutocancelSeconds = new System.Windows.Forms.NumericUpDown();
-            this.label9 = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.nudAutocancelSeconds)).BeginInit();
-            this.cbxMultiCloud2 = new System.Windows.Forms.CheckBox();
-
-            this.SuspendLayout();
+            components = new System.ComponentModel.Container();
+            resultTbx = new System.Windows.Forms.TextBox();
+            label1 = new System.Windows.Forms.Label();
+            authorityCbx = new System.Windows.Forms.ComboBox();
+            clientIdCbx = new System.Windows.Forms.ComboBox();
+            label2 = new System.Windows.Forms.Label();
+            label3 = new System.Windows.Forms.Label();
+            loginHintTxt = new System.Windows.Forms.TextBox();
+            promptCbx = new System.Windows.Forms.ComboBox();
+            atsBtn = new System.Windows.Forms.Button();
+            atiBtn = new System.Windows.Forms.Button();
+            atsAtiBtn = new System.Windows.Forms.Button();
+            accBtn = new System.Windows.Forms.Button();
+            clearBtn = new System.Windows.Forms.Button();
+            btnClearCache = new System.Windows.Forms.Button();
+            cbxScopes = new System.Windows.Forms.ComboBox();
+            label5 = new System.Windows.Forms.Label();
+            label4 = new System.Windows.Forms.Label();
+            label6 = new System.Windows.Forms.Label();
+            cbxAccount = new System.Windows.Forms.ComboBox();
+            toolTip1 = new System.Windows.Forms.ToolTip(components);
+            cbxMsaPt = new System.Windows.Forms.CheckBox();
+            btnExpire = new System.Windows.Forms.Button();
+            btnRemoveAccount = new System.Windows.Forms.Button();
+            cbxBackgroundThread = new System.Windows.Forms.CheckBox();
+            cbxListOsAccounts = new System.Windows.Forms.CheckBox();
+            cbxUseWam = new System.Windows.Forms.ComboBox();
+            cbxPOP = new System.Windows.Forms.CheckBox();
+            UsernameTxt = new System.Windows.Forms.TextBox();
+            label7 = new System.Windows.Forms.Label();
+            label8 = new System.Windows.Forms.Label();
+            PasswordTxt = new System.Windows.Forms.TextBox();
+            atUsernamePwdBtn = new System.Windows.Forms.Button();
+            btnATSperf = new System.Windows.Forms.Button();
+            nudAutocancelSeconds = new System.Windows.Forms.NumericUpDown();
+            label9 = new System.Windows.Forms.Label();
+            cbxMultiCloud2 = new System.Windows.Forms.CheckBox();
+            cbxWithForceRefresh = new System.Windows.Forms.CheckBox();
+            ((System.ComponentModel.ISupportInitialize)nudAutocancelSeconds).BeginInit();
+            SuspendLayout();
             // 
             // resultTbx
             // 
-            this.resultTbx.Location = new System.Drawing.Point(12, 316);
-            this.resultTbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.resultTbx.Multiline = true;
-            this.resultTbx.Name = "resultTbx";
-            this.resultTbx.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.resultTbx.Size = new System.Drawing.Size(709, 390);
-            this.resultTbx.TabIndex = 0;
+            resultTbx.Location = new System.Drawing.Point(12, 316);
+            resultTbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            resultTbx.Multiline = true;
+            resultTbx.Name = "resultTbx";
+            resultTbx.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            resultTbx.Size = new System.Drawing.Size(709, 390);
+            resultTbx.TabIndex = 0;
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(22, 52);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(57, 15);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Authority";
+            label1.AutoSize = true;
+            label1.Location = new System.Drawing.Point(22, 52);
+            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(57, 15);
+            label1.TabIndex = 2;
+            label1.Text = "Authority";
             // 
             // authorityCbx
             // 
-            this.authorityCbx.FormattingEnabled = true;
-            this.authorityCbx.Items.AddRange(new object[] {
-            "https://login.microsoftonline.com/common",
-            "https://login.microsoftonline.com/organizations",
-            "https://login.microsoftonline.com/consumers",
-            "https://login.microsoftonline.com/49f548d0-12b7-4169-a390-bb5304d24462",
-            "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
-            "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
-            "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a",
-            "https://login.windows-ppe.net/organizations",
-            "https://login.windows-ppe.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
-            "https://login.partner.microsoftonline.cn/organizations",
-            "https://login.microsoftonline.us/organizations"});
-            this.authorityCbx.Location = new System.Drawing.Point(85, 48);
-            this.authorityCbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.authorityCbx.Name = "authorityCbx";
-            this.authorityCbx.Size = new System.Drawing.Size(568, 23);
-            this.authorityCbx.TabIndex = 3;
-            this.authorityCbx.Text = "https://login.microsoftonline.com/common";
+            authorityCbx.FormattingEnabled = true;
+            authorityCbx.Items.AddRange(new object[] { "https://login.microsoftonline.com/common", "https://login.microsoftonline.com/organizations", "https://login.microsoftonline.com/consumers", "https://login.microsoftonline.com/49f548d0-12b7-4169-a390-bb5304d24462", "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47", "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a", "https://login.windows-ppe.net/organizations", "https://login.windows-ppe.net/72f988bf-86f1-41af-91ab-2d7cd011db47", "https://login.partner.microsoftonline.cn/organizations", "https://login.microsoftonline.us/organizations" });
+            authorityCbx.Location = new System.Drawing.Point(85, 48);
+            authorityCbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            authorityCbx.Name = "authorityCbx";
+            authorityCbx.Size = new System.Drawing.Size(568, 23);
+            authorityCbx.TabIndex = 3;
+            authorityCbx.Text = "https://login.microsoftonline.com/common";
             // 
             // clientIdCbx
             // 
-            this.clientIdCbx.FormattingEnabled = true;
-            this.clientIdCbx.Location = new System.Drawing.Point(85, 17);
-            this.clientIdCbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.clientIdCbx.Name = "clientIdCbx";
-            this.clientIdCbx.Size = new System.Drawing.Size(568, 23);
-            this.clientIdCbx.TabIndex = 4;
-            this.clientIdCbx.Text = "1d18b3b0-251b-4714-a02a-9956cec86c2d";
-            this.clientIdCbx.SelectedIndexChanged += new System.EventHandler(this.clientIdCbx_SelectedIndexChanged);
+            clientIdCbx.FormattingEnabled = true;
+            clientIdCbx.Location = new System.Drawing.Point(85, 17);
+            clientIdCbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            clientIdCbx.Name = "clientIdCbx";
+            clientIdCbx.Size = new System.Drawing.Size(568, 23);
+            clientIdCbx.TabIndex = 4;
+            clientIdCbx.Text = "1d18b3b0-251b-4714-a02a-9956cec86c2d";
+            clientIdCbx.SelectedIndexChanged += clientIdCbx_SelectedIndexChanged;
             // 
             // label2
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(29, 21);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(48, 15);
-            this.label2.TabIndex = 5;
-            this.label2.Text = "ClientId";
+            label2.AutoSize = true;
+            label2.Location = new System.Drawing.Point(29, 21);
+            label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size(48, 15);
+            label2.TabIndex = 5;
+            label2.Text = "ClientId";
             // 
             // label3
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(10, 113);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(66, 15);
-            this.label3.TabIndex = 7;
-            this.label3.Text = "Login Hint ";
+            label3.AutoSize = true;
+            label3.Location = new System.Drawing.Point(10, 113);
+            label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label3.Name = "label3";
+            label3.Size = new System.Drawing.Size(66, 15);
+            label3.TabIndex = 7;
+            label3.Text = "Login Hint ";
             // 
             // loginHintTxt
             // 
-            this.loginHintTxt.Location = new System.Drawing.Point(85, 111);
-            this.loginHintTxt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.loginHintTxt.Name = "loginHintTxt";
-            this.loginHintTxt.Size = new System.Drawing.Size(256, 23);
-            this.loginHintTxt.TabIndex = 8;
+            loginHintTxt.Location = new System.Drawing.Point(85, 111);
+            loginHintTxt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            loginHintTxt.Name = "loginHintTxt";
+            loginHintTxt.Size = new System.Drawing.Size(256, 23);
+            loginHintTxt.TabIndex = 8;
             // 
             // promptCbx
             // 
-            this.promptCbx.FormattingEnabled = true;
-            this.promptCbx.Items.AddRange(new object[] {
-            "",
-            "select_account",
-            "force_login",
-            "no_prompt",
-            "consent",
-            "never"});
-            this.promptCbx.Location = new System.Drawing.Point(580, 149);
-            this.promptCbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.promptCbx.Name = "promptCbx";
-            this.promptCbx.Size = new System.Drawing.Size(140, 23);
-            this.promptCbx.TabIndex = 10;
+            promptCbx.FormattingEnabled = true;
+            promptCbx.Items.AddRange(new object[] { "", "select_account", "force_login", "no_prompt", "consent", "never" });
+            promptCbx.Location = new System.Drawing.Point(580, 149);
+            promptCbx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            promptCbx.Name = "promptCbx";
+            promptCbx.Size = new System.Drawing.Size(140, 23);
+            promptCbx.TabIndex = 10;
             // 
             // atsBtn
             // 
-            this.atsBtn.Location = new System.Drawing.Point(10, 247);
-            this.atsBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.atsBtn.Name = "atsBtn";
-            this.atsBtn.Size = new System.Drawing.Size(126, 27);
-            this.atsBtn.TabIndex = 11;
-            this.atsBtn.Text = "ATS";
-            this.atsBtn.UseVisualStyleBackColor = true;
-            this.atsBtn.Click += new System.EventHandler(this.atsBtn_Click);
+            atsBtn.Location = new System.Drawing.Point(10, 247);
+            atsBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            atsBtn.Name = "atsBtn";
+            atsBtn.Size = new System.Drawing.Size(126, 27);
+            atsBtn.TabIndex = 11;
+            atsBtn.Text = "ATS";
+            atsBtn.UseVisualStyleBackColor = true;
+            atsBtn.Click += atsBtn_Click;
             // 
             // atiBtn
             // 
-            this.atiBtn.Location = new System.Drawing.Point(144, 247);
-            this.atiBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.atiBtn.Name = "atiBtn";
-            this.atiBtn.Size = new System.Drawing.Size(126, 27);
-            this.atiBtn.TabIndex = 12;
-            this.atiBtn.Text = "ATI";
-            this.atiBtn.UseVisualStyleBackColor = true;
-            this.atiBtn.Click += new System.EventHandler(this.atiBtn_Click);
+            atiBtn.Location = new System.Drawing.Point(144, 247);
+            atiBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            atiBtn.Name = "atiBtn";
+            atiBtn.Size = new System.Drawing.Size(126, 27);
+            atiBtn.TabIndex = 12;
+            atiBtn.Text = "ATI";
+            atiBtn.UseVisualStyleBackColor = true;
+            atiBtn.Click += atiBtn_Click;
             // 
             // atsAtiBtn
             // 
-            this.atsAtiBtn.Location = new System.Drawing.Point(278, 247);
-            this.atsAtiBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.atsAtiBtn.Name = "atsAtiBtn";
-            this.atsAtiBtn.Size = new System.Drawing.Size(126, 27);
-            this.atsAtiBtn.TabIndex = 13;
-            this.atsAtiBtn.Text = "ATS + ATI";
-            this.atsAtiBtn.UseVisualStyleBackColor = true;
-            this.atsAtiBtn.Click += new System.EventHandler(this.atsAtiBtn_Click);
+            atsAtiBtn.Location = new System.Drawing.Point(278, 247);
+            atsAtiBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            atsAtiBtn.Name = "atsAtiBtn";
+            atsAtiBtn.Size = new System.Drawing.Size(126, 27);
+            atsAtiBtn.TabIndex = 13;
+            atsAtiBtn.Text = "ATS + ATI";
+            atsAtiBtn.UseVisualStyleBackColor = true;
+            atsAtiBtn.Click += atsAtiBtn_Click;
             // 
             // accBtn
             // 
-            this.accBtn.Location = new System.Drawing.Point(228, 280);
-            this.accBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.accBtn.Name = "accBtn";
-            this.accBtn.Size = new System.Drawing.Size(126, 27);
-            this.accBtn.TabIndex = 15;
-            this.accBtn.Text = "Get Accounts";
-            this.accBtn.UseVisualStyleBackColor = true;
-            this.accBtn.Click += new System.EventHandler(this.getAccountsBtn_Click);
+            accBtn.Location = new System.Drawing.Point(228, 280);
+            accBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            accBtn.Name = "accBtn";
+            accBtn.Size = new System.Drawing.Size(126, 27);
+            accBtn.TabIndex = 15;
+            accBtn.Text = "Get Accounts";
+            accBtn.UseVisualStyleBackColor = true;
+            accBtn.Click += getAccountsBtn_Click;
             // 
             // clearBtn
             // 
-            this.clearBtn.Location = new System.Drawing.Point(642, 754);
-            this.clearBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.clearBtn.Name = "clearBtn";
-            this.clearBtn.Size = new System.Drawing.Size(79, 27);
-            this.clearBtn.TabIndex = 16;
-            this.clearBtn.Text = "Clear Log";
-            this.clearBtn.UseVisualStyleBackColor = true;
-            this.clearBtn.Click += new System.EventHandler(this.clearBtn_Click);
+            clearBtn.Location = new System.Drawing.Point(642, 754);
+            clearBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            clearBtn.Name = "clearBtn";
+            clearBtn.Size = new System.Drawing.Size(79, 27);
+            clearBtn.TabIndex = 16;
+            clearBtn.Text = "Clear Log";
+            clearBtn.UseVisualStyleBackColor = true;
+            clearBtn.Click += clearBtn_Click;
             // 
             // btnClearCache
             // 
-            this.btnClearCache.Location = new System.Drawing.Point(508, 754);
-            this.btnClearCache.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.btnClearCache.Name = "btnClearCache";
-            this.btnClearCache.Size = new System.Drawing.Size(126, 27);
-            this.btnClearCache.TabIndex = 17;
-            this.btnClearCache.Text = "Clear MSAL Cache";
-            this.btnClearCache.UseVisualStyleBackColor = true;
-            this.btnClearCache.Click += new System.EventHandler(this.btnClearCache_Click);
+            btnClearCache.Location = new System.Drawing.Point(508, 754);
+            btnClearCache.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnClearCache.Name = "btnClearCache";
+            btnClearCache.Size = new System.Drawing.Size(126, 27);
+            btnClearCache.TabIndex = 17;
+            btnClearCache.Text = "Clear MSAL Cache";
+            btnClearCache.UseVisualStyleBackColor = true;
+            btnClearCache.Click += btnClearCache_Click;
             // 
             // cbxScopes
             // 
-            this.cbxScopes.FormattingEnabled = true;
-            this.cbxScopes.Items.AddRange(new object[] {
-            "User.Read",
-            "User.Read User.Read.All",
-            "https://management.core.windows.net//.default",
-            "https://graph.microsoft.com/.default",
-            "499b84ac-1321-427f-aa17-267ca6975798/vso.code_full",
-            "api://51eb3dd6-d8b5-46f3-991d-b1d4870de7de/myaccess",
-            "https://management.core.chinacloudapi.cn//.default",
-            "https://management.core.usgovcloudapi.net//.default"});
-            this.cbxScopes.Location = new System.Drawing.Point(85, 80);
-            this.cbxScopes.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.cbxScopes.Name = "cbxScopes";
-            this.cbxScopes.Size = new System.Drawing.Size(635, 23);
-            this.cbxScopes.TabIndex = 18;
-            this.cbxScopes.Text = "User.Read";
+            cbxScopes.FormattingEnabled = true;
+            cbxScopes.Items.AddRange(new object[] { "User.Read", "User.Read User.Read.All", "https://management.core.windows.net//.default", "https://graph.microsoft.com/.default", "499b84ac-1321-427f-aa17-267ca6975798/vso.code_full", "api://51eb3dd6-d8b5-46f3-991d-b1d4870de7de/myaccess", "https://management.core.chinacloudapi.cn//.default", "https://management.core.usgovcloudapi.net//.default" });
+            cbxScopes.Location = new System.Drawing.Point(85, 80);
+            cbxScopes.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cbxScopes.Name = "cbxScopes";
+            cbxScopes.Size = new System.Drawing.Size(635, 23);
+            cbxScopes.TabIndex = 18;
+            cbxScopes.Text = "User.Read";
             // 
             // label5
             // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(28, 83);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(44, 15);
-            this.label5.TabIndex = 19;
-            this.label5.Text = "Scopes";
+            label5.AutoSize = true;
+            label5.Location = new System.Drawing.Point(28, 83);
+            label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label5.Name = "label5";
+            label5.Size = new System.Drawing.Size(44, 15);
+            label5.TabIndex = 19;
+            label5.Text = "Scopes";
             // 
             // label4
             // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(526, 153);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(47, 15);
-            this.label4.TabIndex = 9;
-            this.label4.Text = "Prompt";
+            label4.AutoSize = true;
+            label4.Location = new System.Drawing.Point(526, 153);
+            label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label4.Name = "label4";
+            label4.Size = new System.Drawing.Size(47, 15);
+            label4.TabIndex = 9;
+            label4.Text = "Prompt";
             // 
             // label6
             // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(349, 113);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(68, 15);
-            this.label6.TabIndex = 21;
-            this.label6.Text = "Or Account";
+            label6.AutoSize = true;
+            label6.Location = new System.Drawing.Point(349, 113);
+            label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label6.Name = "label6";
+            label6.Size = new System.Drawing.Size(68, 15);
+            label6.TabIndex = 21;
+            label6.Text = "Or Account";
             // 
             // cbxAccount
             // 
-            this.cbxAccount.FormattingEnabled = true;
-            this.cbxAccount.Location = new System.Drawing.Point(427, 110);
-            this.cbxAccount.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.cbxAccount.Name = "cbxAccount";
-            this.cbxAccount.Size = new System.Drawing.Size(293, 23);
-            this.cbxAccount.TabIndex = 22;
+            cbxAccount.FormattingEnabled = true;
+            cbxAccount.Location = new System.Drawing.Point(427, 110);
+            cbxAccount.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cbxAccount.Name = "cbxAccount";
+            cbxAccount.Size = new System.Drawing.Size(293, 23);
+            cbxAccount.TabIndex = 22;
             // 
             // cbxMsaPt
             // 
-            this.cbxMsaPt.AutoSize = true;
-            this.cbxMsaPt.Location = new System.Drawing.Point(212, 197);
-            this.cbxMsaPt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.cbxMsaPt.Name = "cbxMsaPt";
-            this.cbxMsaPt.Size = new System.Drawing.Size(122, 19);
-            this.cbxMsaPt.TabIndex = 23;
-            this.cbxMsaPt.Text = "MSA-Passthrough";
-            this.cbxMsaPt.UseVisualStyleBackColor = true;
+            cbxMsaPt.AutoSize = true;
+            cbxMsaPt.Location = new System.Drawing.Point(212, 197);
+            cbxMsaPt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cbxMsaPt.Name = "cbxMsaPt";
+            cbxMsaPt.Size = new System.Drawing.Size(122, 19);
+            cbxMsaPt.TabIndex = 23;
+            cbxMsaPt.Text = "MSA-Passthrough";
+            cbxMsaPt.UseVisualStyleBackColor = true;
             // 
             // btnExpire
             // 
-            this.btnExpire.Location = new System.Drawing.Point(374, 755);
-            this.btnExpire.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.btnExpire.Name = "btnExpire";
-            this.btnExpire.Size = new System.Drawing.Size(126, 27);
-            this.btnExpire.TabIndex = 24;
-            this.btnExpire.Text = "Expire ATs";
-            this.btnExpire.UseVisualStyleBackColor = true;
-            this.btnExpire.Click += new System.EventHandler(this.btnExpire_Click);
+            btnExpire.Location = new System.Drawing.Point(374, 755);
+            btnExpire.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnExpire.Name = "btnExpire";
+            btnExpire.Size = new System.Drawing.Size(126, 27);
+            btnExpire.TabIndex = 24;
+            btnExpire.Text = "Expire ATs";
+            btnExpire.UseVisualStyleBackColor = true;
+            btnExpire.Click += btnExpire_Click;
             // 
             // btnRemoveAccount
             // 
-            this.btnRemoveAccount.Location = new System.Drawing.Point(362, 280);
-            this.btnRemoveAccount.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.btnRemoveAccount.Name = "btnRemoveAccount";
-            this.btnRemoveAccount.Size = new System.Drawing.Size(126, 27);
-            this.btnRemoveAccount.TabIndex = 25;
-            this.btnRemoveAccount.Text = "Remove Acc";
-            this.btnRemoveAccount.UseVisualStyleBackColor = true;
-            this.btnRemoveAccount.Click += new System.EventHandler(this.btnRemoveAcc_Click);
+            btnRemoveAccount.Location = new System.Drawing.Point(362, 280);
+            btnRemoveAccount.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnRemoveAccount.Name = "btnRemoveAccount";
+            btnRemoveAccount.Size = new System.Drawing.Size(126, 27);
+            btnRemoveAccount.TabIndex = 25;
+            btnRemoveAccount.Text = "Remove Acc";
+            btnRemoveAccount.UseVisualStyleBackColor = true;
+            btnRemoveAccount.Click += btnRemoveAcc_Click;
             // 
             // cbxBackgroundThread
             // 
-            this.cbxBackgroundThread.AutoSize = true;
-            this.cbxBackgroundThread.Location = new System.Drawing.Point(349, 197);
-            this.cbxBackgroundThread.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.cbxBackgroundThread.Name = "cbxBackgroundThread";
-            this.cbxBackgroundThread.Size = new System.Drawing.Size(159, 19);
-            this.cbxBackgroundThread.TabIndex = 26;
-            this.cbxBackgroundThread.Text = "Force background thread";
-            this.cbxBackgroundThread.UseVisualStyleBackColor = true;
+            cbxBackgroundThread.AutoSize = true;
+            cbxBackgroundThread.Location = new System.Drawing.Point(349, 197);
+            cbxBackgroundThread.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cbxBackgroundThread.Name = "cbxBackgroundThread";
+            cbxBackgroundThread.Size = new System.Drawing.Size(159, 19);
+            cbxBackgroundThread.TabIndex = 26;
+            cbxBackgroundThread.Text = "Force background thread";
+            cbxBackgroundThread.UseVisualStyleBackColor = true;
             // 
             // cbxListOsAccounts
             // 
-            this.cbxListOsAccounts.AutoSize = true;
-            this.cbxListOsAccounts.Location = new System.Drawing.Point(212, 222);
-            this.cbxListOsAccounts.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.cbxListOsAccounts.Name = "cbxListOsAccounts";
-            this.cbxListOsAccounts.Size = new System.Drawing.Size(113, 19);
-            this.cbxListOsAccounts.TabIndex = 27;
-            this.cbxListOsAccounts.Text = "List OS accounts";
-            this.cbxListOsAccounts.UseVisualStyleBackColor = true;
+            cbxListOsAccounts.AutoSize = true;
+            cbxListOsAccounts.Location = new System.Drawing.Point(212, 222);
+            cbxListOsAccounts.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cbxListOsAccounts.Name = "cbxListOsAccounts";
+            cbxListOsAccounts.Size = new System.Drawing.Size(113, 19);
+            cbxListOsAccounts.TabIndex = 27;
+            cbxListOsAccounts.Text = "List OS accounts";
+            cbxListOsAccounts.UseVisualStyleBackColor = true;
             // 
             // cbxUseWam
             // 
-            this.cbxUseWam.FormattingEnabled = true;
-            this.cbxUseWam.Location = new System.Drawing.Point(10, 193);
-            this.cbxUseWam.Margin = new System.Windows.Forms.Padding(5, 3, 5, 3);
-            this.cbxUseWam.Name = "cbxUseWam";
-            this.cbxUseWam.Size = new System.Drawing.Size(188, 23);
-            this.cbxUseWam.TabIndex = 28;
+            cbxUseWam.FormattingEnabled = true;
+            cbxUseWam.Location = new System.Drawing.Point(10, 193);
+            cbxUseWam.Margin = new System.Windows.Forms.Padding(5, 3, 5, 3);
+            cbxUseWam.Name = "cbxUseWam";
+            cbxUseWam.Size = new System.Drawing.Size(188, 23);
+            cbxUseWam.TabIndex = 28;
             // 
             // cbxPOP
             // 
-            this.cbxPOP.AutoSize = true;
-            this.cbxPOP.Location = new System.Drawing.Point(349, 222);
-            this.cbxPOP.Margin = new System.Windows.Forms.Padding(5, 3, 5, 3);
-            this.cbxPOP.Name = "cbxPOP";
-            this.cbxPOP.Size = new System.Drawing.Size(156, 19);
-            this.cbxPOP.TabIndex = 29;
-            this.cbxPOP.Text = "With Proof-of-Possesion";
-            this.cbxPOP.UseVisualStyleBackColor = true;
+            cbxPOP.AutoSize = true;
+            cbxPOP.Location = new System.Drawing.Point(349, 222);
+            cbxPOP.Margin = new System.Windows.Forms.Padding(5, 3, 5, 3);
+            cbxPOP.Name = "cbxPOP";
+            cbxPOP.Size = new System.Drawing.Size(156, 19);
+            cbxPOP.TabIndex = 29;
+            cbxPOP.Text = "With Proof-of-Possesion";
+            cbxPOP.UseVisualStyleBackColor = true;
             // 
             // UsernameTxt
             // 
-            this.UsernameTxt.Location = new System.Drawing.Point(85, 148);
-            this.UsernameTxt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.UsernameTxt.Name = "UsernameTxt";
-            this.UsernameTxt.Size = new System.Drawing.Size(154, 23);
-            this.UsernameTxt.TabIndex = 30;
+            UsernameTxt.Location = new System.Drawing.Point(85, 148);
+            UsernameTxt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            UsernameTxt.Name = "UsernameTxt";
+            UsernameTxt.Size = new System.Drawing.Size(154, 23);
+            UsernameTxt.TabIndex = 30;
             // 
             // label7
             // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(10, 152);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(60, 15);
-            this.label7.TabIndex = 31;
-            this.label7.Text = "Username";
+            label7.AutoSize = true;
+            label7.Location = new System.Drawing.Point(10, 152);
+            label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label7.Name = "label7";
+            label7.Size = new System.Drawing.Size(60, 15);
+            label7.TabIndex = 31;
+            label7.Text = "Username";
             // 
             // label8
             // 
-            this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(247, 151);
-            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(57, 15);
-            this.label8.TabIndex = 32;
-            this.label8.Text = "Password";
+            label8.AutoSize = true;
+            label8.Location = new System.Drawing.Point(247, 151);
+            label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label8.Name = "label8";
+            label8.Size = new System.Drawing.Size(57, 15);
+            label8.TabIndex = 32;
+            label8.Text = "Password";
             // 
             // PasswordTxt
             // 
-            this.PasswordTxt.Location = new System.Drawing.Point(321, 149);
-            this.PasswordTxt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.PasswordTxt.Name = "PasswordTxt";
-            this.PasswordTxt.Size = new System.Drawing.Size(154, 23);
-            this.PasswordTxt.TabIndex = 33;
-            this.PasswordTxt.UseSystemPasswordChar = true;
+            PasswordTxt.Location = new System.Drawing.Point(321, 149);
+            PasswordTxt.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            PasswordTxt.Name = "PasswordTxt";
+            PasswordTxt.Size = new System.Drawing.Size(154, 23);
+            PasswordTxt.TabIndex = 33;
+            PasswordTxt.UseSystemPasswordChar = true;
             // 
             // atUsernamePwdBtn
             // 
-            this.atUsernamePwdBtn.Location = new System.Drawing.Point(144, 280);
-            this.atUsernamePwdBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.atUsernamePwdBtn.Name = "atUsernamePwdBtn";
-            this.atUsernamePwdBtn.Size = new System.Drawing.Size(76, 27);
-            this.atUsernamePwdBtn.TabIndex = 34;
-            this.atUsernamePwdBtn.Text = "AT U/P";
-            this.atUsernamePwdBtn.UseVisualStyleBackColor = true;
-            this.atUsernamePwdBtn.Click += new System.EventHandler(this.atUsernamePwdBtn_Click);
+            atUsernamePwdBtn.Location = new System.Drawing.Point(144, 280);
+            atUsernamePwdBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            atUsernamePwdBtn.Name = "atUsernamePwdBtn";
+            atUsernamePwdBtn.Size = new System.Drawing.Size(76, 27);
+            atUsernamePwdBtn.TabIndex = 34;
+            atUsernamePwdBtn.Text = "AT U/P";
+            atUsernamePwdBtn.UseVisualStyleBackColor = true;
+            atUsernamePwdBtn.Click += atUsernamePwdBtn_Click;
             // 
             // btnATSperf
             // 
-            this.btnATSperf.Location = new System.Drawing.Point(10, 280);
-            this.btnATSperf.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.btnATSperf.Name = "btnATSperf";
-            this.btnATSperf.Size = new System.Drawing.Size(126, 27);
-            this.btnATSperf.TabIndex = 30;
-            this.btnATSperf.Text = "ATS Perf";
-            this.btnATSperf.UseVisualStyleBackColor = true;
-            this.btnATSperf.Click += new System.EventHandler(this.btnATSperf_Click);
+            btnATSperf.Location = new System.Drawing.Point(10, 280);
+            btnATSperf.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnATSperf.Name = "btnATSperf";
+            btnATSperf.Size = new System.Drawing.Size(126, 27);
+            btnATSperf.TabIndex = 30;
+            btnATSperf.Text = "ATS Perf";
+            btnATSperf.UseVisualStyleBackColor = true;
+            btnATSperf.Click += btnATSperf_Click;
             // 
             // nudAutocancelSeconds
             // 
-            this.nudAutocancelSeconds.Location = new System.Drawing.Point(146, 219);
-            this.nudAutocancelSeconds.Maximum = new decimal(new int[] {
-            120,
-            0,
-            0,
-            0});
-            this.nudAutocancelSeconds.Name = "nudAutocancelSeconds";
-            this.nudAutocancelSeconds.Size = new System.Drawing.Size(58, 23);
-            this.nudAutocancelSeconds.TabIndex = 30;
+            nudAutocancelSeconds.Location = new System.Drawing.Point(146, 219);
+            nudAutocancelSeconds.Maximum = new decimal(new int[] { 120, 0, 0, 0 });
+            nudAutocancelSeconds.Name = "nudAutocancelSeconds";
+            nudAutocancelSeconds.Size = new System.Drawing.Size(58, 23);
+            nudAutocancelSeconds.TabIndex = 30;
             // 
             // label9
             // 
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(10, 223);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(114, 15);
-            this.label9.TabIndex = 31;
-            this.label9.Text = "Autocancel Seconds";
-
+            label9.AutoSize = true;
+            label9.Location = new System.Drawing.Point(10, 223);
+            label9.Name = "label9";
+            label9.Size = new System.Drawing.Size(114, 15);
+            label9.TabIndex = 31;
+            label9.Text = "Autocancel Seconds";
+            // 
             // cbxMultiCloud2
             // 
-            this.cbxMultiCloud2.AutoSize = true;
-            this.cbxMultiCloud2.Location = new System.Drawing.Point(516, 199);
-            this.cbxMultiCloud2.Name = "cbxMultiCloud2";
-            this.cbxMultiCloud2.Size = new System.Drawing.Size(134, 19);
-            this.cbxMultiCloud2.TabIndex = 35;
-            this.cbxMultiCloud2.Text = "Multi Cloud Support";
-            this.cbxMultiCloud2.UseVisualStyleBackColor = true;
-
+            cbxMultiCloud2.AutoSize = true;
+            cbxMultiCloud2.Location = new System.Drawing.Point(516, 199);
+            cbxMultiCloud2.Name = "cbxMultiCloud2";
+            cbxMultiCloud2.Size = new System.Drawing.Size(134, 19);
+            cbxMultiCloud2.TabIndex = 35;
+            cbxMultiCloud2.Text = "Multi Cloud Support";
+            cbxMultiCloud2.UseVisualStyleBackColor = true;
+            // 
+            // cbxWithForceRefresh
+            // 
+            cbxWithForceRefresh.AutoSize = true;
+            cbxWithForceRefresh.Location = new System.Drawing.Point(516, 224);
+            cbxWithForceRefresh.Name = "cbxWithForceRefresh";
+            cbxWithForceRefresh.Size = new System.Drawing.Size(119, 19);
+            cbxWithForceRefresh.TabIndex = 36;
+            cbxWithForceRefresh.Text = "WithForceRefresh";
+            cbxWithForceRefresh.UseVisualStyleBackColor = true;
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-
-            this.ClientSize = new System.Drawing.Size(735, 740);
-
-            this.ClientSize = new System.Drawing.Size(738, 794);
-            this.Controls.Add(this.cbxMultiCloud2);
-
-            this.Controls.Add(this.atUsernamePwdBtn);
-            this.Controls.Add(this.PasswordTxt);
-            this.Controls.Add(this.label8);
-            this.Controls.Add(this.label7);
-            this.Controls.Add(this.UsernameTxt);
-            this.Controls.Add(this.btnATSperf);
-            this.Controls.Add(this.label9);
-            this.Controls.Add(this.nudAutocancelSeconds);
-            this.Controls.Add(this.cbxPOP);
-            this.Controls.Add(this.cbxUseWam);
-            this.Controls.Add(this.cbxListOsAccounts);
-            this.Controls.Add(this.cbxBackgroundThread);
-            this.Controls.Add(this.btnRemoveAccount);
-            this.Controls.Add(this.btnExpire);
-            this.Controls.Add(this.cbxMsaPt);
-            this.Controls.Add(this.cbxAccount);
-            this.Controls.Add(this.label6);
-            this.Controls.Add(this.label5);
-            this.Controls.Add(this.cbxScopes);
-            this.Controls.Add(this.btnClearCache);
-            this.Controls.Add(this.clearBtn);
-            this.Controls.Add(this.accBtn);
-            this.Controls.Add(this.atsAtiBtn);
-            this.Controls.Add(this.atiBtn);
-            this.Controls.Add(this.atsBtn);
-            this.Controls.Add(this.promptCbx);
-            this.Controls.Add(this.label4);
-            this.Controls.Add(this.loginHintTxt);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.clientIdCbx);
-            this.Controls.Add(this.authorityCbx);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.resultTbx);
-            this.Margin = new System.Windows.Forms.Padding(2);
-            this.Name = "Form1";
-            this.Text = "Form1";
-            ((System.ComponentModel.ISupportInitialize)(this.nudAutocancelSeconds)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(738, 794);
+            Controls.Add(cbxWithForceRefresh);
+            Controls.Add(cbxMultiCloud2);
+            Controls.Add(atUsernamePwdBtn);
+            Controls.Add(PasswordTxt);
+            Controls.Add(label8);
+            Controls.Add(label7);
+            Controls.Add(UsernameTxt);
+            Controls.Add(btnATSperf);
+            Controls.Add(label9);
+            Controls.Add(nudAutocancelSeconds);
+            Controls.Add(cbxPOP);
+            Controls.Add(cbxUseWam);
+            Controls.Add(cbxListOsAccounts);
+            Controls.Add(cbxBackgroundThread);
+            Controls.Add(btnRemoveAccount);
+            Controls.Add(btnExpire);
+            Controls.Add(cbxMsaPt);
+            Controls.Add(cbxAccount);
+            Controls.Add(label6);
+            Controls.Add(label5);
+            Controls.Add(cbxScopes);
+            Controls.Add(btnClearCache);
+            Controls.Add(clearBtn);
+            Controls.Add(accBtn);
+            Controls.Add(atsAtiBtn);
+            Controls.Add(atiBtn);
+            Controls.Add(atsBtn);
+            Controls.Add(promptCbx);
+            Controls.Add(label4);
+            Controls.Add(loginHintTxt);
+            Controls.Add(label3);
+            Controls.Add(label2);
+            Controls.Add(clientIdCbx);
+            Controls.Add(authorityCbx);
+            Controls.Add(label1);
+            Controls.Add(resultTbx);
+            Margin = new System.Windows.Forms.Padding(2);
+            Name = "Form1";
+            Text = "Form1";
+            ((System.ComponentModel.ISupportInitialize)nudAutocancelSeconds).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -548,7 +524,7 @@
         private System.Windows.Forms.Label label9;
 
         private System.Windows.Forms.CheckBox cbxMultiCloud2;
-
+        private System.Windows.Forms.CheckBox cbxWithForceRefresh;
     }
 }
 

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -246,6 +246,11 @@ namespace NetDesktopWinForms
                     GetRandomDownstreamUri());
                 }
 
+                if (cbxWithForceRefresh.Checked)
+                {
+                    builder = builder.WithForceRefresh(true);
+                }
+
                 Log($"ATS with IAccount for {acc?.Username ?? acc.HomeAccountId.ToString() ?? "null"}");
                 return await builder
                     .ExecuteAsync(GetAutocancelToken())


### PR DESCRIPTION
Fixes #4457

**Changes proposed in this request**
Currently Broker flows don't allow bypassing broker cache when option .WithForceRefresh(true) is set. This PR proposes to fix that.

**Testing**
No e2e test infra seem to exist for e2e WAM tests. 
Manual validation was done. Test app has been updated to support this option.

**Performance impact**
There's possibility that using builder  .WithForceRefresh(true) will result in 2 network calls if the cache is already expired.
