### PR TITLE
Update OB tests to use OB CI template

### DIFF
--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -66,28 +66,12 @@ steps:
       dotnet workload install maui --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
       dotnet workload install android --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
 
-- task: PowerShell@2
-  displayName: Install Chocolatey
+- task: JavaToolInstaller@0
+  displayName: 'Install Java 11 for Build'
   inputs:
-    targetType: 'inline'
-    script: |
-      Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))      
-
-- ${{ if eq(parameters.Mode, 'build') }}:
-  - task: PowerShell@2
-    displayName: 'Install Java 11 for Build'
-    inputs:
-      targetType: 'inline'
-      script: |
-        choco install openjdk --version=11.0.2.01 -y
-
-- ${{ if eq(parameters.Mode, 'test') }}:
-  - task: JavaToolInstaller@0
-    displayName: 'Use Java 11 for Test'
-    inputs:
-      versionSpec: 11
-      jdkArchitectureOption: x64
-      jdkSourceOption: PreInstalled
+    versionSpec: '11'
+    jdkArchitectureOption: 'x64'
+    jdkSourceOption: 'PreInstalled'
 
 - task: CmdLine@2
   displayName: 'Clear local NuGet cache'

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -24,35 +24,35 @@ steps:
 
 - ${{ if eq(parameters.Mode, 'build') }}:
   - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Desktop project'
+    displayName: 'dotnet workload restore for Desktop project - Build'
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj'
+      arguments: 'restore $(Build.SourcesDirectory)/$(parameters.MsalSourceDir)src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj'
 
 - ${{ if eq(parameters.Mode, 'test') }}:
   - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Desktop project'
+    displayName: 'dotnet workload restore for Desktop project - Test'
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore .\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj'
-      
+      arguments: 'restore $(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj'
+
 - ${{ if eq(parameters.Mode, 'build') }}:
   - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Identity.Client project'
+    displayName: 'dotnet workload restore for Identity.Client project - Build'
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
+      arguments: 'restore $(Build.SourcesDirectory)/$(parameters.MsalSourceDir)src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj'
 
 - ${{ if eq(parameters.Mode, 'test') }}:
   - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Identity.Client project'
+    displayName: 'dotnet workload restore for Identity.Client project - Test'
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore .\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
+      arguments: 'restore $(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj'
       
 - task: PowerShell@2
   displayName: Install MAUI

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -40,8 +40,8 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      dotnet workload install maui --source https://api.nuget.org/v3/index.json
-      dotnet workload install android --source https://api.nuget.org/v3/index.json
+      dotnet workload install maui --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
+      dotnet workload install android --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
 
 - task: PowerShell@2
   displayName: Install Chocolatey

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -28,7 +28,7 @@ steps:
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore $(Build.SourcesDirectory)/$(parameters.MsalSourceDir)src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj'
+      arguments: 'restore $(Build.SourcesDirectory)/$(MsalSourceDir)src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj'
 
 - ${{ if eq(parameters.Mode, 'test') }}:
   - task: DotNetCoreCLI@2
@@ -44,7 +44,7 @@ steps:
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore $(Build.SourcesDirectory)/$(parameters.MsalSourceDir)src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj'
+      arguments: 'restore $(Build.SourcesDirectory)/$(MsalSourceDir)src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj'
 
 - ${{ if eq(parameters.Mode, 'test') }}:
   - task: DotNetCoreCLI@2

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -22,10 +22,6 @@ steps:
   inputs:
     version: 6.x
 
-steps:
-- script: echo "Building solution: $(Solution)"
-  displayName: 'Build Solution'
-
 - ${{ if eq(parameters.Mode, 'build') }}:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet workload restore for Desktop project'

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -22,37 +22,33 @@ steps:
   inputs:
     version: 6.x
 
-- ${{ if eq(parameters.Mode, 'build') }}:
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Desktop project - Build'
-    inputs:
-      command: 'custom'
-      custom: 'workload'
-      arguments: 'restore $(Build.SourcesDirectory)/$(MsalSourceDir)src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj'
+# Compute the source directory based on the parameter MsalSourceDir
+- task: PowerShell@2
+  displayName: 'Compute Source Directory'
+  inputs:
+    targetType: 'inline'
+    script: |
+      # Check if the projects are under MsalSourceDir
+      $MsalBaseDir = "$(Build.SourcesDirectory)/$(MsalSourceDir)"
+      if (Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client.Desktop" -and Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client") {
+          Write-Host "##vso[task.setvariable variable=SourceDir]$MsalBaseDir"
+      } elseif (Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client.Desktop" -and Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client") {
+          Write-Host "##vso[task.setvariable variable=SourceDir]$(Build.SourcesDirectory)/"
+      } else {
+          Write-Error "Unable to determine the correct source directory structure."
+          exit 1
+      }
+  condition: always()
 
-- ${{ if eq(parameters.Mode, 'test') }}:
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Desktop project - Test'
-    inputs:
-      command: 'custom'
-      custom: 'workload'
-      arguments: 'restore $(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj'
-
-- ${{ if eq(parameters.Mode, 'build') }}:
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Identity.Client project - Build'
-    inputs:
-      command: 'custom'
-      custom: 'workload'
-      arguments: 'restore $(Build.SourcesDirectory)/$(MsalSourceDir)src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj'
-
-- ${{ if eq(parameters.Mode, 'test') }}:
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet workload restore for Identity.Client project - Test'
-    inputs:
-      command: 'custom'
-      custom: 'workload'
-      arguments: 'restore $(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj'
+# Use the computed SourceDir for workload restore
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet workload restore for Desktop and Client projects'
+  inputs:
+    command: 'custom'
+    custom: 'workload'
+    arguments: |
+      restore $(SourceDir)src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
+      restore $(SourceDir)src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
       
 - task: PowerShell@2
   displayName: Install MAUI

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -6,6 +6,7 @@ parameters:
   BuildConfiguration: 'release'
   MsalClientSemVer: '4.60.0-devopsbuild' 
   MsalSourceDir: 'microsoft-authentication-library-for-dotnet\' #Default MSAL Location
+  Mode: 'build' # Default to 'build'
 
 steps:
 
@@ -21,20 +22,42 @@ steps:
   inputs:
     version: 6.x
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet workload restore for Desktop project'
-  inputs:
-    command: 'custom'
-    custom: 'workload'
-    arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj'
+steps:
+- script: echo "Building solution: $(Solution)"
+  displayName: 'Build Solution'
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet workload restore for Identity.Client'
-  inputs:
-    command: 'custom'
-    custom: 'workload'
-    arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
+- ${{ if eq(parameters.Mode, 'build') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet workload restore for Desktop project'
+    inputs:
+      command: 'custom'
+      custom: 'workload'
+      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client\\Microsoft.Identity.Client.Desktop.csproj'
 
+- ${{ if eq(parameters.Mode, 'test') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet workload restore for Desktop project'
+    inputs:
+      command: 'custom'
+      custom: 'workload'
+      arguments: 'restore .\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj'
+      
+- ${{ if eq(parameters.Mode, 'build') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet workload restore for Identity.Client project'
+    inputs:
+      command: 'custom'
+      custom: 'workload'
+      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
+
+- ${{ if eq(parameters.Mode, 'test') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet workload restore for Identity.Client project'
+    inputs:
+      command: 'custom'
+      custom: 'workload'
+      arguments: 'restore .\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.csproj'
+      
 - task: PowerShell@2
   displayName: Install MAUI
   inputs:

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -94,8 +94,9 @@ steps:
   inputs:
     script: 'nuget locals all -clear'
 
-- powershell: 'powershell.exe -File "$(MsalSourceDir)build\InstallAndroid.ps1" -ExecutionPolicy Bypass'
-  displayName: 'Install Android'
+- ${{ if eq(parameters.Mode, 'build') }}:
+  - powershell: 'powershell.exe -File "$(MsalSourceDir)build\InstallAndroid.ps1" -ExecutionPolicy Bypass'
+    displayName: 'Install Android'
 
 - task: VSBuild@1
   displayName: 'NuGet restore ${{ parameters.Solution }}'

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -69,12 +69,21 @@ steps:
     script: |
       Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))      
 
-- task: PowerShell@2
-  displayName: Install Java 11
-  inputs:
-    targetType: 'inline'
-    script: |
-      choco install openjdk --version=11.0.2.01 -y
+- ${{ if eq(parameters.Mode, 'build') }}:
+  - task: PowerShell@2
+    displayName: 'Install Java 11 for Build'
+    inputs:
+      targetType: 'inline'
+      script: |
+        choco install openjdk --version=11.0.2.01 -y
+
+- ${{ if eq(parameters.Mode, 'test') }}:
+  - task: JavaToolInstaller@0
+    displayName: 'Use Java 11 for Test'
+    inputs:
+      versionSpec: 11
+      jdkArchitectureOption: x64
+      jdkSourceOption: PreInstalled
 
 - task: CmdLine@2
   displayName: 'Clear local NuGet cache'

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -28,17 +28,25 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      # Check if the projects are under MsalSourceDir
+      # Compute base directory
       $MsalBaseDir = "$(Build.SourcesDirectory)/$(MsalSourceDir)"
-      if (Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client.Desktop" -and Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client") {
+      
+      # Check if both projects exist under MsalSourceDir
+      $DesktopExists = Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client.Desktop"
+      $ClientExists = Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client"
+      
+      # Check if both projects exist directly under Build.SourcesDirectory
+      $AltDesktopExists = Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client.Desktop"
+      $AltClientExists = Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client"
+
+      if ($DesktopExists -and $ClientExists) {
           Write-Host "##vso[task.setvariable variable=SourceDir]$MsalBaseDir"
-      } elseif (Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client.Desktop" -and Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client") {
+      } elseif ($AltDesktopExists -and $AltClientExists) {
           Write-Host "##vso[task.setvariable variable=SourceDir]$(Build.SourcesDirectory)/"
       } else {
           Write-Error "Unable to determine the correct source directory structure."
           exit 1
       }
-  condition: always()
 
 # Use the computed SourceDir for workload restore
 - task: DotNetCoreCLI@2

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -28,7 +28,7 @@ steps:
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client\\Microsoft.Identity.Client.Desktop.csproj'
+      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.Desktop.csproj'
 
 - ${{ if eq(parameters.Mode, 'test') }}:
   - task: DotNetCoreCLI@2
@@ -52,7 +52,7 @@ steps:
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore .\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.csproj'
+      arguments: 'restore .\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj'
       
 - task: PowerShell@2
   displayName: Install MAUI

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -28,7 +28,7 @@ steps:
     inputs:
       command: 'custom'
       custom: 'workload'
-      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.Desktop.csproj'
+      arguments: 'restore microsoft-authentication-library-for-dotnet\src\client\Microsoft.Identity.Client.Desktop\Microsoft.Identity.Client.Desktop.csproj'
 
 - ${{ if eq(parameters.Mode, 'test') }}:
   - task: DotNetCoreCLI@2

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -32,32 +32,32 @@ steps:
       $MsalBaseDir = "$(Build.SourcesDirectory)/$(MsalSourceDir)"
       
       # Check if both projects exist under MsalSourceDir
-      $DesktopExists = Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client.Desktop"
+      $BrokerExists = Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client.Broker"
       $ClientExists = Test-Path "$MsalBaseDir/src/client/Microsoft.Identity.Client"
       
       # Check if both projects exist directly under Build.SourcesDirectory
-      $AltDesktopExists = Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client.Desktop"
+      $AltBrokerExists = Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client.Broker"
       $AltClientExists = Test-Path "$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client"
 
-      if ($DesktopExists -and $ClientExists) {
+      if ($BrokerExists -and $ClientExists) {
           Write-Host "##vso[task.setvariable variable=SourceDir]$MsalBaseDir"
-      } elseif ($AltDesktopExists -and $AltClientExists) {
+      } elseif ($AltBrokerExists -and $AltClientExists) {
           Write-Host "##vso[task.setvariable variable=SourceDir]$(Build.SourcesDirectory)/"
       } else {
           Write-Error "Unable to determine the correct source directory structure."
           exit 1
       }
 
-# Use the computed SourceDir for workload restore
 - task: DotNetCoreCLI@2
-  displayName: 'dotnet workload restore for Desktop and Client projects'
+  displayName: 'Restore required workloads for projects'
   inputs:
     command: 'custom'
     custom: 'workload'
-    arguments: |
-      restore $(SourceDir)src/client/Microsoft.Identity.Client.Desktop/Microsoft.Identity.Client.Desktop.csproj
+    arguments: >
       restore $(SourceDir)src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
-      
+      restore $(SourceDir)src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj
+      --configfile $(SourceDir)NuGet.config
+
 - task: PowerShell@2
   displayName: Install MAUI
   inputs:
@@ -66,12 +66,29 @@ steps:
       dotnet workload install maui --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
       dotnet workload install android --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
 
-- task: JavaToolInstaller@0
-  displayName: 'Install Java 11 for Build'
-  inputs:
-    versionSpec: '11'
-    jdkArchitectureOption: 'x64'
-    jdkSourceOption: 'PreInstalled'
+- ${{ if eq(parameters.Mode, 'build') }}:
+  - task: PowerShell@2
+    displayName: Install Chocolatey
+    inputs:
+      targetType: 'inline'
+      script: |
+        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))      
+
+- ${{ if eq(parameters.Mode, 'build') }}:
+  - task: PowerShell@2
+    displayName: 'Install Java 11 for Build'
+    inputs:
+      targetType: 'inline'
+      script: |
+        choco install openjdk --version=11.0.2.01 -y
+        
+- ${{ if eq(parameters.Mode, 'test') }}:
+  - task: JavaToolInstaller@0
+    displayName: 'Use Java 11 for Test'
+    inputs:
+      versionSpec: 11
+      jdkArchitectureOption: x64
+      jdkSourceOption: PreInstalled
 
 - task: CmdLine@2
   displayName: 'Clear local NuGet cache'

--- a/build/template-OneBranch-Tests-libsandsamples.yaml
+++ b/build/template-OneBranch-Tests-libsandsamples.yaml
@@ -16,7 +16,8 @@ steps:
 
 - template: template-OneBranch-CI-libsandsamples.yaml
   parameters:
-    Solution: 'LibsAndSamples.sln'    
+    Solution: 'LibsAndSamples.sln'
+    Mode: 'test'
 
   # Run All Desktop Tests
 - template: template-run-all-tests.yaml

--- a/build/template-OneBranch-Tests-libsandsamples.yaml
+++ b/build/template-OneBranch-Tests-libsandsamples.yaml
@@ -14,7 +14,7 @@ steps:
   inputs:
     version: 6.x
 
-- template: template-restore-build-libsandsamples.yaml
+- template: template-OneBranch-CI-libsandsamples.yaml
   parameters:
     Solution: 'LibsAndSamples.sln'    
 

--- a/build/template-pack-and-sign-packages.yaml
+++ b/build/template-pack-and-sign-packages.yaml
@@ -28,7 +28,7 @@ steps:
     targetType: 'inline'
     script: |
       dotnet nuget locals all --clear 
-      dotnet workload install android ios macos maui --source https://api.nuget.org/v3/index.json
+      dotnet workload install android ios macos maui --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
 
 - task: JavaToolInstaller@0
   displayName: 'Use Java 11'


### PR DESCRIPTION
Update OB tests to use OB CI template due to [S360 items](https://vnext.s360.msftcloudes.com/blades/security?blade=AssignedTo:All~KPI:1a423da8-b18d-4fd5-b881-9d7a40860434~SLA:1~Forums:All~Program:65a010a5-1e3d-4777-bb89-f149470a507d~waves:All~KPI%20Ranking:All~Tab:Summary~_loc:Security&peopleBasedNodes=jmprieur_team;ddelimarsky_team;bogavril_team&global=4:38bfcbed-2abb-4fe1-9eb7-7df98a14bcfb)

OB pipeline was calling into the classic YAML which points to nuget.org. 