### PR TITLE
Order scopes on save to avoid access token duplication in the cache

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Client.Cache.Items
             string keyId = null,
             string oboCacheKey = null)
             : this(
-                scopes: response.Scope, // token providers send pre-sorted (alphabetically) scopes
+                scopes: ScopeHelper.OrderScopesAlphabetically(response.Scope), // order scopes to avoid cache duplication. This is not in the hot path.
                 cachedAt: DateTimeOffset.UtcNow,
                 expiresOn: DateTimeHelpers.DateTimeOffsetFromDuration(response.ExpiresIn),
                 extendedExpiresOn: DateTimeHelpers.DateTimeOffsetFromDuration(response.ExtendedExpiresIn),
@@ -49,6 +49,7 @@ namespace Microsoft.Identity.Client.Cache.Items
             InitCacheKey();
         }
 
+      
         internal /* for test */ MsalAccessTokenCacheItem(
             string preferredCacheEnv,
             string clientId,

--- a/src/client/Microsoft.Identity.Client/Internal/IdToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/IdToken.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Identity.Client.Internal
         public const string Version = "ver";
         public const string PreferredUsername = "preferred_username";
         public const string Name = "name";
+        public const string Email = "email";
         public const string HomeObjectId = "home_oid";
         public const string GivenName = "given_name";
         public const string FamilyName = "family_name";
@@ -63,6 +64,7 @@ namespace Microsoft.Identity.Client.Internal
         public string PreferredUsername { get; private set; }
 
         public string Name { get; private set; }
+        public string Email { get; private set; }
 
         public string Upn { get; private set; }
 
@@ -112,6 +114,7 @@ namespace Microsoft.Identity.Client.Internal
                 parsedIdToken.TenantId = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.TenantId)?.Value;
                 parsedIdToken.PreferredUsername = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.PreferredUsername)?.Value;
                 parsedIdToken.Name = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.Name)?.Value;
+                parsedIdToken.Email = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.Email)?.Value;
                 parsedIdToken.Upn = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.Upn)?.Value;
                 parsedIdToken.GivenName = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.GivenName)?.Value;
                 parsedIdToken.FamilyName = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.FamilyName)?.Value;
@@ -353,6 +356,7 @@ namespace Microsoft.Identity.Client.Internal
                 parsedIdToken.TenantId = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.TenantId)?.Value;
                 parsedIdToken.PreferredUsername = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.PreferredUsername)?.Value;
                 parsedIdToken.Name = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.Name)?.Value;
+                parsedIdToken.Email = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.Email)?.Value;
                 parsedIdToken.Upn = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.Upn)?.Value;
                 parsedIdToken.GivenName = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.GivenName)?.Value;
                 parsedIdToken.FamilyName = parsedIdToken.ClaimsPrincipal.FindFirst(IdTokenClaim.FamilyName)?.Value;

--- a/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
+++ b/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
@@ -34,7 +34,13 @@ namespace Microsoft.Identity.Client
             }
 
             return idToken.PreferredUsername.NullIfWhiteSpace() ??
-                   idToken.Upn.NullIfWhiteSpace() ??                     
+                   idToken.Upn.NullIfWhiteSpace() ??
+
+#if !iOS // on iOS the username is used for caching, so better not to change this
+
+                   idToken.Email.NullIfWhiteSpace() ??
+                   idToken.Name.NullIfWhiteSpace() ??
+#endif
                    NullPreferredUsernameDisplayLabel;
         }
 

--- a/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/ScopeHelper.cs
@@ -12,6 +12,16 @@ namespace Microsoft.Identity.Client.Utils
     {
         private const string DefaultSuffix = "/.default";
 
+        public static string OrderScopesAlphabetically(string originalScopes)
+        {
+            // split by space and order aphabetically
+            string[] split = originalScopes.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            // order the scopes in alphabetical order
+            Array.Sort(split, StringComparer.OrdinalIgnoreCase);
+            return string.Join(" ", split);
+        }
+
+
         public static bool ScopeContains(ISet<string> outerSet, IEnumerable<string> possibleContainedSet)
         {
             foreach (string key in possibleContainedSet)

--- a/tests/Microsoft.Identity.Test.Common/Core/Helpers/CoreAssert.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Helpers/CoreAssert.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -23,6 +24,24 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
             foreach (string expectedScope in expectedScopes)
             {
                 Assert.IsTrue(actualScopes.Contains(expectedScope));
+            }
+        }
+
+        internal static void AreAccountsEqual(
+            string expectedUsername,
+            string expectedEnv,
+            string expectedId,
+            string expectedTid,
+            string expectedOid,
+            params IAccount[] accounts)
+        {            
+            foreach (var account in accounts)
+            {
+                Assert.AreEqual(expectedUsername, account.Username);
+                Assert.AreEqual(expectedEnv, account.Environment);
+                Assert.AreEqual(expectedId, account.HomeAccountId.Identifier);
+                Assert.AreEqual(expectedTid, account.HomeAccountId.TenantId);
+                Assert.AreEqual(expectedOid, account.HomeAccountId.ObjectId);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -186,6 +186,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string GivenName = "Joe";
         public const string FamilyName = "Doe";
         public const string Username = "joe@localhost.com";
+        public const string Email = "joe@contoso.com";
         public const string PKeyAuthResponse = "PKeyAuth Context=\"context\",Version=\"1.0\"";
 
         public const string RegionName = "REGION_NAME";
@@ -222,6 +223,7 @@ namespace Microsoft.Identity.Test.Unit
                 };
             }
         }
+
 
         public const string MsalCCAKeyVaultUri = "https://buildautomation.vault.azure.net/secrets/AzureADIdentityDivisionTestAgentSecret/";
         public const string MsalCCAKeyVaultSecretName = "AzureADIdentityDivisionTestAgentSecret";

--- a/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/B2CUsernamePasswordIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/HeadlessTests/B2CUsernamePasswordIntegrationTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var acc = (await msalPublicClient.GetAccountsAsync().ConfigureAwait(false)).Single();
             var claimsPrincipal = acc.GetTenantProfiles().Single().ClaimsPrincipal;
 
-            Assert.AreEqual(TokenResponseHelper.NullPreferredUsernameDisplayLabel, acc.Username);
+            Assert.AreNotEqual(TokenResponseHelper.NullPreferredUsernameDisplayLabel, acc.Username);
             Assert.IsNotNull(claimsPrincipal.FindFirst("Name"));
             Assert.IsNotNull(claimsPrincipal.FindFirst("nbf"));
             Assert.IsNotNull(claimsPrincipal.FindFirst("exp"));

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedCacheFormatTests.cs
@@ -262,10 +262,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         private void ValidateAccount(ITokenCacheInternal cache)
         {
-            // TODO: NEED TO LOOK INTO HOW TO HANDLE THIS TEST
-            //ValidateCacheEntityValue
-            //    (ExpectedAccountCacheValue, cache.GetAllAccountCacheItems(requestContext));
-
             var accountCacheItem = cache.Accessor.GetAllAccounts().First();
             var iOSKey = accountCacheItem.iOSCacheKey;
 
@@ -273,7 +269,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             Assert.AreEqual(_expectedAccountCacheKeyIosService, iOSKey.iOSService);
             Assert.AreEqual(_expectedAccountCacheKeyIosAccount, iOSKey.iOSAccount);
-            Assert.AreEqual(_expectedAccountCacheKeyIosGeneric, iOSKey.iOSGeneric);
             Assert.AreEqual(MsalCacheKeys.iOSAuthorityTypeToAttrType["MSSTS"], iOSKey.iOSType);
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedSchemaValidationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/UnifiedSchemaValidationTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             var expectedJsonObject = new JObject
             {
                 ["secret"] = "<removed_at>",
-                ["target"] = "Calendars.Read openid profile Tasks.Read User.Read email",
+                ["target"] = "Calendars.Read email openid profile Tasks.Read User.Read",
                 ["extended_expires_on"] = extExpiresOn,
                 ["ext_expires_on"] = extExpiresOn,
                 ["credential_type"] = "AccessToken",
@@ -93,7 +93,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // 2. Verify cache key
             IiOSKey key = credential.iOSCacheKey;
 
-            string expectedServiceKey = "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read openid profile tasks.read user.read email";
+            string expectedServiceKey = "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read email openid profile tasks.read user.read";
             Assert.AreEqual(expectedServiceKey, key.iOSService);
 
             string expectedAccountKey = "9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca-login.microsoftonline.com";
@@ -248,7 +248,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             var expectedJsonObject = new JObject
             {
                 ["secret"] = "<removed_at>",
-                ["target"] = "Tasks.Read User.Read openid profile",
+                ["target"] = "openid profile Tasks.Read User.Read",
                 ["extended_expires_on"] = extExpiresOn,
                 ["ext_expires_on"] = extExpiresOn,
                 ["credential_type"] = "AccessToken",
@@ -266,7 +266,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // 2. Verify cache key
             IiOSKey key = credential.iOSCacheKey;
 
-            string expectedServiceKey = "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-9188040d-6c67-4c5b-b112-36a304b66dad-tasks.read user.read openid profile";
+            string expectedServiceKey = "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-9188040d-6c67-4c5b-b112-36a304b66dad-openid profile tasks.read user.read";
             Assert.AreEqual(expectedServiceKey, key.iOSService);
 
             string expectedAccountKey = "00000000-0000-0000-40c0-3bac188d01d1.9188040d-6c67-4c5b-b112-36a304b66dad-login.microsoftonline.com";
@@ -728,7 +728,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             var expectedJsonObject = new JObject
             {
                 ["secret"] = "<removed_at>",
-                ["target"] = "Calendars.Read openid profile Tasks.Read User.Read email",
+                ["target"] = "Calendars.Read email openid profile Tasks.Read User.Read",
                 ["extended_expires_on"] = extExpiresOn,
                 ["ext_expires_on"] = extExpiresOn,
                 ["credential_type"] = "AccessToken",
@@ -746,7 +746,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // 2. Verify cache key
             IiOSKey key = credential.iOSCacheKey;
 
-            string expectedServiceKey = "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read openid profile tasks.read user.read email";
+            string expectedServiceKey = "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read email openid profile tasks.read user.read";
             Assert.AreEqual(expectedServiceKey, key.iOSService);
 
             string expectedAccountKey = "9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca-login.microsoftonline.com";

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
@@ -3,11 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -39,7 +43,11 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                     CreateOidcHttpHandler(authority + @"/" + Constants.WellKnownOpenIdConfigurationPath));
 
                 httpManager.AddMockHandler(
-                    CreateTokenResponseHttpHandler(authority + "/connect/token", "api", includeScopeInResponse ? "api" : null));
+                    CreateTokenResponseHttpHandler(
+                        authority + "/connect/token",
+                        scopesInRequest: "api",
+                        scopesInResponse: includeScopeInResponse ? "api" : null, 
+                        grant: "client_credentials"));
 
                 Assert.AreEqual(authority + "/", app.Authority);
                 var confidentailClientApp = (ConfidentialClientApplication)app;
@@ -62,6 +70,136 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+      
+        [TestMethod]
+        public async Task UserAuth_HappyPath_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                string authority = "https://demo.duendesoftware.com";
+                var requestedScopes = new[] { "all:catchreport", "email" };
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithExperimentalFeatures(true)
+                    .WithRedirectUri("http://some_redirect_uri")
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithLegacyCacheCompatibility(false)
+                    .WithGenericAuthority(authority)
+                    .Build();
+
+                httpManager.AddMockHandler(
+                    CreateOidcHttpHandler(authority + @"/" + Constants.WellKnownOpenIdConfigurationPath));
+
+                httpManager.AddMockHandler(
+                     CreateTokenResponseHttpHandler(
+                         authority + "/connect/token",
+                         scopesInRequest: string.Join(" ", requestedScopes),
+                         scopesInResponse: "openid profile email all:catchreport offline_access",
+                         grant: "authorization_code"));
+
+                Debug.WriteLine("Scopes returned: openid profile email all:catchreport offline_access");
+                var result = await cca.AcquireTokenByAuthorizationCode(requestedScopes, "auth_code")
+                                        .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                var result2 = await cca.AcquireTokenSilent(requestedScopes, result.Account)                
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource);
+
+                CoreAssert.AreAccountsEqual(
+                    TestConstants.Email,
+                    (new Uri(authority)).Host,
+                    "sub",
+                    null,
+                    "sub",
+                    result.Account, 
+                    result2.Account);
+
+            }
+        }
+
+        // Test for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4474
+        [TestMethod]
+        public async Task UserAuth_ScopeOrder_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                string authority = "https://demo.duendesoftware.com";
+                var requestedScopes = new[] { "all:catchreport", "email" };
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithExperimentalFeatures(true)
+                    .WithRedirectUri("http://some_redirect_uri")
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithLegacyCacheCompatibility(false)
+                    .WithGenericAuthority(authority)
+                    .Build();
+
+                httpManager.AddMockHandler(
+                    CreateOidcHttpHandler(authority + @"/" + Constants.WellKnownOpenIdConfigurationPath));
+
+                httpManager.AddMockHandler(
+                     CreateTokenResponseHttpHandler(
+                         authority + "/connect/token",
+                         scopesInRequest: string.Join(" ", requestedScopes),
+                         scopesInResponse: "openid profile email all:catchreport offline_access",
+                         grant: "authorization_code"));
+
+                Debug.WriteLine("Scopes returned: openid profile email all:catchreport offline_access");
+                var result = await cca.AcquireTokenByAuthorizationCode(requestedScopes, "auth_code")
+                                        .ExecuteAsync().ConfigureAwait(false);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                var accounts = (await cca.GetAccountsAsync().ConfigureAwait(false));
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                var account1 = accounts.First();
+                Assert.AreEqual("sub", account1.HomeAccountId.Identifier);
+                Assert.AreEqual(null, account1.HomeAccountId.TenantId);
+
+                // This is because of how we've done it in ADFS. Probably doesn't matter what value is used here, as it is not defined for non-Microsoft.
+                Assert.AreEqual("sub", account1.HomeAccountId.ObjectId);
+
+                // the account id is based only on the sub claim
+                var account2 = await cca.GetAccountAsync("sub").ConfigureAwait(false);
+
+                CoreAssert.AreAccountsEqual(
+                    TestConstants.Email,
+                    (new Uri(authority)).Host,
+                    "sub",
+                    null,
+                    "sub",
+                    account1,
+                    account2,
+                    result.Account);
+
+                Debug.WriteLine("STS scopes returned in a different order ");
+                httpManager.AddMockHandler(
+                    CreateTokenResponseHttpHandler(
+                        authority + "/connect/token",
+                        scopesInRequest: string.Join(" ", requestedScopes),
+                        scopesInResponse: "email openid profile all:catchreport offline_access", // this is different from above!
+                        grant: "refresh_token"));
+
+                var result2 = await cca.AcquireTokenSilent(requestedScopes, result.Account)
+                    .WithForceRefresh(true)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource);
+
+                Debug.WriteLine("This would result in multiple matching tokens error");
+                var result3 = await cca.AcquireTokenSilent(requestedScopes, result.Account)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.Cache, result3.AuthenticationResultMetadata.TokenSource);
             }
         }
 
@@ -146,22 +284,34 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         private static MockHttpMessageHandler CreateTokenResponseHttpHandler(
             string tokenEndpoint,
             string scopesInRequest,
-            string scopesInResponse)
+            string scopesInResponse, 
+            string grant)
         {
             IDictionary<string, string> expectedRequestBody = new Dictionary<string, string>
             {
                 { "scope", scopesInRequest },
-                { "grant_type", "client_credentials" },
+                { "grant_type", grant },
                 { "client_id", TestConstants.ClientId },
                 { "client_secret", TestConstants.ClientSecret }
             };
 
-            string responseWithScopes = @"{ ""access_token"":""secret"", ""expires_in"":3600, ""token_type"":""Bearer"", ""scope"":""api"" }";
+            string responseWithScopes = @"{ ""access_token"":""secret"", ""expires_in"":3600, ""token_type"":""Bearer"", ""scope"":""scope_placeholder"" }";
             string responseWithoutScopes = @"{ ""access_token"":""secret"", ""expires_in"":3600, ""token_type"":""Bearer"" }";
 
-            string response = scopesInResponse == null ?
-                responseWithScopes.Replace("api", scopesInResponse)
+            string response = scopesInResponse != null ?
+                responseWithScopes.Replace("scope_placeholder", scopesInResponse)
                 : responseWithoutScopes;
+
+            // user flows have ID token - inject it into the response
+            if (grant != "client_credentials")
+            {
+                response = response.Insert(response.Length - 1, ",\"id_token\":\"" + CreateIdToken() + "\"");
+
+                // insert a fake refresh token with key refresh_token
+                response = response.Insert(response.Length - 1, ",\"refresh_token\":\"secret\"");
+
+                expectedRequestBody["scope"] = scopesInRequest + " openid profile offline_access";
+            }
 
             return new MockHttpMessageHandler()
             {
@@ -170,6 +320,22 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 ExpectedPostData = expectedRequestBody,
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(response)
             };
+        }        
+
+        private static string CreateIdToken()
+        {
+            // as per https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+            // but not all claims are required. Adding only a few that MSAL uses.
+            string id = "{\"aud\": \"e854a4a7-6c34-449c-b237-fc7a28093d84\"," +
+                       "\"iss\": \"https://demo.duendesoftware.com\"," +
+                       "\"iat\": 1455833828," +
+                       "\"exp\": 1455837728," +
+                       "\"name\": \""+ TestConstants.Email + "\"," +
+                       "\"email\": \""+ TestConstants.Email + "\"," +
+                       "\"sub\": \"sub\"" +
+                "}";
+
+            return string.Format(CultureInfo.InvariantCulture, "someheader.{0}.somesignature", Base64UrlHelpers.Encode(id));
         }
 
         private static MockHttpMessageHandler CreateOidcHttpHandler(string oidcEndpoint)

--- a/tests/Microsoft.Identity.Test.Unit/Resources/AADTestData.txt
+++ b/tests/Microsoft.Identity.Test.Unit/Resources/AADTestData.txt
@@ -25,13 +25,13 @@
     "uti": "6nciX02SMki9k73-F1sZAA",
     "ver": "2.0"
   },
-  "at_cache_key": "9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca-login.windows.net-accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read openid profile tasks.read user.read email",
-  "at_cache_key_ios_service": "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read openid profile tasks.read user.read email",
+  "at_cache_key": "9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca-login.windows.net-accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read email openid profile tasks.read user.read",
+  "at_cache_key_ios_service": "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-calendars.read email openid profile tasks.read user.read",
   "at_cache_key_ios_account": "9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca-login.windows.net",
   "at_cache_key_ios_generic": "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-f645ad92-e38d-4d1a-b510-d1b09a74a8ca",
   "at_cache_value": {
     "secret": "<removed_at>",
-    "target": "Calendars.Read openid profile Tasks.Read User.Read email",
+    "target": "Calendars.Read email openid profile Tasks.Read User.Read",
     "extended_expires_on": "1538801522",
     "credential_type": "AccessToken",
     "environment": "login.windows.net",

--- a/tests/Microsoft.Identity.Test.Unit/Resources/MSATestData.txt
+++ b/tests/Microsoft.Identity.Test.Unit/Resources/MSATestData.txt
@@ -25,13 +25,13 @@
     "tid": "9188040d-6c67-4c5b-b112-36a304b66dad",
     "aio": "DWgKnl!EsfVkSU8jFVbxM6PhZaR2EyXsMBymRGSXvREu4i*FmBU1RBl5hHvNvoGSGlqdBJFxndAsA6*Z3qZBr0c9vaIRwUpeICV*SXZjw8!B"
   },
-  "at_cache_key": "00000000-0000-0000-40c0-3bac188d01d1.9188040d-6c67-4c5b-b112-36a304b66dad-login.windows.net-accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-9188040d-6c67-4c5b-b112-36a304b66dad-tasks.read user.read openid profile",
-  "at_cache_key_ios_service": "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-9188040d-6c67-4c5b-b112-36a304b66dad-tasks.read user.read openid profile",
+  "at_cache_key": "00000000-0000-0000-40c0-3bac188d01d1.9188040d-6c67-4c5b-b112-36a304b66dad-login.windows.net-accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-9188040d-6c67-4c5b-b112-36a304b66dad-openid profile tasks.read user.read",
+  "at_cache_key_ios_service": "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-9188040d-6c67-4c5b-b112-36a304b66dad-openid profile tasks.read user.read",
   "at_cache_key_ios_account": "00000000-0000-0000-40c0-3bac188d01d1.9188040d-6c67-4c5b-b112-36a304b66dad-login.windows.net",
   "at_cache_key_ios_generic": "accesstoken-b6c69a37-df96-4db0-9088-2ab96e1d8215-9188040d-6c67-4c5b-b112-36a304b66dad",
   "at_cache_value": {
     "secret": "<removed_at>",
-    "target": "Tasks.Read User.Read openid profile",
+    "target": "openid profile Tasks.Read User.Read",
     "credential_type": "AccessToken",
     "environment": "login.windows.net",
     "realm": "9188040d-6c67-4c5b-b112-36a304b66dad",


### PR DESCRIPTION
Fixes #4474 


I verified that I am not touching the hot path (getting token from the cache), the reorder happens on saving token response from HTTP, which is already heavy operation.