### PR TITLE
Expose client capabilities in AssertionRequestOptions for MSI FIC scenarios 

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading;
 namespace Microsoft.Identity.Client
 {
@@ -25,6 +26,11 @@ namespace Microsoft.Identity.Client
         /// The intended token endpoint
         /// </summary>
         public string TokenEndpoint { get; set; }
+
+        /// <summary>
+        /// Client Capabilities to be included in the client assertion
+        /// </summary>
+        public IEnumerable<string> ClientCapabilities { get; set; }
 
         /// <summary>
         /// Claims to be included in the client assertion

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1857,6 +1857,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             options.TokenEndpoint = "https://login.microsoft.com/v2.0/token";
             options.CancellationToken = CancellationToken.None;
             options.Claims = TestConstants.Claims;
+            options.ClientCapabilities = TestConstants.ClientCapabilities;
         }
     }
 }


### PR DESCRIPTION
Fixes #4948

**Changes proposed in this request**
Updated AssertionRequestOptions to handle client capabilities for MSI Federated Identity Credential (FIC) scenarios, ensuring that higher-level SDKs can pass capabilities to MSAL.

**Testing**
unit tests

**Performance impact**
n/a

**Documentation**
- [ ] All relevant documentation is updated.
