### PR TITLE
Update CodeCoverage.runsettings to exclude test code

### DIFF
--- a/build/CodeCoverage.runsettings
+++ b/build/CodeCoverage.runsettings
@@ -36,6 +36,7 @@ Included items must then not match any entries in the exclude list to remain inc
                                 <Source>.*\\json\\.*</Source>
                                 <Source>.*\\android\\.*</Source>
                                 <Source>.*\\ios\\.*</Source>
+                                <Source>.*\\test\\.*</Source>
                             </Exclude>
                         </Sources>
                     </CodeCoverage>


### PR DESCRIPTION
This pull request includes a small change to the `build/CodeCoverage.runsettings` file. The change adds a new source directory to the exclusion list for code coverage.

* [`build/CodeCoverage.runsettings`](diffhunk://#diff-eb51b230aa0f3d6e10a8230236b20cb645a386f18723bb8c92d1ff310435e9b7R39): Added `.*\test\.*` to the list of excluded sources for code coverage.