### PR TITLE
Remove TokenType from auth result metadata

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Client
         /// Represents the token type used for client telemetry only.
         /// It is separate from the other token types as it is set locally rather than coming from the server.
         /// </summary>
-        public int TelemetryTokenType { get; set; }
+        internal int TelemetryTokenType { get; set; }
 
         /// <summary>
         /// Time, in microseconds, spent in the token creation of the extended token.

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-Microsoft.Identity.Client.AuthenticationResultMetadata.TelemetryTokenType.get -> int


### PR DESCRIPTION
Fixes #4996


This is for internal usages only. For external use, ppl should use `AuthenicationResult.TokenType`