### PR TITLE
Updating stopwatch operations to use singleton

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Core;
@@ -139,24 +141,27 @@ namespace Microsoft.Identity.Client.Cache
                             }
                             finally
                             {
-                                var args = new TokenCacheNotificationArgs(
-                                  TokenCacheInternal,
-                                  _requestParams.AppConfig.ClientId,
-                                  _requestParams.Account,
-                                  hasStateChanged: false,
-                                  isApplicationCache: TokenCacheInternal.IsApplicationCache,
-                                  suggestedCacheKey: key,
-                                  hasTokens: TokenCacheInternal.HasTokensNoLocks(),
-                                  cancellationToken: _requestParams.RequestContext.UserCancellationToken,
-                                  suggestedCacheExpiry: null,
-                                  correlationId: _requestParams.RequestContext.CorrelationId,
-                                  requestScopes: _requestParams.Scope,
-                                  requestTenantId: _requestParams.AuthorityManager.OriginalAuthority.TenantId,
-                                  identityLogger: _requestParams.RequestContext.Logger.IdentityLogger,
-                                  piiLoggingEnabled: _requestParams.RequestContext.Logger.PiiLoggingEnabled,
-                                  telemetryData: telemetryData);
+                                var measureDurationResult = await StopWatchService.MeasureCodeBlockAsync(async () =>
+                                {
+                                    var args = new TokenCacheNotificationArgs(
+                                      TokenCacheInternal,
+                                      _requestParams.AppConfig.ClientId,
+                                      _requestParams.Account,
+                                      hasStateChanged: false,
+                                      isApplicationCache: TokenCacheInternal.IsApplicationCache,
+                                      suggestedCacheKey: key,
+                                      hasTokens: TokenCacheInternal.HasTokensNoLocks(),
+                                      cancellationToken: _requestParams.RequestContext.UserCancellationToken,
+                                      suggestedCacheExpiry: null,
+                                      correlationId: _requestParams.RequestContext.CorrelationId,
+                                      requestScopes: _requestParams.Scope,
+                                      requestTenantId: _requestParams.AuthorityManager.OriginalAuthority.TenantId,
+                                      identityLogger: _requestParams.RequestContext.Logger.IdentityLogger,
+                                      piiLoggingEnabled: _requestParams.RequestContext.Logger.PiiLoggingEnabled,
+                                      telemetryData: telemetryData);
 
-                                var measureDurationResult = await TokenCacheInternal.OnAfterAccessAsync(args).MeasureAsync().ConfigureAwait(false);
+                                    await TokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);
+                                }).ConfigureAwait(false);
                                 RequestContext.ApiEvent.DurationInCacheInMs += measureDurationResult.Milliseconds;
 
                             }

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.Http
@@ -216,8 +217,12 @@ namespace Microsoft.Identity.Client.Http
                     () => $"[HttpManager] Sending request. Method: {method}. URI: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}{endpoint.AbsolutePath}")}. ",
                     () => $"[HttpManager] Sending request. Method: {method}. Host: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}")}. ");
 
-                HttpClient client = GetHttpClient();
-                MeasureDurationResult<HttpResponseMessage> measureDurationResult = await client.SendAsync(requestMessage, cancellationToken).MeasureAsync().ConfigureAwait(false);
+                var measureDurationResult = await StopWatchService.MeasureCodeBlockAsync(async () =>
+                {
+                    HttpClient client = GetHttpClient();
+                    return await client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+
                 using (HttpResponseMessage responseMessage = measureDurationResult.Result)
                 {
                     LastRequestDurationInMs = measureDurationResult.Milliseconds;

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.Http
 {
@@ -215,14 +216,11 @@ namespace Microsoft.Identity.Client.Http
                     () => $"[HttpManager] Sending request. Method: {method}. URI: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}{endpoint.AbsolutePath}")}. ",
                     () => $"[HttpManager] Sending request. Method: {method}. Host: {(endpoint == null ? "NULL" : $"{endpoint.Scheme}://{endpoint.Authority}")}. ");
 
-                Stopwatch sw = Stopwatch.StartNew();
-
                 HttpClient client = GetHttpClient();
-
-                using (HttpResponseMessage responseMessage =
-                    await client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false))
+                MeasureDurationResult<HttpResponseMessage> measureDurationResult = await client.SendAsync(requestMessage, cancellationToken).MeasureAsync().ConfigureAwait(false);
+                using (HttpResponseMessage responseMessage = measureDurationResult.Result)
                 {
-                    LastRequestDurationInMs = sw.ElapsedMilliseconds;
+                    LastRequestDurationInMs = measureDurationResult.Milliseconds;
                     logger.Verbose(()=>$"[HttpManager] Received response. Status code: {responseMessage.StatusCode}. ");
 
                     HttpResponse returnValue = await CreateResponseAsync(responseMessage).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Logger/DurationLogHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Logger/DurationLogHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.Internal.Logger
 {
@@ -12,7 +13,7 @@ namespace Microsoft.Identity.Client.Internal.Logger
         private readonly ILoggerAdapter _logger;
         private readonly string _measuredBlockName;
         private readonly LogLevel _logLevel;
-        private readonly Stopwatch _stopwatch;
+        private readonly long _startMilliseconds;
 
         public DurationLogHelper(
             ILoggerAdapter logger,
@@ -22,14 +23,14 @@ namespace Microsoft.Identity.Client.Internal.Logger
             _logger = logger;
             _measuredBlockName = measuredBlockName;
             _logLevel = logLevel;
-            _stopwatch = Stopwatch.StartNew();
+            _startMilliseconds = StopWatchService.CurrentElapsedMilliseconds;
 
             _logger.Log(LogLevel.Verbose, string.Empty, $"Starting {measuredBlockName}");
         }
 
         public void Dispose()
         {
-            _logger.Log(LogLevel.Verbose, string.Empty, $"Finished {_measuredBlockName} in {_stopwatch.ElapsedMilliseconds} ms");
+            _logger.Log(LogLevel.Verbose, string.Empty, $"Finished {_measuredBlockName} in {StopWatchService.CurrentElapsedMilliseconds - _startMilliseconds} ms");
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     UpdateTelemetry(measureDurationResult.Milliseconds + measureTelemetryDurationResult.Milliseconds, apiEvent, authenticationResult);
                     LogMetricsFromAuthResult(authenticationResult, AuthenticationRequestParameters.RequestContext.Logger);
                     LogSuccessfulTelemetryToClient(authenticationResult, telemetryEventDetails, telemetryClients);
-                    LogMsalSuccessTelemetryToOtel(authenticationResult, apiEvent.ApiId.ToString(), measureDurationResult.Milliseconds * 1000);
+                    LogMsalSuccessTelemetryToOtel(authenticationResult, apiEvent.ApiId.ToString(), measureDurationResult.Ticks / (TimeSpan.TicksPerMillisecond / 1000));
 
                     return authenticationResult;
                 }

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -190,12 +190,12 @@ namespace Microsoft.Identity.Client
                             identityLogger: requestParams.RequestContext.Logger.IdentityLogger,
                             piiLoggingEnabled: requestParams.RequestContext.Logger.PiiLoggingEnabled);
 
-                        var measuredResultDuration = await Task.Run( async () => 
+                        var measuredResultDuration = await StopWatchService.MeasureCodeBlockAsync( async () => 
                         {
                             await tokenCacheInternal.OnBeforeAccessAsync(args).ConfigureAwait(false);
                             await tokenCacheInternal.OnBeforeWriteAsync(args).ConfigureAwait(false);
 
-                        }).MeasureAsync().ConfigureAwait(false);
+                        }).ConfigureAwait(false);
 
                         requestParams.RequestContext.ApiEvent.DurationInCacheInMs += measuredResultDuration.Milliseconds;
                     }

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -190,11 +190,14 @@ namespace Microsoft.Identity.Client
                             identityLogger: requestParams.RequestContext.Logger.IdentityLogger,
                             piiLoggingEnabled: requestParams.RequestContext.Logger.PiiLoggingEnabled);
 
-                        Stopwatch sw = Stopwatch.StartNew();
+                        var measuredResultDuration = await Task.Run( async () => 
+                        {
+                            await tokenCacheInternal.OnBeforeAccessAsync(args).ConfigureAwait(false);
+                            await tokenCacheInternal.OnBeforeWriteAsync(args).ConfigureAwait(false);
 
-                        await tokenCacheInternal.OnBeforeAccessAsync(args).ConfigureAwait(false);
-                        await tokenCacheInternal.OnBeforeWriteAsync(args).ConfigureAwait(false);
-                        requestParams.RequestContext.ApiEvent.DurationInCacheInMs += sw.ElapsedMilliseconds;
+                        }).MeasureAsync().ConfigureAwait(false);
+
+                        requestParams.RequestContext.ApiEvent.DurationInCacheInMs += measuredResultDuration.Milliseconds;
                     }
 
                     // Don't cache access tokens from broker
@@ -262,9 +265,8 @@ namespace Microsoft.Identity.Client
                             identityLogger: requestParams.RequestContext.Logger.IdentityLogger,
                             piiLoggingEnabled: requestParams.RequestContext.Logger.PiiLoggingEnabled);
 
-                        Stopwatch sw = Stopwatch.StartNew();
-                        await tokenCacheInternal.OnAfterAccessAsync(args).ConfigureAwait(false);
-                        requestParams.RequestContext.ApiEvent.DurationInCacheInMs += sw.ElapsedMilliseconds;
+                        var measuredTimeDuration = await tokenCacheInternal.OnAfterAccessAsync(args).MeasureAsync().ConfigureAwait(false);
+                        requestParams.RequestContext.ApiEvent.DurationInCacheInMs += measuredTimeDuration.Milliseconds;
 
                         LogCacheContents(requestParams);
                     }

--- a/src/client/Microsoft.Identity.Client/Utils/MeasureDurationResult.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/MeasureDurationResult.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Utils
+{
+    /// <summary>
+    /// Structure that holds a <see cref="Task"/> result and duration of the <see cref="Task"/> in milliseconds
+    /// </summary>
+    internal struct MeasureDurationResult<TResult>
+    {
+        public MeasureDurationResult(TResult result, long milliseconds)
+        {
+            Result = result;
+            Milliseconds = milliseconds;
+        }
+
+        public TResult Result { get; }
+
+        public long Milliseconds { get; }
+    }
+
+    /// <summary>
+    /// Structure that holds a duration of the <see cref="Task"/> in milliseconds.
+    /// </summary>
+    internal struct MeasureDurationResult
+    {
+        public MeasureDurationResult(long milliseconds)
+        {
+            Milliseconds = milliseconds;
+        }
+
+        public long Milliseconds { get; }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Utils/MeasureDurationResult.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/MeasureDurationResult.cs
@@ -14,15 +14,18 @@ namespace Microsoft.Identity.Client.Utils
     /// </summary>
     internal struct MeasureDurationResult<TResult>
     {
-        public MeasureDurationResult(TResult result, long milliseconds)
+        public MeasureDurationResult(TResult result, long ticks)
         {
             Result = result;
-            Milliseconds = milliseconds;
+            Milliseconds = ticks / TimeSpan.TicksPerMillisecond;
+            Ticks = ticks;
         }
 
         public TResult Result { get; }
 
         public long Milliseconds { get; }
+
+        public long Ticks { get; }
     }
 
     /// <summary>
@@ -30,11 +33,14 @@ namespace Microsoft.Identity.Client.Utils
     /// </summary>
     internal struct MeasureDurationResult
     {
-        public MeasureDurationResult(long milliseconds)
+        public MeasureDurationResult(long ticks)
         {
-            Milliseconds = milliseconds;
+            Milliseconds = ticks / TimeSpan.TicksPerMillisecond;
+            Ticks = ticks;
         }
 
         public long Milliseconds { get; }
+
+        public long Ticks { get; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
@@ -18,8 +18,11 @@ namespace Microsoft.Identity.Client.Utils
         /// <summary>
         /// Singleton stopwatch.
         /// </summary>
-        internal static readonly Stopwatch Watch = Stopwatch.StartNew();
+        public static readonly Stopwatch Watch = Stopwatch.StartNew();
 
+        /// <summary>
+        /// Current elapsed miliseconds of the stop watch
+        /// </summary>
         public static long CurrentElapsedMilliseconds {
             get 
             {
@@ -28,9 +31,34 @@ namespace Microsoft.Identity.Client.Utils
         }
 
         /// <summary>
+        /// Measures the duration of a codeblock
+        /// </summary>
+        /// <param name="codeBlock"></param>
+        /// <returns></returns>
+        public static MeasureDurationResult MeasureCodeBlock(Action codeBlock)
+        {
+            _ = codeBlock ?? throw new ArgumentNullException(nameof(codeBlock));
+
+            var startMs = Watch.ElapsedMilliseconds;
+            codeBlock.Invoke();
+
+            return new MeasureDurationResult(Watch.ElapsedMilliseconds - startMs);
+        }
+
+        /// <summary>
+        /// Measures the duration of an asyncronous codeblock
+        /// </summary>
+        /// <param name="codeBlock"></param>
+        /// <returns></returns>
+        public static async Task<MeasureDurationResult> MeasureCodeBlockAsync(Func<Task> codeBlock)
+        {
+            return await codeBlock.Invoke().MeasureAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Measures duration of <paramref name="task"/> in milliseconds.
         /// </summary>
-        internal static async Task<MeasureDurationResult> MeasureAsync(this Task task)
+        public static async Task<MeasureDurationResult> MeasureAsync(this Task task)
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
@@ -43,7 +71,7 @@ namespace Microsoft.Identity.Client.Utils
         /// <summary>
         /// Measures duration of <paramref name="task"/> in milliseconds.
         /// </summary>
-        internal static async Task<MeasureDurationResult<TResult>> MeasureAsync<TResult>(this Task<TResult> task)
+        public static async Task<MeasureDurationResult<TResult>> MeasureAsync<TResult>(this Task<TResult> task)
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 

--- a/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client.Utils
+{
+    /// <summary>
+    /// Singleton timer used to measure the duration tasks.
+    /// </summary>
+    internal static class StopWatchService
+    {
+        /// <summary>
+        /// Singleton stopwatch.
+        /// </summary>
+        internal static readonly Stopwatch Watch = Stopwatch.StartNew();
+
+        public static long CurrentElapsedMilliseconds {
+            get 
+            {
+                return Watch.ElapsedMilliseconds;
+            }
+        }
+
+        /// <summary>
+        /// Measures duration of <paramref name="task"/> in milliseconds.
+        /// </summary>
+        internal static async Task<MeasureDurationResult> MeasureAsync(this Task task)
+        {
+            _ = task ?? throw new ArgumentNullException(nameof(task));
+
+            var startMs = Watch.ElapsedMilliseconds;
+            await task.ConfigureAwait(false);
+
+            return new MeasureDurationResult(Watch.ElapsedMilliseconds - startMs);
+        }
+
+        /// <summary>
+        /// Measures duration of <paramref name="task"/> in milliseconds.
+        /// </summary>
+        internal static async Task<MeasureDurationResult<TResult>> MeasureAsync<TResult>(this Task<TResult> task)
+        {
+            _ = task ?? throw new ArgumentNullException(nameof(task));
+
+            var startMs = Watch.ElapsedMilliseconds;
+            var taskResult = await task.ConfigureAwait(false);
+
+            return new MeasureDurationResult<TResult>(taskResult, Watch.ElapsedMilliseconds - startMs);
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
@@ -53,10 +53,24 @@ namespace Microsoft.Identity.Client.Utils
         internal static async Task<MeasureDurationResult> MeasureCodeBlockAsync(Func<Task> codeBlock)
         {
             _ = codeBlock ?? throw new ArgumentNullException(nameof(codeBlock));
-            var startMs = Watch.ElapsedMilliseconds;
+            var startTicks = Watch.ElapsedTicks;
             await codeBlock.Invoke().ConfigureAwait(false);
 
-            return new MeasureDurationResult(Watch.ElapsedMilliseconds - startMs);
+            return new MeasureDurationResult(Watch.ElapsedTicks - startTicks);
+        }
+
+        /// <summary>
+        /// Measures the duration of an asyncronous codeblock
+        /// </summary>
+        /// <param name="codeBlock"></param>
+        /// <returns></returns>
+        internal static async Task<MeasureDurationResult<TResult>> MeasureCodeBlockAsync<TResult>(Func<Task<TResult>> codeBlock)
+        {
+            _ = codeBlock ?? throw new ArgumentNullException(nameof(codeBlock));
+            var startTicks = Watch.ElapsedTicks;
+            var result = await codeBlock.Invoke().ConfigureAwait(false);
+
+            return new MeasureDurationResult<TResult>(result, Watch.ElapsedTicks - startTicks);
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Identity.Client.Utils
         /// <summary>
         /// Singleton stopwatch.
         /// </summary>
-        public static readonly Stopwatch Watch = Stopwatch.StartNew();
+        internal static readonly Stopwatch Watch = Stopwatch.StartNew();
 
         /// <summary>
         /// Current elapsed miliseconds of the stop watch
         /// </summary>
-        public static long CurrentElapsedMilliseconds {
+        internal static long CurrentElapsedMilliseconds {
             get 
             {
                 return Watch.ElapsedMilliseconds;
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client.Utils
         /// </summary>
         /// <param name="codeBlock"></param>
         /// <returns></returns>
-        public static MeasureDurationResult MeasureCodeBlock(Action codeBlock)
+        internal static MeasureDurationResult MeasureCodeBlock(Action codeBlock)
         {
             _ = codeBlock ?? throw new ArgumentNullException(nameof(codeBlock));
 
@@ -50,35 +50,40 @@ namespace Microsoft.Identity.Client.Utils
         /// </summary>
         /// <param name="codeBlock"></param>
         /// <returns></returns>
-        public static async Task<MeasureDurationResult> MeasureCodeBlockAsync(Func<Task> codeBlock)
+        internal static async Task<MeasureDurationResult> MeasureCodeBlockAsync(Func<Task> codeBlock)
         {
-            return await codeBlock.Invoke().MeasureAsync().ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Measures duration of <paramref name="task"/> in milliseconds.
-        /// </summary>
-        public static async Task<MeasureDurationResult> MeasureAsync(this Task task)
-        {
-            _ = task ?? throw new ArgumentNullException(nameof(task));
-
+            _ = codeBlock ?? throw new ArgumentNullException(nameof(codeBlock));
             var startMs = Watch.ElapsedMilliseconds;
-            await task.ConfigureAwait(false);
+            await codeBlock.Invoke().ConfigureAwait(false);
 
             return new MeasureDurationResult(Watch.ElapsedMilliseconds - startMs);
         }
 
         /// <summary>
-        /// Measures duration of <paramref name="task"/> in milliseconds.
+        /// Measures duration of <paramref name="task"/> in ticks and milliseconds.
         /// </summary>
-        public static async Task<MeasureDurationResult<TResult>> MeasureAsync<TResult>(this Task<TResult> task)
+        internal static async Task<MeasureDurationResult> MeasureAsync(this Task task)
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
-            var startMs = Watch.ElapsedMilliseconds;
-            var taskResult = await task.ConfigureAwait(false);
+            var startTicks = Watch.ElapsedTicks;
+            await task.ConfigureAwait(false);
 
-            return new MeasureDurationResult<TResult>(taskResult, Watch.ElapsedMilliseconds - startMs);
+            return new MeasureDurationResult(Watch.ElapsedTicks - startTicks);
+            ;
+        }
+
+        /// <summary>
+        /// Measures duration of <paramref name="task"/> in ticks and milliseconds.
+        /// </summary>
+        internal static async Task<MeasureDurationResult<TResult>> MeasureAsync<TResult>(this Task<TResult> task)
+        {
+            _ = task ?? throw new ArgumentNullException(nameof(task));
+
+            var startTicks = Watch.ElapsedTicks;
+            var taskResult = await task.ConfigureAwait(true);
+
+            return new MeasureDurationResult<TResult>(taskResult, Watch.ElapsedTicks - startTicks);
         }
     }
 }


### PR DESCRIPTION
Fixes #
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4442

**Changes proposed in this request**
Updating stopwatch operations to use singleton

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
Negligible impact

Previous benchmark
| Method                | CacheSize   | EnableCacheSerialization | Mean       | Min        | Max        | Gen0    | Gen1    | Allocated |
|---------------------- |------------ |------------------------- |-----------:|-----------:|-----------:|--------:|--------:|----------:|
| AcquireTokenForClient | (1, 10)     | False                    |  10.998 us |  10.525 us |  12.647 us |  0.6714 |       - |  11.36 KB |
| AcquireTokenForClient | (1, 10)     | True                     | 110.139 us | 105.564 us | 118.477 us | 11.4746 |  3.4180 | 188.86 KB |
| AcquireTokenForClient | (10000, 10) | False                    |  18.480 us |  18.381 us |  18.577 us |  0.6714 |       - |  11.37 KB |
| AcquireTokenForClient | (10000, 10) | True                     | 107.464 us | 106.922 us | 108.408 us | 11.4746 | 11.4746 | 188.86 KB |
| AcquireTokenForClient | ?           | ?                        | 223.279 us | 220.400 us | 226.700 us |       - |       - |   37.3 KB |
| AcquireTokenForOBO    | (1, 10)     | False                    |  18.704 us |  18.616 us |  18.803 us |  1.1597 |       - |  19.09 KB |
| AcquireTokenForOBO    | (1, 10)     | True                     | 152.497 us | 151.113 us | 155.036 us | 15.8691 |  5.1270 | 263.12 KB |
| AcquireTokenForOBO    | (10000, 10) | False                    |  28.505 us |  27.649 us |  31.739 us |  1.1597 |       - |   19.1 KB |
| AcquireTokenForOBO    | (10000, 10) | True                     | 152.674 us | 151.935 us | 154.820 us | 15.8691 |  5.1270 | 263.12 KB |
| AcquireTokenForOBO    | ?           | ?                        | 308.000 us | 294.800 us | 319.700 us |       - |       - |  78.63 KB |
| AcquireTokenSilent    | (1, 10)     | ?                        |  15.385 us |  15.272 us |  15.530 us |  0.9766 |       - |  16.43 KB |
| AcquireTokenSilent    | (10000, 10) | ?                        |  25.311 us |  25.222 us |  25.447 us |  0.9766 |       - |  16.44 KB |
| GetAccount            | (1, 10)     | ?                        |   7.921 us |   7.868 us |   7.981 us |  0.4883 |       - |   8.11 KB |
| GetAccount            | (10000, 10) | ?                        |  15.875 us |  15.838 us |  15.919 us |  0.4883 |       - |   8.12 KB |
| RemoveAccount         | (1, 10)     | ?                        |  38.555 us |  37.100 us |  42.000 us |       - |       - |   6.34 KB |
| RemoveAccount         | (10000, 10) | ?                        | 115.380 us | 105.600 us | 142.000 us |       - |       - |   6.36 KB |

New Benchmark

| Method                | CacheSize   | EnableCacheSerialization | Mean       | Min        | Max        | Gen0    | Gen1   | Allocated |
|---------------------- |------------ |------------------------- |-----------:|-----------:|-----------:|--------:|-------:|----------:|
| AcquireTokenForClient | (1, 10)     | False                    |  11.167 us |  11.110 us |  11.311 us |  0.7019 |      - |  11.61 KB |
| AcquireTokenForClient | (1, 10)     | True                     | 108.521 us | 108.134 us | 108.745 us | 11.4746 | 3.4180 | 189.33 KB |
| AcquireTokenForClient | (10000, 10) | False                    |  20.325 us |  20.236 us |  20.386 us |  0.7019 |      - |  11.62 KB |
| AcquireTokenForClient | (10000, 10) | True                     | 108.698 us | 108.216 us | 109.404 us | 11.4746 | 3.0518 | 189.33 KB |
| AcquireTokenForClient | ?           | ?                        | 221.785 us | 214.950 us | 228.050 us |       - |      - |  38.13 KB |
| AcquireTokenForOBO    | (1, 10)     | False                    |  19.495 us |  19.313 us |  19.596 us |  1.1597 |      - |  19.34 KB |
| AcquireTokenForOBO    | (1, 10)     | True                     | 156.097 us | 155.376 us | 157.109 us | 16.1133 | 6.1035 | 263.59 KB |
| AcquireTokenForOBO    | (10000, 10) | False                    |  28.871 us |  28.678 us |  29.161 us |  1.1597 |      - |  19.35 KB |
| AcquireTokenForOBO    | (10000, 10) | True                     | 155.376 us | 154.462 us | 156.940 us | 16.1133 | 4.8828 | 263.59 KB |
| AcquireTokenForOBO    | ?           | ?                        | 310.859 us | 298.900 us | 326.800 us |       - |      - |   79.4 KB |
| AcquireTokenSilent    | (1, 10)     | ?                        |  15.863 us |  15.713 us |  16.027 us |  0.9766 |      - |  16.68 KB |
| AcquireTokenSilent    | (10000, 10) | ?                        |  26.016 us |  25.905 us |  26.181 us |  1.0071 |      - |  16.69 KB |
| GetAccount            | (1, 10)     | ?                        |   7.687 us |   7.647 us |   7.738 us |  0.4883 |      - |   8.11 KB |
| GetAccount            | (10000, 10) | ?                        |  17.546 us |  17.498 us |  17.602 us |  0.4883 |      - |   8.12 KB |
| RemoveAccount         | (1, 10)     | ?                        |  35.580 us |  33.400 us |  37.500 us |       - |      - |   6.34 KB |
| RemoveAccount         | (10000, 10) | ?                        | 123.940 us | 112.000 us | 152.100 us |       - |      - |   6.36 KB |

**Documentation**
- [ ] All relevant documentation is updated.
