### PR TITLE
Update code coverage policy

### DIFF
--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -74,10 +74,9 @@ jobs: #Build and stage projects
       checkCoverage: '$(CodeCoverageGateEnabled)'
       coverageFailOption: 'build'
       coverageType: 'lines'
-      allowCoverageVariance: true 
-      coverageVariance: 1 # Specify by how much the current amount of covered or uncovered code (depending on the parameter *Use Uncovered Elements*) may deviate from the previous value before the policy fails. Please be aware that the code coverage may slowly but steadily decrease from build to build if you allow a code coverage variance. Thus, you should keep this value as low as possible.
+      allowCoverageVariance: false 
+      coverageVariance: 0.01 # Specify by how much the current amount of covered or uncovered code (depending on the parameter *Use Uncovered Elements*) may deviate from the previous value before the policy fails. Please be aware that the code coverage may slowly but steadily decrease from build to build if you allow a code coverage variance. Thus, you should keep this value as low as possible.
       treat0of0as100: true
-      forceCoverageImprovement: true
       coverageUpperThreshold: '90'
       includePartiallySucceeded: false
       fallbackOnPRTargetBranch: false


### PR DESCRIPTION
Enabling the build to not fail if the code coverage value is maintained

Fixes #
Basically, this will allow us to make changes to non covered lines without the build failing. the policy is a lot more lenient while still nudging us in the right direction. The build will now fail if the code coverage falls below the baseline which is set by the nightly build that targets main

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
