### PR TITLE
Fix failing CIAM tests

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/CiamIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/CiamIntegrationTests.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var labResponse = await LabUserHelper.GetLabUserDataAsync(new UserQuery()
             {
                 FederationProvider = FederationProvider.CIAM,
-                SignInAudience = SignInAudience.AzureAdMyOrg,
-                PublicClient = PublicClient.no
             }).ConfigureAwait(false);
 
             //https://tenantName.ciamlogin.com/

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/CiamIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/CiamIntegrationTests.cs
@@ -92,8 +92,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var labResponse = await LabUserHelper.GetLabUserDataAsync(new UserQuery()
             {
                 FederationProvider = FederationProvider.CIAM,
-                SignInAudience = SignInAudience.AzureAdMyOrg,
-                PublicClient = PublicClient.no
             }).ConfigureAwait(false);
 
 


### PR DESCRIPTION
Lab now switched to a new API and this test is now failing. The data was wrongly added to the old Lab DB, and is now corrected in the new Lab DB. 