### PR TITLE
Removing known key check for cache key extensions

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/StorageJsonKeys.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/StorageJsonKeys.cs
@@ -43,45 +43,5 @@ namespace Microsoft.Identity.Client.Cache
         public const string ExtendedExpiresOn_MsalCompat = "ext_expires_on";
 
         public const string CacheExtensions = "ext";
-
-        //Known storeage keys need to be added here
-        public static readonly HashSet<string> s_knownStorageJsonKeys = new HashSet<string>
-        {
-            HomeAccountId, 
-            Environment, 
-            Realm, 
-            LocalAccountId, 
-            Username, 
-            AuthorityType, 
-            AlternativeAccountId,
-            GivenName, 
-            FamilyName, 
-            MiddleName,
-            Name, 
-            AvatarUrl, 
-            CredentialType,
-            ClientId,
-            Secret,
-            Target,
-            CachedAt, 
-            ExpiresOn, 
-            RefreshOn, 
-            ExtendedExpiresOn, 
-            ClientInfo,
-            FamilyId,
-            AppMetadata, 
-            KeyId,
-            TokenType, 
-            WamAccountIds, 
-            AccountSource,
-            UserAssertionHash,
-            ExtendedExpiresOn_MsalCompat, 
-            CacheExtensions
-        };
-
-        public static bool IsKnownStorageJsonKey(string key)
-        {
-            return s_knownStorageJsonKeys.Contains(key);
-        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
@@ -38,22 +38,6 @@ namespace Microsoft.Identity.Client.Extensibility
                 return builder;
             }
 
-            StringBuilder offendingKeys = new();
-
-            //Ensure known JSON keys are not added to cache key components
-            foreach (var kvp in cacheKeyComponents)
-            {
-                if (StorageJsonKeys.IsKnownStorageJsonKey(kvp.Key))
-                {
-                    offendingKeys.AppendLine(kvp.Key);
-                }
-            }
-
-            if (offendingKeys.Length != 0)
-            {
-                throw new ArgumentException($"Keys added to {nameof(cacheKeyComponents)} are invalid. Offending keys are: {offendingKeys.ToString()}");
-            }
-
             if (builder.CommonParameters.CacheKeyComponents == null)
             {
                 builder.CommonParameters.CacheKeyComponents = new SortedList<string, string>(cacheKeyComponents);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CacheKeyExtensionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CacheKeyExtensionTests.cs
@@ -40,13 +40,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                                                                 { "key1", "value1" }
                                                                             };
 
-        private Dictionary<string, string> _knownKeyList = new Dictionary<string, string>
-                                                                            {
-                                                                                { "client_id", "value1" },
-                                                                                { "name", "value2" },
-                                                                                { "environment", "value3" }
-                                                                            };
-
         private Dictionary<string, string> _additionalCacheKeysCombined = new Dictionary<string, string>
                                                                             {
                                                                                 { "key1", "value1" },
@@ -311,35 +304,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.IsNotNull(result);
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
                 ValidateCacheKeyComponents(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().First(), _additionalCacheKeys1, expectedPopCacheKey);
-            }
-        }
-
-        [TestMethod]
-        public async Task CacheExtEnsureInputKeysAreValidTestAsync()
-        {
-            string expectedExceptionMessage = "Keys added to cacheKeyComponents are invalid. Offending keys are: client_id\r\nname\r\nenvironment\r\n";
-            using (var httpManager = new MockHttpManager())
-            {
-                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                                              .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
-                                              .WithRedirectUri(TestConstants.RedirectUri)
-                                              .WithClientSecret(TestConstants.ClientSecret)
-                                              .WithHttpManager(httpManager)
-                                              .WithExperimentalFeatures()
-                                              .BuildConcrete();
-
-                var appCacheAccess = app.AppTokenCache.RecordAccess();
-
-                //Ensure that an exception is thrown when known keys are added to the cache key components
-                var exception = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-                {
-                    await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
-                        .WithAdditionalCacheKeyComponents(_knownKeyList)
-                        .ExecuteAsync(CancellationToken.None)
-                        .ConfigureAwait(false);
-                }).ConfigureAwait(false);
-
-                Assert.AreEqual(expectedExceptionMessage, exception.Message);
             }
         }
 


### PR DESCRIPTION
Fixes #
Removing known key check for cache key extension. This is no longer needed because cache key components are added to an additional node which prevents clashing with known JSON keys.

**Changes proposed in this request**
Removing known key check for cache key extension.

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
