### PR TITLE
[BUILDS] Add Java SDK Version 11 in packaging step to Resolve Xamarin Build Failure 

### DIFF
--- a/build/template-pack-and-sign-packages.yaml
+++ b/build/template-pack-and-sign-packages.yaml
@@ -55,6 +55,13 @@ steps:
       dotnet workload install maui --source https://api.nuget.org/v3/index.json
       dotnet workload install android ios macos maui --source https://api.nuget.org/v3/index.json
 
+- task: JavaToolInstaller@0
+  displayName: 'Use Java 11'
+  inputs:
+    versionSpec: 11
+    jdkArchitectureOption: x64
+    jdkSourceOption: PreInstalled
+    
 - task: VSBuild@1
   displayName: 'NuGet restore'
   inputs:


### PR DESCRIPTION
We're seeing build failures due to an outdated Java version. The error XA0031 indicates we need Java SDK 11.0 or higher for the Xamarin Android project, hence including it now in the pack and sign step for the legacy builds. 