### PR TITLE
Resolve broken MS Learn links stemming from auto-generated reference.

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Overrides the tenant ID specified in the authority at the application level. This operation preserves the authority host (environment).
         /// 
-        /// If an authority was not specified at the application level, the default used is https://login.microsoftonline.com/common.
+        /// If an authority was not specified at the application level, the default used is `https://login.microsoftonline.com/common`.
         /// </summary>
         /// <param name="tenantId">Tenant ID of the Microsoft Entra ID tenant
         /// or a domain associated with this Microsoft Entra ID tenant, in order to sign-in a user of a specific organization only.</param>
@@ -290,7 +290,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Extracts the tenant ID from the provided authority URI and overrides the tenant ID specified in the authority at the application level. This operation preserves the authority host (environment) provided to the application builder.
-        /// If an authority was not provided to the application builder, this method will replace the tenant ID in the default authority - https://login.microsoftonline.com/common.
+        /// If an authority was not provided to the application builder, this method will replace the tenant ID in the default authority - `https://login.microsoftonline.com/common`.
         /// </summary>
         /// <param name="authorityUri">URI from which to extract the tenant ID</param>
         /// <returns>The builder to chain the .With methods.</returns>

--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client
         /// </listheader>
         /// <item>
         /// <term>.NET desktop</term>
-        /// <Description><c>https://login.microsoftonline.com/common/oauth2/nativeclient</c></Description>
+        /// <Description><c>`https://login.microsoftonline.com/common/oauth2/nativeclient`</c></Description>
         /// </item>
         /// <item>
         /// <term>UWP</term>

--- a/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/src/client/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client
         string Name { get; }
 
         /// <summary>
-        /// In MSAL.NET 1.x was the URL of the identity provider (e.g. https://login.microsoftonline.com/tenantId).
+        /// In MSAL.NET 1.x was the URL of the identity provider (e.g. `https://login.microsoftonline.com/tenantId`).
         /// From MSAL.NET 2.x use <see cref="IAccount.Environment"/> which retrieves the host only (e.g. login.microsoftonline.com).
         /// See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
@@ -833,7 +833,7 @@ namespace Microsoft.Identity.Client
         #region MSAL3X deprecations
 
         /// <summary>
-        /// Constructor of the application. It will use https://login.microsoftonline.com/common as the default authority.
+        /// Constructor of the application. It will use `https://login.microsoftonline.com/common` as the default authority.
         /// </summary>
         /// <param name="clientId">Client ID (also known as App ID) of the application as registered in the
         /// application registration portal (https://aka.ms/msal-net-register-app)/. REQUIRED</param>


### PR DESCRIPTION
Fixes #
Broken links

**Changes proposed in this request**

Minor change to resolve broken links on MS Learn. In reference docs where the example authority `https://login.microsoftonline.com/common`  and others surface without backticks, it's picked up as a broken link, as per the broken links report. 

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
None

**Documentation**
- [ ] All relevant documentation is updated.
- Once merged and a CI job to auto-generate the reference is triggered,  about 5 broken links on MS Learn will auto-resolve.
