### PR TITLE
Unobsolete GetAccountsAsync

### DIFF
--- a/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Identity.Client
         new AcquireTokenSilentParameterBuilder AcquireTokenSilent(IEnumerable<string> scopes, string loginHint);
 
         /// <summary>
+        /// This method is strictly to be used with ROPC flow in test environments. It is not recommended to use ROPC in production applications.
         /// Use <see cref="IClientApplicationBase.GetAccountAsync(string)"/> in web apps and web APIs, and use a token cache serializer for better security and performance. See https://aka.ms/msal-net-cca-token-cache-serialization.
         /// </summary>
         new Task<IEnumerable<IAccount>> GetAccountsAsync();

--- a/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IConfidentialClientApplication.cs
@@ -96,8 +96,6 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Use <see cref="IClientApplicationBase.GetAccountAsync(string)"/> in web apps and web APIs, and use a token cache serializer for better security and performance. See https://aka.ms/msal-net-cca-token-cache-serialization.
         /// </summary>
-        [Obsolete("Use GetAccountAsync(identifier) in web apps and web APIs, and use a token cache serializer for better security and performance. See https://aka.ms/msal-net-cca-token-cache-serialization.")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
         new Task<IEnumerable<IAccount>> GetAccountsAsync();
     }
 }


### PR DESCRIPTION
Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
Remove the obsolete attribute from the GetAccountsAsync method in the IConfidentialClientApplication interface to make it available for ROPC silent flow in Id web

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
