### PR TITLE
Handle error response from cloud shell and add tests

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
             if (!string.IsNullOrEmpty(managedIdentityErrorResponse.ErrorDescription))
             {
-                stringBuilder.Append($"Error Message: {managedIdentityErrorResponse.ErrorDescription} ");
+                stringBuilder.Append($"Error Description: {managedIdentityErrorResponse.ErrorDescription} ");
             }
 
             if (!string.IsNullOrEmpty(managedIdentityErrorResponse.CorrelationId))

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -161,6 +161,11 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 stringBuilder.Append($"Managed Identity Correlation ID: {managedIdentityErrorResponse.CorrelationId} Use this Correlation ID for further investigation.");
             }
 
+            if (stringBuilder.Length == "[Managed Identity] ".Length)
+            {
+                return $"{MsalErrorMessage.ManagedIdentityUnexpectedErrorResponse}.";
+            }
+
             return stringBuilder.ToString();
         }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 stringBuilder.Append($"Managed Identity Correlation ID: {managedIdentityErrorResponse.CorrelationId} Use this Correlation ID for further investigation.");
             }
 
-            if (stringBuilder.Equals(ManagedIdentityPrefix))
+            if (stringBuilder.Length == ManagedIdentityPrefix.Length)
             {
                 return $"{MsalErrorMessage.ManagedIdentityUnexpectedErrorResponse}.";
             }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         protected readonly RequestContext _requestContext;
         internal const string TimeoutError = "[Managed Identity] Authentication unavailable. The request to the managed identity endpoint timed out.";
         internal readonly ManagedIdentitySource _sourceType;
+        private const string ManagedIdentityPrefix = "[Managed Identity] ";
 
         protected AbstractManagedIdentity(RequestContext requestContext, ManagedIdentitySource sourceType)
         {
@@ -139,7 +140,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
         private string ExtractErrorMessageFromManagedIdentityErrorResponse(ManagedIdentityErrorResponse managedIdentityErrorResponse)
         {
-            StringBuilder stringBuilder = new StringBuilder("[Managed Identity] ");
+            StringBuilder stringBuilder = new StringBuilder(ManagedIdentityPrefix);
 
             if (!string.IsNullOrEmpty(managedIdentityErrorResponse.Error))
             {
@@ -161,7 +162,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 stringBuilder.Append($"Managed Identity Correlation ID: {managedIdentityErrorResponse.CorrelationId} Use this Correlation ID for further investigation.");
             }
 
-            if (stringBuilder.Length == "[Managed Identity] ".Length)
+            if (stringBuilder.Equals(ManagedIdentityPrefix))
             {
                 return $"{MsalErrorMessage.ManagedIdentityUnexpectedErrorResponse}.";
             }
@@ -178,7 +179,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
                 JsonHelper.TryGetValue(json, "error", out var error);
 
-                StringBuilder errorMessage = new StringBuilder("[Managed Identity] ");
+                StringBuilder errorMessage = new StringBuilder(ManagedIdentityPrefix);
 
                 if (JsonHelper.TryGetValue(JsonHelper.ToJsonObject(error), "code", out var errorCode))
                 {

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -419,6 +419,7 @@ namespace Microsoft.Identity.Client
         public const string ManagedIdentityInvalidResponse = "[Managed Identity] Invalid response, the authentication response received did not contain the expected fields.";
         public const string ManagedIdentityUnexpectedResponse = "[Managed Identity] Unexpected exception occurred when parsing the response. See the inner exception for details.";
         public const string ManagedIdentityExactlyOneScopeExpected = "[Managed Identity] To acquire token for managed identity, exactly one scope must be passed.";
+        public const string ManagedIdentityUnexpectedErrorResponse = "[Managed Identity] The error response was either empty or could not be parsed.";
 
         public const string ManagedIdentityEndpointInvalidUriError = "[Managed Identity] The environment variable {0} contains an invalid Uri {1} in {2} managed identity source.";
         public const string ManagedIdentityNoChallengeError = "[Managed Identity] Did not receive expected WWW-Authenticate header in the response from Azure Arc Managed Identity Endpoint.";

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -11,6 +11,7 @@ using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Unit;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.ManagedIdentity;
 
 namespace Microsoft.Identity.Test.Common.Core.Mocks
 {
@@ -129,9 +130,24 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
           "\"ext_expires_in\":\"12345\",\"token_type\":\"Bearer\"}";
         }
 
-        public static string GetMsiErrorResponse()
+        public static string GetMsiErrorResponse(ManagedIdentitySource source)
         {
-            return "{\"statusCode\":\"500\",\"message\":\"An unexpected error occured while fetching the AAD Token.\",\"correlationId\":\"7d0c9763-ff1d-4842-a3f3-6d49e64f4513\"}";
+            switch (source)
+            {
+                case ManagedIdentitySource.AppService:
+                    return "{\"statusCode\":500,\"message\":\"An unexpected error occured while fetching the AAD Token.\",\"correlationId\":\"4ce26535-1769-4001-96e3-9019ce00922d\"}";
+
+                case ManagedIdentitySource.Imds:
+                case ManagedIdentitySource.AzureArc:
+                case ManagedIdentitySource.ServiceFabric:
+                    return "{\"error\":\"invalid_resource\",\"error_description\":\"AADSTS500011: The resource principal named scope was not found in the tenant named Microsoft. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You might have sent your authentication request to the wrong tenant.\\r\\nTrace ID: GUID\\r\\nCorrelation ID: GUID\\r\\nTimestamp: 2024-02-14 23:11:50Z\",\"error_codes\":\"[500011]\",\"timestamp\":\"2022-11-10 23:11:50Z\",\"trace_id\":\"GUID\",\"correlation_id\":\"GUID\",\"error_uri\":\"errorUri\"}";
+
+                case ManagedIdentitySource.CloudShell:
+                    return "{\"error\":{\"code\":\"AudienceNotSupported\",\"message\":\"Audience scope is not a supported MSI token audience.Supported audiences:https://management.core.windows.net/,https://management.azure.com/,https://graph.windows.net/,https://vault.azure.net,https://datalake.azure.net/,https://outlook.office365.com/,https://graph.microsoft.com/,https://batch.core.windows.net/,https://analysis.windows.net/powerbi/api,https://storage.azure.com/,https://rest.media.azure.net,https://api.loganalytics.io,https://ossrdbms-aad.database.windows.net,https://www.yammer.com,https://digitaltwins.azure.net,0b07f429-9f4b-4714-9392-cc5e8e80c8b0,822c8694-ad95-4735-9c55-256f7db2f9b4,https://dev.azuresynapse.net,https://database.windows.net,https://quantum.microsoft.com,https://iothubs.azure.net,2ff814a6-3304-4ab8-85cb-cd0e6f879c1d,https://azuredatabricks.net/,ce34e7e5-485f-4d76-964f-b3d2b16d1e4f,https://azure-devices-provisioning.net,https://managedhsm.azure.net,499b84ac-1321-427f-aa17-267ca6975798,https://api.adu.microsoft.com/,https://purview.azure.net/,6dae42f8-4368-4678-94ff-3960e28e3630\"}}";
+
+                default:
+                    return "";
+            }
         }
 
         public static string GetMsiImdsErrorResponse()

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -155,8 +155,8 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return "{\"error\":\"invalid_resource\"," +
                 "\"error_description\":\"AADSTS500011: The resource principal named user.read was not found in the tenant named Microsoft. " +
                 "This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. " +
-                "You might have sent your authentication request to the wrong tenant.\r\nTrace ID: 2dff494a-0226-4f41-8859-d9f560ca8903" +
-                "\r\nCorrelation ID: 77145480-bc5a-4ebe-ae4d-e4a8b7d727cf\r\nTimestamp: 2022-11-10 23:12:37Z\"," +
+                "You might have sent your authentication request to the wrong tenant.\\r\\nTrace ID: 2dff494a-0226-4f41-8859-d9f560ca8903" +
+                "\\r\\nCorrelation ID: 77145480-bc5a-4ebe-ae4d-e4a8b7d727cf\\r\\nTimestamp: 2022-11-10 23:12:37Z\"," +
                 "\"error_codes\":[500011],\"timestamp\":\"2022-11-10 23:12:37Z\",\"trace_id\":\"2dff494a-0226-4f41-8859-d9f560ca8903\"," +
                 "\"correlation_id\":\"77145480-bc5a-4ebe-ae4d-e4a8b7d727cf\",\"error_uri\":\"https://westus2.login.microsoft.com/error?code=500011\"}";
         }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(ex);
                 Assert.AreEqual(ManagedIdentitySource.Imds.ToString(), ex.AdditionalExceptionData[MsalException.ManagedIdentitySource]);
                 Assert.AreEqual(MsalError.ManagedIdentityRequestFailed, ex.ErrorCode);
-                Assert.IsTrue(ex.Message.Contains(ImdsManagedIdentitySource.IdentityUnavailableError));
+                Assert.IsTrue(ex.Message.Contains(ImdsManagedIdentitySource.IdentityUnavailableError), $"The error message is not as expected. Error message: {ex.Message}. Expected message: {ImdsManagedIdentitySource.IdentityUnavailableError}");
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -285,9 +285,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
-                httpManager.AddManagedIdentityMockHandler(endpoint, resource, MockHelpers.GetMsiErrorResponse(),
+                httpManager.AddManagedIdentityMockHandler(endpoint, resource, MockHelpers.GetMsiErrorResponse(managedIdentitySource),
                     managedIdentitySource, statusCode: HttpStatusCode.InternalServerError);
-                httpManager.AddManagedIdentityMockHandler(endpoint, resource, MockHelpers.GetMsiErrorResponse(),
+                httpManager.AddManagedIdentityMockHandler(endpoint, resource, MockHelpers.GetMsiErrorResponse(managedIdentitySource),
                     managedIdentitySource, statusCode: HttpStatusCode.InternalServerError);
 
                 MsalServiceException ex = await Assert.ThrowsExceptionAsync<MsalServiceException>(async () =>
@@ -297,6 +297,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(ex);
                 Assert.AreEqual(managedIdentitySource.ToString(), ex.AdditionalExceptionData[MsalException.ManagedIdentitySource]);
                 Assert.AreEqual(MsalError.ManagedIdentityRequestFailed, ex.ErrorCode);
+                Assert.IsFalse(ex.Message.Contains(MsalErrorMessage.ManagedIdentityUnexpectedErrorResponse));
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry.Resources;
 using static Microsoft.Identity.Test.Common.Core.Helpers.ManagedIdentityTestUtil;
 
 namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
@@ -32,6 +33,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         internal const string AzureArcEndpoint = "http://localhost:40342/metadata/identity/oauth2/token";
         internal const string CloudShellEndpoint = "http://localhost:40342/metadata/identity/oauth2/token";
         internal const string ServiceFabricEndpoint = "http://localhost:40342/metadata/identity/oauth2/token";
+        internal const string ExpectedErrorMessage = "Expected error message.";
+        internal const string ExpectedErrorCode = "ErrorCode";
+        internal const string ExpectedCorrelationId = "Some GUID";
 
         [DataTestMethod]
         [DataRow("http://127.0.0.1:41564/msi/token/", Resource, ManagedIdentitySource.AppService)]
@@ -298,6 +302,52 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.AreEqual(managedIdentitySource.ToString(), ex.AdditionalExceptionData[MsalException.ManagedIdentitySource]);
                 Assert.AreEqual(MsalError.ManagedIdentityRequestFailed, ex.ErrorCode);
                 Assert.IsFalse(ex.Message.Contains(MsalErrorMessage.ManagedIdentityUnexpectedErrorResponse));
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("{\"statusCode\":500,\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID" })]
+        [DataRow("{\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID" })]
+        [DataRow("{\"error\":\"errorCode\",\"error_description\":\"Error message\"}", new string[] { "errorCode", "Error message" })]
+        [DataRow("{\"error_description\":\"Error message\"}", new string[] { "Error message" })]
+        [DataRow("{\"message\":\"Error message\"}", new string[] { "Error message" })]
+        [DataRow("{\"error\":{\"code\":\"errorCode\"}}", new string[] { "errorCode" })]
+        [DataRow("{\"error\":{\"message\":\"Error message\"}}", new string[] { "Error message" })]
+        [DataRow("{\"error\":{\"code\":\"errorCode\",\"message\":\"Error message\"}}", new string[] { "errorCode", "Error message" })]
+        [DataRow("{\"error\":{\"code\":\"errorCode\",\"message\":\"Error message\",\"innererror\":{\"trace\":\"trace\"}}}", new string[] { "errorCode", "Error message" })]
+        [DataRow("{\"notExpectedJson\":\"someValue\"}", new string[] { MsalErrorMessage.ManagedIdentityUnexpectedErrorResponse })]
+        [DataRow("notExpectedJson", new string[] { MsalErrorMessage.ManagedIdentityUnexpectedErrorResponse })]
+        public async Task ManagedIdentityTestErrorResponseParsing(string errorResponse, string[] expectedInErrorResponse)
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager(isManagedIdentity: true))
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.AppService, AppServiceEndpoint);
+
+                var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager);
+
+                // Disabling shared cache options to avoid cross test pollution.
+                miBuilder.Config.AccessorOptions = null;
+                var mi = miBuilder.Build();
+
+                httpManager.AddManagedIdentityMockHandler(AppServiceEndpoint, Resource, errorResponse,
+                    ManagedIdentitySource.AppService, statusCode: HttpStatusCode.InternalServerError);
+                httpManager.AddManagedIdentityMockHandler(AppServiceEndpoint, Resource, errorResponse,
+                    ManagedIdentitySource.AppService, statusCode: HttpStatusCode.InternalServerError);
+
+                MsalServiceException ex = await Assert.ThrowsExceptionAsync<MsalServiceException>(async () =>
+                    await mi.AcquireTokenForManagedIdentity(Resource)
+                    .ExecuteAsync().ConfigureAwait(false)).ConfigureAwait(false);
+
+                Assert.IsNotNull(ex);
+                Assert.AreEqual(ManagedIdentitySource.AppService.ToString(), ex.AdditionalExceptionData[MsalException.ManagedIdentitySource]);
+                Assert.AreEqual(MsalError.ManagedIdentityRequestFailed, ex.ErrorCode);
+
+                foreach (var expectedErrorSubString in expectedInErrorResponse)
+                {
+                    Assert.IsTrue(ex.Message.Contains(expectedErrorSubString));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4402 

**Changes proposed in this request**
* Add error message parsing for cloud shell error response where the message is in nested JSON
* Add mock for error messages from different sources.

**Testing**
Updated unit tests

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
