### PR TITLE
Stop replacing "%20" to "+" since it is obsoleted

### DIFF
--- a/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Identity.Client.Utils
             }
 
             message = Uri.EscapeDataString(message);
-            message = message.Replace("%20", "+");
 
             return message;
         }
@@ -44,7 +43,7 @@ namespace Microsoft.Identity.Client.Utils
             {
                 return message;
             }
-
+            // Keep trying to replace "+" to "%20" to increase compatibility
             message = message.Replace("+", "%20");
             message = Uri.UnescapeDataString(message);
 

--- a/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.Utils
             {
                 return message;
             }
-            // Keep trying to replace "+" to "%20" to increase compatibility
+           // Replace "+" with "%20" for backward compatibility with older systems that used "+" for spaces.
             message = message.Replace("+", "%20");
             message = Uri.UnescapeDataString(message);
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/CoreHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/CoreHelperTests.cs
@@ -15,12 +15,28 @@ namespace Microsoft.Identity.Test.Unit.CoreTests
         [TestMethod]
         public void UrlEncodeDecodeTest()
         {
-            Assert.AreEqual(CoreHelpers.UrlEncode("https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize"), "https%3A%2F%2Flogin.microsoftonline.com%2Forganizations%2Foauth2%2Fv2.0%2Fauthorize");
-            Assert.AreEqual(CoreHelpers.UrlEncode("https://management.core.windows.net//.default openid profile offline_access"), "https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default%20openid%20profile%20offline_access");
+            // url without blank can be converted correctly.
+            Assert.AreEqual(CoreHelpers.UrlEncode("https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize"), 
+                "https%3A%2F%2Flogin.microsoftonline.com%2Forganizations%2Foauth2%2Fv2.0%2Fauthorize");
+            // url with blank can be converted correctly. " " needs to be replaced by "%20"
+            Assert.AreEqual(CoreHelpers.UrlEncode("https://management.core.windows.net//.default openid profile offline_access"), 
+                "https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default%20openid%20profile%20offline_access");
 
-            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Flogin.microsoftonline.com%2Forganizations%2Foauth2%2Fv2.0%2Fauthorize"), "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize");
-            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default%20openid%20profile%20offline_access"), "https://management.core.windows.net//.default openid profile offline_access");
-            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default+openid+profile+offline_access"), "https://management.core.windows.net//.default openid profile offline_access");
+            // Encoded url should be decoded correctly.
+            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Flogin.microsoftonline.com%2Forganizations%2Foauth2%2Fv2.0%2Fauthorize"), 
+                "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize");
+            // Encoded url with blank should be decoded correctly.
+            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default%20openid%20profile%20offline_access"), 
+                "https://management.core.windows.net//.default openid profile offline_access");
+            // Encoded url with "+" should be decoded correctly.
+            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default+openid+profile+offline_access"), 
+                "https://management.core.windows.net//.default openid profile offline_access");
+
+            // Test special OAuth characters (query string scenarios)
+            Assert.AreEqual(CoreHelpers.UrlEncode("redirect_uri=https://example.com/callback?code=1234"),
+                "redirect_uri%3Dhttps%3A%2F%2Fexample.com%2Fcallback%3Fcode%3D1234");
+            Assert.AreEqual(CoreHelpers.UrlDecode("redirect_uri%3Dhttps%3A%2F%2Fexample.com%2Fcallback%3Fcode%3D1234"),
+                "redirect_uri=https://example.com/callback?code=1234");
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/CoreHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/CoreHelperTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Test.Unit.CoreTests
+{
+    public class CoreHelperTests
+    {
+        [TestMethod]
+        public void UrlEncodeDecodeTest()
+        {
+            ClientInfo clientInfo = ClientInfo.CreateFromJson("eyJ1aWQiOiJteS11aWQiLCJ1dGlkIjoibXktdXRpZCJ9");
+            Assert.IsNotNull(clientInfo);
+            Assert.AreEqual(TestConstants.Uid, clientInfo.UniqueObjectIdentifier);
+            Assert.AreEqual(TestConstants.Utid, clientInfo.UniqueTenantIdentifier);
+
+            string originalUrl = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?scope=openid%20profile%20offline_access&response_type=code";
+            string urlWithPlus = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?scope=openid+profile+offline_access&response_type=code";
+
+            string encodedUrl = CoreHelpers.UrlEncode(originalUrl);
+            Assert.AreEqual(encodedUrl, originalUrl);
+            string decodedUIrl = CoreHelpers.UrlDecode(urlWithPlus);
+            Assert.AreEqual(decodedUIrl, originalUrl);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/CoreHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/CoreHelperTests.cs
@@ -9,23 +9,18 @@ using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Test.Unit.CoreTests
 {
+    [TestClass]
     public class CoreHelperTests
     {
         [TestMethod]
         public void UrlEncodeDecodeTest()
         {
-            ClientInfo clientInfo = ClientInfo.CreateFromJson("eyJ1aWQiOiJteS11aWQiLCJ1dGlkIjoibXktdXRpZCJ9");
-            Assert.IsNotNull(clientInfo);
-            Assert.AreEqual(TestConstants.Uid, clientInfo.UniqueObjectIdentifier);
-            Assert.AreEqual(TestConstants.Utid, clientInfo.UniqueTenantIdentifier);
+            Assert.AreEqual(CoreHelpers.UrlEncode("https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize"), "https%3A%2F%2Flogin.microsoftonline.com%2Forganizations%2Foauth2%2Fv2.0%2Fauthorize");
+            Assert.AreEqual(CoreHelpers.UrlEncode("https://management.core.windows.net//.default openid profile offline_access"), "https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default%20openid%20profile%20offline_access");
 
-            string originalUrl = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?scope=openid%20profile%20offline_access&response_type=code";
-            string urlWithPlus = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?scope=openid+profile+offline_access&response_type=code";
-
-            string encodedUrl = CoreHelpers.UrlEncode(originalUrl);
-            Assert.AreEqual(encodedUrl, originalUrl);
-            string decodedUIrl = CoreHelpers.UrlDecode(urlWithPlus);
-            Assert.AreEqual(decodedUIrl, originalUrl);
+            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Flogin.microsoftonline.com%2Forganizations%2Foauth2%2Fv2.0%2Fauthorize"), "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize");
+            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default%20openid%20profile%20offline_access"), "https://management.core.windows.net//.default openid profile offline_access");
+            Assert.AreEqual(CoreHelpers.UrlDecode("https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default+openid+profile+offline_access"), "https://management.core.windows.net//.default openid profile offline_access");
         }
     }
 }


### PR DESCRIPTION


Fixes #5061 https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5061
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**

MSAL .NET is converting "openid%20profile%20offline_access" to "openid+profile+offline_access"

Partner prefers the original format since: "Some third party Identity Providers [namely Broadcom Siteminder] do NOT allow the usage of "+" to represent a space in URLs, in particular to separate scopes in the "authorize" endpoint."

“+” is defined in rfc1866 https://www.rfc-editor.org/rfc/rfc1866.txt made in 1995:
7.5. Queries and Indexes
The keywords are escaped according to [URL] and joined
   by `+'.

rfc1866 is obsoleted by rfc2854 https://www.rfc-editor.org/rfc/rfc2854.txt made in 2000, while rfc2854 does not suggest using "+"


**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
