### PR TITLE
Temporary Workaround for AAD JWT Token Signing Algorithm Issue

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -141,10 +141,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// True if SHA2 and PSS can be used for creating the client credential from a certificate 
         /// </summary>
-        internal bool IsSha2CredentialSupported =>
-            AuthorityType != AuthorityType.Dsts &&
-            AuthorityType != AuthorityType.Generic &&
-            AuthorityType != AuthorityType.Adfs;
+        internal bool IsSha2CredentialSupported => false; 
 
         #region Builders
         internal static AuthorityInfo FromAuthorityUri(string authorityUri, bool validateAuthority)

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -104,15 +104,15 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         }
 
         [DataTestMethod]
-        [DataRow(TestConstants.AuthorityCommonTenant, true)]
-        [DataRow(TestConstants.AuthorityCommonPpeAuthority, true)]
+        [DataRow(TestConstants.AuthorityCommonTenant, false)]
+        [DataRow(TestConstants.AuthorityCommonPpeAuthority, false)]
         [DataRow(TestConstants.DstsAuthorityCommon, false)]
         [DataRow(TestConstants.DstsAuthorityTenanted, false)]
-        [DataRow(TestConstants.CiamAuthorityMainFormat, true)]
-        [DataRow(TestConstants.CiamAuthorityWithFriendlyName, true)]
-        [DataRow(TestConstants.CiamAuthorityWithGuid, true)]
-        [DataRow(TestConstants.B2CAuthority, true)]
-        [DataRow(TestConstants.B2CCustomDomain, true)]
+        [DataRow(TestConstants.CiamAuthorityMainFormat, false)]
+        [DataRow(TestConstants.CiamAuthorityWithFriendlyName, false)]
+        [DataRow(TestConstants.CiamAuthorityWithGuid, false)]
+        [DataRow(TestConstants.B2CAuthority, false)]
+        [DataRow(TestConstants.B2CCustomDomain, false)]
         [DataRow(TestConstants.ADFSAuthority, false)]
         public void IsSha2Supported(string inputAuthority, bool expected)
         {


### PR DESCRIPTION
Fixes #4690

- Because of a bug in Azure Active Directory (AAD) related to handling JWT tokens signed with certain algorithms. This bug prevents the successful utilization of SHA2 and PSS signing algorithms under specific conditions, leading to authentication failures.
- As a temporary measure to circumvent this AAD issue, we have disabled the use of SHA2 and PSS for creating client credentials from certificates. This is achieved by setting IsSha2CredentialSupported to false. This change ensures compatibility with AAD's current capabilities and allows token acquisition to proceed without encountering the identified bug.

**Changes proposed in this request**
- Modified the `IsSha2CredentialSupported` property to always return false, bypassing the SHA2 and PSS check for certificate-based client credentials

**Testing**
- unit tests 

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
