### PR TITLE
Enable SNI + MTLS Pop Integration Tests

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             TestCommon.ResetInternalStaticCaches();
         }
 
-        //[TestMethod]
+        [TestMethod]
         public async Task Sni_Gets_Pop_Token_Successfully_TestAsync()
         {
             // Arrange: Use the public cloud settings for testing


### PR DESCRIPTION
This pull request includes a small change to the `tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs` file. The change re-enables the `Sni_Gets_Pop_Token_Successfully_TestAsync` test method by uncommenting the `[TestMethod]` attribute.

ESTS confirmed of the fix and this should be good to go