### PR TITLE
Fix bug in MeasureDurationResult

### DIFF
--- a/src/client/Microsoft.Identity.Client/Utils/MeasureDurationResult.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/MeasureDurationResult.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Identity.Client.Utils
         public MeasureDurationResult(TResult result, long ticks)
         {
             Result = result;
-            Milliseconds = (long)(ticks / s_tickFrequency / TimeSpan.TicksPerMillisecond);
-            Microseconds = (long)(ticks * s_tickFrequency / TicksPerMicrosecond % 1000);
+            Milliseconds = (long)(ticks * s_tickFrequency / TimeSpan.TicksPerMillisecond);
+            Microseconds = (long)(ticks * s_tickFrequency / TicksPerMicrosecond);
             Ticks = ticks;
         }
 
@@ -51,8 +51,8 @@ namespace Microsoft.Identity.Client.Utils
 
         public MeasureDurationResult(long ticks)
         {
-            Milliseconds = (long)(ticks * s_tickFrequency / TimeSpan.TicksPerMillisecond % 1000);
-            Microseconds = (long)(ticks * s_tickFrequency / TicksPerMicrosecond % 1000);
+            Milliseconds = (long)(ticks * s_tickFrequency / TimeSpan.TicksPerMillisecond);
+            Microseconds = (long)(ticks * s_tickFrequency / TicksPerMicrosecond);
             Ticks = ticks;
         }
 

--- a/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/StopWatchService.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Identity.Client.Utils
     /// Singleton timer used to measure the duration tasks.
     /// </summary>
     internal static class StopwatchService
-
     {
         /// <summary>
         /// Singleton stopwatch.
@@ -85,7 +84,6 @@ namespace Microsoft.Identity.Client.Utils
             await task.ConfigureAwait(false);
 
             return new MeasureDurationResult(Watch.ElapsedTicks - startTicks);
-            ;
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/StopWatchServiceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/StopWatchServiceTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.UtilTests
+{
+    [TestClass]
+    public class StopWatchServiceTests
+    {
+        [TestMethod]
+        public void MeasureCodeBlock()
+        {
+            MeasureDurationResult result = StopwatchService.MeasureCodeBlock(() => Thread.Sleep(50));
+
+            Assert.IsTrue(result.Milliseconds >= 50, "Measured time is less than expected.");
+            Assert.IsTrue(result.Milliseconds < 100, "Measured time is too high.");
+
+            long diff = result.Microseconds - (result.Milliseconds * 1000);
+            Assert.IsTrue(diff >= -1000, "Microseconds is less than expected.");
+            Assert.IsTrue(diff < 1000, "Microseconds is too high.");
+        }
+
+        [TestMethod]
+        public async Task MeasureCodeBlockAsync()
+        {
+            MeasureDurationResult result = await StopwatchService.MeasureCodeBlockAsync(async () =>
+            {
+                await Task.Delay(50).ConfigureAwait(true);
+            }).ConfigureAwait(true);
+
+            Assert.IsTrue(result.Milliseconds >= 50, "Measured time is less than expected.");
+            Assert.IsTrue(result.Milliseconds < 100, "Measured time is too high.");
+
+            long diff = result.Microseconds - (result.Milliseconds * 1000);
+            Assert.IsTrue(diff >= -1000, "Microseconds is less than expected.");
+            Assert.IsTrue(diff < 1000, "Microseconds is too high.");
+        }
+
+        [TestMethod]
+        public async Task MeasureCodeBlockAsyncWithResult()
+        {
+            MeasureDurationResult<int> result = await StopwatchService.MeasureCodeBlockAsync(async () =>
+            {
+                await Task.Delay(50).ConfigureAwait(true);
+                return 42;
+            }).ConfigureAwait(true);
+
+            Assert.AreEqual(42, result.Result, "Result is not as expected.");
+            Assert.IsTrue(result.Milliseconds >= 50, "Measured time is less than expected.");
+            Assert.IsTrue(result.Milliseconds < 100, "Measured time is too high.");
+
+            long diff = result.Microseconds - (result.Milliseconds * 1000);
+            Assert.IsTrue(diff >= -1000, "Microseconds is less than expected.");
+            Assert.IsTrue(diff < 1000, "Microseconds is too high.");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4895 and #5036
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
Updated the MeasureDurationResult class to properly measure milliseconds and microseconds so that the measuredurationresult accurately reflects the total elapsed time without being limited by the modulus operator

**Testing**
Used the sample app to ensure that stopwatch measured time aligned with the durationtotalinms within the authenticationresultmetadata when there is a change of scopes

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
