### PR TITLE
#4605 Only include needed packages

### DIFF
--- a/src/client/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
+++ b/src/client/Microsoft.Identity.Client.Extensions.Msal/Microsoft.Identity.Client.Extensions.Msal.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet and AssemblyInfo metadata">
@@ -19,6 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.IO.FileSystem.AccessControl" />
   </ItemGroup>
 

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -135,6 +135,8 @@
 
     <!--System.Text.Json replaces internal NewtonSoft for NET 6-->
     <Compile Remove="$(PathToMsalSources)\json\**\*.*" />
+
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNet6)' or '$(TargetFramework)' == '$(TargetFrameworkNet6Win)'">
@@ -155,6 +157,8 @@
 
     <PackageReference Include="Microsoft.Web.WebView2" />
     <PackageReference Include="Microsoft.Identity.Client.NativeInterop" IncludeAssets="all" />
+
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
 
     <!--System.Text.Json replaces internal NewtonSoft for NET 6-->
     <Compile Remove="$(PathToMsalSources)\json\**\*.*" />

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -31,7 +31,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(TargetFrameworkNetStandard);$(TargetFrameworkIos);$(TargetFrameworkAndroid9);$(TargetFrameworkAndroid10);$(TargetFrameworkNet6Ios);$(TargetFrameworkNet6Android);$(TargetFrameworkNet6Mac);$(TargetFrameworkNet6)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Linux')) Or '$(NetCoreOnly)' !='' ">$(TargetFrameworkNetStandard);$(TargetFrameworkNet6)</TargetFrameworks>
   </PropertyGroup>
-  
+
   <!-- Package excluding Windows Desktop and Mobile TFMs https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3863 -->
   <PropertyGroup Condition="'$(NET_ONLY_INTERNAL_PACKAGE)' != ''">
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworkNetDesktop462);$(TargetFrameworkNetStandard);$(TargetFrameworkNet6);</TargetFrameworks>
@@ -48,12 +48,12 @@
 
     <!-- Copyright needs to be in the form of © not (c) to be compliant -->
     <Title>Microsoft Authentication Library for .NET</Title>
-   
+
     <DisableExtraReferences>true</DisableExtraReferences>
-    <!-- for https://github.com/xamarin/xamarin-macios/issues/7249 -->    
+    <!-- for https://github.com/xamarin/xamarin-macios/issues/7249 -->
   </PropertyGroup>
 
-  
+
 
   <PropertyGroup>
     <PathToMsalSources>$(MSBuildThisFileDirectory)</PathToMsalSources>
@@ -135,15 +135,13 @@
 
     <!--System.Text.Json replaces internal NewtonSoft for NET 6-->
     <Compile Remove="$(PathToMsalSources)\json\**\*.*" />
-
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNet6)' or '$(TargetFramework)' == '$(TargetFrameworkNet6Win)'">
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNet6Win)'">
     <Compile Include="$(PathToMsalSources)\Platforms\net6\**\*.cs" LinkBase="Platforms\net6" />
     <Compile Include="$(PathToMsalSources)\Platforms\netcore\**\*.cs" LinkBase="Platforms\netcore" />
@@ -158,17 +156,15 @@
     <PackageReference Include="Microsoft.Web.WebView2" />
     <PackageReference Include="Microsoft.Identity.Client.NativeInterop" IncludeAssets="all" />
 
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-
     <!--System.Text.Json replaces internal NewtonSoft for NET 6-->
     <Compile Remove="$(PathToMsalSources)\json\**\*.*" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNet6Win)'">
     <UseWindowsForms>true</UseWindowsForms>
-    <!-- 
-    MSAL will run on Windows 7 and 8 but requires to be built against Win10 to use WinRT APIs for WAM 
-    See https://docs.microsoft.com/en-us/dotnet/standard/analyzers/platform-compat-analyzer and 
+    <!--
+    MSAL will run on Windows 7 and 8 but requires to be built against Win10 to use WinRT APIs for WAM
+    See https://docs.microsoft.com/en-us/dotnet/standard/analyzers/platform-compat-analyzer and
     https://github.com/dotnet/designs/blob/main/accepted/2020/platform-checks/platform-checks.md for details
     -->
     <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
@@ -176,7 +172,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetDesktop462)' ">
     <Compile Include="$(PathToMsalSources)\Platforms\Features\OpenTelemetry\**\*.cs" />
-    
+
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
@@ -219,7 +215,7 @@
 
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkIos)'">
-    <Compile Include="$(PathToMsalSources)\Platforms\iOS\**\*.cs" />    
+    <Compile Include="$(PathToMsalSources)\Platforms\iOS\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -234,7 +230,7 @@
     <PackageReference Include="System.Runtime.Serialization.Formatters" />
     <PackageReference Include="System.Xml.XmlDocument" />
     <PackageReference Include="System.Security.SecureString" />
-  </ItemGroup> 
+  </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid'))">
     <Compile Include="$(PathToMsalSources)\Platforms\Android\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
@@ -267,7 +263,7 @@
     <PackageReference Include="Xamarin.AndroidX.Browser" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNet6Ios)' Or '$(TargetFramework)' == '$(TargetFrameworkNet6Mac)'">
-    <Compile Include="$(PathToMsalSources)\Platforms\iOS\**\*.cs" />    
+    <Compile Include="$(PathToMsalSources)\Platforms\iOS\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
     <PackageReference Include="System.Security.SecureString" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #4605 
**Changes proposed in this request**

- Add net 6 as TFM for Microsoft.Identity.Client.Extensions.Msal
- Make System.IO.FileSystem.AccessControl only included for Net standard 2.0 in Microsoft.Identity.Client.Extensions.Msal

**Documentation**
- [x] All relevant documentation is updated.
