### PR TITLE
Fix for #4775 - deprecate WithClientAssertion(string)

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -198,6 +198,8 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="signedClientAssertion">The client assertion used to prove the identity of the application to Azure AD. This is a Base-64 encoded JWT.</param>
         /// <returns></returns>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("This method is not recommended. Use overload with Func<AssertionRequestOptions, Task<string>> instead, and return a non-expired assertion, which can be Federated Credential. See https://aka.ms/msal-net-client-assertion", false)]
         public ConfidentialClientApplicationBuilder WithClientAssertion(string signedClientAssertion)
         {
             if (string.IsNullOrWhiteSpace(signedClientAssertion))
@@ -216,7 +218,7 @@ namespace Microsoft.Identity.Client
         /// This is a delegate that computes a Base-64 encoded JWT for each authentication call.</param>
         /// <returns>The ConfidentialClientApplicationBuilder to chain more .With methods</returns>
         /// <remarks> Callers can use this mechanism to cache their assertions </remarks>
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]        
         public ConfidentialClientApplicationBuilder WithClientAssertion(Func<string> clientAssertionDelegate)
         {
             if (clientAssertionDelegate == null)
@@ -240,7 +242,7 @@ namespace Microsoft.Identity.Client
         /// This is a delegate that computes a Base-64 encoded JWT for each authentication call.</param>
         /// <returns>The ConfidentialClientApplicationBuilder to chain more .With methods</returns>
         /// <remarks> Callers can use this mechanism to cache their assertions </remarks>
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]        
         public ConfidentialClientApplicationBuilder WithClientAssertion(Func<CancellationToken, Task<string>> clientAssertionAsyncDelegate)
         {
             if (clientAssertionAsyncDelegate == null)
@@ -253,10 +255,11 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Configures an async delegate that creates a client assertion. See https://aka.ms/msal-net-client-assertion
+        /// Configures an async delegate that creates a client assertion. The delegate is invoked only a token cannot be retrieved from the cache.
+        /// 
+        /// See https://aka.ms/msal-net-client-assertion
         /// </summary>
-        /// <param name="clientAssertionAsyncDelegate">An async delegate computing the client assertion used to prove the identity of the application to Azure AD.
-        /// This is a delegate that computes a Base-64 encoded JWT for each authentication call.</param>
+        /// <param name="clientAssertionAsyncDelegate">An async delegate that returns the client assertion. Assertion lifetime is the responsability of the caller.</param>
         /// <returns>The ConfidentialClientApplicationBuilder to chain more .With methods</returns>
         /// <remarks> Callers can use this mechanism to cache their assertions </remarks>
         public ConfidentialClientApplicationBuilder WithClientAssertion(Func<AssertionRequestOptions, Task<string>> clientAssertionAsyncDelegate)

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -199,7 +199,8 @@ namespace Microsoft.Identity.Client
         /// <param name="signedClientAssertion">The client assertion used to prove the identity of the application to Azure AD. This is a Base-64 encoded JWT.</param>
         /// <returns></returns>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        [Obsolete("This method is not recommended. Use overload with Func<AssertionRequestOptions, Task<string>> instead, and return a non-expired assertion, which can be Federated Credential. See https://aka.ms/msal-net-client-assertion", false)]
+        [Obsolete("This method is not recommended. Use overload with Func<AssertionRequestOptions, Task<string>> instead, and return a non-expired assertion, which can be a Federated Credential. See https://aka.ms/msal-net-client-assertion", false)]
+
         public ConfidentialClientApplicationBuilder WithClientAssertion(string signedClientAssertion)
         {
             if (string.IsNullOrWhiteSpace(signedClientAssertion))

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -256,11 +256,13 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Configures an async delegate that creates a client assertion. The delegate is invoked only a token cannot be retrieved from the cache.
+        /// Configures an async delegate that creates a client assertion. The delegate is invoked only when a token cannot be retrieved from the cache.
+
         /// 
         /// See https://aka.ms/msal-net-client-assertion
         /// </summary>
-        /// <param name="clientAssertionAsyncDelegate">An async delegate that returns the client assertion. Assertion lifetime is the responsability of the caller.</param>
+        /// <param name="clientAssertionAsyncDelegate">An async delegate that returns the client assertion. Assertion lifetime is the responsibility of the caller.</param>
+
         /// <returns>The ConfidentialClientApplicationBuilder to chain more .With methods</returns>
         /// <remarks> Callers can use this mechanism to cache their assertions </remarks>
         public ConfidentialClientApplicationBuilder WithClientAssertion(Func<AssertionRequestOptions, Task<string>> clientAssertionAsyncDelegate)

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsTests.NetFwk.cs
@@ -318,13 +318,11 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                         settings.Authority + "/oauth2/token" :
                         settings.Authority + "/oauth2/v2.0/token";
 
-                    string signedAssertionManual = GetSignedClientAssertionManual(
+                    builder.WithClientAssertion(() => GetSignedClientAssertionManual(
                       settings.ClientId,
                       aud, // for AAD use v2.0, but not for ADFS
                       settings.GetCertificate(),
-                      useSha2AndPssForAssertion);
-
-                    builder.WithClientAssertion(signedAssertionManual);
+                      useSha2AndPssForAssertion));
                     break;
 
                 case CredentialType.ClientAssertion_Wilson:
@@ -332,12 +330,11 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                        settings.Authority + "/oauth2/token" :
                        settings.Authority + "/oauth2/v2.0/token";
 
-                    string clientAssertion = GetSignedClientAssertionUsingWilson(
-                        settings.ClientId,
-                        aud2,
-                        settings.GetCertificate());
-
-                    builder.WithClientAssertion(clientAssertion);
+                    builder.WithClientAssertion(
+                        () => GetSignedClientAssertionUsingWilson(
+                            settings.ClientId,
+                            aud2,
+                            settings.GetCertificate()));
                     break;
 
                 case CredentialType.ClientClaims_ExtraClaims:

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsTests.WithRegion.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsTests.WithRegion.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var builder = ConfidentialClientApplicationBuilder.Create(settings.ClientId);
             if (useClaims)
             {
-                builder.WithClientAssertion(GetSignedClientAssertionUsingMsalInternal(settings.ClientId, GetClaims(settings)));
+                builder.WithClientAssertion(() => GetSignedClientAssertionUsingMsalInternal(settings.ClientId, GetClaims(settings)));
             }
             else
             {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -453,7 +453,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     Assert.AreEqual(cert, app.Certificate);
                     break;
                 case CredentialType.SignedAssertion:
+#pragma warning disable CS0618 // Type or member is soft obsolete
                     builder = builder.WithClientAssertion(TestConstants.DefaultClientAssertion);
+#pragma warning restore CS0618 // Type or member is soft obsolete
                     app = builder.BuildConcrete();
                     Assert.IsNull(app.Certificate);
                     break;

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TelemetryClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/TelemetryClientTests.cs
@@ -550,7 +550,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 case AssertionType.ClientAssertion:
                     _cca = ConfidentialClientApplicationBuilder
                         .Create(TestConstants.ClientId)
-                        .WithClientAssertion(TestConstants.DefaultClientAssertion)
+                        .WithClientAssertion(() => TestConstants.DefaultClientAssertion)
                         .WithHttpManager(_harness.HttpManager)
                         .WithExperimentalFeatures()
                         .WithTelemetryClient(_telemetryClient)


### PR DESCRIPTION
Fixes #4775 

CC @Robbie-Microsoft @Avery-Dunn @rayluo - please review and if we agree on this, let's apply it to all MSALs.