### PR TITLE
Remove experimental flag on Managed Identity Claims and Capabilities APIs

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Identity.Client
         /// <returns>The builder to chain .With methods.</returns>
         public AcquireTokenForManagedIdentityParameterBuilder WithClaims(string claims)
         {
-            ValidateUseOfExperimentalFeature("WithClaims");
             CommonParameters.Claims = claims;
             return this;
         }

--- a/src/client/Microsoft.Identity.Client/AppConfig/ManagedIdentityApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ManagedIdentityApplicationBuilder.cs
@@ -89,14 +89,11 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <remarks>
         /// MSAL will transform these into special claims request. See https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter for
-        /// details on claim requests. This is an experimental API. The method signature may change in the future 
-        /// without involving a major version upgrade.
+        /// details on claim requests. 
         /// For more details see https://aka.ms/msal-net-claims-request
         /// </remarks>
         public ManagedIdentityApplicationBuilder WithClientCapabilities(IEnumerable<string> clientCapabilities)
         {
-            ValidateUseOfExperimentalFeature();
-
             if (clientCapabilities != null && clientCapabilities.Any())
             {
                 Config.ClientCapabilities = clientCapabilities;

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ManagedIdentityTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ManagedIdentityTests.NetFwk.cs
@@ -450,7 +450,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             builder.Config.AccessorOptions = null;
 
             IManagedIdentityApplication mia = builder
-                .WithExperimentalFeatures(true)
                 .WithHttpManager(proxyHttpManager).Build();
 
             return mia;

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -296,7 +296,6 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(managedIdentitySource, endpoint);
 
                 var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
-                    .WithExperimentalFeatures(true)
                     .WithClientCapabilities(TestConstants.ClientCapabilities)
                     .WithHttpManager(httpManager);
 


### PR DESCRIPTION
Fixes #4921

**Changes proposed in this request**
Remove experimental flag on Managed Identity Claims and Capabilities APIs

**Testing**
unit and integ tests 

**Performance impact**
none

**Documentation**
still in internal preview so nothing to update yet.
