### PR TITLE
Revert "avoid allocating full scopes string twice ParseScopesForTelemetry"

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -215,21 +215,19 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
                 if (Uri.IsWellFormedUriString(firstScope, UriKind.Absolute))
                 {
-                    var firstScopeAsUri = new Uri(firstScope);
+                    Uri firstScopeAsUri = new Uri(firstScope);
                     resource = $"{firstScopeAsUri.Scheme}://{firstScopeAsUri.Host}";
 
-                    var stringBuilder = new StringBuilder();
+                    StringBuilder stringBuilder = new StringBuilder();
 
                     foreach (string scope in AuthenticationRequestParameters.Scope)
                     {
-                        var splitString = scope.Split([firstScopeAsUri.Host], StringSplitOptions.None);
-                        var scopeToAppend = splitString.Length > 1 ? splitString[1].TrimStart('/') : splitString.FirstOrDefault();
+                        var splitString = scope.Split(new[] { firstScopeAsUri.Host }, StringSplitOptions.None);
+                        string scopeToAppend = splitString.Length > 1 ? splitString[1].TrimStart('/') + " " : splitString.FirstOrDefault();
                         stringBuilder.Append(scopeToAppend);
-                        stringBuilder.Append(' ');
                     }
 
-                    stringBuilder.Length -= 1;
-                    scopes = stringBuilder.ToString();
+                    scopes = stringBuilder.ToString().TrimEnd(' ');
                 }
                 else
                 {


### PR DESCRIPTION
Reverts AzureAD/microsoft-authentication-library-for-dotnet#4577.

This breaks the one branch build for release:
 https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1246330&view=logs&j=15dfcb1a-0989-5cf6-3160-3e181e44de87&t=cdee0a61-8978-5bd6-7f9d-8251f4e5ad03&l=27