### PR TITLE
Add harden runner on trigger_onebranch_ci.yml

### DIFF
--- a/.github/workflows/trigger_onebranch_ci.yml
+++ b/.github/workflows/trigger_onebranch_ci.yml
@@ -12,8 +12,13 @@ jobs:
         name: Call OneBranch ADO Pipeline (CI)
         runs-on: ubuntu-latest
         steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+          with:
+            egress-policy: audit
+
         - name: Azure Pipelines Action
-          uses: Azure/pipelines@v1
+          uses: Azure/pipelines@354dddefceb0b503a61338ca81e4091eae3bc84f # v1
           with:
             azure-devops-project-url: https://identitydivision.visualstudio.com/IDDP
             azure-pipeline-name: 'MSAL.NET-OneBranch-Release-Official'


### PR DESCRIPTION
Fixes #
[https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/security/code-scanning](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/security/code-scanning)

**Changes proposed in this request**
Harden-Runner GitHub Action installs a security agent on the Github-hosted runner to prevent exfiltration of credentials, monitor the build process, and detect compromised dependencies

**Testing**
gh security

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
