### PR TITLE
Adding api to enable additional caching parameters

### DIFF
--- a/build/platform_and_feature_flags.props
+++ b/build/platform_and_feature_flags.props
@@ -23,4 +23,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;SUPPORTS_CONFIDENTIAL_CLIENT;SUPPORTS_BROKER;SUPPORTS_CUSTOM_CACHE;SUPPORTS_WIN32;</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNet6Android)' or '$(TargetFramework)' == '$(TargetFrameworkNet6Ios)'">
+    <DefineConstants>$(DefineConstants);MOBILE</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -348,22 +348,6 @@ namespace Microsoft.Identity.Client
             return this as T;
         }
 
-        /// <summary>
-        /// Specifies additional parameters acquired from authentication responses to be cached with the access token that are normally not included in the cache object.
-        /// </summary>
-        /// <param name="cacheParameters">Additional parameters to cache</param>
-        /// <returns></returns>
-        public T WithAdditionalCacheParameters(IEnumerable<string> cacheParameters)
-        {
-            if (cacheParameters != null && cacheParameters.Count() == 0)
-            {
-                throw new ArgumentNullException(nameof(cacheParameters));
-            }
-
-            CommonParameters.AdditionalCacheParameters = cacheParameters;
-            return this as T;
-        }
-
         internal /* for testing */ T WithAuthenticationScheme(IAuthenticationScheme scheme)
         {
             CommonParameters.AuthenticationScheme = scheme ?? throw new ArgumentNullException(nameof(scheme));

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Specifies additional parameters acquired from authentication responses to be cached with the access token that are normally not included in the cache key.
+        /// Specifies additional parameters acquired from authentication responses to be cached with the access token that are normally not included in the cache object.
         /// </summary>
         /// <param name="cacheParameters">Additional parameters to cache</param>
         /// <returns></returns>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
@@ -344,6 +345,22 @@ namespace Microsoft.Identity.Client
                 throw new ArgumentNullException(nameof(authorityUri));
             }
             CommonParameters.AuthorityOverride = new AuthorityInfo(AuthorityType.B2C, authorityUri, false);
+            return this as T;
+        }
+
+        /// <summary>
+        /// Specifies additional parameters acquired from authentication responses to be cached with the access token that are normally not included in the cache key.
+        /// </summary>
+        /// <param name="cacheParameters">Additional parameters to cache</param>
+        /// <returns></returns>
+        public T WithAdditionalCacheParameters(IEnumerable<string> cacheParameters)
+        {
+            if (cacheParameters != null && cacheParameters.Count() == 0)
+            {
+                throw new ArgumentNullException(nameof(cacheParameters));
+            }
+
+            CommonParameters.AdditionalCacheParameters = cacheParameters;
             return this as T;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -29,6 +29,6 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public PoPAuthenticationConfiguration PopAuthenticationConfiguration { get; set; }
         public Func<OnBeforeTokenRequestData, Task> OnBeforeTokenRequestHandler { get; internal set; }
         public X509Certificate2 MtlsCertificate { get; internal set; }
-
+        public IEnumerable<string> AdditionalCacheParameters { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -29,6 +29,6 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public PoPAuthenticationConfiguration PopAuthenticationConfiguration { get; set; }
         public Func<OnBeforeTokenRequestData, Task> OnBeforeTokenRequestHandler { get; internal set; }
         public X509Certificate2 MtlsCertificate { get; internal set; }
-        public IEnumerable<string> AdditionalCacheParameters { get; set; }
+        public List<string> AdditionalCacheParameters { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Identity.Client
             CorrelationId = correlationID;
             ApiEvent = apiEvent;
             AuthenticationResultMetadata = new AuthenticationResultMetadata(tokenSource);
-            AdditionalResponseParameters = msalAccessTokenCacheItem.PersistedCacheParameters?.Count > 0 ?
+            AdditionalResponseParameters = msalAccessTokenCacheItem?.PersistedCacheParameters?.Count > 0 ?
                                                                     (IReadOnlyDictionary<string, string>)msalAccessTokenCacheItem.PersistedCacheParameters : 
                                                                     additionalResponseParameters;
             if (msalAccessTokenCacheItem != null)

--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -166,7 +166,9 @@ namespace Microsoft.Identity.Client
             CorrelationId = correlationID;
             ApiEvent = apiEvent;
             AuthenticationResultMetadata = new AuthenticationResultMetadata(tokenSource);
-            AdditionalResponseParameters = additionalResponseParameters;
+            AdditionalResponseParameters = msalAccessTokenCacheItem.PersistedCacheParameters?.Count > 0 ?
+                                                                    (IReadOnlyDictionary<string, string>)msalAccessTokenCacheItem.PersistedCacheParameters : 
+                                                                    additionalResponseParameters;
             if (msalAccessTokenCacheItem != null)
             {
                 AccessToken = authenticationScheme.FormatAccessToken(msalAccessTokenCacheItem);

--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -69,7 +69,14 @@ namespace Microsoft.Identity.Client.Cache.Items
 
             var cacheParameters = extraDataFromResponse
                                     .Where(x => persistedCacheParameters.Contains(x.Key))
+#if SUPPORTS_SYSTEM_TEXT_JSON
                                     .ToDictionary(x => x.Key, x => x.Value.ToString());
+#else
+                                    //Avoid formatting arrays because it adds new lines after every element
+                                    .ToDictionary(x => x.Key, x => x.Value.Type == JTokenType.Array || x.Value.Type == JTokenType.Object ?
+                                                                                    x.Value.ToString(Json.Formatting.None) :
+                                                                                    x.Value.ToString());
+#endif
 
             return cacheParameters;
         }

--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Identity.Client.Cache.Items
             RawClientInfo = response.ClientInfo;
             HomeAccountId = homeAccountId;
             OboCacheKey = oboCacheKey;
-            AdditionalCacheParameters = AcquireCacheParametersFromResponse(additionalRequestRapameters, response.ExtensionData);
+            PersistedCacheParameters = AcquireCacheParametersFromResponse(additionalRequestRapameters, response.ExtensionData);
 
             InitCacheKey();
         }
@@ -237,7 +237,7 @@ namespace Microsoft.Identity.Client.Cache.Items
         /// Additional parameters that were requested in the token request and are stored in the cache.
         /// These are acquired from the response and are stored in the cache for later use.
         /// </summary>
-        internal IDictionary<string, string> AdditionalCacheParameters { get; private set; }
+        internal IDictionary<string, string> PersistedCacheParameters { get; private set; }
 
         private Lazy<IiOSKey> iOSCacheKeyLazy;
         public IiOSKey iOSCacheKey => iOSCacheKeyLazy.Value;

--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -48,8 +48,9 @@ namespace Microsoft.Identity.Client.Cache.Items
             RawClientInfo = response.ClientInfo;
             HomeAccountId = homeAccountId;
             OboCacheKey = oboCacheKey;
+#if !iOS && !ANDROID
             PersistedCacheParameters = AcquireCacheParametersFromResponse(additionalRequestRapameters, response.ExtensionData);
-
+#endif
             InitCacheKey();
         }
 

--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -48,27 +48,28 @@ namespace Microsoft.Identity.Client.Cache.Items
             RawClientInfo = response.ClientInfo;
             HomeAccountId = homeAccountId;
             OboCacheKey = oboCacheKey;
-#if !iOS && !ANDROID
+#if !MOBILE
             PersistedCacheParameters = AcquireCacheParametersFromResponse(persistedCacheParameters, response.ExtensionData);
 #endif
             InitCacheKey();
         }
 
+#if !MOBILE
         private IDictionary<string, string> AcquireCacheParametersFromResponse(
                                                     IEnumerable<string> persistedCacheParameters,
 #if SUPPORTS_SYSTEM_TEXT_JSON
-                                                    IDictionary<string, JsonElement> extraDataFromResponse)
+                                                    Dictionary<string, JsonElement> extraDataFromResponse)
 #else
-                                                    IDictionary<string, JToken> extraDataFromResponse)
+                                                    Dictionary<string, JToken> extraDataFromResponse)
 #endif
         {
-            if (persistedCacheParameters == null)
+            if (persistedCacheParameters == null || !persistedCacheParameters.Any())
             {
                 return null;
             }
 
             var cacheParameters = extraDataFromResponse
-                                    .Where(x => persistedCacheParameters.Contains(x.Key))
+                                    .Where(x => persistedCacheParameters.Contains(x.Key, StringComparer.InvariantCultureIgnoreCase))
 #if SUPPORTS_SYSTEM_TEXT_JSON
                                     .ToDictionary(x => x.Key, x => x.Value.ToString());
 #else
@@ -77,10 +78,9 @@ namespace Microsoft.Identity.Client.Cache.Items
                                                                                     x.Value.ToString(Json.Formatting.None) :
                                                                                     x.Value.ToString());
 #endif
-
             return cacheParameters;
         }
-
+#endif
         internal /* for test */ MsalAccessTokenCacheItem(
             string preferredCacheEnv,
             string clientId,

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Identity.Client.Extensibility
             return builder;
         }
 
+#if !MOBILE
         /// <summary>
         /// Specifies additional parameters acquired from authentication responses to be cached with the access token that are normally not included in the cache object.
         /// these values can be read from the <see cref="AuthenticationResult.AdditionalResponseParameters"/> parameter.
@@ -71,7 +72,7 @@ namespace Microsoft.Identity.Client.Extensibility
             IEnumerable<string> cacheParameters)
             where T : AbstractAcquireTokenParameterBuilder<T>
         {
-            if (cacheParameters != null && cacheParameters.Count() == 0)
+            if (cacheParameters != null && !cacheParameters.Any())
             {
                 return builder;
             }
@@ -89,5 +90,6 @@ namespace Microsoft.Identity.Client.Extensibility
             }
             return builder;
         }
+#endif
     }   
 }

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -53,6 +55,38 @@ namespace Microsoft.Identity.Client.Extensibility
             builder.ValidateUseOfExperimentalFeature();
             builder.CommonParameters.AuthenticationScheme = new ExternalBoundTokenScheme(keyId, expectedTokenTypeFromAad);
 
+            return builder;
+        }
+
+        /// <summary>
+        /// Specifies additional parameters acquired from authentication responses to be cached with the access token that are normally not included in the cache object.
+        /// these values can be read from the <see cref="AuthenticationResult.AdditionalResponseParameters"/> parameter.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="builder">The builder to chain options to</param>
+        /// <param name="cacheParameters">Additional parameters to cache</param>
+        /// <returns></returns>
+        public static AbstractAcquireTokenParameterBuilder<T> WithAdditionalCacheParameters<T>(
+            this AbstractAcquireTokenParameterBuilder<T> builder, 
+            IEnumerable<string> cacheParameters)
+            where T : AbstractAcquireTokenParameterBuilder<T>
+        {
+            if (cacheParameters != null && cacheParameters.Count() == 0)
+            {
+                return builder;
+            }
+
+            builder.ValidateUseOfExperimentalFeature();
+
+            //Check if the cache parameters are already initialized, if so, add to the existing list
+            if (builder.CommonParameters.AdditionalCacheParameters != null)
+            {
+                builder.CommonParameters.AdditionalCacheParameters.AddRange(cacheParameters);
+            }
+            else
+            {
+                builder.CommonParameters.AdditionalCacheParameters = cacheParameters.ToList<string>();
+            }
             return builder;
         }
     }   

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -115,6 +115,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public IAuthenticationScheme AuthenticationScheme => _commonParameters.AuthenticationScheme;
 
+        public IEnumerable<string> AdditionalCacheParameters => _commonParameters.AdditionalCacheParameters;
+
         #region TODO REMOVE FROM HERE AND USE FROM SPECIFIC REQUEST PARAMETERS
         // TODO: ideally, these can come from the particular request instance and not be in RequestBase since it's not valid for all requests.
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public IAuthenticationScheme AuthenticationScheme => _commonParameters.AuthenticationScheme;
 
-        public IEnumerable<string> AdditionalCacheParameters => _commonParameters.AdditionalCacheParameters;
+        public IEnumerable<string> PersistedCacheParameters => _commonParameters.AdditionalCacheParameters;
 
         #region TODO REMOVE FROM HERE AND USE FROM SPECIFIC REQUEST PARAMETERS
         // TODO: ideally, these can come from the particular request instance and not be in RequestBase since it's not valid for all requests.

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -93,7 +93,8 @@ namespace Microsoft.Identity.Client.OAuth2
 #if SUPPORTS_SYSTEM_TEXT_JSON
             foreach (KeyValuePair<string, JsonElement> item in ExtensionData)
             {
-                if (item.Value.ValueKind != JsonValueKind.Undefined)
+                if (item.Value.ValueKind != JsonValueKind.Undefined ||
+                    item.Value.ValueKind != JsonValueKind.Null)
                 {
                     stringExtensionData.Add(item.Key, item.Value.ToString());
                 }

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -93,12 +93,7 @@ namespace Microsoft.Identity.Client.OAuth2
 #if SUPPORTS_SYSTEM_TEXT_JSON
             foreach (KeyValuePair<string, JsonElement> item in ExtensionData)
             {
-                if (item.Value.ValueKind == JsonValueKind.String ||
-                   item.Value.ValueKind == JsonValueKind.Number ||
-                   item.Value.ValueKind == JsonValueKind.True ||
-                   item.Value.ValueKind == JsonValueKind.False ||
-                   item.Value.ValueKind == JsonValueKind.Array ||
-                   item.Value.ValueKind == JsonValueKind.Null)
+                if (item.Value.ValueKind != JsonValueKind.Undefined)
                 {
                     stringExtensionData.Add(item.Key, item.Value.ToString());
                 }
@@ -114,10 +109,13 @@ namespace Microsoft.Identity.Client.OAuth2
                    item.Value.Type == JTokenType.Guid ||
                    item.Value.Type == JTokenType.Integer ||
                    item.Value.Type == JTokenType.TimeSpan ||
-                   item.Value.Type == JTokenType.Array ||
                    item.Value.Type == JTokenType.Null)
                 {
                     stringExtensionData.Add(item.Key, item.Value.ToString());
+                }
+                else if (item.Value.Type == JTokenType.Array || item.Value.Type == JTokenType.Object)
+                {
+                    stringExtensionData.Add(item.Key, item.Value.ToString(Formatting.None));
                 }
             }
 #endif

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Identity.Client.OAuth2
                    item.Value.ValueKind == JsonValueKind.Number ||
                    item.Value.ValueKind == JsonValueKind.True ||
                    item.Value.ValueKind == JsonValueKind.False ||
+                   item.Value.ValueKind == JsonValueKind.Array ||
                    item.Value.ValueKind == JsonValueKind.Null)
                 {
                     stringExtensionData.Add(item.Key, item.Value.ToString());
@@ -113,6 +114,7 @@ namespace Microsoft.Identity.Client.OAuth2
                    item.Value.Type == JTokenType.Guid ||
                    item.Value.Type == JTokenType.Integer ||
                    item.Value.Type == JTokenType.TimeSpan ||
+                   item.Value.Type == JTokenType.Array ||
                    item.Value.Type == JTokenType.Null)
                 {
                     stringExtensionData.Add(item.Key, item.Value.ToString());

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Identity.Client
                         tenantId,
                         homeAccountId,
                         requestParams.AuthenticationScheme.KeyId,
-                        CacheKeyFactory.GetOboKey(requestParams.LongRunningOboCacheKey, requestParams.UserAssertion));
+                        CacheKeyFactory.GetOboKey(requestParams.LongRunningOboCacheKey, requestParams.UserAssertion),
+                        requestParams.AdditionalCacheParameters);
             }
 
             if (!string.IsNullOrEmpty(response.RefreshToken))

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Client
                         homeAccountId,
                         requestParams.AuthenticationScheme.KeyId,
                         CacheKeyFactory.GetOboKey(requestParams.LongRunningOboCacheKey, requestParams.UserAssertion),
-                        requestParams.AdditionalCacheParameters);
+                        requestParams.PersistedCacheParameters);
             }
 
             if (!string.IsNullOrEmpty(response.RefreshToken))

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             string token = "header.payload.signature",
             string expiry = "3599",
             string tokenType = "Bearer",
-            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"]"
+            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"],\"additional_param5\":{\"value5json\":\"value5\"}"
             )
         {
             return CreateSuccessResponseMessage(

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             string tokenType = "Bearer")
         {
             return CreateSuccessResponseMessage(
-                "{\"token_type\":\"" + tokenType + "\",\"expires_in\":\"" + expiry + "\",\"access_token\":\"" + token + "\"}");
+                "{\"token_type\":\"" + tokenType + "\",\"expires_in\":\"" + expiry + "\",\"access_token\":\"" + token + "\",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\"}");
         }
 
         public static HttpResponseMessage CreateSuccessTokenResponseMessage(

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -344,6 +344,17 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 "{\"token_type\":\"" + tokenType + "\",\"expires_in\":\"" + expiry + "\",\"access_token\":\"" + token + "\",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\"}");
         }
 
+        public static HttpResponseMessage CreateSuccessfulClientCredentialTokenResponseWithAdditionalParamsMessage(
+            string token = "header.payload.signature",
+            string expiry = "3599",
+            string tokenType = "Bearer",
+            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"]"
+            )
+        {
+            return CreateSuccessResponseMessage(
+                "{\"token_type\":\"" + tokenType + "\",\"expires_in\":\"" + expiry + "\",\"access_token\":\"" + token + "\"" + additionalparams + "}");
+        }
+
         public static HttpResponseMessage CreateSuccessTokenResponseMessage(
             string uniqueId,
             string displayableId,

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             string token = "header.payload.signature",
             string expiry = "3599",
             string tokenType = "Bearer",
-            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"],\"additional_param5\":{\"value5json\":\"value5\"}"
+            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\",\"GUID2\",\"GUID3\"],\"additional_param5\":{\"value5json\":\"value5\"}"
             )
         {
             return CreateSuccessResponseMessage(

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             string expiresIn = "3599",
             string tokenType = "Bearer",
             IList<string> unexpectedHttpHeaders = null,
-            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"]")
+            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"],\"additional_param5\":{\"value5json\":\"value5\"}")
         {
             var handler = new MockHttpMessageHandler()
             {

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -197,6 +197,26 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             return handler;
         }
 
+        public static MockHttpMessageHandler AddMockHandlerSuccessfulClientCredentialTokenResponseWithAdditionalParamsMessage(
+            this MockHttpManager httpManager,
+            string token = "header.payload.signature",
+            string expiresIn = "3599",
+            string tokenType = "Bearer",
+            IList<string> unexpectedHttpHeaders = null,
+            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"]")
+        {
+            var handler = new MockHttpMessageHandler()
+            {
+                ExpectedMethod = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseWithAdditionalParamsMessage(token, expiresIn, tokenType, additionalparams),
+                UnexpectedRequestHeaders = unexpectedHttpHeaders
+            };
+
+            httpManager.AddMockHandler(handler);
+
+            return handler;
+        }
+
         public static MockHttpMessageHandler AddMockHandlerForThrottledResponseMessage(
             this MockHttpManager httpManager)
         {

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             string expiresIn = "3599",
             string tokenType = "Bearer",
             IList<string> unexpectedHttpHeaders = null,
-            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\", \"GUID2\", \"GUID3\"],\"additional_param5\":{\"value5json\":\"value5\"}")
+            string additionalparams = ",\"additional_param1\":\"value1\",\"additional_param2\":\"value2\",\"additional_param3\":\"value3\",\"additional_param4\":[\"GUID\",\"GUID2\",\"GUID3\"],\"additional_param5\":{\"value5json\":\"value5\"}")
         {
             var handler = new MockHttpMessageHandler()
             {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
@@ -180,10 +180,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.IsFalse(extMap.ContainsKey("id_token"));
                 Assert.IsFalse(extMap.ContainsKey("client_info"));
 
-                // only scalar properties should be in the map
-                Assert.IsFalse(extMap.ContainsKey("object_extension"));
-                Assert.IsFalse(extMap.ContainsKey("array_extension"));
-
                 // all other properties should be in the map
                 Assert.AreEqual("1209599", extMap["number_extension"]);
                 Assert.AreEqual("True", extMap["true_extension"]);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
@@ -228,29 +228,34 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                               .WithAuthority("https://login.microsoftonline.com/tid/")
                               .WithClientSecret(TestConstants.ClientSecret)
+                              .WithExperimentalFeatures(true)
                               .WithHttpManager(httpManager)
                               .BuildConcrete();
 
-                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseWithAdditionalParamsMessage();
 
                 var result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
-                    .WithAdditionalCacheParameters(new List<string> { "additional_param1", "additional_param2", "additional_param3" })
+                    .WithAdditionalCacheParameters(new List<string> { "additional_param1", "additional_param2", "additional_param3", "additional_param4" })
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
-                var parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().AdditionalCacheParameters;
-                Assert.IsTrue(parameters.Count == 3);
+                var parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
+                Assert.IsTrue(parameters.Count == 4);
 
                 parameters.TryGetValue("additional_param1", out string additionalParam1);
                 parameters.TryGetValue("additional_param2", out string additionalParam2);
                 parameters.TryGetValue("additional_param3", out string additionalParam3);
+                parameters.TryGetValue("additional_param4", out string additionalParam4);
 
                 Assert.AreEqual("value1", additionalParam1);
                 Assert.AreEqual("value2", additionalParam2);
                 Assert.AreEqual("value3", additionalParam3);
+                Assert.AreEqual("[\"GUID\", \"GUID2\", \"GUID3\"]", additionalParam4);
 
                 Assert.AreEqual("Bearer", result.TokenType);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                //Validate that the additional parameters are reflected in the AuthenticationResult.AdditionalResponseParameters
+                Assert.AreEqual((IReadOnlyDictionary<string, string>)parameters, result.AdditionalResponseParameters);
 
                 //Verify cache parameters still exist
                 result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
@@ -261,16 +266,20 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual("Bearer", result.TokenType);
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
 
-                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().AdditionalCacheParameters;
-                Assert.IsTrue(parameters.Count == 3);
+                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
+                Assert.IsTrue(parameters.Count == 4);
 
                 parameters.TryGetValue("additional_param1", out additionalParam1);
                 parameters.TryGetValue("additional_param2", out additionalParam2);
                 parameters.TryGetValue("additional_param3", out additionalParam3);
+                parameters.TryGetValue("additional_param4", out additionalParam4);
 
                 Assert.AreEqual("value1", additionalParam1);
                 Assert.AreEqual("value2", additionalParam2);
                 Assert.AreEqual("value3", additionalParam3);
+                Assert.AreEqual("[\"GUID\", \"GUID2\", \"GUID3\"]", additionalParam4);
+
+                Assert.AreEqual((IReadOnlyDictionary<string, string>)parameters, result.AdditionalResponseParameters);
 
                 //Verify cache parameters still exist without using WithAdditionalCacheParameters
                 result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
@@ -280,8 +289,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual("Bearer", result.TokenType);
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
 
-                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().AdditionalCacheParameters;
-                Assert.IsTrue(parameters.Count == 3);
+                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
+                Assert.IsTrue(parameters.Count == 4);
 
                 parameters.TryGetValue("additional_param1", out additionalParam1);
                 parameters.TryGetValue("additional_param2", out additionalParam2);
@@ -291,21 +300,24 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual("value2", additionalParam2);
                 Assert.AreEqual("value3", additionalParam3);
 
+                Assert.AreEqual((IReadOnlyDictionary<string, string>)parameters, result.AdditionalResponseParameters);
+
                 //Ensure not all cache parameters are required
                 app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                         .WithClientSecret(TestConstants.ClientSecret)
+                        .WithExperimentalFeatures(true)
                         .WithAuthority("https://login.microsoftonline.com/tid/")
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
-                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseWithAdditionalParamsMessage();
 
                 result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
                     .WithAdditionalCacheParameters(new List<string> { "additional_param1", "additional_param3" })
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
-                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().AdditionalCacheParameters;
+                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
                 Assert.IsTrue(parameters.Count == 2);
 
                 parameters.TryGetValue("additional_param1", out additionalParam1);
@@ -314,20 +326,23 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual("value1", additionalParam1);
                 Assert.AreEqual("value3", additionalParam3);
 
+                Assert.AreEqual((IReadOnlyDictionary<string, string>)parameters, result.AdditionalResponseParameters);
+
                 //Ensure missing cache parameters are not added
                 app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                       .WithClientSecret(TestConstants.ClientSecret)
+                      .WithExperimentalFeatures(true)
                       .WithAuthority("https://login.microsoftonline.com/tid/")
                       .WithHttpManager(httpManager)
                       .BuildConcrete();
 
-                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseWithAdditionalParamsMessage();
                 result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
-                    .WithAdditionalCacheParameters(new List<string> { "additional_param4" })
+                    .WithAdditionalCacheParameters(new List<string> { "additional_paramN" })
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
-                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().AdditionalCacheParameters;
+                parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
                 parameters.TryGetValue("additional_param1", out string additionalParam);
                 Assert.IsNull(additionalParam);
             }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
@@ -235,22 +235,28 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseWithAdditionalParamsMessage();
 
                 var result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
-                    .WithAdditionalCacheParameters(new List<string> { "additional_param1", "additional_param2", "additional_param3", "additional_param4" })
+                    .WithAdditionalCacheParameters(new List<string> { "additional_param1", "additional_param2", "additional_param3", "additional_param4", "additional_param5" })
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 var parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
-                Assert.IsTrue(parameters.Count == 4);
+                Assert.IsTrue(parameters.Count == 5);
 
                 parameters.TryGetValue("additional_param1", out string additionalParam1);
                 parameters.TryGetValue("additional_param2", out string additionalParam2);
                 parameters.TryGetValue("additional_param3", out string additionalParam3);
                 parameters.TryGetValue("additional_param4", out string additionalParam4);
+                parameters.TryGetValue("additional_param5", out string additionalParam5);
 
                 Assert.AreEqual("value1", additionalParam1);
                 Assert.AreEqual("value2", additionalParam2);
                 Assert.AreEqual("value3", additionalParam3);
+#if SUPPORTS_SYSTEM_TEXT_JSON
                 Assert.AreEqual("[\"GUID\", \"GUID2\", \"GUID3\"]", additionalParam4);
+#else
+                Assert.AreEqual("[\"GUID\",\"GUID2\",\"GUID3\"]", additionalParam4);
+#endif
+                Assert.AreEqual("{\"value5json\":\"value5\"}", additionalParam5);
 
                 Assert.AreEqual("Bearer", result.TokenType);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
@@ -267,17 +273,23 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
 
                 parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
-                Assert.IsTrue(parameters.Count == 4);
+                Assert.IsTrue(parameters.Count == 5);
 
                 parameters.TryGetValue("additional_param1", out additionalParam1);
                 parameters.TryGetValue("additional_param2", out additionalParam2);
                 parameters.TryGetValue("additional_param3", out additionalParam3);
                 parameters.TryGetValue("additional_param4", out additionalParam4);
+                parameters.TryGetValue("additional_param5", out additionalParam5);
 
                 Assert.AreEqual("value1", additionalParam1);
                 Assert.AreEqual("value2", additionalParam2);
                 Assert.AreEqual("value3", additionalParam3);
+#if SUPPORTS_SYSTEM_TEXT_JSON
                 Assert.AreEqual("[\"GUID\", \"GUID2\", \"GUID3\"]", additionalParam4);
+#else
+                Assert.AreEqual("[\"GUID\",\"GUID2\",\"GUID3\"]", additionalParam4);
+#endif
+                Assert.AreEqual("{\"value5json\":\"value5\"}", additionalParam5);
 
                 Assert.AreEqual((IReadOnlyDictionary<string, string>)parameters, result.AdditionalResponseParameters);
 
@@ -290,17 +302,23 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
 
                 parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
-                Assert.IsTrue(parameters.Count == 4);
+                Assert.IsTrue(parameters.Count == 5);
 
                 parameters.TryGetValue("additional_param1", out additionalParam1);
                 parameters.TryGetValue("additional_param2", out additionalParam2);
                 parameters.TryGetValue("additional_param3", out additionalParam3);
                 parameters.TryGetValue("additional_param4", out additionalParam4);
+                parameters.TryGetValue("additional_param5", out additionalParam5);
 
                 Assert.AreEqual("value1", additionalParam1);
                 Assert.AreEqual("value2", additionalParam2);
                 Assert.AreEqual("value3", additionalParam3);
+#if SUPPORTS_SYSTEM_TEXT_JSON
                 Assert.AreEqual("[\"GUID\", \"GUID2\", \"GUID3\"]", additionalParam4);
+#else
+                Assert.AreEqual("[\"GUID\",\"GUID2\",\"GUID3\"]", additionalParam4);
+#endif
+                Assert.AreEqual("{\"value5json\":\"value5\"}", additionalParam5);
 
                 Assert.AreEqual((IReadOnlyDictionary<string, string>)parameters, result.AdditionalResponseParameters);
 
@@ -347,7 +365,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
                 parameters.TryGetValue("additional_param1", out string additionalParam);
                 Assert.IsNull(additionalParam);
-                Assert.IsTrue(result.AdditionalResponseParameters.Count == 4);
+                Assert.IsTrue(result.AdditionalResponseParameters.Count == 5);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtensiblityTests.cs
@@ -295,10 +295,12 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 parameters.TryGetValue("additional_param1", out additionalParam1);
                 parameters.TryGetValue("additional_param2", out additionalParam2);
                 parameters.TryGetValue("additional_param3", out additionalParam3);
+                parameters.TryGetValue("additional_param4", out additionalParam4);
 
                 Assert.AreEqual("value1", additionalParam1);
                 Assert.AreEqual("value2", additionalParam2);
                 Assert.AreEqual("value3", additionalParam3);
+                Assert.AreEqual("[\"GUID\", \"GUID2\", \"GUID3\"]", additionalParam4);
 
                 Assert.AreEqual((IReadOnlyDictionary<string, string>)parameters, result.AdditionalResponseParameters);
 
@@ -345,6 +347,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 parameters = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single().PersistedCacheParameters;
                 parameters.TryGetValue("additional_param1", out string additionalParam);
                 Assert.IsNull(additionalParam);
+                Assert.IsTrue(result.AdditionalResponseParameters.Count == 4);
             }
         }
 


### PR DESCRIPTION
Fixes #
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4922

**Changes proposed in this request**
Adding WithAdditionalCacheParameters api

**Testing**
Unit

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
