### PR TITLE
Resolve CS0108 Warning by Explicitly Hiding Base Member in MsalManage…

### DIFF
--- a/src/client/Microsoft.Identity.Client/MsalManagedIdentityException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalManagedIdentityException.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Specifies the managed identity source from which the exception initiates.
         /// </summary>
-        public ManagedIdentitySource ManagedIdentitySource { get; }
+        public new ManagedIdentitySource ManagedIdentitySource { get; }
 
         /// <summary>
         /// Retry error codes specific to managed identity


### PR DESCRIPTION
This pull request addresses the CS0108 compiler warning encountered in MsalManagedIdentityException.

Fixes #

**Testing**
existing unit, integration

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated. (N/A) 
