### PR TITLE
Remove obsolete Software Bill Of Materials (SBOM) task

### DIFF
--- a/build/template-pack-and-sign-all-nugets.yaml
+++ b/build/template-pack-and-sign-all-nugets.yaml
@@ -61,8 +61,3 @@ steps:
   inputs:
     script: 'dotnet nuget verify ${{ parameters.NugetPackagesWildcard }}'
   continueOnError: true
-
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'Get Software Bill Of Materials (SBOM)'
-  inputs:
-       BuildDropPath: '${{ parameters.ArtifactPublishPath }}'


### PR DESCRIPTION
Fixes #5007

**Changes proposed in this request**
Remove obsolete sbom task, as per OB [instructions ](https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/pipelinerequirements/generatingsbom)it is auto added. Also the old task is [calling into maven based on the S360](https://msit.powerbi.com/groups/me/apps/8eed334f-05e9-4651-a3a1-280eab2d78b1/reports/b03c5e3f-b064-413d-8464-c3e2478cacfa/b249ddf707be1eb3a4dc?ctid=72f988bf-86f1-41af-91ab-2d7cd011db47&experience=power-bi&filter=S360DetailsWave2%2Fs360Id%20eq%20%274c65f0a86de9821c8d0e008814c00b672a3f8079832c09c51bf5d741d95de53f%27). 

Click [here](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1394750&view=logs&j=15dfcb1a-0989-5cf6-3160-3e181e44de87&t=5ba6599d-da82-5bef-521d-5e569b80bee0&l=1) to see the auto generated task in OB pipeline added. 

**Testing**
builds

**Performance impact**
none

**Documentation**
n/a
