### PR TITLE
Changed consent handler to find element by name instead of ID

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/SeleniumExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/SeleniumExtensions.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Identity.Test.Integration.Infrastructure
 
             HandlePrompt(driver, "otherTile");
             EnterUsername(driver, user, withLoginHint, adfsOnly, fields);
-            HandlePrompt(driver, CoreUiTestConstants.NextButton);
+            HandlePrompt(driver, CoreUiTestConstants.WebSubmitId);
             EnterPassword(driver, user, fields);
 
             HandleConsent(driver, user, fields, prompt);
@@ -251,7 +251,7 @@ namespace Microsoft.Identity.Test.Integration.Infrastructure
             if (prompt == Prompt.Consent)
             {
                 Trace.WriteLine("Consenting...");
-                driver.WaitForElementToBeVisibleAndEnabled(By.Id(fields.AADSignInButtonId)).Click();
+                driver.WaitForElementToBeVisibleAndEnabled(By.Name(fields.AADSignInButtonId)).Click();
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
@@ -77,8 +77,6 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
-        // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4879
-        [Ignore]
         public async Task InteractiveConsentPromptAsync()
         {
             var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);


### PR DESCRIPTION
…from id to name

Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->
#4879 

**Changes proposed in this request**
Edited HandleConsent in SeleniumExtensions.cs to search for the element by name instead of id since an id was not assigned to the "Accept" Button on the consent UI
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
