### PR TITLE
Fix for #4608- do not throw exception for ADFS + WithTenantId

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/BaseAbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/BaseAbstractApplicationBuilder.cs
@@ -132,7 +132,6 @@ namespace Microsoft.Identity.Client
         /// If both WithLogging apis are set, this one will override the other
         /// </param>
         /// <returns>The builder to chain the .With methods</returns>
-        /// <remarks>This is an experimental API. The method signature may change in the future without involving a major version upgrade.</remarks>
         public T WithLogging(
             IIdentityLogger identityLogger,
             bool enablePiiLogging = false)
@@ -218,13 +217,6 @@ namespace Microsoft.Identity.Client
                 // Both WithAuthority and WithTenant were used at app config level
                 if (!string.IsNullOrEmpty(Config.TenantId))
                 {
-                    if (!Config.Authority.AuthorityInfo.CanBeTenanted)
-                    {
-                        throw new MsalClientException(
-                            MsalError.TenantOverrideNonAad,
-                            $"Cannot use WithTenantId(tenantId) in the application builder, because the authority {Config.Authority.AuthorityInfo.AuthorityType} doesn't support it.");
-                    }
-
                     string tenantedAuthority = Config.Authority.GetTenantedAuthority(
                         Config.TenantId,
                         forceSpecifiedTenant: true);

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -176,34 +176,6 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
         }
 
         [TestMethod]
-        public void GenericAuthorityWithTenant()
-        {
-            var ex = AssertException.Throws<MsalClientException>(() =>
-                ConfidentialClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .WithTenantId(TestConstants.TenantId2)
-                    .WithOidcAuthority(TestConstants.GenericAuthority)
-                    .Build()
-            );
-
-            Assert.AreEqual(ex.ErrorCode, MsalError.TenantOverrideNonAad);
-        }
-
-        [TestMethod]
-        public void AdfsAuthorityWithTenant()
-        {
-            var ex = AssertException.Throws<MsalClientException>(() =>
-                ConfidentialClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .WithTenantId(TestConstants.TenantId2)
-                    .WithAuthority(TestConstants.ADFSAuthority)
-                    .Build()
-            );
-
-            Assert.AreEqual(ex.ErrorCode, MsalError.TenantOverrideNonAad);
-        }
-
-        [TestMethod]
         public void WithTenantId_B2C()
         {
             var app = ConfidentialClientApplicationBuilder


### PR DESCRIPTION
Fixes #4608 

This will help partners (Id.Web) keep their code simple and not having to worry about authority type in OBO.

https://github.com/AzureAD/microsoft-identity-web/issues/2509


<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
