### PR TITLE
Update the System.Security.SecureString package reference instead of including it

### DIFF
--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -146,13 +146,13 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(TargetFrameworkNetAndroid)'">
     <Compile Include="$(PathToMsalSources)\Platforms\Android\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
-    <PackageReference Include="System.Security.SecureString" />
+    <PackageReference Update="System.Security.SecureString" />
     <PackageReference Include="Xamarin.AndroidX.Browser" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetIos)'">
     <Compile Include="$(PathToMsalSources)\Platforms\iOS\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\PlatformsCommon\PlatformNotSupported\ApiConfig\SystemWebViewOptions.cs" />
-    <PackageReference Include="System.Security.SecureString" />
+    <PackageReference Update="System.Security.SecureString" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: [Perf run failure](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1411117&view=logs&j=97e6c0f4-d22b-53e5-1a93-e7d20714371e&t=b4dce3fc-ba9a-595d-5211-18b24f8149a9) 
This pull request includes a small but important change to the `Microsoft.Identity.Client.csproj` file. The change updates the `System.Security.SecureString` package reference instead of including it, which ensures that the latest version of the package is used.

* [`src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj`](diffhunk://#diff-9ac6db6bc92909bb7098ee9bef1bdf9d3b58b44ea30beb38e6844493426c8543L149-R155): Changed `PackageReference Include` to `PackageReference Update` for `System.Security.SecureString` to ensure the latest version is used.
