### PR TITLE
Fix Date-Time Parsing in GetDurationFromNowInSeconds for Multiple Formats

### DIFF
--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -249,10 +249,21 @@ namespace Microsoft.Identity.Client.OAuth2
 
         internal static MsalTokenResponse CreateFromManagedIdentityResponse(ManagedIdentityResponse managedIdentityResponse)
         {
-            ValidateManagedIdentityResult(managedIdentityResponse);
+            // Validate that the access token is present. If it is missing, handle the error accordingly.
+            if (string.IsNullOrEmpty(managedIdentityResponse.AccessToken))
+            {
+                HandleInvalidExternalValueError(nameof(managedIdentityResponse.AccessToken));
+            }
 
+            // Parse and validate the "ExpiresOn" timestamp, which indicates when the token will expire.
             long expiresIn = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(managedIdentityResponse.ExpiresOn);
 
+            if (expiresIn <= 0)
+            {
+                HandleInvalidExternalValueError(nameof(managedIdentityResponse.ExpiresOn));
+            }
+
+            // Construct and return an MsalTokenResponse object with the necessary details.
             return new MsalTokenResponse
             {
                 AccessToken = managedIdentityResponse.AccessToken,
@@ -273,21 +284,6 @@ namespace Microsoft.Identity.Client.OAuth2
             }
 
             return null;
-        }
-
-        private static void ValidateManagedIdentityResult(ManagedIdentityResponse response)
-        {
-            if (string.IsNullOrEmpty(response.AccessToken))
-            {
-                HandleInvalidExternalValueError(nameof(response.AccessToken));
-            }
-
-            long expiresIn = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(response.ExpiresOn);
-
-            if (expiresIn <= 0)
-            {
-                HandleInvalidExternalValueError(nameof(response.ExpiresOn));
-            }
         }
 
         internal static MsalTokenResponse CreateFromAppProviderResponse(AppTokenProviderResult tokenProviderResponse)

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Identity.Client.OAuth2
         {
             ValidateManagedIdentityResult(managedIdentityResponse);
 
-            long expiresIn = DateTimeHelpers.GetDurationFromNowInSeconds(managedIdentityResponse.ExpiresOn);
+            long expiresIn = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(managedIdentityResponse.ExpiresOn);
 
             return new MsalTokenResponse
             {

--- a/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/MsalTokenResponse.cs
@@ -282,7 +282,8 @@ namespace Microsoft.Identity.Client.OAuth2
                 HandleInvalidExternalValueError(nameof(response.AccessToken));
             }
 
-            long expiresIn = DateTimeHelpers.GetDurationFromNowInSeconds(response.ExpiresOn);
+            long expiresIn = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(response.ExpiresOn);
+
             if (expiresIn <= 0)
             {
                 HandleInvalidExternalValueError(nameof(response.ExpiresOn));

--- a/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
@@ -63,7 +63,18 @@ namespace Microsoft.Identity.Client.Utils
             return (long)unixTimestamp - CurrDateTimeInUnixTimestamp();
         }
 
-        public static long GetDurationFromNowInSeconds(string dateTimeStamp)
+        public static long GetDurationFromNowInSeconds(string unixTimestampInFuture)
+        {
+            if (string.IsNullOrEmpty(unixTimestampInFuture))
+            {
+                return 0;
+            }
+
+            long expiresOnUnixTimestamp = long.Parse(unixTimestampInFuture, CultureInfo.InvariantCulture);
+            return expiresOnUnixTimestamp - CurrDateTimeInUnixTimestamp();
+        }
+
+        public static long GetDurationFromManagedIdentityTimestamp(string dateTimeStamp)
         {
             if (string.IsNullOrEmpty(dateTimeStamp))
             {
@@ -71,27 +82,17 @@ namespace Microsoft.Identity.Client.Utils
             }
 
             // First, try to parse as Unix timestamp (number of seconds since epoch)
+            // Example: "1697490590" (Unix timestamp representing seconds since 1970-01-01)
             if (long.TryParse(dateTimeStamp, out long expiresOnUnixTimestamp))
             {
                 return expiresOnUnixTimestamp - DateTimeHelpers.CurrDateTimeInUnixTimestamp();
             }
 
             // Try parsing as ISO 8601 
+            // Example: "2024-10-18T19:51:37.0000000+00:00" (ISO 8601 format)
             if (DateTimeOffset.TryParse(dateTimeStamp, null, DateTimeStyles.RoundtripKind, out DateTimeOffset expiresOnDateTime))
             {
                 return (long)(expiresOnDateTime - DateTimeOffset.UtcNow).TotalSeconds;
-            }
-
-            // Try RFC 1123 format 
-            if (DateTimeOffset.TryParseExact(dateTimeStamp, "R", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out expiresOnDateTime))
-            {
-                return (long)(expiresOnDateTime - DateTimeOffset.UtcNow).TotalSeconds;
-            }
-
-            // Try parsing Unix timestamp in milliseconds 
-            if (long.TryParse(dateTimeStamp, out long expiresOnMillisTimestamp) && dateTimeStamp.Length > 10)
-            {
-                return (expiresOnMillisTimestamp / 1000) - DateTimeHelpers.CurrDateTimeInUnixTimestamp();
             }
 
             // If no format works, throw an MSAL client exception

--- a/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
@@ -63,39 +63,39 @@ namespace Microsoft.Identity.Client.Utils
             return (long)unixTimestamp - CurrDateTimeInUnixTimestamp();
         }
 
-        public static long GetDurationFromNowInSeconds(string expiresOn)
+        public static long GetDurationFromNowInSeconds(string dateTimeStamp)
         {
-            if (string.IsNullOrEmpty(expiresOn))
+            if (string.IsNullOrEmpty(dateTimeStamp))
             {
                 return 0;
             }
 
             // First, try to parse as Unix timestamp (number of seconds since epoch)
-            if (long.TryParse(expiresOn, out long expiresOnUnixTimestamp))
+            if (long.TryParse(dateTimeStamp, out long expiresOnUnixTimestamp))
             {
                 return expiresOnUnixTimestamp - DateTimeHelpers.CurrDateTimeInUnixTimestamp();
             }
 
             // Try parsing as ISO 8601 
-            if (DateTimeOffset.TryParse(expiresOn, null, DateTimeStyles.RoundtripKind, out DateTimeOffset expiresOnDateTime))
+            if (DateTimeOffset.TryParse(dateTimeStamp, null, DateTimeStyles.RoundtripKind, out DateTimeOffset expiresOnDateTime))
             {
                 return (long)(expiresOnDateTime - DateTimeOffset.UtcNow).TotalSeconds;
             }
 
             // Try RFC 1123 format 
-            if (DateTimeOffset.TryParseExact(expiresOn, "R", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out expiresOnDateTime))
+            if (DateTimeOffset.TryParseExact(dateTimeStamp, "R", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out expiresOnDateTime))
             {
                 return (long)(expiresOnDateTime - DateTimeOffset.UtcNow).TotalSeconds;
             }
 
             // Try parsing Unix timestamp in milliseconds 
-            if (long.TryParse(expiresOn, out long expiresOnMillisTimestamp) && expiresOn.Length > 10)
+            if (long.TryParse(dateTimeStamp, out long expiresOnMillisTimestamp) && dateTimeStamp.Length > 10)
             {
                 return (expiresOnMillisTimestamp / 1000) - DateTimeHelpers.CurrDateTimeInUnixTimestamp();
             }
 
             // If no format works, throw an MSAL client exception
-            throw new MsalClientException("invalid_token_expiration_format", $"Failed to parse Expires On value. Invalid format for expiresOn: '{expiresOn}'.");
+            throw new MsalClientException("invalid_timestamp_format", $"Failed to parse date-time stamp from identity provider. Invalid format: '{dateTimeStamp}'.");
         }
 
         public static DateTimeOffset? DateTimeOffsetFromDuration(long? duration)

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -113,9 +113,21 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             ",\"id_token_expires_in\":\"3600\"}";
         }
 
-        public static string GetMsiSuccessfulResponse(int expiresInHours = 1)
+        public static string GetMsiSuccessfulResponse(int expiresInHours = 1, bool useIsoFormat = false)
         {
-            string expiresOn = DateTimeHelpers.DateTimeToUnixTimestamp(DateTime.UtcNow.AddHours(expiresInHours));
+            string expiresOn;
+
+            if (useIsoFormat)
+            {
+                // Return ISO 8601 format
+                expiresOn = DateTime.UtcNow.AddHours(expiresInHours).ToString("o", CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                // Return Unix timestamp format
+                expiresOn = DateTimeHelpers.DateTimeToUnixTimestamp(DateTime.UtcNow.AddHours(expiresInHours));
+            }
+
             return
           "{\"access_token\":\"" + TestConstants.ATSecret + "\",\"expires_on\":\"" + expiresOn + "\",\"resource\":\"https://management.azure.com/\",\"token_type\":" +
           "\"Bearer\",\"client_id\":\"client_id\"}";

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -841,6 +841,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
                 Assert.AreEqual(ApiEvent.ApiIds.AcquireTokenForSystemAssignedManagedIdentity, builder.CommonParameters.ApiId);
                 Assert.AreEqual(refreshOnHasValue, result.AuthenticationResultMetadata.RefreshOn.HasValue);
+                Assert.IsTrue(result.ExpiresOn > DateTimeOffset.UtcNow, "The token's ExpiresOn should be in the future.");
+
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -806,10 +806,13 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [DataTestMethod]
-        [DataRow(1, false)]
-        [DataRow(2, false)]
-        [DataRow(3, true)]
-        public async Task ManagedIdentityExpiresOnTestAsync(int expiresInHours, bool refreshOnHasValue)
+        [DataRow(1, false, false)]
+        [DataRow(2, false, false)]
+        [DataRow(3, true, false)]
+        [DataRow(1, false, true)]
+        [DataRow(2, false, true)]
+        [DataRow(3, true, true)]
+        public async Task ManagedIdentityExpiresOnTestAsync(int expiresInHours, bool refreshOnHasValue, bool useIsoFormat)
         {
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager(isManagedIdentity: true))

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -806,12 +806,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [DataTestMethod]
-        [DataRow(1, false, false)]
-        [DataRow(2, false, false)]
-        [DataRow(3, true, false)]
-        [DataRow(1, false, true)]
-        [DataRow(2, false, true)]
-        [DataRow(3, true, true)]
+        [DataRow(1, false, false)] // Unix timestamp
+        [DataRow(2, false, false)] // Unix timestamp
+        [DataRow(3, true, false)]  // Unix timestamp
+        [DataRow(1, false, true)]  // ISO 8601
+        [DataRow(2, false, true)]  // ISO 8601
+        [DataRow(3, true, true)]   // ISO 8601
         public async Task ManagedIdentityExpiresOnTestAsync(int expiresInHours, bool refreshOnHasValue, bool useIsoFormat)
         {
             using (new EnvVariableContext())
@@ -830,7 +830,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 httpManager.AddManagedIdentityMockHandler(
                     AppServiceEndpoint,
                     Resource,
-                    MockHelpers.GetMsiSuccessfulResponse(expiresInHours),
+                    MockHelpers.GetMsiSuccessfulResponse(expiresInHours, useIsoFormat),
                     ManagedIdentitySource.AppService);
 
                 AcquireTokenForManagedIdentityParameterBuilder builder = mi.AcquireTokenForManagedIdentity(Resource);

--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.UtilTests
+{
+    [TestClass]
+    public class DateTimeHelperTests
+    {
+        [TestMethod]
+        public void TestGetDurationFromNowInSeconds()
+        {
+            // Arrange
+            var currentTime = DateTimeOffset.UtcNow;
+
+            // Unix timestamp (seconds since epoch)
+            string unixTimestamp = DateTimeHelpers.DateTimeToUnixTimestamp(currentTime);
+            long result = DateTimeHelpers.GetDurationFromNowInSeconds(unixTimestamp);
+            Assert.IsTrue(result >= 0, "Unix timestamp failed");
+
+            // ISO 8601 format
+            string iso8601 = currentTime.ToString("o", CultureInfo.InvariantCulture); // ISO 8601 with "o" format
+            result = DateTimeHelpers.GetDurationFromNowInSeconds(iso8601);
+            Assert.IsTrue(result >= 0, "ISO 8601 failed");
+
+            // RFC 1123 format
+            string rfc1123 = currentTime.ToString("R", CultureInfo.InvariantCulture); // RFC 1123 with "R" format
+            result = DateTimeHelpers.GetDurationFromNowInSeconds(rfc1123);
+            Assert.IsTrue(result >= 0, "RFC 1123 failed");
+
+            // Common format: MM/dd/yyyy HH:mm:ss
+            string commonFormat1 = currentTime.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
+            result = DateTimeHelpers.GetDurationFromNowInSeconds(commonFormat1);
+            Assert.IsTrue(result >= 0, "Common Format 1 failed");
+
+            // Common format: yyyy-MM-dd HH:mm:ss
+            string commonFormat2 = currentTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+            result = DateTimeHelpers.GetDurationFromNowInSeconds(commonFormat2);
+            Assert.IsTrue(result >= 0, "Common Format 2 failed");
+
+            // Invalid format: This should throw an MsalClientException
+            string invalidFormat = "invalid-date-format";
+            Assert.ThrowsException<MsalClientException>(() =>
+            {
+                DateTimeHelpers.GetDurationFromNowInSeconds(invalidFormat);
+            });
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
@@ -18,42 +18,65 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
     public class DateTimeHelperTests
     {
         [TestMethod]
-        public void TestGetDurationFromNowInSeconds()
+        public void TestGetDurationFromNowInSecondsForUnixTimestampOnly()
         {
             // Arrange
             var currentTime = DateTimeOffset.UtcNow;
 
-            // Unix timestamp (seconds since epoch)
-            string unixTimestamp = DateTimeHelpers.DateTimeToUnixTimestamp(currentTime);
-            long result = DateTimeHelpers.GetDurationFromNowInSeconds(unixTimestamp);
-            Assert.IsTrue(result >= 0, "Unix timestamp failed");
+            // Example 1: Valid Unix timestamp (seconds since epoch)
+            long currentUnixTimestamp = DateTimeHelpers.CurrDateTimeInUnixTimestamp(); // e.g., 1697490590
+            string unixTimestampString = currentUnixTimestamp.ToString(CultureInfo.InvariantCulture);
+            long result = DateTimeHelpers.GetDurationFromNowInSeconds(unixTimestampString);
+            Assert.IsTrue(result >= 0, "Valid Unix timestamp (seconds) failed");
 
-            // ISO 8601 format
-            string iso8601 = currentTime.ToString("o", CultureInfo.InvariantCulture); // ISO 8601 with "o" format
-            result = DateTimeHelpers.GetDurationFromNowInSeconds(iso8601);
+            // Example 2: Unix timestamp in the future
+            string futureUnixTimestamp = (currentUnixTimestamp + 3600).ToString(); // 1 hour from now
+            result = DateTimeHelpers.GetDurationFromNowInSeconds(futureUnixTimestamp);
+            Assert.IsTrue(result > 0, "Future Unix timestamp failed");
+
+            // Example 3: Unix timestamp in the past
+            string pastUnixTimestamp = (currentUnixTimestamp - 3600).ToString(); // 1 hour ago
+            result = DateTimeHelpers.GetDurationFromNowInSeconds(pastUnixTimestamp);
+            Assert.IsTrue(result < 0, "Past Unix timestamp failed");
+
+            // Example 4: Empty string (should return 0)
+            string emptyString = string.Empty;
+            result = DateTimeHelpers.GetDurationFromNowInSeconds(emptyString);
+            Assert.AreEqual(0, result, "Empty string did not return 0 as expected.");
+        }
+
+        [TestMethod]
+        public void TestGetDurationFromNowInSecondsFromManagedIdentity()
+        {
+            // Arrange
+            var currentTime = DateTimeOffset.UtcNow;
+
+            // Example 1: Unix timestamp (seconds since epoch)
+            string unixTimestampInSeconds = DateTimeHelpers.DateTimeToUnixTimestamp(currentTime); // e.g., 1697490590
+            long result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(unixTimestampInSeconds);
+            Assert.IsTrue(result >= 0, "Unix timestamp (seconds) failed");
+
+            // Example 2: ISO 8601 format
+            string iso8601 = currentTime.ToString("o", CultureInfo.InvariantCulture); // e.g., 2024-10-18T19:51:37.0000000+00:00
+            result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(iso8601);
             Assert.IsTrue(result >= 0, "ISO 8601 failed");
 
-            // RFC 1123 format
-            string rfc1123 = currentTime.ToString("R", CultureInfo.InvariantCulture); // RFC 1123 with "R" format
-            result = DateTimeHelpers.GetDurationFromNowInSeconds(rfc1123);
-            Assert.IsTrue(result >= 0, "RFC 1123 failed");
-
-            // Common format: MM/dd/yyyy HH:mm:ss
-            string commonFormat1 = currentTime.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
-            result = DateTimeHelpers.GetDurationFromNowInSeconds(commonFormat1);
+            // Example 3: Common format (MM/dd/yyyy HH:mm:ss)
+            string commonFormat1 = currentTime.ToString("MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture); // e.g., 10/18/2024 19:51:37
+            result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(commonFormat1);
             Assert.IsTrue(result >= 0, "Common Format 1 failed");
 
-            // Common format: yyyy-MM-dd HH:mm:ss
-            string commonFormat2 = currentTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-            result = DateTimeHelpers.GetDurationFromNowInSeconds(commonFormat2);
+            // Example 4: Common format (yyyy-MM-dd HH:mm:ss)
+            string commonFormat2 = currentTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture); // e.g., 2024-10-18 19:51:37
+            result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(commonFormat2);
             Assert.IsTrue(result >= 0, "Common Format 2 failed");
 
-            // Invalid format: This should throw an MsalClientException
+            // Example 5: Invalid format (should throw an MsalClientException)
             string invalidFormat = "invalid-date-format";
             Assert.ThrowsException<MsalClientException>(() =>
             {
-                DateTimeHelpers.GetDurationFromNowInSeconds(invalidFormat);
-            });
+                DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(invalidFormat);
+            }, "Invalid format did not throw an exception as expected.");
         }
     }
 }


### PR DESCRIPTION
Fixes #4963

**Changes proposed in this request**
This PR add a new GetDurationFromNowInSeconds specific to MI in MSAL to handle multiple date-time formats while calculating the duration from now. Specifically, the fix:

- Adds support for Unix timestamps, ISO 8601 and other common date-time formats.
- Adds improved error handling for unsupported or invalid date formats by throwing an MsalClientException.
- Ensures that fallback logic only throws an exception after attempting valid date-time parsing strategies.

**Testing**
- Added additional test cases to validate handling of various date-time formats including Unix timestamps, ISO 8601, and common date-time formats (MM/dd/yyyy HH:mm:ss, yyyy-MM-dd HH:mm:ss).
- Added a test case for invalid date-time formats to ensure that the method throws an MsalClientException for malformed input.
- Extended the Managed Identity tests as well

**Performance impact**
None

**Documentation**
- [ ] All relevant documentation is updated.
