### PR TITLE
Mark `WithSignedHttpRequestProofOfPossession` as experimental

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         public T WithSignedHttpRequestProofOfPossession(PoPAuthenticationConfiguration popAuthenticationConfiguration)
         {
+            ValidateUseOfExperimentalFeature();
+
             CommonParameters.PopAuthenticationConfiguration = popAuthenticationConfiguration ?? throw new ArgumentNullException(nameof(popAuthenticationConfiguration));
 
             CommonParameters.AuthenticationOperation = new PopAuthenticationOperation(CommonParameters.PopAuthenticationConfiguration, ServiceBundle);

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/PoPTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/PoPTests.NetFwk.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .WithTestLogging()
                 .Build();
 
@@ -107,6 +108,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var cca = ConfidentialClientApplicationBuilder
                 .Create(settings.ClientId)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .WithTestLogging()
                 .WithAuthority(settings.Authority).Build();
             ConfigureInMemoryCache(cca);
@@ -155,7 +157,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var cca = ConfidentialClientApplicationBuilder.Create(settings.ClientId)
                 .WithTestLogging()
                 .WithAuthority(settings.Authority)
-                .WithClientSecret(settings.GetSecret()).Build();
+                .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
+                .Build();
             ConfigureInMemoryCache(cca);
 
             var result = await cca
@@ -176,6 +180,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .WithHttpClientFactory(new NoAccessHttpClientFactory()) // token should be served from the cache, no network access necessary
                 .Build();
             ConfigureInMemoryCache(cca);
@@ -221,6 +226,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .WithTestLogging()
                 .Build();
 
@@ -257,6 +263,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .Build();
 
             //RSA provider
@@ -294,6 +301,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .Build();
 
             //RSA provider
@@ -324,6 +332,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .Build();
 
             // Create an RSA key Wilson style (SigningCredentials)
@@ -389,6 +398,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .Build();
 
             //ECD Provider
@@ -520,6 +530,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .Build();
 
             // Create a new InMemoryCryptoProvider and get its JWK
@@ -572,6 +583,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .Build();
 
             // Create a new InMemoryCryptoProvider and get its JWK
@@ -659,6 +671,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .Create(settings.ClientId)
                 .WithAuthority(settings.Authority)
                 .WithClientSecret(settings.GetSecret())
+                .WithExperimentalFeatures(true)
                 .Build();
 
             var popConfig = new PoPAuthenticationConfiguration(new Uri(ProtectedUrl))

--- a/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 ConfidentialClientApplication app =
                     ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                               .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithExperimentalFeatures(true)
                                                               .WithHttpManager(httpManager)
                                                               .BuildConcrete();
 
@@ -91,6 +92,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 ConfidentialClientApplication app =
                     ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                               .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithExperimentalFeatures(true)
                                                               .WithHttpManager(httpManager)
                                                               .BuildConcrete();
 
@@ -128,6 +130,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 ConfidentialClientApplication app =
                     ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                               .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithExperimentalFeatures(true)
                                                               .WithHttpManager(httpManager)
                                                               .BuildConcrete();
 
@@ -403,6 +406,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 ConfidentialClientApplication app =
                     ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                               .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithExperimentalFeatures(true)
                                                               .WithHttpManager(httpManager)
                                                               .BuildConcrete();
                 var testTimeService = new TestTimeService();
@@ -579,6 +583,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 ConfidentialClientApplication app =
                     ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                               .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithExperimentalFeatures(true)
                                                               .WithHttpManager(httpManager)
                                                               .BuildConcrete();
 
@@ -647,6 +652,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
             {
                 ConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                                   .WithClientSecret(TestConstants.ClientSecret)
+                                                                  .WithExperimentalFeatures(true)
                                                                   .WithHttpManager(httpManager)
                                                                   .BuildConcrete();
 

--- a/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationOperationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PopAuthenticationOperationTests.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                 .WithHttpManager(harness.HttpManager)
                                 .WithClientSecret("some-secret")
+                                .WithExperimentalFeatures(true)
                                 .BuildConcrete();
 
                 TokenCacheHelper.PopulateCache(app.AppTokenCacheInternal.Accessor);


### PR DESCRIPTION
Mark `WithSignedHttpRequestProofOfPossession` as experimental