### PR TITLE
Reordered the condition for ManagedIdentitySource.MachineLearning to be checked after ManagedIdentitySource.AppService instead of before it. 

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -62,11 +62,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             string imdsEndpoint = EnvironmentVariables.ImdsEndpoint;
             string podIdentityEndpoint = EnvironmentVariables.PodIdentityEndpoint;
 
-            if (!string.IsNullOrEmpty(msiSecretMachineLearning) && !string.IsNullOrEmpty(msiEndpoint))
-            {
-                return ManagedIdentitySource.MachineLearning;
-            }
-            else if (!string.IsNullOrEmpty(identityEndpoint) && !string.IsNullOrEmpty(identityHeader))
+            if (!string.IsNullOrEmpty(identityEndpoint) && !string.IsNullOrEmpty(identityHeader))
             {
                 if (!string.IsNullOrEmpty(identityServerThumbprint))
                 {
@@ -76,6 +72,10 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 {
                     return ManagedIdentitySource.AppService;
                 }
+            }
+            else if (!string.IsNullOrEmpty(msiSecretMachineLearning) && !string.IsNullOrEmpty(msiEndpoint))
+            {
+                return ManagedIdentitySource.MachineLearning;
             }
             else if (!string.IsNullOrEmpty(msiEndpoint))
             {

--- a/tests/Microsoft.Identity.Test.Common/Core/Helpers/ManagedIdentityTestUtil.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Helpers/ManagedIdentityTestUtil.cs
@@ -66,6 +66,21 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
             }
         }
 
+        public static void SetUpgradeScenarioEnvironmentVariables(ManagedIdentitySource managedIdentitySource, string endpoint, string secret = "secret", string thumbprint = "thumbprint")
+        {
+            // Use the common method to set base environment variables
+            SetEnvironmentVariables(managedIdentitySource, endpoint, secret, thumbprint);
+
+            // Add upgrade-specific variables where needed
+            switch (managedIdentitySource)
+            {
+                case ManagedIdentitySource.AppService:
+                    Environment.SetEnvironmentVariable("MSI_ENDPOINT", endpoint);
+                    Environment.SetEnvironmentVariable("MSI_SECRET", secret);
+                    break;
+            }
+        }
+
         /// <summary>
         /// Create the MIA with the http proxy
         /// </summary>

--- a/tests/Microsoft.Identity.Test.Common/Core/Helpers/ManagedIdentityTestUtil.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Helpers/ManagedIdentityTestUtil.cs
@@ -66,7 +66,27 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
             }
         }
 
-        public static void SetUpgradeScenarioEnvironmentVariables(ManagedIdentitySource managedIdentitySource, string endpoint, string secret = "secret", string thumbprint = "thumbprint")
+        /// <summary>
+        /// Sets environment variables for testing upgrade scenarios.
+        /// This method mimics a scenario where older environment variables
+        /// (e.g., MSI_ENDPOINT and MSI_SECRET) from previous versions of
+        /// App Service (2017) still exist after an upgrade to newer versions (2019).
+        /// It ensures that MSAL's Managed Identity source detection can correctly
+        /// handle both legacy and new variables.
+        /// </summary>
+        /// <param name="managedIdentitySource">
+        /// The type of managed identity source being tested (e.g., AppService, MachineLearning).
+        /// </param>
+        /// <param name="endpoint">
+        /// The endpoint URL to be set as part of the environment variables.
+        /// </param>
+        /// <param name="secret">
+        /// Optional: The secret value to be set (default is "secret").
+        /// </param>
+        /// <param name="thumbprint">
+        /// Optional: The certificate thumbprint to be set (default is "thumbprint").
+        /// </param>
+        internal static void SetUpgradeScenarioEnvironmentVariables(ManagedIdentitySource managedIdentitySource, string endpoint, string secret = "secret", string thumbprint = "thumbprint")
         {
             // Use the common method to set base environment variables
             SetEnvironmentVariables(managedIdentitySource, endpoint, secret, thumbprint);

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
@@ -20,6 +20,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
     public class AppServiceTests : TestBase
     {
         private const string AppService = "App Service";
+        internal const string AppServiceEndpoint = "http://127.0.0.1:41564/msi/token";
+        internal const string MachineLearningEndpoint = "http://localhost:7071/msi/token";
+        internal const string ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+        internal const string AzureArcEndpoint = "http://localhost:40342/metadata/identity/oauth2/token";
+        internal const string CloudShellEndpoint = "http://localhost:40342/metadata/identity/oauth2/token";
+        internal const string ServiceFabricEndpoint = "https://localhost:2377/metadata/identity/oauth2/token";
 
         [TestMethod]
         public async Task AppServiceInvalidEndpointAsync()
@@ -45,6 +51,28 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.AreEqual(MsalError.InvalidManagedIdentityEndpoint, ex.ErrorCode);
                 Assert.AreEqual(ManagedIdentitySource.AppService.ToString(), ex.AdditionalExceptionData[MsalException.ManagedIdentitySource]);
                 Assert.AreEqual(string.Format(CultureInfo.InvariantCulture, MsalErrorMessage.ManagedIdentityEndpointInvalidUriError, "IDENTITY_ENDPOINT", "127.0.0.1:41564/msi/token", AppService), ex.Message);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("http://127.0.0.1:41564/msi/token/", ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
+        [DataRow(AppServiceEndpoint, ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
+        [DataRow(ImdsEndpoint, ManagedIdentitySource.Imds, ManagedIdentitySource.DefaultToImds)]
+        [DataRow(null, ManagedIdentitySource.Imds, ManagedIdentitySource.DefaultToImds)]
+        [DataRow(AzureArcEndpoint, ManagedIdentitySource.AzureArc, ManagedIdentitySource.AzureArc)]
+        [DataRow(CloudShellEndpoint, ManagedIdentitySource.CloudShell, ManagedIdentitySource.CloudShell)]
+        [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, ManagedIdentitySource.ServiceFabric)]
+        [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, ManagedIdentitySource.MachineLearning)]
+        public void TestAppServiceUpgradeScenario(
+            string endpoint,
+            ManagedIdentitySource managedIdentitySource,
+            ManagedIdentitySource expectedManagedIdentitySource)
+        {
+            using (new EnvVariableContext())
+            {
+                SetUpgradeScenarioEnvironmentVariables(managedIdentitySource, endpoint);
+
+                Assert.AreEqual(expectedManagedIdentitySource, ManagedIdentityApplication.GetManagedIdentitySource());
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
@@ -54,14 +54,10 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             }
         }
 
+        // Regression test for Bug ID #5077 - ManagedIdentityCredential authentication failed 
         [DataTestMethod]
         [DataRow("http://127.0.0.1:41564/msi/token/", ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
         [DataRow(AppServiceEndpoint, ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
-        [DataRow(ImdsEndpoint, ManagedIdentitySource.Imds, ManagedIdentitySource.DefaultToImds)]
-        [DataRow(null, ManagedIdentitySource.Imds, ManagedIdentitySource.DefaultToImds)]
-        [DataRow(AzureArcEndpoint, ManagedIdentitySource.AzureArc, ManagedIdentitySource.AzureArc)]
-        [DataRow(CloudShellEndpoint, ManagedIdentitySource.CloudShell, ManagedIdentitySource.CloudShell)]
-        [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, ManagedIdentitySource.ServiceFabric)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, ManagedIdentitySource.MachineLearning)]
         public void TestAppServiceUpgradeScenario(
             string endpoint,

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
@@ -22,10 +22,6 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         private const string AppService = "App Service";
         internal const string AppServiceEndpoint = "http://127.0.0.1:41564/msi/token";
         internal const string MachineLearningEndpoint = "http://localhost:7071/msi/token";
-        internal const string ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
-        internal const string AzureArcEndpoint = "http://localhost:40342/metadata/identity/oauth2/token";
-        internal const string CloudShellEndpoint = "http://localhost:40342/metadata/identity/oauth2/token";
-        internal const string ServiceFabricEndpoint = "https://localhost:2377/metadata/identity/oauth2/token";
 
         [TestMethod]
         public async Task AppServiceInvalidEndpointAsync()


### PR DESCRIPTION
Fixes #5077

This pull request includes updates to the `ManagedIdentityClient` to enhance the logic for determining the managed identity source and adds new test methods to cover these changes. The most important changes include reordering the conditions in the `GetManagedIdentitySource` method, adding a new method to set environment variables for upgrade scenarios, and introducing new test cases for various managed identity sources.

Enhancements to managed identity source logic:

* [`src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs`](diffhunk://#diff-13058fddef4867b4d36dca3120b5b961ae64b039b32bcf5ad410a364b36fbfa8L65-R65): Reordered the conditions in the `GetManagedIdentitySource` method to check for `identityEndpoint` and `identityHeader` before `msiSecretMachineLearning` and `msiEndpoint`. [[1]](diffhunk://#diff-13058fddef4867b4d36dca3120b5b961ae64b039b32bcf5ad410a364b36fbfa8L65-R65) [[2]](diffhunk://#diff-13058fddef4867b4d36dca3120b5b961ae64b039b32bcf5ad410a364b36fbfa8R76-R79)

New method for setting environment variables:

* [`tests/Microsoft.Identity.Test.Common/Core/Helpers/ManagedIdentityTestUtil.cs`](diffhunk://#diff-016e6e32127e37c79ab4f73cf7dc06330cccf24af4f3435de2242aabdeb5a1c5R69-R83): Added `SetUpgradeScenarioEnvironmentVariables` method to set environment variables specific to upgrade scenarios.

Additional test cases:

* [`tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs`](diffhunk://#diff-f23e429abb461254d75c66d67705abc21af0e19f471f72a48523b13effcdeec1R23-R28): Added internal constants for various endpoints and a new data-driven test method `TestAppServiceUpgradeScenario` to validate the managed identity source detection logic for different scenarios. [[1]](diffhunk://#diff-f23e429abb461254d75c66d67705abc21af0e19f471f72a48523b13effcdeec1R23-R28) [[2]](diffhunk://#diff-f23e429abb461254d75c66d67705abc21af0e19f471f72a48523b13effcdeec1R56-R77)