### PR TITLE
Remove obsolete ApplicationOptions.Component property

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationOptions.cs
@@ -74,14 +74,6 @@ namespace Microsoft.Identity.Client
         public string RedirectUri { get; set; }
 
         /// <summary>
-        /// Identifier of the component (libraries/SDK) consuming MSAL.NET.
-        /// This will allow for disambiguation between MSAL usage by the app vs MSAL usage by component libraries.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Should use ClientName and ClientVersion properties instead of Component", true)]
-        public string Component { get; set; }
-
-        /// <summary>
         /// The name of the calling application for telemetry purposes.
         /// </summary>
         public string ClientName { get; set; }


### PR DESCRIPTION
Fixes #4453

**Changes proposed in this request**
Remove obsolete ApplicationOptions.Component property. It's obsoleted with an error, so shouldn't be used anywhere anyway.

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [x] All relevant documentation is updated.
