### PR TITLE
Support for SNI MTLS POP with DSTS Authorities

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -135,7 +135,8 @@ namespace Microsoft.Identity.Client
             {
                 string authorityUri = ServiceBundle.Config.Authority.AuthorityInfo.CanonicalAuthority.AbsoluteUri;
 
-                if (ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType != AuthorityType.Aad)
+                if (ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType != AuthorityType.Aad && 
+                    ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType != AuthorityType.Dsts)
                 {
                     throw new MsalClientException(
                         MsalError.InvalidAuthorityType,
@@ -149,7 +150,9 @@ namespace Microsoft.Identity.Client
                         MsalErrorMessage.MtlsNonTenantedAuthorityNotAllowedMessage);
                 }
 
-                if (string.IsNullOrEmpty(ServiceBundle.Config.AzureRegion))
+                // Check for Azure region only if the authority is AAD
+                if (ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType == AuthorityType.Aad &&
+                    string.IsNullOrEmpty(ServiceBundle.Config.AzureRegion))
                 {
                     throw new MsalClientException(
                         MsalError.MtlsPopWithoutRegion,

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -112,6 +112,8 @@ namespace Microsoft.Identity.Test.Unit
         public const string DstsAuthorityTenantless = "https://some.url.dsts.core.azure-test.net/dstsv2/";
         public const string DstsAuthorityTenanted = DstsAuthorityTenantless + TenantId + "/";
         public const string DstsAuthorityCommon = DstsAuthorityTenantless + Common + "/";
+        public const string DstsAuthorityMtlsTenantless = "https://mtls.some.url.dsts.core.azure-test.net/dstsv2/";
+        public const string DstsAuthorityMtlsTenanted = DstsAuthorityMtlsTenantless + TenantId + "/";
 
         public const string GenericAuthority = "https://demo.duendesoftware.com";
 

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -112,8 +112,6 @@ namespace Microsoft.Identity.Test.Unit
         public const string DstsAuthorityTenantless = "https://some.url.dsts.core.azure-test.net/dstsv2/";
         public const string DstsAuthorityTenanted = DstsAuthorityTenantless + TenantId + "/";
         public const string DstsAuthorityCommon = DstsAuthorityTenantless + Common + "/";
-        public const string DstsAuthorityMtlsTenantless = "https://mtls.some.url.dsts.core.azure-test.net/dstsv2/";
-        public const string DstsAuthorityMtlsTenanted = DstsAuthorityMtlsTenantless + TenantId + "/";
 
         public const string GenericAuthority = "https://demo.duendesoftware.com";
 


### PR DESCRIPTION
## Overview 

This pull request introduces changes to the Microsoft Authentication Library (MSAL) for .NET to support Mutual TLS (mTLS) Proof of Possession (PoP) when using DSTS authority. 

Fixes : #5060 

## Key Changes
### Support for DSTS in MTLS Checks:

Modified the validation logic in AcquireTokenForClientParameterBuilder to accept DSTS as a valid authority type for MTLS PoP operations. Previously, the logic only supported Azure AD authorities. This change allows the library to handle MTLS PoP with DSTS, broadening the scope of its applicability.

### Region Check Adjustment for Azure AD:

Updated the logic to enforce region checks strictly for Azure AD authorities when performing MTLS PoP. This modification prevents the region-related exception from being incorrectly applied to DSTS authorities, which do not utilize Azure regions in the same manner.

### Unit Tests:

Added new unit tests in MtlsPopTests.cs to validate the successful integration of MTLS PoP with DSTS authorities, ensuring that both common and tenanted DSTS endpoints are correctly handled. Additionally, tests were included to verify that the use of a non-tenanted 'common' authority with MTLS PoP correctly throws the expected exceptions, reinforcing the requirement for a tenanted authority in such scenarios.

### Next Steps
- **Release:** We will be releasing a public preview of MSAL with these changes
- **Testing:** Further integration and end-to-end tests will be done by the DSTS team.
- **Documentation:** Update the DSTS documentation to reflect these new capabilities and provide guidance on configuring MTLS PoP with DSTS. (After sign off from DSTS)