### PR TITLE
Fix Pre-release Regression: Correct JSON Web Key (JWK) Encoding for RSA Public Key Export

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/InMemoryCryptoProvider.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/InMemoryCryptoProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
         /// </summary>
         private static string ComputeCanonicalJwk(RSAParameters rsaPublicKey)
         {
-            //Important: This format cannot be modefied as it needs to be the same as what is used in the service when calculating hashes.
+            //Important: This format cannot be modified as it needs to be the same as what is used in the service when calculating hashes.
             return $@"{{""{JsonWebKeyParameterNames.E}"":""{Base64UrlHelpers.Encode(rsaPublicKey.Exponent)}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.RSA}"",""{JsonWebKeyParameterNames.N}"":""{Base64UrlHelpers.Encode(rsaPublicKey.Modulus)}""}}";
         }
 

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/InMemoryCryptoProvider.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/InMemoryCryptoProvider.cs
@@ -56,9 +56,8 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
         /// </summary>
         private static string ComputeCanonicalJwk(RSAParameters rsaPublicKey)
         {
-            return $@"{{""{JsonWebKeyParameterNames.E}"":""{Base64UrlHelpers.Encode(rsaPublicKey.Exponent)}"",
-               ""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.RSA}"",
-               ""{JsonWebKeyParameterNames.N}"":""{Base64UrlHelpers.Encode(rsaPublicKey.Modulus)}""}}";
+            //Important: This format cannot be modefied as it needs to be the same as what is used in the service when calculating hashes.
+            return $@"{{""{JsonWebKeyParameterNames.E}"":""{Base64UrlHelpers.Encode(rsaPublicKey.Exponent)}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.RSA}"",""{JsonWebKeyParameterNames.N}"":""{Base64UrlHelpers.Encode(rsaPublicKey.Modulus)}""}}";
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
+        // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4879
+        [Ignore]
         public async Task InteractiveConsentPromptAsync()
         {
             var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
@@ -31,6 +31,8 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
+using JsonWebAlgorithmsKeyTypes = Microsoft.Identity.Client.AuthScheme.PoP.JsonWebAlgorithmsKeyTypes;
+using JsonWebKeyParameterNames = Microsoft.Identity.Client.AuthScheme.PoP.JsonWebKeyParameterNames;
 
 namespace Microsoft.Identity.Test.Unit.Pop
 {
@@ -677,6 +679,22 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 Assert.IsTrue(!string.IsNullOrEmpty(claims.FindAll("nonce").Single().Value));
                 AssertSingedHttpRequestClaims(provider, claims);
             }
+        }
+
+        [TestMethod]
+        public void ValidateCanonicalJwkFormat()
+        {
+            // Arrange
+            var provider = PoPProviderFactory.GetOrCreateProvider();
+            var actualCanonicaljwk = provider.CannonicalPublicKeyJwk;
+
+            // Act and Assert
+
+            // Parse the JWK to get the RSA parameters so that we can create a new canonical JWK in expected format
+            var jsonWebKey = JsonWebKey.Create(actualCanonicaljwk);
+            var expectedCanonicalJwk = $@"{{""{JsonWebKeyParameterNames.E}"":""{jsonWebKey.E}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.RSA}"",""{JsonWebKeyParameterNames.N}"":""{jsonWebKey.N}""}}";
+
+            Assert.AreEqual(expectedCanonicalJwk, actualCanonicaljwk);
         }
     }
 }


### PR DESCRIPTION
Fixes #4881
This pull request addresses a regression identified in the pre-release phase that caused incorrect encoding of JSON Web Key (JWK) parameters in the RSA public key export function. 

**Changes proposed in this request**
- revert the change.
- Added unit tests to verify the correct encoding of JWK parameters.

**Testing**
unit tests

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
