### PR TITLE
PublicClientApplicationBuilder - allow non-GUID client id for AuthorityType.Generic

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -377,8 +377,11 @@ namespace Microsoft.Identity.Client
         {
             base.Validate();
 
-            //ADFS does not require client id to be in the form of a GUID.
-            if (Config.Authority.AuthorityInfo?.AuthorityType != AuthorityType.Adfs && !Guid.TryParse(Config.ClientId, out _))
+            // ADFS and generic authority do not require client id to be in the form of a GUID.
+            bool isGuidFormatMandatory = 
+                Config.Authority.AuthorityInfo?.AuthorityType != AuthorityType.Adfs &&
+                Config.Authority.AuthorityInfo?.AuthorityType != AuthorityType.Generic;
+            if (isGuidFormatMandatory && !Guid.TryParse(Config.ClientId, out _))
             {
                 throw new MsalClientException(MsalError.ClientIdMustBeAGuid, MsalErrorMessage.ClientIdMustBeAGuid);
             }

--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -377,15 +377,6 @@ namespace Microsoft.Identity.Client
         {
             base.Validate();
 
-            // ADFS and generic authority do not require client id to be in the form of a GUID.
-            bool isGuidFormatMandatory = 
-                Config.Authority.AuthorityInfo?.AuthorityType != AuthorityType.Adfs &&
-                Config.Authority.AuthorityInfo?.AuthorityType != AuthorityType.Generic;
-            if (isGuidFormatMandatory && !Guid.TryParse(Config.ClientId, out _))
-            {
-                throw new MsalClientException(MsalError.ClientIdMustBeAGuid, MsalErrorMessage.ClientIdMustBeAGuid);
-            }
-
 #if __MOBILE__ 
             if (Config.IsBrokerEnabled && Config.MultiCloudSupportEnabled)
             {

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -764,12 +764,6 @@ namespace Microsoft.Identity.Client
         public const string NoClientId = "no_client_id";
 
         /// <summary>
-        /// <para>What happens?</para>You've specified a client ID that is not a <see cref="Guid"/>
-        /// <para>Mitigation</para>Use the application ID (a GUID) from the application portal as client ID in this SDK
-        /// </summary>
-        public const string ClientIdMustBeAGuid = "client_id_must_be_guid";
-
-        /// <summary>
         /// <para>What happens?</para>You have configured both a telemetry callback and a telemetry config. 
         /// <para>Mitigation</para>Only one telemetry mechanism can be configured.
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -245,7 +245,6 @@ namespace Microsoft.Identity.Client
 
         public const string ClientCredentialAuthenticationTypesAreMutuallyExclusive = "ClientSecret, Certificate and ClientAssertion are mutually exclusive properties. Only specify one. See https://aka.ms/msal-net-client-credentials. ";
         public const string ClientCredentialAuthenticationTypeMustBeDefined = "One client credential type required either: ClientSecret, Certificate, ClientAssertion or AppTokenProvider must be defined when creating a Confidential Client. Only specify one. See https://aka.ms/msal-net-client-credentials. ";
-        public const string ClientIdMustBeAGuid = "Error: ClientId is not a GUID. ";
 
         public static string InvalidRedirectUriReceived(string invalidRedirectUri)
         {

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/GenericAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/GenericAuthorityTests.cs
@@ -3,22 +3,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
-using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common.Core.Helpers;
-using Microsoft.Identity.Test.Integration.Infrastructure;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium;
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
 {
@@ -26,15 +21,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
     public class GenericAuthorityTests
     {
         private const string DemoDuendeSoftwareDotCom = "https://demo.duendesoftware.com";
-
-        #region MSTest Hooks
-
-        /// <summary>
-        /// Initialized by MSTest (do not make private or readonly)
-        /// </summary>
-        public TestContext TestContext { get; set; }
-
-        #endregion MSTest Hooks
 
         /// Based on the publicly available https://demo.duendesoftware.com/
         [TestMethod]
@@ -57,36 +43,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.AreEqual("api", response.Scopes.AsSingleString());
             Assert.AreEqual("Bearer", response.TokenType);
             Assert.AreEqual(TokenSource.Cache, response2.AuthenticationResultMetadata.TokenSource);
-        }
-
-        /// Based on the publicly available https://demo.duendesoftware.com/
-        [TestMethod]
-        public async Task ShouldSupportAcquireTokenInteractiveWithDuendeDemoInstanceAsync()
-        {
-            string[] scopes = new[] { "openid profile email api offline_access" };
-            const string username = "bob", password = "bob";
-
-            var pca = PublicClientApplicationBuilder
-                .Create("interactive.public")
-                .WithRedirectUri(SeleniumWebUI.FindFreeLocalhostRedirectUri())
-                .WithExperimentalFeatures()
-                .WithOidcAuthority(DemoDuendeSoftwareDotCom)
-                .Build();
-
-            AcquireTokenInteractiveParameterBuilder builder = pca
-                .AcquireTokenInteractive(scopes)
-                .WithCustomWebUi(CreateSeleniumCustomWebUI(username, password));
-
-            AuthenticationResult result = await builder
-                .ExecuteAsync()
-                .ConfigureAwait(false);
-
-            Assert.IsNotNull(result);
-            Assert.IsNotNull(result.Scopes);
-            Assert.IsNotNull(result.AccessToken);
-            Assert.IsNotNull(result.IdToken);
-            Assert.AreEqual(5, result.Scopes.Count());
-            Assert.AreEqual("Bearer", result.TokenType);
         }
 
         /// Based on the publicly available https://demo.duendesoftware.com/
@@ -153,20 +109,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                                                                    );
             var assertion = tokenHandler.WriteToken(securityToken);
             return Task.FromResult(assertion);
-        }
-
-        private SeleniumWebUI CreateSeleniumCustomWebUI(string username, string password)
-        {
-            return new SeleniumWebUI((driver) =>
-            {
-                Trace.WriteLine("Starting Selenium automation");
-
-                driver.FindElementById("Input_Username").SendKeys(username);
-                driver.FindElementById("Input_Password").SendKeys(password);
-
-                var loginBtn = driver.WaitForElementToBeVisibleAndEnabled(By.Name("Input.Button"));
-                loginBtn?.Click();
-            }, TestContext);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/GenericAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/GenericAuthorityTests.cs
@@ -3,17 +3,22 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Integration.Infrastructure;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
 {
@@ -21,6 +26,15 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
     public class GenericAuthorityTests
     {
         private const string DemoDuendeSoftwareDotCom = "https://demo.duendesoftware.com";
+
+        #region MSTest Hooks
+
+        /// <summary>
+        /// Initialized by MSTest (do not make private or readonly)
+        /// </summary>
+        public TestContext TestContext { get; set; }
+
+        #endregion MSTest Hooks
 
         /// Based on the publicly available https://demo.duendesoftware.com/
         [TestMethod]
@@ -43,6 +57,36 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.AreEqual("api", response.Scopes.AsSingleString());
             Assert.AreEqual("Bearer", response.TokenType);
             Assert.AreEqual(TokenSource.Cache, response2.AuthenticationResultMetadata.TokenSource);
+        }
+
+        /// Based on the publicly available https://demo.duendesoftware.com/
+        [TestMethod]
+        public async Task ShouldSupportAcquireTokenInteractiveWithDuendeDemoInstanceAsync()
+        {
+            string[] scopes = new[] { "openid profile email api offline_access" };
+            const string username = "bob", password = "bob";
+
+            var pca = PublicClientApplicationBuilder
+                .Create("interactive.public")
+                .WithRedirectUri(SeleniumWebUI.FindFreeLocalhostRedirectUri())
+                .WithExperimentalFeatures()
+                .WithOidcAuthority(DemoDuendeSoftwareDotCom)
+                .Build();
+
+            AcquireTokenInteractiveParameterBuilder builder = pca
+                .AcquireTokenInteractive(scopes)
+                .WithCustomWebUi(CreateSeleniumCustomWebUI(username, password));
+
+            AuthenticationResult result = await builder
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.Scopes);
+            Assert.IsNotNull(result.AccessToken);
+            Assert.IsNotNull(result.IdToken);
+            Assert.AreEqual(5, result.Scopes.Count());
+            Assert.AreEqual("Bearer", result.TokenType);
         }
 
         /// Based on the publicly available https://demo.duendesoftware.com/
@@ -109,6 +153,20 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                                                                    );
             var assertion = tokenHandler.WriteToken(securityToken);
             return Task.FromResult(assertion);
+        }
+
+        private SeleniumWebUI CreateSeleniumCustomWebUI(string username, string password)
+        {
+            return new SeleniumWebUI((driver) =>
+            {
+                Trace.WriteLine("Starting Selenium automation");
+
+                driver.FindElementById("Input_Username").SendKeys(username);
+                driver.FindElementById("Input_Password").SendKeys(password);
+
+                var loginBtn = driver.WaitForElementToBeVisibleAndEnabled(By.Name("Input.Button"));
+                loginBtn?.Click();
+            }, TestContext);
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/PublicClientApplicationBuilderTests.cs
@@ -51,30 +51,6 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         }
 
         [TestMethod]
-        public void ClientIdMustBeAGuid()
-        {
-            var ex = AssertException.Throws<MsalClientException>(
-                () => PublicClientApplicationBuilder.Create("http://my.app")
-                        .WithAuthority(TestConstants.AadAuthorityWithTestTenantId)
-                        .Build());
-
-            Assert.AreEqual(MsalError.ClientIdMustBeAGuid, ex.ErrorCode);
-
-            ex = AssertException.Throws<MsalClientException>(
-              () => PublicClientApplicationBuilder.Create("http://my.app")
-                      .WithAuthority(TestConstants.B2CAuthority)
-                      .Build());
-
-            Assert.AreEqual(MsalError.ClientIdMustBeAGuid, ex.ErrorCode);
-
-            // ADFS does not have this constraint
-            PublicClientApplicationBuilder.Create("http://my.app")
-                        .WithAuthority(new Uri(TestConstants.ADFSAuthority))
-                        .Build();
-
-        }
-
-        [TestMethod]
         public void TestConstructor_ClientIdOverride()
         {
             const string ClientId = "7b94cb0c-3744-4e6e-908b-ae10368b765d";


### PR DESCRIPTION
Fixes #4686
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
- allowed non-GUID client ids for `AuthorityType.Generic`
- this allows usage of `PublicClientApplicationBuilder` with Identity Providers such as Duende IdentityServer or Keycloak

**Testing**
- added test for `AcquireTokenInteractive` in `GenericAuthorityTests` which uses [Duende IdentityServer](https://demo.duendesoftware.com)
- also manually tested with Keycloak

**Performance impact**
- no performance impact for existing functionality

**Documentation**
- [ ] All relevant documentation is updated.
