### PR TITLE
Fix some unit tests which did not declare their dependency on HTTP

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManager.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManager.cs
@@ -15,6 +15,7 @@ using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
 
 namespace Microsoft.Identity.Test.Common.Core.Mocks
 {
@@ -70,6 +71,15 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         }
 
         public int QueueSize => _httpMessageHandlerQueue.Count;
+
+        /// <summary>
+        /// For use only in threads that spin many threads. Not thread safe.
+        /// </summary>
+        public void ClearQueue()
+        {
+            while (_httpMessageHandlerQueue.TryDequeue(out _))
+                ;
+        }
 
         public long LastRequestDurationInMs => 3000;
 

--- a/tests/Microsoft.Identity.Test.Unit/AppTokenProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppTokenProviderTests.cs
@@ -23,87 +23,93 @@ namespace Microsoft.Identity.Test.Unit
         [TestMethod]
         public async Task ValidateAppTokenProviderAsync()
         {
-            bool usingClaims = false;
-            string differentScopesForAt = string.Empty;
-            int callbackInvoked = 0;
-            var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                          .WithAppTokenProvider((AppTokenProviderParameters parameters) =>
-                                                          {
-                                                              Assert.IsNotNull(parameters.Scopes);
-                                                              Assert.IsNotNull(parameters.CorrelationId);
-                                                              Assert.IsNotNull(parameters.TenantId);
-                                                              Assert.IsNotNull(parameters.CancellationToken);
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
-                                                              if (usingClaims)
+                bool usingClaims = false;
+                string differentScopesForAt = string.Empty;
+                int callbackInvoked = 0;
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithAppTokenProvider((AppTokenProviderParameters parameters) =>
                                                               {
-                                                                  Assert.IsNotNull(parameters.Claims);
-                                                              }
+                                                                  Assert.IsNotNull(parameters.Scopes);
+                                                                  Assert.IsNotNull(parameters.CorrelationId);
+                                                                  Assert.IsNotNull(parameters.TenantId);
+                                                                  Assert.IsNotNull(parameters.CancellationToken);
 
-                                                              Interlocked.Increment(ref callbackInvoked);
+                                                                  if (usingClaims)
+                                                                  {
+                                                                      Assert.IsNotNull(parameters.Claims);
+                                                                  }
 
-                                                              return Task.FromResult(GetAppTokenProviderResult(differentScopesForAt));
-                                                          })
-                                                          .BuildConcrete();
+                                                                  Interlocked.Increment(ref callbackInvoked);
 
-            // AcquireToken from app provider
-            AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                                                                  return Task.FromResult(GetAppTokenProviderResult(differentScopesForAt));
+                                                              })
+                                                              .WithHttpManager(harness.HttpManager)
+                                                              .BuildConcrete();
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(1, callbackInvoked);
+                // AcquireToken from app provider
+                AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            var tokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(1, callbackInvoked);
 
-            Assert.AreEqual(1, tokens.Count);
+                var tokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
 
-            var token = tokens.FirstOrDefault();
-            Assert.IsNotNull(token);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, token.Secret);
+                Assert.AreEqual(1, tokens.Count);
 
-            // AcquireToken from cache
-            result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                var token = tokens.FirstOrDefault();
+                Assert.IsNotNull(token);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, token.Secret);
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
-            Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(1, callbackInvoked);
+                // AcquireToken from cache
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            // Expire token
-            TokenCacheHelper.ExpireAllAccessTokens(app.AppTokenCacheInternal);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(1, callbackInvoked);
 
-            // Acquire token from app provider with expired token
-            result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                // Expire token
+                TokenCacheHelper.ExpireAllAccessTokens(app.AppTokenCacheInternal);
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(2, callbackInvoked);
+                // Acquire token from app provider with expired token
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            differentScopesForAt = "new scope";
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(2, callbackInvoked);
 
-            // Acquire token from app provider with new scopes
-            result = await app.AcquireTokenForClient(new[] { differentScopesForAt })
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                differentScopesForAt = "new scope";
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Count, 2);
-            Assert.AreEqual(3, callbackInvoked);
+                // Acquire token from app provider with new scopes
+                result = await app.AcquireTokenForClient(new[] { differentScopesForAt })
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            // Acquire token from app provider with claims. Should not use cache
-            result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .WithClaims(TestConstants.Claims)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Count, 2);
+                Assert.AreEqual(3, callbackInvoked);
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(4, callbackInvoked);
+                // Acquire token from app provider with claims. Should not use cache
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .WithClaims(TestConstants.Claims)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(4, callbackInvoked);
+            }
         }
 
         [DataTestMethod]
@@ -113,39 +119,44 @@ namespace Microsoft.Identity.Test.Unit
         [DataRow(7200, 500, 500)]
         public async Task CheckRefreshInAsync(long expiresInResponse, long refreshInResponse, long expectedRefreshIn)
         {
-            string differentScopesForAt = string.Empty;
-            var app1 = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                          .WithAppTokenProvider((AppTokenProviderParameters _) =>
-                                                          {
-                                                              AppTokenProviderResult result = new AppTokenProviderResult
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                string differentScopesForAt = string.Empty;
+                var app1 = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithAppTokenProvider((AppTokenProviderParameters _) =>
                                                               {
-                                                                  AccessToken = TestConstants.DefaultAccessToken,
-                                                                  ExpiresInSeconds = expiresInResponse,
-                                                                  RefreshInSeconds = refreshInResponse == 0 ? null : refreshInResponse,
-                                                              };
+                                                                  AppTokenProviderResult result = new AppTokenProviderResult
+                                                                  {
+                                                                      AccessToken = TestConstants.DefaultAccessToken,
+                                                                      ExpiresInSeconds = expiresInResponse,
+                                                                      RefreshInSeconds = refreshInResponse == 0 ? null : refreshInResponse,
+                                                                  };
 
-                                                              return Task.FromResult(result);
-                                                          })
-                                                          .Build();
+                                                                  return Task.FromResult(result);
+                                                              })
+                                                              .WithHttpManager(harness.HttpManager)
+                                                              .Build();
 
-            // AcquireToken from app provider
-            AuthenticationResult result = await app1.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .ExecuteAsync().ConfigureAwait(false);
+                // AcquireToken from app provider
+                AuthenticationResult result = await app1.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .ExecuteAsync().ConfigureAwait(false);
 
-            if (expectedRefreshIn == 0)
-            {
-                Assert.IsFalse(result.AuthenticationResultMetadata.RefreshOn.HasValue);
-            }
-            else
-            {
-                DateTimeOffset expectedRefreshOn = DateTimeOffset.UtcNow;
-                if (expectedRefreshIn != 0)
-                    expectedRefreshOn = expectedRefreshOn + TimeSpan.FromSeconds(expectedRefreshIn);
+                if (expectedRefreshIn == 0)
+                {
+                    Assert.IsFalse(result.AuthenticationResultMetadata.RefreshOn.HasValue);
+                }
+                else
+                {
+                    DateTimeOffset expectedRefreshOn = DateTimeOffset.UtcNow;
+                    if (expectedRefreshIn != 0)
+                        expectedRefreshOn = expectedRefreshOn + TimeSpan.FromSeconds(expectedRefreshIn);
 
-                CoreAssert.IsWithinRange(
-                    expectedRefreshOn,
-                    result.AuthenticationResultMetadata.RefreshOn.Value,
-                    TimeSpan.FromSeconds(2));
+                    CoreAssert.IsWithinRange(
+                        expectedRefreshOn,
+                        result.AuthenticationResultMetadata.RefreshOn.Value,
+                        TimeSpan.FromSeconds(2));
+                }
             }
         }
 
@@ -162,45 +173,56 @@ namespace Microsoft.Identity.Test.Unit
         [TestMethod]
         public async Task ParallelRequests_CallTokenEndpointOnceAsync()
         {
-            int numOfTasks = 10;
-            int identityProviderHits = 0;
-            int cacheHits = 0;
-
-            var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                .WithAuthority("https://login.microsoftonline.com/tid")
-                .WithAppTokenProvider((AppTokenProviderParameters _) =>
-                {
-                    return Task.FromResult(GetAppTokenProviderResult());
-                })
-                .BuildConcrete();
-
-            Task[] tasks = new Task[numOfTasks];
-            for (int i = 0; i < numOfTasks; i++)
+            using (var harness = CreateTestHarness())
             {
-                tasks[i] = Task.Run(async () =>
+
+                int numOfTasks = 10;
+                int identityProviderHits = 0;
+                int cacheHits = 0;
+
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithAuthority("https://login.microsoftonline.com/tid")
+                    .WithHttpManager(harness.HttpManager)
+                    .WithAppTokenProvider((AppTokenProviderParameters _) =>
+                    {
+                        return Task.FromResult(GetAppTokenProviderResult());
+                    })
+                    .BuildConcrete();
+
+                Task[] tasks = new Task[numOfTasks];
+                for (int i = 0; i < numOfTasks; i++)
                 {
-                    AuthenticationResult authResult = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                    harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
-                    if (authResult.AuthenticationResultMetadata.TokenSource == TokenSource.IdentityProvider)
+                    tasks[i] = Task.Run(async () =>
                     {
-                        // Increment identity hits count
-                        Interlocked.Increment(ref identityProviderHits);
-                        Assert.IsTrue(identityProviderHits == 1);
-                    }
-                    else
-                    {
-                        // Increment cache hits count
-                        Interlocked.Increment(ref cacheHits);
-                    }
-                });
+                        AuthenticationResult authResult = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+
+                        if (authResult.AuthenticationResultMetadata.TokenSource == TokenSource.IdentityProvider)
+                        {
+                            // Increment identity hits count
+                            Interlocked.Increment(ref identityProviderHits);
+                            Assert.IsTrue(identityProviderHits == 1);
+                        }
+                        else
+                        {
+                            // Increment cache hits count
+                            Interlocked.Increment(ref cacheHits);
+                        }
+                    });
+                }
+
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                Debug.WriteLine($"Total Identity Hits: {identityProviderHits}");
+                Debug.WriteLine($"Total Cache Hits: {cacheHits}");
+                Assert.IsTrue(cacheHits == 9);
+
+                harness.HttpManager.ClearQueue();
+
             }
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            Debug.WriteLine($"Total Identity Hits: {identityProviderHits}");
-            Debug.WriteLine($"Total Cache Hits: {cacheHits}");
-            Assert.IsTrue(cacheHits == 9);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -55,43 +55,47 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             bool serializeCache,
             bool expectToCallAdalLegacyCache)
         {
-            // Arrange
-            var legacyCachePersistence = Substitute.For<ILegacyCachePersistence>();
-            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isLegacyCacheEnabled: enableLegacyCacheCompatibility);
-            var requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
-            var response = TestConstants.CreateMsalTokenResponse();
-
-            ITokenCacheInternal cache = new TokenCache(serviceBundle, false);
-            ((TokenCache)cache).LegacyCachePersistence = legacyCachePersistence;
-            if (serializeCache) // no point in invoking the Legacy ADAL cache if you're only keeping it memory
+            using (MockHttpManager mockHttpManager = new MockHttpManager())
             {
-                cache.SetBeforeAccess((_) => { });
-            }
+                // Arrange
+                var legacyCachePersistence = Substitute.For<ILegacyCachePersistence>();
+                mockHttpManager.AddInstanceDiscoveryMockHandler();
+                var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(mockHttpManager, isLegacyCacheEnabled: enableLegacyCacheCompatibility);
+                var requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
+                var response = TestConstants.CreateMsalTokenResponse();
 
-            var requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
-            requestParams.AuthorityManager = new AuthorityManager(
-                requestContext,
-                Authority.CreateAuthorityWithTenant(
-                    requestParams.AuthorityInfo,
-                    TestConstants.Utid));
-            requestParams.Account = new Account(TestConstants.s_userIdentifier, $"1{TestConstants.DisplayableId}", TestConstants.ProductionPrefNetworkEnvironment);
+                ITokenCacheInternal cache = new TokenCache(serviceBundle, false);
+                ((TokenCache)cache).LegacyCachePersistence = legacyCachePersistence;
+                if (serializeCache) // no point in invoking the Legacy ADAL cache if you're only keeping it memory
+                {
+                    cache.SetBeforeAccess((_) => { });
+                }
 
-            // Act
-            await cache.FindRefreshTokenAsync(requestParams).ConfigureAwait(true);
-            await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(true);
-            await cache.GetAccountsAsync(requestParams).ConfigureAwait(true);
-            await cache.RemoveAccountAsync(requestParams.Account, requestParams).ConfigureAwait(true);
+                var requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
+                requestParams.AuthorityManager = new AuthorityManager(
+                    requestContext,
+                    Authority.CreateAuthorityWithTenant(
+                        requestParams.AuthorityInfo,
+                        TestConstants.Utid));
+                requestParams.Account = new Account(TestConstants.s_userIdentifier, $"1{TestConstants.DisplayableId}", TestConstants.ProductionPrefNetworkEnvironment);
 
-            // Assert
-            if (expectToCallAdalLegacyCache)
-            {
-                legacyCachePersistence.ReceivedWithAnyArgs().LoadCache();
-                legacyCachePersistence.ReceivedWithAnyArgs().WriteCache(Arg.Any<byte[]>());
-            }
-            else
-            {
-                legacyCachePersistence.DidNotReceiveWithAnyArgs().LoadCache();
-                legacyCachePersistence.DidNotReceiveWithAnyArgs().WriteCache(Arg.Any<byte[]>());
+                // Act
+                await cache.FindRefreshTokenAsync(requestParams).ConfigureAwait(true);
+                await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(true);
+                await cache.GetAccountsAsync(requestParams).ConfigureAwait(true);
+                await cache.RemoveAccountAsync(requestParams.Account, requestParams).ConfigureAwait(true);
+
+                // Assert
+                if (expectToCallAdalLegacyCache)
+                {
+                    legacyCachePersistence.ReceivedWithAnyArgs().LoadCache();
+                    legacyCachePersistence.ReceivedWithAnyArgs().WriteCache(Arg.Any<byte[]>());
+                }
+                else
+                {
+                    legacyCachePersistence.DidNotReceiveWithAnyArgs().LoadCache();
+                    legacyCachePersistence.DidNotReceiveWithAnyArgs().WriteCache(Arg.Any<byte[]>());
+                }
             }
         }
 
@@ -102,36 +106,43 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             bool multiCloudSupportEnabled)
         {
             // Arrange
-            var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(null, isMultiCloudSupportEnabled: multiCloudSupportEnabled);
-            var requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
-            var response = TestConstants.CreateMsalTokenResponse();
+            using (MockHttpManager mockHttpManager = new MockHttpManager())
+            {
+                mockHttpManager.AddInstanceDiscoveryMockHandler();
 
-            ITokenCacheInternal cache = new TokenCache(serviceBundle, false);
+                var serviceBundle = TestCommon.CreateServiceBundleWithCustomHttpManager(
+                    mockHttpManager,
+                    isMultiCloudSupportEnabled: multiCloudSupportEnabled);
+                var requestContext = new RequestContext(serviceBundle, Guid.NewGuid());
+                var response = TestConstants.CreateMsalTokenResponse();
 
-            var requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
-            requestParams.AuthorityManager = new AuthorityManager(
-                requestContext,
-                Authority.CreateAuthorityWithTenant(
-                    requestParams.AuthorityInfo,
-                    TestConstants.Utid));
-            requestParams.Account = new Account(TestConstants.s_userIdentifier, $"1{TestConstants.DisplayableId}", TestConstants.ProductionPrefNetworkEnvironment);
+                ITokenCacheInternal cache = new TokenCache(serviceBundle, false);
 
-            var res = await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(true);
+                var requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
+                requestParams.AuthorityManager = new AuthorityManager(
+                    requestContext,
+                    Authority.CreateAuthorityWithTenant(
+                        requestParams.AuthorityInfo,
+                        TestConstants.Utid));
+                requestParams.Account = new Account(TestConstants.s_userIdentifier, $"1{TestConstants.DisplayableId}", TestConstants.ProductionPrefNetworkEnvironment);
 
-            IEnumerable<IAccount> accounts = await cache.GetAccountsAsync(requestParams).ConfigureAwait(true);
-            Assert.IsNotNull(accounts);
-            Assert.IsNotNull(accounts.Single());
+                var res = await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(true);
 
-            MsalRefreshTokenCacheItem refreshToken = await cache.FindRefreshTokenAsync(requestParams).ConfigureAwait(true);
-            Assert.IsNotNull(refreshToken);
+                IEnumerable<IAccount> accounts = await cache.GetAccountsAsync(requestParams).ConfigureAwait(true);
+                Assert.IsNotNull(accounts);
+                Assert.IsNotNull(accounts.Single());
 
-            MsalIdTokenCacheItem idToken = cache.GetIdTokenCacheItem(res.Item1);
-            Assert.IsNotNull(idToken);
+                MsalRefreshTokenCacheItem refreshToken = await cache.FindRefreshTokenAsync(requestParams).ConfigureAwait(true);
+                Assert.IsNotNull(refreshToken);
 
-            await cache.RemoveAccountAsync(requestParams.Account, requestParams).ConfigureAwait(true);
-            accounts = await cache.GetAccountsAsync(requestParams).ConfigureAwait(true);
-            Assert.IsNotNull(accounts);
-            Assert.IsTrue(accounts.IsNullOrEmpty());
+                MsalIdTokenCacheItem idToken = cache.GetIdTokenCacheItem(res.Item1);
+                Assert.IsNotNull(idToken);
+
+                await cache.RemoveAccountAsync(requestParams.Account, requestParams).ConfigureAwait(true);
+                accounts = await cache.GetAccountsAsync(requestParams).ConfigureAwait(true);
+                Assert.IsNotNull(accounts);
+                Assert.IsTrue(accounts.IsNullOrEmpty());
+            }
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -916,14 +916,19 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             using (var httpManager = new MockHttpManager())
             {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
                 ConfidentialClientApplicationOptions applicationOptions;
                 applicationOptions = new ConfidentialClientApplicationOptions();
                 applicationOptions.ClientId = "fakeId";
                 applicationOptions.RedirectUri = "https://example.com";
                 applicationOptions.ClientSecret = "rwerewrwe";
 
-                var confidentialClientApplicationBuilder = ConfidentialClientApplicationBuilder
-                                                                    .CreateWithApplicationOptions(applicationOptions);
+                var confidentialClientApplicationBuilder =
+                    ConfidentialClientApplicationBuilder
+                        .CreateWithApplicationOptions(applicationOptions)
+                        .WithHttpManager(httpManager);
+
                 var confidentialClientApplication = confidentialClientApplicationBuilder.Build();
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -1577,37 +1582,43 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         // Regression test for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1193
         public async Task GetAuthorizationRequestUrl_ReturnsUri_Async()
         {
-            string[] s_userReadScope = { "User.Read" };
+            using (var harness = base.CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
-            var cca = ConfidentialClientApplicationBuilder
-                   .Create(TestConstants.ClientId)
-                   .WithClientSecret("secret")
-                   .WithRedirectUri(TestConstants.RedirectUri)
-                   .Build();
+                string[] s_userReadScope = { "User.Read" };
 
-            var uri1 = await cca.GetAuthorizationRequestUrl(s_userReadScope).ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
-            var uri2 = await cca.GetAuthorizationRequestUrl(s_userReadScope).ExecuteAsync().ConfigureAwait(false);
+                var cca = ConfidentialClientApplicationBuilder
+                       .Create(TestConstants.ClientId)
+                       .WithHttpManager(harness.HttpManager)
+                       .WithClientSecret("secret")
+                       .WithRedirectUri(TestConstants.RedirectUri)
+                       .Build();
 
-            Assert.AreEqual(uri1.Host, uri2.Host);
-            Assert.AreEqual(uri1.LocalPath, uri2.LocalPath);
+                var uri1 = await cca.GetAuthorizationRequestUrl(s_userReadScope).ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+                var uri2 = await cca.GetAuthorizationRequestUrl(s_userReadScope).ExecuteAsync().ConfigureAwait(false);
 
-            var uriParams1 = uri1.ParseQueryString();
-            var uriParams2 = uri2.ParseQueryString();
+                Assert.AreEqual(uri1.Host, uri2.Host);
+                Assert.AreEqual(uri1.LocalPath, uri2.LocalPath);
 
-            CollectionAssert.AreEquivalent(
-                "offline_access openid profile User.Read".Split(' '),
-                uriParams1["scope"].Split(' '));
-            CollectionAssert.AreEquivalent(
-                "offline_access openid profile User.Read".Split(' '),
-                uriParams2["scope"].Split(' '));
-            CoreAssert.AreEqual("code", uriParams1["response_type"], uriParams2["response_type"]);
-            CoreAssert.AreEqual(TestConstants.ClientId, uriParams1["client_id"], uriParams2["client_id"]);
-            CoreAssert.AreEqual(TestConstants.RedirectUri, uriParams1["redirect_uri"], uriParams2["redirect_uri"]);
-            CoreAssert.AreEqual("select_account", uriParams1["prompt"], uriParams2["prompt"]);
+                var uriParams1 = uri1.ParseQueryString();
+                var uriParams2 = uri2.ParseQueryString();
 
-            Assert.AreEqual(uriParams1["x-client-OS"], uriParams2["x-client-OS"]);
-            Assert.AreEqual(uriParams1["x-client-Ver"], uriParams2["x-client-Ver"]);
-            Assert.AreEqual(uriParams1["x-client-SKU"], uriParams2["x-client-SKU"]);
+                CollectionAssert.AreEquivalent(
+                    "offline_access openid profile User.Read".Split(' '),
+                    uriParams1["scope"].Split(' '));
+                CollectionAssert.AreEquivalent(
+                    "offline_access openid profile User.Read".Split(' '),
+                    uriParams2["scope"].Split(' '));
+                CoreAssert.AreEqual("code", uriParams1["response_type"], uriParams2["response_type"]);
+                CoreAssert.AreEqual(TestConstants.ClientId, uriParams1["client_id"], uriParams2["client_id"]);
+                CoreAssert.AreEqual(TestConstants.RedirectUri, uriParams1["redirect_uri"], uriParams2["redirect_uri"]);
+                CoreAssert.AreEqual("select_account", uriParams1["prompt"], uriParams2["prompt"]);
+
+                Assert.AreEqual(uriParams1["x-client-OS"], uriParams2["x-client-OS"]);
+                Assert.AreEqual(uriParams1["x-client-Ver"], uriParams2["x-client-Ver"]);
+                Assert.AreEqual(uriParams1["x-client-SKU"], uriParams2["x-client-SKU"]);
+            }
         }
 
         [TestMethod]
@@ -1826,87 +1837,93 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [TestMethod]
         public async Task ValidateAppTokenProviderAsync()
         {
-            bool usingClaims = false;
-            string differentScopesForAt = string.Empty;
-            int callbackInvoked = 0;
-            var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                                                          .WithAppTokenProvider((AppTokenProviderParameters parameters) =>
-                                                          {
-                                                              Assert.IsNotNull(parameters.Scopes);
-                                                              Assert.IsNotNull(parameters.CorrelationId);
-                                                              Assert.IsNotNull(parameters.TenantId);
-                                                              Assert.IsNotNull(parameters.CancellationToken);
+            using (var harness = base.CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
-                                                              if (usingClaims)
+                bool usingClaims = false;
+                string differentScopesForAt = string.Empty;
+                int callbackInvoked = 0;
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithAppTokenProvider((AppTokenProviderParameters parameters) =>
                                                               {
-                                                                  Assert.IsNotNull(parameters.Claims);
-                                                              }
+                                                                  Assert.IsNotNull(parameters.Scopes);
+                                                                  Assert.IsNotNull(parameters.CorrelationId);
+                                                                  Assert.IsNotNull(parameters.TenantId);
+                                                                  Assert.IsNotNull(parameters.CancellationToken);
 
-                                                              Interlocked.Increment(ref callbackInvoked);
+                                                                  if (usingClaims)
+                                                                  {
+                                                                      Assert.IsNotNull(parameters.Claims);
+                                                                  }
 
-                                                              return Task.FromResult(GetAppTokenProviderResult(differentScopesForAt));
-                                                          })
-                                                          .BuildConcrete();
+                                                                  Interlocked.Increment(ref callbackInvoked);
 
-            // AcquireToken from app provider
-            AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                                                                  return Task.FromResult(GetAppTokenProviderResult(differentScopesForAt));
+                                                              })
+                                                              .WithHttpManager(harness.HttpManager)
+                                                              .BuildConcrete();
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(1, callbackInvoked);
+                // AcquireToken from app provider
+                AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            var tokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(1, callbackInvoked);
 
-            Assert.AreEqual(1, tokens.Count);
+                var tokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
 
-            var token = tokens.FirstOrDefault();
-            Assert.IsNotNull(token);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, token.Secret);
+                Assert.AreEqual(1, tokens.Count);
 
-            // AcquireToken from cache
-            result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                var token = tokens.FirstOrDefault();
+                Assert.IsNotNull(token);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, token.Secret);
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
-            Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(1, callbackInvoked);
+                // AcquireToken from cache
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            // Expire token
-            TokenCacheHelper.ExpireAllAccessTokens(app.AppTokenCacheInternal);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(1, callbackInvoked);
 
-            // Acquire token from app provider with expired token
-            result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                // Expire token
+                TokenCacheHelper.ExpireAllAccessTokens(app.AppTokenCacheInternal);
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(2, callbackInvoked);
+                // Acquire token from app provider with expired token
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            differentScopesForAt = "new scope";
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(2, callbackInvoked);
 
-            // Acquire token from app provider with new scopes
-            result = await app.AcquireTokenForClient(new[] { differentScopesForAt })
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                differentScopesForAt = "new scope";
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Count, 2);
-            Assert.AreEqual(3, callbackInvoked);
+                // Acquire token from app provider with new scopes
+                result = await app.AcquireTokenForClient(new[] { differentScopesForAt })
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
 
-            // Acquire token from app provider with claims. Should not use cache
-            result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                                                    .WithClaims(TestConstants.Claims)
-                                                    .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Count, 2);
+                Assert.AreEqual(3, callbackInvoked);
 
-            Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
-            Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-            Assert.AreEqual(4, callbackInvoked);
+                // Acquire token from app provider with claims. Should not use cache
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                        .WithClaims(TestConstants.Claims)
+                                                        .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TestConstants.DefaultAccessToken + differentScopesForAt, result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(4, callbackInvoked);
+            }
         }
 
         private AppTokenProviderResult GetAppTokenProviderResult(string differentScopesForAt = "", long? refreshIn = 1000)


### PR DESCRIPTION
To repro: 

1. Disconnect from Internet
2. Run affected UT

Actual: test fails with Socket exception (the instance discovery fails)
Expected: unit tests should not depend on HTTP