### PR TITLE
re-enabling the use of SHA2 and PSS for creating client credentials from certificate

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -141,7 +141,10 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// True if SHA2 and PSS can be used for creating the client credential from a certificate 
         /// </summary>
-        internal bool IsSha2CredentialSupported => false; 
+        internal bool IsSha2CredentialSupported =>
+            AuthorityType != AuthorityType.Dsts &&
+            AuthorityType != AuthorityType.Generic &&
+            AuthorityType != AuthorityType.Adfs;
 
         #region Builders
         internal static AuthorityInfo FromAuthorityUri(string authorityUri, bool validateAuthority)

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -104,15 +104,15 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         }
 
         [DataTestMethod]
-        [DataRow(TestConstants.AuthorityCommonTenant, false)]
-        [DataRow(TestConstants.AuthorityCommonPpeAuthority, false)]
+        [DataRow(TestConstants.AuthorityCommonTenant, true)]
+        [DataRow(TestConstants.AuthorityCommonPpeAuthority, true)]
         [DataRow(TestConstants.DstsAuthorityCommon, false)]
         [DataRow(TestConstants.DstsAuthorityTenanted, false)]
-        [DataRow(TestConstants.CiamAuthorityMainFormat, false)]
-        [DataRow(TestConstants.CiamAuthorityWithFriendlyName, false)]
-        [DataRow(TestConstants.CiamAuthorityWithGuid, false)]
-        [DataRow(TestConstants.B2CAuthority, false)]
-        [DataRow(TestConstants.B2CCustomDomain, false)]
+        [DataRow(TestConstants.CiamAuthorityMainFormat, true)]
+        [DataRow(TestConstants.CiamAuthorityWithFriendlyName, true)]
+        [DataRow(TestConstants.CiamAuthorityWithGuid, true)]
+        [DataRow(TestConstants.B2CAuthority, true)]
+        [DataRow(TestConstants.B2CCustomDomain, true)]
         [DataRow(TestConstants.ADFSAuthority, false)]
         public void IsSha2Supported(string inputAuthority, bool expected)
         {


### PR DESCRIPTION
Fixes #4695

**Changes proposed in this request**
Relates to #4690 

Because of a bug in Azure Active Directory (AAD) related to handling JWT tokens signed with certain algorithms, we rolled back the usage of SHA2 and PSS for creating client creds.

**Testing**
Unit tests 

**Performance impact**
None

**Documentation**
- [ ] All relevant documentation is updated.
