### PR TITLE
Updating cryptographic error when cert is disposed.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/JsonWebToken.cs
@@ -133,12 +133,13 @@ namespace Microsoft.Identity.Client.Internal
         private static string ComputeCertThumbprint(X509Certificate2 certificate, bool useSha2)
         {
             string thumbprint = null;
-
-            if (useSha2)
+            try
             {
+                if (useSha2)
+                {
 #if NET6_0_OR_GREATER
 
-                thumbprint = Base64UrlHelpers.Encode(certificate.GetCertHash(HashAlgorithmName.SHA256));
+                    thumbprint = Base64UrlHelpers.Encode(certificate.GetCertHash(HashAlgorithmName.SHA256));
 #else
                 using (var hasher = SHA256.Create())
                 {
@@ -146,12 +147,16 @@ namespace Microsoft.Identity.Client.Internal
                     thumbprint = Base64UrlHelpers.Encode(hash);
                 }
 #endif
+                }
+                else
+                {
+                    thumbprint = Base64UrlHelpers.Encode(certificate.GetCertHash());
+                }
             }
-            else
+            catch (CryptographicException ex)
             {
-                thumbprint = Base64UrlHelpers.Encode(certificate.GetCertHash());
+                throw new MsalClientException(MsalError.CryptographicError, MsalErrorMessage.CryptographicError, ex);
             }
-
             return thumbprint;
         }
 

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1150,5 +1150,10 @@ namespace Microsoft.Identity.Client
         /// Setting the CIAM authority (ex. "{tenantName}.ciamlogin.com") at the request level is not supported. The CIAM authority must be set during application creation.
         /// </summary>
         public const string SetCiamAuthorityAtRequestLevelNotSupported = "set_ciam_authority_at_request_level_not_supported";
+
+        /// <summary>
+        /// A cryptographic exception occurred when trying to use the provided certificate
+        /// </summary>
+        public const string CryptographicError = "cryptographic_error";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -428,5 +428,6 @@ namespace Microsoft.Identity.Client
         public const string CombinedUserAppCacheNotSupported = "Using a combined flat storage, like a file, to store both app and user tokens is not supported. Use a partitioned token cache (for ex. distributed cache like Redis) or separate files for app and user token caches. See https://aka.ms/msal-net-token-cache-serialization .";
         public const string JsonParseErrorMessage = "There was an error parsing the response from the token endpoint, see inner exception for details. Verify that your app is configured correctly. If this is a B2C app, one possible cause is acquiring a token for Microsoft Graph, which is not supported. See https://aka.ms/msal-net-up";
         public const string SetCiamAuthorityAtRequestLevelNotSupported = "Setting the CIAM authority (ex. \"{tenantName}.ciamlogin.com\") at the request level is not supported. The CIAM authority must be set during application creation";
+        public const string CryptographicError = "A cryptographic exception occurred. Possible cause: the certificate has been disposed. See inner exception for full details.";
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -612,7 +612,7 @@ namespace Microsoft.Identity.Test.Unit
 
         [TestMethod]
         [Description("Check if the certificate is disposed and throw proper exception")]
-        public async Task DisposedCertExceptionForCCAsync()
+        public async Task DisposedCert_ThrowsSpecificException_Test()
         {
             using (var harness = CreateTestHarness())
             {
@@ -654,7 +654,7 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.AreEqual(MsalError.CryptographicError, exception.ErrorCode);
                 Assert.AreEqual(MsalErrorMessage.CryptographicError, exception.Message);
 
-                //Testing OBO flwo
+                //Testing OBO flow
                 exception = await Assert.ThrowsExceptionAsync<MsalClientException>(async () =>
                 {
                     await app.AcquireTokenOnBehalfOf(TestConstants.s_scope, new UserAssertion(TestConstants.UserAssertion))

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithCertTest.cs
@@ -610,6 +610,63 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        [TestMethod]
+        [Description("Check if the certificate is disposed and throw proper exception")]
+        public async Task DisposedCertExceptionForCCAsync()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                SetupMocks(harness.HttpManager);
+
+                ConfidentialClientApplication app = null;
+                //initialize client app with cert then dispose of it
+                using (var certificate = new X509Certificate2(
+                    ResourceHelper.GetTestResourceRelativePath("RSATestCertDotNet.pfx")))
+                {
+                    app = ConfidentialClientApplicationBuilder
+                        .Create(TestConstants.ClientId)
+                        .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
+                        .WithRedirectUri(TestConstants.RedirectUri)
+                        .WithHttpManager(harness.HttpManager)
+                        .WithCertificate(certificate)
+                        .BuildConcrete();
+                }
+
+                //Testing client credential flow
+                var exception = await Assert.ThrowsExceptionAsync<MsalClientException>(async () =>
+                {
+                    await app.AcquireTokenForClient(TestConstants.s_scope)
+                             .ExecuteAsync(CancellationToken.None)
+                             .ConfigureAwait(false);
+                }).ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.CryptographicError, exception.ErrorCode);
+                Assert.AreEqual(MsalErrorMessage.CryptographicError, exception.Message);
+
+                //Testing auth code flow
+                exception = await Assert.ThrowsExceptionAsync<MsalClientException>(async () =>
+                {
+                    await app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
+                             .ExecuteAsync(CancellationToken.None)
+                             .ConfigureAwait(false);
+                }).ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.CryptographicError, exception.ErrorCode);
+                Assert.AreEqual(MsalErrorMessage.CryptographicError, exception.Message);
+
+                //Testing OBO flwo
+                exception = await Assert.ThrowsExceptionAsync<MsalClientException>(async () =>
+                {
+                    await app.AcquireTokenOnBehalfOf(TestConstants.s_scope, new UserAssertion(TestConstants.UserAssertion))
+                             .ExecuteAsync(CancellationToken.None)
+                             .ConfigureAwait(false);
+                }).ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.CryptographicError, exception.ErrorCode);
+                Assert.AreEqual(MsalErrorMessage.CryptographicError, exception.Message);
+            }
+        }
+
         private static string ComputeCertThumbprint(X509Certificate2 certificate, bool useSha2)
         {
             string thumbprint = null;


### PR DESCRIPTION
Fixes #
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4602

**Changes proposed in this request**
Updating cryptographic error when cert is disposed.

**Testing**
Unit

**Performance impact**
N/A

**Documentation**
- [ ] All relevant documentation is updated.
