### PR TITLE
Prototype extensiblity with example

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthScheme/Bearer/BearerAuthenticationScheme.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/Bearer/BearerAuthenticationScheme.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Identity.Client.AuthScheme.Bearer
 
         public string KeyId => null;
 
-        public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
+        public void FormatResult(AuthenticationResult authenticationResult)
         {
-            return msalAccessTokenCacheItem.Secret;
+            // no-op for Bearer tokens
         }
 
         public IReadOnlyDictionary<string, string> GetTokenRequestParams()

--- a/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationScheme.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationScheme.cs
@@ -3,18 +3,22 @@
 
 using System.Collections.Generic;
 using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Client.Extensibility;
 
 namespace Microsoft.Identity.Client.AuthScheme
 {
     /// <summary>
-    /// Used to modify the experience depending on the type of token asked. 
+    /// Extensiblity interface Used to modify the experience depending on the type of token asked. 
     /// </summary>
-    internal interface IAuthenticationScheme
+    public interface IAuthenticationScheme 
     {
+        //TODO bogavril - abstract class instead of interface?
+        //TODO bogavril - replace legacy POP impl in Id.Web with this and hard deprecate WithKeyId extensiblity point
+
         /// <summary>
-        /// Value to log to telemetry to indicate pop usage.
+        /// Value to log to HTTP telemetry.
         /// </summary>
-        TokenType TelemetryTokenType { get; }
+        TokenType TelemetryTokenType { get; }  // TODO: bogavril - enums are not good for extensiblity, consider using INT
 
         /// <summary>
         /// Prefix for the HTTP header that has the token. E.g. "Bearer" or "POP"
@@ -37,7 +41,7 @@ namespace Microsoft.Identity.Client.AuthScheme
         /// <summary>
         /// Creates the access token that goes into an Authorization HTTP header. 
         /// </summary>
-        string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem);
+        void FormatResult(AuthenticationResult authenticationResult); 
 
         /// <summary>
         /// Expected to match the token_type parameter returned by ESTS. Used to disambiguate

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PoPAuthenticationScheme.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PoPAuthenticationScheme.cs
@@ -67,11 +67,12 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
             };
         }
 
-        public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
+        public void FormatResult(AuthenticationResult authenticationResult)
         {
             if (!_popAuthenticationConfiguration.SignHttpRequest)
             {
-                return msalAccessTokenCacheItem.Secret;
+                // token will be signed by the caller
+                return;
             }
 
             var header = new JObject();
@@ -79,13 +80,13 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
             header[JsonWebTokenConstants.KeyId] = KeyId;
             header[JsonWebTokenConstants.Type] = Constants.PoPTokenType;
 
-            var body = CreateBody(msalAccessTokenCacheItem);
+            var body = CreateBody(authenticationResult.AccessToken);
 
             string popToken = CreateJWS(JsonHelper.JsonObjectToString(body), JsonHelper.JsonObjectToString(header));
-            return popToken;
+            authenticationResult.AccessToken = popToken;
         }
 
-        private JObject CreateBody(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
+        private JObject CreateBody(string accessToken)
         {
             var publicKeyJwk = JToken.Parse(_popCryptoProvider.CannonicalPublicKeyJwk);
             var body = new JObject
@@ -96,7 +97,7 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
                     [PoPClaimTypes.JWK] = publicKeyJwk
                 },
                 [PoPClaimTypes.Ts] = DateTimeHelpers.CurrDateTimeInUnixTimestamp(),
-                [PoPClaimTypes.At] = msalAccessTokenCacheItem.Secret,
+                [PoPClaimTypes.At] = accessToken,
                 [PoPClaimTypes.Nonce] = _popAuthenticationConfiguration.Nonce ?? CreateSimpleNonce(),
             };
 

--- a/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PopBrokerAuthenticationScheme.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/PoP/PopBrokerAuthenticationScheme.cs
@@ -25,10 +25,9 @@ namespace Microsoft.Identity.Client.AuthScheme.PoP
 
         public string AccessTokenType => Constants.PoPTokenType;
 
-        public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
+        public void FormatResult(AuthenticationResult authenticationResult)
         {
-            //no op
-            return msalAccessTokenCacheItem.Secret;
+            // no-op, the token is already in POP format from the broker            
         }
 
         public IReadOnlyDictionary<string, string> GetTokenRequestParams()

--- a/src/client/Microsoft.Identity.Client/AuthScheme/SSHCertificates/SSHCertAuthenticationScheme.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/SSHCertificates/SSHCertAuthenticationScheme.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Identity.Client.AuthScheme.SSHCertificates
 
         public string KeyId { get; }
 
-        public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
+        public void FormatResult(AuthenticationResult authenticationResult)
         {
-            return msalAccessTokenCacheItem.Secret;
+            // no-op, the access token doesn't require any formatting
         }
 
         public IReadOnlyDictionary<string, string> GetTokenRequestParams()

--- a/src/client/Microsoft.Identity.Client/AuthScheme/TokenType.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/TokenType.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Identity.Client.AuthScheme
     /// <summary>
     /// Specifies the token type to log to telemetry.
     /// </summary>
-    internal enum TokenType
+    public enum TokenType
     {
         /// <summary>
         /// Bearer token type.
@@ -14,7 +14,7 @@ namespace Microsoft.Identity.Client.AuthScheme
         Bearer = 1,
 
         /// <summary>
-        /// Pop token type.
+        /// Pop token type (referrs to the official SHR POP)
         /// </summary>
         Pop = 2,
 
@@ -24,8 +24,10 @@ namespace Microsoft.Identity.Client.AuthScheme
         SshCert = 3,
 
         /// <summary>
-        /// External token type.
+        /// External token type. Currently used by the unoficial SHR POP implementation.
         /// </summary>
         External = 4
+
+        // values up to 20 are reserved for internal use
     }
 }

--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -169,7 +169,6 @@ namespace Microsoft.Identity.Client
             AdditionalResponseParameters = additionalResponseParameters;
             if (msalAccessTokenCacheItem != null)
             {
-                AccessToken = authenticationScheme.FormatAccessToken(msalAccessTokenCacheItem);
                 ExpiresOn = msalAccessTokenCacheItem.ExpiresOn;
                 Scopes = msalAccessTokenCacheItem.ScopeSet;
 
@@ -185,6 +184,9 @@ namespace Microsoft.Identity.Client
                     AuthenticationResultMetadata.RefreshOn = msalAccessTokenCacheItem.RefreshOn;
                 }
             }
+
+            // Important: only call this at the end!
+            authenticationScheme.FormatResult(this);
         }
 
         //Default constructor for testing
@@ -193,7 +195,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Access Token that can be used as a bearer token to access protected web APIs
         /// </summary>
-        public string AccessToken { get; }
+        public string AccessToken { get; set; }
 
         /// <summary>
         /// In case when Azure AD has an outage, to be more resilient, it can return tokens with

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -2,11 +2,36 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client.AuthScheme;
 
 namespace Microsoft.Identity.Client.Extensibility
 {
+    /// <summary>
+    /// TODO: design for 2 things - Test User and CDT
+    /// </summary>
+    public class AddIn
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public Func<OnBeforeTokenRequestData, Task> OnBeforeTokenRequestHandler { get; set; }
+
+        /// <summary>
+        /// Changes the 
+        /// </summary>
+        /// TODO: guidance on how this interacts with OnBeforeTokenRequestHandler
+        public IAuthenticationScheme AuthenticationScheme { get; set; }
+
+        /// <summary>
+        /// When the token endpoint responds with a token, it may include additional properties in the response. This list instructs MSAL to save the properties in the token cache. 
+        /// The properties will be returned as part of the <see cref="AuthenticationResult.AdditionalResponseParameters"/> 
+        /// </summary>
+        /// <remarks>Currently supports only key value properties </remarks>  // TODO: need to model JObject etc, but probably as string
+        public IReadOnlyList<string> AdditionalAccessTokenPropertiesToCache { get; set; }  //TODO: bogavril - implement this
+    }
 
     /// <summary>
     /// Extensions for all AcquireToken methods
@@ -22,11 +47,44 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <param name="onBeforeTokenRequestHandler">An async delegate which gets invoked just before MSAL makes a token request</param>
         /// <returns>The builder to chain other options to.</returns>
         public static AbstractAcquireTokenParameterBuilder<T> OnBeforeTokenRequest<T>(
-            this AbstractAcquireTokenParameterBuilder<T> builder, 
-            Func<OnBeforeTokenRequestData, Task> onBeforeTokenRequestHandler) 
+            this AbstractAcquireTokenParameterBuilder<T> builder,
+            Func<OnBeforeTokenRequestData, Task> onBeforeTokenRequestHandler)
             where T : AbstractAcquireTokenParameterBuilder<T>
-        {            
+        {
+            if (builder.CommonParameters.OnBeforeTokenRequestHandler != null && onBeforeTokenRequestHandler != null)
+            {
+                throw new InvalidOperationException("Cannot set OnBeforeTokenRequest handler twice.");
+            }
+
             builder.CommonParameters.OnBeforeTokenRequestHandler = onBeforeTokenRequestHandler;
+
+            return builder;
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="addIn"></param>
+        /// <returns></returns>
+        public static AbstractAcquireTokenParameterBuilder<T> WithAddIn<T>( // TODO: bogavril - support a list of add-ins ? 
+           this AbstractAcquireTokenParameterBuilder<T> builder,
+           AddIn addIn)
+            where T : AbstractAcquireTokenParameterBuilder<T>
+        {
+            if (builder.CommonParameters.OnBeforeTokenRequestHandler != null && addIn.OnBeforeTokenRequestHandler != null)
+            {
+                throw new InvalidOperationException("Cannot set both an add-in and an OnBeforeTokenRequestHandler");
+            }
+
+            builder.CommonParameters.OnBeforeTokenRequestHandler = addIn.OnBeforeTokenRequestHandler;
+
+            if (addIn.AuthenticationScheme != null)
+                builder.WithAuthenticationScheme(addIn.AuthenticationScheme);
+
+            // TODO: bogavril - AdditionalAccessTokenPropertiesToCache needs implementation
 
             return builder;
         }
@@ -55,5 +113,5 @@ namespace Microsoft.Identity.Client.Extensibility
 
             return builder;
         }
-    }   
+    }
 }

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -9,29 +9,6 @@ using Microsoft.Identity.Client.AuthScheme;
 
 namespace Microsoft.Identity.Client.Extensibility
 {
-    /// <summary>
-    /// TODO: design for 2 things - Test User and CDT
-    /// </summary>
-    public class AddIn
-    {
-        /// <summary>
-        /// 
-        /// </summary>
-        public Func<OnBeforeTokenRequestData, Task> OnBeforeTokenRequestHandler { get; set; }
-
-        /// <summary>
-        /// Changes the 
-        /// </summary>
-        /// TODO: guidance on how this interacts with OnBeforeTokenRequestHandler
-        public IAuthenticationScheme AuthenticationScheme { get; set; }
-
-        /// <summary>
-        /// When the token endpoint responds with a token, it may include additional properties in the response. This list instructs MSAL to save the properties in the token cache. 
-        /// The properties will be returned as part of the <see cref="AuthenticationResult.AdditionalResponseParameters"/> 
-        /// </summary>
-        /// <remarks>Currently supports only key value properties </remarks>  // TODO: need to model JObject etc, but probably as string
-        public IReadOnlyList<string> AdditionalAccessTokenPropertiesToCache { get; set; }  //TODO: bogavril - implement this
-    }
 
     /// <summary>
     /// Extensions for all AcquireToken methods
@@ -71,7 +48,7 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <returns></returns>
         public static AbstractAcquireTokenParameterBuilder<T> WithAddIn<T>( // TODO: bogavril - support a list of add-ins ? 
            this AbstractAcquireTokenParameterBuilder<T> builder,
-           AddIn addIn)
+           MsalAddIn addIn)
             where T : AbstractAcquireTokenParameterBuilder<T>
         {
             if (builder.CommonParameters.OnBeforeTokenRequestHandler != null && addIn.OnBeforeTokenRequestHandler != null)

--- a/src/client/Microsoft.Identity.Client/Extensibility/ExternalBoundTokenScheme.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/ExternalBoundTokenScheme.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Identity.Client.Extensibility
 
         public string AccessTokenType => _tokenType;
 
-        public string FormatAccessToken(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
+        public void FormatResult(AuthenticationResult authenticationResult)
         {
-            return msalAccessTokenCacheItem.Secret;
+            // no-op, the implementers will format the token
         }
 
         public IReadOnlyDictionary<string, string> GetTokenRequestParams()

--- a/src/client/Microsoft.Identity.Client/Extensibility/MsalAddIn.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/MsalAddIn.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.AuthScheme;
+
+namespace Microsoft.Identity.Client.Extensibility
+{
+    /// <summary>
+    /// TODO: design for 2 things - Test User and CDT
+    /// </summary>
+    public class MsalAddIn
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public Func<OnBeforeTokenRequestData, Task> OnBeforeTokenRequestHandler { get; set; }
+
+        /// <summary>
+        /// Changes the 
+        /// </summary>
+        /// TODO: guidance on how this interacts with OnBeforeTokenRequestHandler
+        public IAuthenticationScheme AuthenticationScheme { get; set; }
+
+        /// <summary>
+        /// When the token endpoint responds with a token, it may include additional properties in the response. This list instructs MSAL to save the properties in the token cache. 
+        /// The properties will be returned as part of the <see cref="AuthenticationResult.AdditionalResponseParameters"/> 
+        /// </summary>
+        /// <remarks>Currently supports only key value properties </remarks>  // TODO: need to model JObject etc, but probably as string
+        public IReadOnlyList<string> AdditionalAccessTokenPropertiesToCache { get; set; }  //TODO: bogavril - implement this
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -87,8 +87,10 @@
     <Compile Include="$(PathToMsalSources)\**\*.cs" Exclude="$(PathToMsalSources)\obj\**\*.*" />
     <Compile Remove="$(PathToMsalSources)\Platforms\**\*.*;$(PathToMsalSources)\Resources\*.cs" />
     <Compile Remove="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
+    <Compile Include="AuthScheme\IAuthenticationScheme.cs" />
     <EmbeddedResource Include="$(PathToMsalSources)\Properties\Microsoft.Identity.Client.rd.xml" />
     <None Include="$(PathToMsalSources)\..\..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="AuthScheme\IAuthenticationScheme.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationSchemeTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationSchemeTests.cs
@@ -45,7 +45,10 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             authScheme.AccessTokenType.Returns("bearer");
             authScheme.KeyId.Returns("keyid");
             authScheme.GetTokenRequestParams().Returns(new Dictionary<string, string>() { { "tokenParam", "tokenParamValue" } });
-            authScheme.FormatAccessToken(default).ReturnsForAnyArgs(x => "enhanced_secret_" + ((MsalAccessTokenCacheItem)x[0]).Secret);
+
+            // When FormatResult is called, change the AccessToken property 
+            authScheme.WhenForAnyArgs(x => x.FormatResult(default)).Do(x => x[0] = "enhanced_secret_" + ((AuthenticationResult)x[0]).AccessToken);
+
 
             using (var httpManager = new MockHttpManager())
             {
@@ -112,7 +115,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     Arg.Any<AcquireTokenInteractiveParameters>()).Returns(
                     MockHelpers.CreateMsalRunTimeBrokerTokenResponse(null, Constants.PoPAuthHeaderPrefix));
                 mockBroker.AcquireTokenSilentAsync(
-                    Arg.Any<AuthenticationRequestParameters>(), 
+                    Arg.Any<AuthenticationRequestParameters>(),
                     Arg.Any<AcquireTokenSilentParameters>()).Returns(
                     MockHelpers.CreateMsalRunTimeBrokerTokenResponse(null, Constants.PoPAuthHeaderPrefix));
 
@@ -164,7 +167,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             authScheme.AuthorizationHeaderPrefix.Returns("BearToken");
             authScheme.KeyId.Returns("keyid");
             authScheme.GetTokenRequestParams().Returns(new Dictionary<string, string>() { { "tokenParam", "tokenParamValue" } });
-            authScheme.FormatAccessToken(default).ReturnsForAnyArgs(x => "enhanced_secret_" + ((MsalAccessTokenCacheItem)x[0]).Secret);
+            authScheme.WhenForAnyArgs(x => x.FormatResult(default)).Do(x => x[0] = "enhanced_secret_" + ((AuthenticationResult)x[0]).AccessToken);
 
             using (var httpManager = new MockHttpManager())
             {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 MockHttpMessageHandler handler = httpManager.
                     AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
 
-                AddIn exampleAddIn = new AddIn()
+                MsalAddIn exampleAddIn = new MsalAddIn()
                 {
                     AdditionalAccessTokenPropertiesToCache = new[] { "ds_nonce", "ds_enc" },
                     // OnBeforeTokenRequestHandler not needed for this flow

--- a/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationSchemeTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationSchemeTests.cs
@@ -70,8 +70,9 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 // Act
                 PopAuthenticationScheme authenticationScheme = new PopAuthenticationScheme(popConfig, harness.ServiceBundle);
                 var tokenParams = authenticationScheme.GetTokenRequestParams();
-                var popTokenString = authenticationScheme.FormatAccessToken(msalAccessTokenCacheItem);
-                JwtSecurityToken decodedPopToken = new JwtSecurityToken(popTokenString);
+                AuthenticationResult ar = new AuthenticationResult(msalAccessTokenCacheItem, null, null, Guid.NewGuid(), TokenSource.IdentityProvider, default, default, default, default);
+                authenticationScheme.FormatResult(ar);
+                JwtSecurityToken decodedPopToken = new JwtSecurityToken(ar.AccessToken);
 
                 // Assert
                 Assert.AreEqual("PoP", authenticationScheme.AuthorizationHeaderPrefix);


### PR DESCRIPTION
Please review directly the tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs to see an example

The src/client/Microsoft.Identity.Client/Extensibility/MsalAddIn.cs has been added as an agreegation of mulitple extensiblity points in MSAL. 


TODO: telemetry signals like time to create CDT