### PR TITLE
Add Test for Acquiring MSI Token and Exchanging for ESTS Token in Confidential Client Application

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -53,12 +53,14 @@ namespace Microsoft.Identity.Test.Unit
         public const string TenantId2 = "aaaaaaab-aaaa-aaaa-bbbb-aaaaaaaaaaaa";
         public const string AadTenantId = "751a212b-4003-416e-b600-e1f48e40db9f";
         public const string MsaTenantId = "9188040d-6c67-4c5b-b112-36a304b66dad";
+        public const string MsftTenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         public const string SomeTenantId = "sometenantid";
         public const string CatsAreAwesome = "catsareawesome";
         public const string TenantIdNumber1 = "12345679";
         public const string TenantIdNumber2 = "987654321";
         public const string TenantIdString = "tenantid";
         public const string AadAuthorityWithTestTenantId = "https://login.microsoftonline.com/" + AadTenantId + "/";
+        public const string AadAuthorityWithMsftTenantId = "https://login.microsoftonline.com/" + MsftTenantId + "/";
         public static readonly IDictionary<string, string> s_clientAssertionClaims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "client_ip", "some_ip" }, { "aud", "some_audience" } };
         public const string RTSecret = "someRT";
         public const string ATSecret = "some-access-token";

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ManagedIdentityTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ManagedIdentityTests.NetFwk.cs
@@ -20,6 +20,7 @@ using Microsoft.Identity.Client.ManagedIdentity;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Integration.NetFx.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
+using Microsoft.Identity.Test.Unit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Microsoft.Identity.Test.Common.Core.Helpers.ManagedIdentityTestUtil;
 
@@ -37,6 +38,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         //Shared User Assigned Client ID
         private const string UserAssignedClientID = "3b57c42c-3201-4295-ae27-d6baec5b7027";
+        
+        private const string LabAccessClientID = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9";
+
+        private const string LabVaultAccessUserAssignedClientID = "4b7a4b0b-ecb2-409e-879a-1e21a15ddaf6";
 
         private const string UserAssignedObjectID = "9fc6a41b-e161-43ba-90ba-12f172141c23";
 
@@ -181,6 +186,90 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 //5. Validate the second call to token endpoint gets returned from the cache
                 Assert.AreEqual(TokenSource.Cache,
                     result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public async Task AcquireMsiToken_ExchangeForEstsToken_Successfully()
+        {
+            string resource = "api://AzureAdTokenExchange";
+
+            //Arrange
+            using (new EnvVariableContext())
+            {
+                // Fetch the env variables from the resource and set them locally
+                Dictionary<string, string> envVariables =
+                    await GetEnvironmentVariablesAsync(MsiAzureResource.WebApp).ConfigureAwait(false);
+
+                //Set the Environment Variables
+                SetEnvironmentVariables(envVariables);
+
+                //Reset cached source with update in environment variables
+                ManagedIdentityClient.resetCachedSource();
+
+                //form the http proxy URI 
+                string uri = s_baseURL + $"MSIToken?" +
+                    $"azureresource={MsiAzureResource.WebApp}&uri=";
+
+                //Create CCA with Proxy
+                IManagedIdentityApplication mia = CreateMIAWithProxy(uri, LabVaultAccessUserAssignedClientID, UserAssignedIdentityId.ClientId);
+
+                AuthenticationResult result;
+                //Act
+                result = await mia
+                            .AcquireTokenForManagedIdentity(resource)
+                            .ExecuteAsync().ConfigureAwait(false);
+
+                //Assert
+                //1. Token Type
+                Assert.AreEqual("Bearer", result.TokenType);
+
+                //2. First token response is from the MSI Endpoint
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                //3. Validate the ExpiresOn falls within a 24 hour range from now
+                CoreAssert.IsWithinRange(
+                                DateTimeOffset.UtcNow + TimeSpan.FromHours(0),
+                                result.ExpiresOn,
+                                TimeSpan.FromHours(24));
+
+                result = await mia
+                    .AcquireTokenForManagedIdentity(resource)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                //4. Validate the scope
+                Assert.IsTrue(result.Scopes.All(resource.Contains));
+
+                //5. Validate the second call to token endpoint gets returned from the cache
+                Assert.AreEqual(TokenSource.Cache,
+                    result.AuthenticationResultMetadata.TokenSource);
+
+                //6. Gets a token for the user-assigned Managed Identity.
+                var miAssertionProvider = async (AssertionRequestOptions _) =>
+                {
+                    var miResult = await mia.AcquireTokenForManagedIdentity(resource)
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    return miResult.AccessToken;
+                };
+
+                //7. Get a token for the ESTS resource using MI token as an assertion
+                IConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(LabAccessClientID)
+                    .WithAuthority(TestConstants.AadAuthorityWithMsftTenantId, false)
+                    .WithClientAssertion(miAssertionProvider)
+                    .Build();
+
+                string[] scopes = { "https://msidlabs.vault.azure.net/.default" };
+                AuthenticationResult ccaResult = await app.AcquireTokenForClient(scopes)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert: Validate successful CCA token acquisition
+                Assert.AreEqual("Bearer", ccaResult.TokenType);
+                Assert.IsNotNull(ccaResult.AccessToken);
+                Assert.IsTrue(ccaResult.ExpiresOn > DateTimeOffset.UtcNow);
             }
         }
 


### PR DESCRIPTION
Fixes #4834

**Changes proposed in this request**
This PR introduces a new unit test to validate the process of acquiring a MSI token and subsequently using it as an assertion to obtain a token from ESTS. The test performs the following steps:

 - Acquires an MSI token using a user-assigned Managed Identity.
 - Validates the token acquisition from the MSI endpoint.
 - Uses the obtained MSI token to create and configure a Confidential Client Application.
 - Acquires a token for the CCA with the appropriate scopes.
 - Validates the successful acquisition and properties of the CCA token.

Was able to use the existing lab setup and the msi helper service for this test. 

**Testing**
test itself

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
