### PR TITLE
Revert "update langVersion to 12"

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,7 +27,7 @@
     <IsPackable>true</IsPackable>
     
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>12</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">

--- a/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+++ b/src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworkNetStandard>netstandard2.0</TargetFrameworkNetStandard>
     <TargetFrameworkNetDesktop Condition="$([MSBuild]::IsOsPlatform('Windows'))">net462</TargetFrameworkNetDesktop>
 
+    <LangVersion>8.0</LangVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TargetFramework Condition="'$(TargetFrameworkNetDesktop)' == ''">$(TargetFrameworkNetStandard)</TargetFramework>
     <TargetFrameworks Condition="'$(TargetFrameworkNetDesktop)' != ''">$(TargetFrameworkNetStandard);$(TargetFrameworkNetDesktop)</TargetFrameworks>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,6 +2,5 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
   <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 </Project>

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Microsoft.Identity.Test.Integration.NetCore.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Identity.Test.Integration.netfx/Microsoft.Identity.Test.Integration.NetFx.csproj
+++ b/tests/Microsoft.Identity.Test.Integration.netfx/Microsoft.Identity.Test.Integration.NetFx.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);DESKTOP;NET_FX</DefineConstants>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Identity.Test.Performance/Microsoft.Identity.Test.Performance.csproj
+++ b/tests/Microsoft.Identity.Test.Performance/Microsoft.Identity.Test.Performance.csproj
@@ -8,6 +8,7 @@
     <!-- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation#debugtype -->
     <!--<DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>-->
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>

--- a/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
+++ b/tests/Microsoft.Identity.Test.Unit/Microsoft.Identity.Test.Unit.csproj
@@ -8,6 +8,8 @@
     <TargetFrameworks>$(TargetFrameworkNetDesktop48);$(TargetFrameworkNet6);$(TargetFrameworkNet6Win)</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
+    <LangVersion>latest</LangVersion>
+
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
 
     <Platforms>AnyCPU;x64</Platforms>

--- a/tests/devapps/DesktopTestApp/DesktopTestApp.csproj
+++ b/tests/devapps/DesktopTestApp/DesktopTestApp.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>

--- a/tests/devapps/FociTestApp/FociTestApp.csproj
+++ b/tests/devapps/FociTestApp/FociTestApp.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>

--- a/tests/devapps/Intune-xamarin-Android/Intune-xamarin-Android.csproj
+++ b/tests/devapps/Intune-xamarin-Android/Intune-xamarin-Android.csproj
@@ -63,6 +63,7 @@
     <DebugType>portable</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/devapps/Intune-xamarin-ios/IntuneMAMSampleiOS.csproj
+++ b/tests/devapps/Intune-xamarin-ios/IntuneMAMSampleiOS.csproj
@@ -71,6 +71,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug + MobileApps|iPhone'">
@@ -80,6 +81,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/devapps/MultiCloudTestApp/MultiCloudTestApp.csproj
+++ b/tests/devapps/MultiCloudTestApp/MultiCloudTestApp.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>

--- a/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
+++ b/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.17763.0</TargetFrameworks>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+    <LangVersion>8</LangVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseWinForms>true</UseWinForms>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>

--- a/tests/devapps/WAM/NetDesktopWpf/NetDesktopWpfWAM.csproj
+++ b/tests/devapps/WAM/NetDesktopWpf/NetDesktopWpfWAM.csproj
@@ -41,6 +41,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>

--- a/tests/devapps/WAM/NetFrameworkWam/NetDesktopWinFormsWAM.csproj
+++ b/tests/devapps/WAM/NetFrameworkWam/NetDesktopWinFormsWAM.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>

--- a/tests/devapps/WAM/UWPWam/UWP standalone WAM.csproj
+++ b/tests/devapps/WAM/UWPWam/UWP standalone WAM.csproj
@@ -171,6 +171,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
@@ -183,6 +184,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>ARM</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
@@ -195,6 +197,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>ARM64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
@@ -207,6 +210,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>


### PR DESCRIPTION
Reverts AzureAD/microsoft-authentication-library-for-dotnet#4494 to unblock the release. The one branch release build fails for lang version 12.