### PR TITLE
Disable OB Test Code Coverage

### DIFF
--- a/build/template-OneBranch-Tests-libsandsamples.yaml
+++ b/build/template-OneBranch-Tests-libsandsamples.yaml
@@ -25,7 +25,7 @@ steps:
     testSelector: 'testAssemblies'
     testAssemblyVer2: '**\CacheCompat\CommonCache.Test.Unit\bin\**\CommonCache.Test.Unit.dll'
     searchFolder: '$(System.DefaultWorkingDirectory)'
-    codeCoverageEnabled: true
+    codeCoverageEnabled: false
     failOnMinTestsNotRun: true
     minimumExpectedTests: '1'
     runInParallel: true


### PR DESCRIPTION
Disable OB Test Code Coverage

https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1412185&view=codecoverage-tab

![image](https://github.com/user-attachments/assets/289ed48d-f013-464d-9917-023234af7d1d)
