### PR TITLE
Add Java 11 Installer to IDDP Artifacts Feed and Update Pipeline for Installation

### DIFF
--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -67,14 +67,18 @@ steps:
       dotnet workload install android --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
 
 - ${{ if eq(parameters.Mode, 'build') }}:
-  - task: UniversalPackages@0
-    displayName: 'Download Java 11 Installer from Azure Artifacts'
+  - task: PowerShell@2
+    displayName: 'Download Java 11 from Azure Artifacts'
     inputs:
-      command: download
-      vstsFeed: 'IDDP_PublicPackages'  
-      packageName: 'java11'            
-      version: '11.0.24'              
-      downloadDirectory: '$(Build.ArtifactStagingDirectory)'
+      targetType: 'inline'
+      script: |
+        $env:SYSTEM_ACCESSTOKEN = "$(System.AccessToken)"
+        az artifacts universal download `
+          --organization "https://identitydivision.visualstudio.com/" `
+          --feed "IDDP_PublicPackages" `
+          --name "java11" `
+          --version "11.0.24" `
+          --path "$(Build.ArtifactStagingDirectory)\Java"
 
 - ${{ if eq(parameters.Mode, 'build') }}:
   - task: PowerShell@2
@@ -82,7 +86,7 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        $installerPath = "$(Build.ArtifactStagingDirectory)\jdk-11.0.24_windows-x64_bin.exe"
+        $installerPath = "$(Build.ArtifactStagingDirectory)\Java\jdk-11.0.24_windows-x64_bin.exe"
         Start-Process $installerPath -ArgumentList "/s" -NoNewWindow -Wait
 
         # Set JAVA_HOME and update PATH

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -67,17 +67,14 @@ steps:
       dotnet workload install android --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
 
 - ${{ if eq(parameters.Mode, 'build') }}:
-  - task: PowerShell@2
+  - task: UniversalPackages@0
     displayName: 'Download Java 11 from Azure Artifacts'
     inputs:
-      targetType: 'inline'
-      script: |
-        az devops configure --defaults organization=https://identitydivision.visualstudio.com/
-        az artifacts universal download `
-          --feed "IDDP_PublicPackages" `
-          --name "java11" `
-          --version "11.0.24" `
-          --path "$(Build.ArtifactStagingDirectory)\Java"
+      command: download
+      vstsFeed: 'IDDP_PublicPackages'
+      packageName: 'java11'
+      version: '11.0.24'
+      downloadDirectory: '$(Build.ArtifactStagingDirectory)\Java'
 
 - ${{ if eq(parameters.Mode, 'build') }}:
   - task: PowerShell@2

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -72,9 +72,8 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        $env:SYSTEM_ACCESSTOKEN = "$(System.AccessToken)"
+        az devops configure --defaults organization=https://identitydivision.visualstudio.com/
         az artifacts universal download `
-          --organization "https://identitydivision.visualstudio.com/" `
           --feed "IDDP_PublicPackages" `
           --name "java11" `
           --version "11.0.24" `

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -67,20 +67,37 @@ steps:
       dotnet workload install android --source "https://pkgs.dev.azure.com/IdentityDivision/_packaging/IDDP_PublicPackages/nuget/v3/index.json"
 
 - ${{ if eq(parameters.Mode, 'build') }}:
-  - task: PowerShell@2
-    displayName: Install Chocolatey
+  - task: UniversalPackages@0
+    displayName: 'Download Java 11 Installer from Azure Artifacts'
     inputs:
-      targetType: 'inline'
-      script: |
-        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))      
+      command: download
+      vstsFeed: 'IDDP_PublicPackages'  
+      packageName: 'java11'            
+      version: '11.0.24'              
+      downloadDirectory: '$(Build.ArtifactStagingDirectory)'
 
 - ${{ if eq(parameters.Mode, 'build') }}:
   - task: PowerShell@2
-    displayName: 'Install Java 11 for Build'
+    displayName: 'Install Java 11'
     inputs:
       targetType: 'inline'
       script: |
-        choco install openjdk --version=11.0.2.01 -y
+        $installerPath = "$(Build.ArtifactStagingDirectory)\jdk-11.0.24_windows-x64_bin.exe"
+        Start-Process $installerPath -ArgumentList "/s" -NoNewWindow -Wait
+
+        # Set JAVA_HOME and update PATH
+        $env:JAVA_HOME = "C:\Program Files\Java\jdk-11.0.24"
+        [Environment]::SetEnvironmentVariable("JAVA_HOME", $env:JAVA_HOME, [System.EnvironmentVariableTarget]::Machine)
+        $env:PATH += ";$env:JAVA_HOME\bin"
+
+- ${{ if eq(parameters.Mode, 'build') }}:
+  - task: PowerShell@2
+    displayName: 'Validate Java Installation'
+    inputs:
+      targetType: 'inline'
+      script: |
+        java -version
+        echo "JAVA_HOME is set to $env:JAVA_HOME"
         
 - ${{ if eq(parameters.Mode, 'test') }}:
   - task: JavaToolInstaller@0

--- a/build/template-OneBranch-CI-libsandsamples.yaml
+++ b/build/template-OneBranch-CI-libsandsamples.yaml
@@ -70,11 +70,13 @@ steps:
   - task: UniversalPackages@0
     displayName: 'Download Java 11 from Azure Artifacts'
     inputs:
-      command: download
-      vstsFeed: 'IDDP_PublicPackages'
-      packageName: 'java11'
-      version: '11.0.24'
-      downloadDirectory: '$(Build.ArtifactStagingDirectory)\Java'
+      command: 'download'                      
+      downloadDirectory: '$(Build.ArtifactStagingDirectory)\Java' 
+      feedsToUse: 'internal'                   
+      vstsFeed: 'IDDP_PublicPackages'          
+      vstsFeedPackage: 'java11'                
+      vstsPackageVersion: '11.0.24'            
+      verbosity: 'Information'                 
 
 - ${{ if eq(parameters.Mode, 'build') }}:
   - task: PowerShell@2


### PR DESCRIPTION
Fixes #5010

**Changes proposed in this request**
This PR addresses the need for a reliable way to download and install Java 11 in the build pipeline. The following changes have been made:

- Added the Java 11 installer to the IDDP_PublicPackages feed in Azure Artifacts.
- Updated the pipeline to download the Java 11 package using the UniversalPackages@0 task, ensuring seamless integration with Azure DevOps.
- Documented the process for adding the installer to the feed and the steps for downloading it in the pipeline.

**Testing**
[builds](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1395225&view=logs&j=15dfcb1a-0989-5cf6-3160-3e181e44de87&t=9d00a300-ce3a-59b5-a527-1bf7913420ae)

**Performance impact**
none

**Documentation**
- [ ] OneNote for internal use
