### PR TITLE
Fix the config authority type to acquire the type from AuthorityInfo

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -501,7 +501,8 @@ namespace Microsoft.Identity.Client
                 cloudInstanceUri,
                 tenant,
                 validateAuthority);
-            Config.Authority = new AadAuthority(authorityInfo);
+
+            Config.Authority = authorityInfo.CreateAuthority();
 
             return this as T;
         }

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string ADFSAuthority2 = "https://someAdfs.com/adfs/";
 
         public const string DstsAuthorityTenantless = "https://some.url.dsts.core.azure-test.net/dstsv2/";
-        public const string DstsAuthorityTenanted = "https://some.url.dsts.core.azure-test.net/dstsv2/" + TenantId + "/";
-        public const string DstsAuthorityCommon = "https://some.url.dsts.core.azure-test.net/dstsv2/" + Common + "/";
+        public const string DstsAuthorityTenanted = DstsAuthorityTenantless + TenantId + "/";
+        public const string DstsAuthorityCommon = DstsAuthorityTenantless + Common + "/";
 
         public const string GenericAuthority = "https://demo.duendesoftware.com";
 

--- a/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ApiConfigTests/AuthorityTests.cs
@@ -433,6 +433,30 @@ namespace Microsoft.Identity.Test.Unit.ApiConfigTests
             Assert.IsFalse(s_b2cAuthority.AuthorityInfo.IsDefaultAuthority);
         }
 
+        [DataTestMethod]
+        [DataRow(TestConstants.AuthorityCommonTenant, typeof(AadAuthority), "Aad")]
+        [DataRow(TestConstants.AuthorityCommonPpeAuthority, typeof(AadAuthority), "Aad")]
+        [DataRow(TestConstants.AuthorityConsumersTenant, typeof(AadAuthority), "Aad")]
+        [DataRow(TestConstants.AuthorityOrganizationsTenant, typeof(AadAuthority), "Aad")]
+        [DataRow(TestConstants.AuthorityGuidTenant, typeof(AadAuthority), "Aad")]
+        [DataRow(TestConstants.DstsAuthorityCommon, typeof(DstsAuthority), "Dsts")]
+        [DataRow(TestConstants.DstsAuthorityTenantless, typeof(DstsAuthority), "Dsts")]
+        [DataRow(TestConstants.ADFSAuthority, typeof(AdfsAuthority), "Adfs")]
+        [DataRow(TestConstants.CiamAuthorityMainFormat, typeof(CiamAuthority), "Ciam")]
+        public void VerifyConfigAuthorityType(string authorityHost, Type authorityTypeInstance, string authorityType)
+        {
+            string tenantId = "tenant";
+
+            var app = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithAuthority(authorityHost, tenantId)
+                .WithClientSecret("secret")
+                .BuildConcrete();
+
+            Assert.IsInstanceOfType(app.ServiceBundle.Config.Authority, authorityTypeInstance);
+            Assert.AreEqual(app.AuthorityInfo.AuthorityType.ToString(), authorityType);
+        }
+
         private static void VerifyAuthority(
             Authority configAuthority,
             Authority requestAuthority,


### PR DESCRIPTION
Fixes #4927 

**Changes proposed in this request**
Update code to use the type from authority info to build authority instead of creating aad authority 

**Testing**
Unit tests

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
