### PR TITLE
Set UseShellExecute to false in OpenLinuxBrowser

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/netstandard/NetCorePlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/netstandard/NetCorePlatformProxy.cs
@@ -242,7 +242,8 @@ namespace Microsoft.Identity.Client.Platforms.netstandard
             ProcessStartInfo psi = new ProcessStartInfo(openToolPath, url)
             {
                 RedirectStandardOutput = true,
-                RedirectStandardError = true
+                RedirectStandardError = true,
+                UseShellExecute = false
             };
 
             Process.Start(psi);


### PR DESCRIPTION
Fixes #5075
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->
Set `UseShellExecute` to false when set `RedirectStandardOutput` to true.
Ref: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.redirectstandardoutput?view=net-8.0#remarks
**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
