### PR TITLE
Remove AccountSource from public IAccount interface to avoid breaking change

### DIFF
--- a/src/client/Microsoft.Identity.Client/IAccount.cs
+++ b/src/client/Microsoft.Identity.Client/IAccount.cs
@@ -33,11 +33,5 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <remarks>Can be null, for example if this account was migrated to MSAL.NET from ADAL.NET v3's token cache</remarks>
         AccountId HomeAccountId { get; }
-
-        /// <summary>
-        /// The initial flow that established the account. For example, device code flow.
-        /// </summary>
-        /// <remarks>Can be null. Currently only device code flow updates this property with a valid string</remarks>
-        string AccountSource { get; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -61,8 +61,9 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                        UiRequiredExceptionClassification.AcquireTokenSilentFailed);
                 }
 
-                bool isAccountSourceDeviceCodeFlow = !string.IsNullOrEmpty(AuthenticationRequestParameters.Account.AccountSource) &&
-                                               AuthenticationRequestParameters.Account.AccountSource == "device_code_flow";
+                var account = AuthenticationRequestParameters.Account as Account;
+                bool isAccountSourceDeviceCodeFlow = !string.IsNullOrEmpty(account.AccountSource) &&
+                                               account.AccountSource == "device_code_flow";
 
                 if (isBrokerConfigured && !isAccountSourceDeviceCodeFlow)
                 {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/SilentRequest.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                 }
 
                 var account = AuthenticationRequestParameters.Account as Account;
-                bool isAccountSourceDeviceCodeFlow = !string.IsNullOrEmpty(account.AccountSource) &&
+                bool isAccountSourceDeviceCodeFlow = account !=null &&
                                                account.AccountSource == "device_code_flow";
 
                 if (isBrokerConfigured && !isAccountSourceDeviceCodeFlow)

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -1154,13 +1154,14 @@ namespace Microsoft.Identity.Client
 
             var tenantProfiles = await GetTenantProfilesAsync(requestParameters, msalAccessTokenCacheItem.HomeAccountId).ConfigureAwait(false);
 
+            var account = requestParameters.Account as Account;
             var accountCacheItem = Accessor.GetAccount(
                 new MsalAccountCacheItem(
                         msalAccessTokenCacheItem.Environment,
                         msalAccessTokenCacheItem.TenantId,
                         msalAccessTokenCacheItem.HomeAccountId,
-                        requestParameters.Account?.AccountSource,
-                        requestParameters.Account?.Username));
+                        account?.AccountSource,
+                        account?.Username));
 
             return new Account(
                 msalAccessTokenCacheItem.HomeAccountId,

--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/DeviceCodeFlowIntegrationTest.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/DeviceCodeFlowIntegrationTest.cs
@@ -153,7 +153,8 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
             Assert.IsFalse(userCacheAccess.LastAfterAccessNotificationArgs.IsApplicationCache);
 
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Account.AccountSource == "device_code_flow");
+            var account = result.Account as Account;
+            Assert.IsTrue(account.AccountSource == "device_code_flow");
             Assert.IsTrue(!string.IsNullOrEmpty(result.AccessToken));
             TestCommon.ValidateNoKerberosTicketFromAuthenticationResult(result);
 

--- a/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/Form1.cs
@@ -817,7 +817,8 @@ namespace NetDesktopWinForms
                 "" :
                 $"({Account.Environment})";
             string homeTenantId = account?.HomeAccountId?.TenantId?.Substring(0, 5);
-            string accountSource = account?.AccountSource;
+            var accountObj = account as Account;
+            string accountSource = accountObj?.AccountSource;
 
             DisplayValue = displayValue ?? $"{Account.Username} {env} {homeTenantId} {accountSource}";
         }


### PR DESCRIPTION

**Changes proposed in this request**
The previous check in to fix a device code flow issue unintentionally introduced a breaking change by adding a new property in IAccount public interface. Remove the new property in IAccount and only depend on the internal Account object for the new property.

**Testing**
The Integration test has been updated to test the change.

**Performance impact**
None

