### PR TITLE
Add harden runner on benchmark-action.yml

### DIFF
--- a/.github/workflows/benchmark-action.yml
+++ b/.github/workflows/benchmark-action.yml
@@ -18,21 +18,26 @@ jobs:
     name: Run performance benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
         with:
           dotnet-version: '6.0.418'
       - name: Run benchmark
         run: cd tests/Microsoft.Identity.Test.Performance && dotnet run -c release -f net6.0 --exporters json 
 
       - name: Download previous benchmark data
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark
 
       - name: Store AcquireTokenNoCacheTests result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@cc9ac13ce81036c9b67fcfe2cb95ca366684b9ea # v1.19.3
         with:
           name: AcquireTokenNoCache
           tool: 'benchmarkdotnet'
@@ -48,7 +53,7 @@ jobs:
           benchmark-data-dir-path: benchmarks
 
       - name: Store AcquireTokenForClientCacheTests result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@cc9ac13ce81036c9b67fcfe2cb95ca366684b9ea # v1.19.3
         with:
           name: AcquireTokenForClientWithCache
           tool: 'benchmarkdotnet'
@@ -64,7 +69,7 @@ jobs:
           benchmark-data-dir-path: benchmarks
 
       - name: Store AcquireTokenForOboCacheTests result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@cc9ac13ce81036c9b67fcfe2cb95ca366684b9ea # v1.19.3
         with:
           name: AcquireTokenForOboWithCache
           tool: 'benchmarkdotnet'
@@ -80,7 +85,7 @@ jobs:
           benchmark-data-dir-path: benchmarks
 
       - name: Store TokenCacheTests result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@cc9ac13ce81036c9b67fcfe2cb95ca366684b9ea # v1.19.3
         with:
           name: TokenCacheTestsWithCache
           tool: 'benchmarkdotnet'


### PR DESCRIPTION
Fixes #
[https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/security/code-scanning](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/security/code-scanning)

**Changes proposed in this request**
Harden-Runner GitHub Action installs a security agent on the Github-hosted runner to prevent exfiltration of credentials, monitor the build process, and detect compromised dependencies

**Testing**
gh security

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
