### PR TITLE
update the deprecated openURL(:) api to openURL(:options:completionHandler) 

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
                 () => iOSBrokerConstants.BrokerPayloadPii + paramsAsQuery,
                 () => iOSBrokerConstants.BrokerPayloadNoPii + brokerPayload.Count);
 
-            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.open(url, new NSDictionary(), null));
+            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.Open(url, new NSDictionary(), null));
 
             using (_logger.LogBlockDuration("waiting for broker response"))
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
                 () => iOSBrokerConstants.BrokerPayloadPii + paramsAsQuery,
                 () => iOSBrokerConstants.BrokerPayloadNoPii + brokerPayload.Count);
 
-            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.OpenUrl(url));
+            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.open(url, new NSDictionary(), null));
 
             using (_logger.LogBlockDuration("waiting for broker response"))
             {

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
                 () => iOSBrokerConstants.BrokerPayloadPii + paramsAsQuery,
                 () => iOSBrokerConstants.BrokerPayloadNoPii + brokerPayload.Count);
 
-            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.Open(url, new NSDictionary(), null));
+            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.OpenUrl(url, new UIApplicationOpenUrlOptions(), null));
 
             using (_logger.LogBlockDuration("waiting for broker response"))
             {


### PR DESCRIPTION
Fix for the issue - https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4958