### PR TITLE
Adding correlation id to MSAL Exception

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -113,6 +113,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 catch (MsalException ex)
                 {
                     apiEvent.ApiErrorCode = ex.ErrorCode;
+                    if (string.IsNullOrWhiteSpace(ex.CorrelationId))
+                    {
+                        ex.CorrelationId = AuthenticationRequestParameters.CorrelationId.ToString();
+                    }
                     AuthenticationRequestParameters.RequestContext.Logger.ErrorPii(ex);
                     LogMsalErrorTelemetryToClient(ex, telemetryEventDetails, telemetryClients);
 
@@ -124,7 +128,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     apiEvent.ApiErrorCode = ex.GetType().Name;
                     AuthenticationRequestParameters.RequestContext.Logger.ErrorPii(ex);
                     LogMsalErrorTelemetryToClient(ex, telemetryEventDetails, telemetryClients);
-                    
+
                     LogMsalFailedTelemetryToOtel(ex.GetType().Name);
                     throw;
                 }

--- a/src/client/Microsoft.Identity.Client/MsalException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalException.cs
@@ -143,6 +143,11 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// An ID that can used to piece up a single authentication flow.
+        /// </summary>
+        public string CorrelationId { get; set; }
+
+        /// <summary>
         /// A property bag with extra details for this exception.
         /// </summary>
         public IReadOnlyDictionary<string, string> AdditionalExceptionData { get; set; }

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -210,11 +210,6 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        /// <summary>
-        /// An ID that can used to piece up a single authentication flow.
-        /// </summary>
-        public string CorrelationId { get; set; }
-
         #endregion
 
         /// <remarks>

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionTests.cs
@@ -6,6 +6,7 @@ using System.Data.SqlClient;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.Internal;
@@ -430,6 +431,24 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
             AssertPropertyHasPublicGetAndSet(typeof(MsalServiceException), "Headers");
             AssertPropertyHasPublicGetAndSet(typeof(MsalServiceException), "ResponseBody");
             AssertPropertyHasPublicGetAndSet(typeof(MsalServiceException), "CorrelationId");
+        }
+
+        [TestMethod]
+        public async Task CorrelationIdInExceptions()
+        {
+            var ex = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(async () =>
+                {
+                    var app = PublicClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithDefaultRedirectUri()
+                    .Build();
+
+                    await app.AcquireTokenSilent(TestConstants.s_graphScopes, TestConstants.s_user).ExecuteAsync().ConfigureAwait(false);
+                }
+            ).ConfigureAwait(false);
+
+            Assert.IsFalse(string.IsNullOrEmpty(ex.CorrelationId));
+            Assert.IsFalse(string.IsNullOrEmpty(((MsalException)ex).CorrelationId));
         }
 
         private void AssertPropertyHasPublicGetAndSet(Type t, string propertyName)

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionTests.cs
@@ -6,6 +6,8 @@ using System.Data.SqlClient;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Http;
@@ -15,13 +17,15 @@ using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.PlatformsCommon.Factories;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.ExceptionTests
 {
 
     [TestClass]
-    public class MsalExceptionTests
+    [DeploymentItem(@"Resources\RSATestCertDotNet.pfx")]
+    public class MsalExceptionTests : TestBase
     {
         private const string ExCode = "exCode";
         private const string ExMessage = "exMessage";
@@ -434,21 +438,75 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         }
 
         [TestMethod]
-        public async Task CorrelationIdInExceptions()
+        public async Task CorrelationIdInServiceExceptions()
         {
+            var app = PublicClientApplicationBuilder
+                        .Create(TestConstants.ClientId)
+                        .WithDefaultRedirectUri()
+                        .Build();
             var ex = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(async () =>
                 {
-                    var app = PublicClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .WithDefaultRedirectUri()
-                    .Build();
-
                     await app.AcquireTokenSilent(TestConstants.s_graphScopes, TestConstants.s_user).ExecuteAsync().ConfigureAwait(false);
                 }
             ).ConfigureAwait(false);
 
             Assert.IsFalse(string.IsNullOrEmpty(ex.CorrelationId));
             Assert.IsFalse(string.IsNullOrEmpty(((MsalException)ex).CorrelationId));
+
+            Guid guid = Guid.NewGuid();
+            ex = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(async () =>
+                {
+                    await app.AcquireTokenSilent(TestConstants.s_graphScopes, TestConstants.s_user).WithCorrelationId(guid).ExecuteAsync().ConfigureAwait(false);
+                }
+            ).ConfigureAwait(false);
+
+            Assert.AreEqual(guid.ToString(), ex.CorrelationId);
+            Assert.AreEqual(guid.ToString(), ((MsalException)ex).CorrelationId);
+        }
+
+        [TestMethod]
+        public async Task CorrelationIdInClientExceptions()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler(TestConstants.AuthorityCommonTenant + TestConstants.DiscoveryEndPoint));
+
+                ConfidentialClientApplication app = null;
+                using (var certificate = new X509Certificate2(
+                    ResourceHelper.GetTestResourceRelativePath("RSATestCertDotNet.pfx")))
+                {
+                    app = ConfidentialClientApplicationBuilder
+                        .Create(TestConstants.ClientId)
+                        .WithAuthority(new System.Uri(ClientApplicationBase.DefaultAuthority), true)
+                        .WithRedirectUri(TestConstants.RedirectUri)
+                        .WithHttpManager(harness.HttpManager)
+                        .WithCertificate(certificate)
+                        .BuildConcrete();
+                }
+
+                var ex = await Assert.ThrowsExceptionAsync<MsalClientException>(async () =>
+                {
+                    await app.AcquireTokenForClient(TestConstants.s_scope)
+                             .ExecuteAsync(CancellationToken.None)
+                             .ConfigureAwait(false);
+                }).ConfigureAwait(false);
+
+                Assert.IsFalse(string.IsNullOrEmpty(ex.CorrelationId));
+                Assert.IsFalse(string.IsNullOrEmpty(((MsalException)ex).CorrelationId));
+
+                Guid guid = Guid.NewGuid();
+                ex = await AssertException.TaskThrowsAsync<MsalClientException>(async () =>
+                {
+                    await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                 .WithCorrelationId(guid)
+                                                 .ExecuteAsync(CancellationToken.None)
+                                                 .ConfigureAwait(false);
+                }
+                ).ConfigureAwait(false);
+
+                Assert.AreEqual(guid.ToString(), ex.CorrelationId);
+                Assert.AreEqual(guid.ToString(), ((MsalException)ex).CorrelationId);
+            }
         }
 
         private void AssertPropertyHasPublicGetAndSet(Type t, string propertyName)


### PR DESCRIPTION
Fixes #
Fix for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4187

**Changes proposed in this request**
Adding correlation id to `MsalException` class

**Testing**
Unit

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
