### PR TITLE
[MSI V2 Feature] Adding IMDSV2 probe logic

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (_managedIdentityParameters.ForceRefresh || !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ForceRefreshOrClaims;
-                
+
                 logger.Info("[ManagedIdentityRequest] Skipped looking for a cached access token because ForceRefresh or Claims were set. " +
                     "This means either a force refresh was requested or claims were present.");
 
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 logger.Info("[ManagedIdentityRequest] Access token retrieved from cache.");
 
                 try
-                {  
+                {
                     var proactivelyRefresh = SilentRequestHelper.NeedsRefresh(cachedAccessTokenItem);
 
                     // If needed, refreshes token in the background
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         }
 
         private async Task<AuthenticationResult> GetAccessTokenAsync(
-            CancellationToken cancellationToken, 
+            CancellationToken cancellationToken,
             ILoggerAdapter logger)
         {
             AuthenticationResult authResult;
@@ -115,7 +115,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // Bypass cache and send request to token endpoint, when
                 // 1. Force refresh is requested, or
                 // 2. If the access token needs to be refreshed proactively.
-                if (_managedIdentityParameters.ForceRefresh || 
+                if (_managedIdentityParameters.ForceRefresh ||
                     AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo == CacheRefreshReason.ProactivelyRefreshed ||
                     !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
                 {
@@ -152,8 +152,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             await ResolveAuthorityAsync().ConfigureAwait(false);
 
-            ManagedIdentityClient managedIdentityClient = 
-                new ManagedIdentityClient(AuthenticationRequestParameters.RequestContext);
+            ManagedIdentityClient managedIdentityClient =
+                await ManagedIdentityClient.CreateAsync(AuthenticationRequestParameters.RequestContext)
+                .ConfigureAwait(false);
 
             ManagedIdentityResponse managedIdentityResponse =
                 await managedIdentityClient

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    internal class ImdsCredentialProbeManager
+    {
+        private const string CredentialEndpoint = "http://169.254.169.254/metadata/identity/credential";
+        private const string ProbeBody = ".";
+        private const string ImdsHeader = "IMDS/";
+        private readonly IHttpManager _httpManager;
+        private readonly ILoggerAdapter _logger;
+
+        public ImdsCredentialProbeManager(IHttpManager httpManager, ILoggerAdapter logger)
+        {
+            _httpManager = httpManager ?? throw new ArgumentNullException(nameof(httpManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<bool> ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            _logger.Info("[Credential Probe] Initiating probe to IMDS credential endpoint.");
+
+            var request = new ManagedIdentityRequest(HttpMethod.Post, new Uri($"{CredentialEndpoint}?cred-api-version=1.0"))
+            {
+                Content = ProbeBody
+            };
+
+            HttpContent httpContent = request.CreateHttpContent();
+
+            _logger.Info($"[Credential Probe] Sending request to {CredentialEndpoint}");
+
+            try
+            {
+                HttpResponse response = await _httpManager.SendRequestAsync(
+                    request.ComputeUri(),
+                    request.Headers,
+                    httpContent,
+                    request.Method,
+                    _logger,
+                    doNotThrow: true,
+                    mtlsCertificate: null,
+                    customHttpClient: null,
+                    cancellationToken).ConfigureAwait(false);
+
+                LogResponseDetails(response);
+
+                return EvaluateProbeResponse(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.Info($"[Credential Probe] Exception during probe: {ex.Message}");
+                return false;
+            }
+        }
+
+        private void LogResponseDetails(HttpResponse response)
+        {
+            if (response == null)
+            {
+                _logger.Info("[Credential Probe] No response received from the server.");
+                return;
+            }
+
+            _logger.Info($"[Credential Probe] Response received from the server. Response Status Code: {response.StatusCode}");
+        }
+
+        private bool EvaluateProbeResponse(HttpResponse response)
+        {
+            if (response == null)
+            {
+                _logger.Error("[Credential Probe] No response received from the server.");
+                return false;
+            }
+
+            _logger.Info($"[Credential Probe] Evaluating response from credential endpoint. Status Code: {response.StatusCode}");
+
+            if (response.HeadersAsDictionary.TryGetValue("server", out string serverHeader) &&
+                serverHeader.TrimStart().StartsWith(ImdsHeader, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.Info("[Credential Probe] Credential endpoint supported. Server Header contains IMDS.");
+                return true;
+            }
+
+            _logger.Warning($"[Credential Probe] Credential endpoint not supported. Status Code: {response.StatusCode}");
+            return false;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     customHttpClient: null,
                     cancellationToken).ConfigureAwait(false);
 
-                LogResponseDetails(response);
-
                 return EvaluateProbeResponse(response);
             }
             catch (Exception ex)
@@ -62,27 +60,19 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             }
         }
 
-        private void LogResponseDetails(HttpResponse response)
-        {
-            if (response == null)
-            {
-                _logger.Info("[Credential Probe] No response received from the server.");
-                return;
-            }
-
-            _logger.Info($"[Credential Probe] Response received from the server. Response Status Code: {response.StatusCode}");
-        }
-
         private bool EvaluateProbeResponse(HttpResponse response)
         {
+            // 1. Handle null response
             if (response == null)
             {
                 _logger.Error("[Credential Probe] No response received from the server.");
                 return false;
             }
 
-            _logger.Info($"[Credential Probe] Evaluating response from credential endpoint. Status Code: {response.StatusCode}");
+            // 2. Log basic details
+            _logger.Info($"[Credential Probe] Response received from the server. Status Code: {response.StatusCode}");
 
+            // 3. Evaluate IMDS header
             if (response.HeadersAsDictionary.TryGetValue("server", out string serverHeader) &&
                 serverHeader.TrimStart().StartsWith(ImdsHeader, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsV2ManagedIdentitySource.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    internal class ImdsV2ManagedIdentitySource : AbstractManagedIdentity
+    {
+        /// <summary>
+        /// Factory method to create an instance of `CredentialManagedIdentitySource`.
+        /// </summary>
+        public static AbstractManagedIdentity Create(RequestContext requestContext)
+        {
+            requestContext.Logger.Info(() => "[Managed Identity] Using credential based managed identity.");
+
+            return new ImdsV2ManagedIdentitySource(requestContext);
+        }
+
+        private ImdsV2ManagedIdentitySource(RequestContext requestContext) :
+            base(requestContext, ManagedIdentitySource.ImdsV2)
+        {
+        }
+
+        /// <summary>
+        /// Even though the Credential flow does not use this request, we need to satisfy the abstract contract.
+        /// Return a minimal, valid ManagedIdentityRequest using the fixed credential endpoint.
+        /// </summary>
+        /// <param name="resource">The resource identifier (ignored in this flow).</param>
+        /// <returns>A ManagedIdentityRequest instance using the credential endpoint.</returns>
+        protected override ManagedIdentityRequest CreateRequest(string resource)
+        {
+            // Return a minimal request with the fixed credential endpoint.
+            return new ManagedIdentityRequest(
+                HttpMethod.Post,
+                new Uri("http://169.254.169.254/metadata/identity/credential?cred-api-version=1.0"));
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -9,6 +9,7 @@ using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;
 using System.IO;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
 
 namespace Microsoft.Identity.Client.ManagedIdentity
 {
@@ -19,38 +20,77 @@ namespace Microsoft.Identity.Client.ManagedIdentity
     {
         private const string WindowsHimdsFilePath = "%Programfiles%\\AzureConnectedMachineAgent\\himds.exe";
         private const string LinuxHimdsFilePath = "/opt/azcmagent/bin/himds";
+
+        // Cache for the managed identity source
+        private static ManagedIdentitySource? s_cachedManagedIdentitySource;
+        private static readonly SemaphoreSlim s_credentialSemaphore = new(1, 1);
         private readonly AbstractManagedIdentity _identitySource;
 
-        public ManagedIdentityClient(RequestContext requestContext)
+        internal static async Task<ManagedIdentityClient> CreateAsync(RequestContext requestContext)
         {
-            using (requestContext.Logger.LogMethodDuration())
-            {
-                _identitySource = SelectManagedIdentitySource(requestContext);
-            }
+            requestContext.Logger?.Info("[ManagedIdentityClient] Creating ManagedIdentityClient.");
+
+            AbstractManagedIdentity identitySource = await SelectManagedIdentitySourceAsync(
+                requestContext,
+                requestContext.UserCancellationToken)
+                .ConfigureAwait(false);
+
+            requestContext.Logger?.Info($"[ManagedIdentityClient] Managed identity source selected: {identitySource.GetType().Name}.");
+
+            return new ManagedIdentityClient(identitySource);
         }
 
-        internal Task<ManagedIdentityResponse> SendTokenRequestForManagedIdentityAsync(AcquireTokenForManagedIdentityParameters parameters, CancellationToken cancellationToken)
+        private ManagedIdentityClient(AbstractManagedIdentity identitySource)
+        {
+            _identitySource = identitySource ?? throw new ArgumentNullException(nameof(identitySource), "Identity source cannot be null.");
+        }
+
+        /// <summary>
+        /// Resets the cached managed identity source. Used only for testing purposes.
+        /// </summary>
+        internal static void ResetManagedIdentitySourceCache()
+        {
+            s_cachedManagedIdentitySource = null;
+        }
+
+        internal Task<ManagedIdentityResponse> SendTokenRequestForManagedIdentityAsync(
+            AcquireTokenForManagedIdentityParameters parameters, CancellationToken cancellationToken)
         {
             return _identitySource.AuthenticateAsync(parameters, cancellationToken);
         }
 
-        // This method tries to create managed identity source for different sources, if none is created then defaults to IMDS.
-        private static AbstractManagedIdentity SelectManagedIdentitySource(RequestContext requestContext)
+        /// <summary>
+        /// This method tries to create managed identity source for different sources. 
+        /// If none is created then defaults to IMDS.
+        /// </summary>
+        /// <param name="requestContext"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private static async Task<AbstractManagedIdentity> SelectManagedIdentitySourceAsync(
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
         {
-            return GetManagedIdentitySource(requestContext.Logger) switch
+            ManagedIdentitySource source = await GetManagedIdentitySourceAsync(
+                requestContext.ServiceBundle,
+                cancellationToken).ConfigureAwait(false);
+
+            return source switch
             {
                 ManagedIdentitySource.ServiceFabric => ServiceFabricManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.AppService => AppServiceManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.MachineLearning => MachineLearningManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.CloudShell => CloudShellManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.AzureArc => AzureArcManagedIdentitySource.Create(requestContext),
+                ManagedIdentitySource.ImdsV2 => ImdsV2ManagedIdentitySource.Create(requestContext),
                 _ => new ImdsManagedIdentitySource(requestContext)
             };
         }
 
-        // Detect managed identity source based on the availability of environment variables.
-        // The result of this method is not cached because reading environment variables is cheap. 
-        // This method is perf sensitive any changes should be benchmarked.
+        /// <summary>
+        /// Compute the managed identity source based on the environment variables.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <returns></returns>
         internal static ManagedIdentitySource GetManagedIdentitySource(ILoggerAdapter logger = null)
         {
             string identityEndpoint = EnvironmentVariables.IdentityEndpoint;
@@ -97,6 +137,128 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             }
         }
 
+        /// <summary>
+        /// Compute the managed identity source based on the environment variables and the probe.
+        /// </summary>
+        /// <param name="serviceBundle"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static async Task<ManagedIdentitySource> GetManagedIdentitySourceAsync(
+            IServiceBundle serviceBundle,
+            CancellationToken cancellationToken = default)
+        {
+            if (serviceBundle == null)
+            {
+                throw new ArgumentNullException(nameof(serviceBundle), "ServiceBundle is required to initialize the probe manager.");
+            }
+
+            ILoggerAdapter logger = serviceBundle.ApplicationLogger;
+
+            logger.Verbose(() => s_cachedManagedIdentitySource.HasValue
+                ? "[Managed Identity] Using cached managed identity source."
+                : "[Managed Identity] Computing managed identity source asynchronously.");
+
+            if (s_cachedManagedIdentitySource.HasValue)
+            {
+                return s_cachedManagedIdentitySource.Value;
+            }
+
+            // Using SemaphoreSlim to prevent multiple threads from computing at the same time
+            logger.Verbose(() => "[Managed Identity] Entering managed identity source semaphore.");
+            await s_credentialSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            logger.Verbose(() => "[Managed Identity] Entered managed identity source semaphore.");
+
+            try
+            {
+                // Ensure another thread didn't set this while waiting on semaphore
+                if (s_cachedManagedIdentitySource.HasValue)
+                {
+                    return s_cachedManagedIdentitySource.Value;
+                }
+
+                // Initialize probe manager
+                var probeManager = new ImdsCredentialProbeManager(
+                    serviceBundle.HttpManager,
+                    serviceBundle.ApplicationLogger);
+
+                // Compute the managed identity source
+                s_cachedManagedIdentitySource = await ComputeManagedIdentitySourceAsync(
+                    probeManager,
+                    serviceBundle.ApplicationLogger,
+                    cancellationToken).ConfigureAwait(false);
+
+                logger.Info($"[Managed Identity] Managed identity source determined: {s_cachedManagedIdentitySource.Value}.");
+
+                return s_cachedManagedIdentitySource.Value;
+            }
+            finally
+            {
+                s_credentialSemaphore.Release();
+                logger.Verbose(() => "[Managed Identity] Released managed identity source semaphore.");
+            }
+        }
+
+        /// <summary>
+        /// Compute the managed identity source based on the environment variables and the probe.
+        /// </summary>
+        /// <param name="imdsCredentialProbeManager"></param>
+        /// <param name="logger"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private static async Task<ManagedIdentitySource> ComputeManagedIdentitySourceAsync(
+            ImdsCredentialProbeManager imdsCredentialProbeManager,
+            ILoggerAdapter logger,
+            CancellationToken cancellationToken)
+        {
+            string identityEndpoint = EnvironmentVariables.IdentityEndpoint;
+            string identityHeader = EnvironmentVariables.IdentityHeader;
+            string identityServerThumbprint = EnvironmentVariables.IdentityServerThumbprint;
+            string msiEndpoint = EnvironmentVariables.MsiEndpoint;
+            string imdsEndpoint = EnvironmentVariables.ImdsEndpoint;
+            string msiSecretMachineLearning = EnvironmentVariables.MsiSecret;
+
+            if (!string.IsNullOrEmpty(identityEndpoint) && !string.IsNullOrEmpty(identityHeader))
+            {
+                if (!string.IsNullOrEmpty(identityServerThumbprint))
+                {
+                    return ManagedIdentitySource.ServiceFabric;
+                }
+                else
+                {
+                    return ManagedIdentitySource.AppService;
+                }
+            }
+            else if (!string.IsNullOrEmpty(msiSecretMachineLearning) && !string.IsNullOrEmpty(msiEndpoint))
+            {
+                return ManagedIdentitySource.MachineLearning;
+            }
+            else if (!string.IsNullOrEmpty(msiEndpoint))
+            {
+                return ManagedIdentitySource.CloudShell;
+            }
+            else if (ValidateAzureArcEnvironment(identityEndpoint, imdsEndpoint, logger))
+            {
+                return ManagedIdentitySource.AzureArc;
+            }
+            else
+            {
+                logger?.Info("[Managed Identity] Probing for credential endpoint.");
+                bool isSuccess = await imdsCredentialProbeManager.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+
+                if (isSuccess)
+                {
+                    logger?.Info("[Managed Identity] Credential endpoint detected.");
+                    return ManagedIdentitySource.ImdsV2;
+                }
+                else
+                {
+                    logger?.Verbose(() => "[Managed Identity] Defaulting to IMDS as credential endpoint not detected.");
+                    return ManagedIdentitySource.DefaultToImds;
+                }
+            }
+        }
+
         // Method to return true if a file exists and is not empty to validate the Azure arc environment.
         private static bool ValidateAzureArcEnvironment(string identityEndpoint, string imdsEndpoint, ILoggerAdapter logger)
         {
@@ -118,8 +280,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             {
                 logger?.Verbose(() => "[Managed Identity] Azure Arc managed identity is available through file detection.");
                 return true;
-            } 
-            
+            }
+
             logger?.Verbose(() => "[Managed Identity] Azure Arc managed identity is not available.");
             return false;
         }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -144,9 +144,9 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
-        public static async Task<ManagedIdentitySource> GetManagedIdentitySourceAsync(
+        internal static async Task<ManagedIdentitySource> GetManagedIdentitySourceAsync(
             IServiceBundle serviceBundle,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             if (serviceBundle == null)
             {

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityRequest.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityRequest.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
         public IDictionary<string, string> QueryParameters { get; }
 
+        public string Content { get; internal set; }
+
         public ManagedIdentityRequest(HttpMethod method, Uri endpoint)
         {
             Method = method;
@@ -38,6 +40,22 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             uriBuilder.AppendQueryParameters(QueryParameters);
 
             return uriBuilder.Uri;
+        }
+
+        public HttpContent CreateHttpContent()
+        {
+            if (!string.IsNullOrEmpty(Content))
+            {
+                return new StringContent(Content, Encoding.UTF8, "application/json");
+            }
+
+            if (BodyParameters.Count > 0)
+            {
+                var formData = new FormUrlEncodedContent(BodyParameters);
+                return formData;
+            }
+
+            return null; // No body content
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
@@ -53,6 +53,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         /// <summary>
         /// The source to acquire token for managed identity is Machine Learning Service.
         /// </summary>
-        MachineLearning
+        MachineLearning,
+
+        /// <summary>
+        /// Indicates that the source is credential endpoint based on the probe.
+        /// This is used to detect the new managed identity credential source.
+        /// </summary>
+        ImdsV2
     }
 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -36,11 +36,15 @@ namespace Microsoft.Identity.Client
 
             AppTokenCacheInternal = configuration.AppTokenCacheInternalForTest ?? new TokenCache(ServiceBundle, true);
 
-            this.ServiceBundle.ApplicationLogger.Verbose(()=>$"ManagedIdentityApplication {configuration.GetHashCode()} created");
+            s_serviceBundle = this.ServiceBundle;
+
+            s_serviceBundle.ApplicationLogger.Verbose(() => $"ManagedIdentityApplication {configuration.GetHashCode()} created");
         }
 
         // Stores all app tokens
         internal ITokenCacheInternal AppTokenCacheInternal { get; }
+
+        private static IServiceBundle s_serviceBundle;
 
         /// <inheritdoc/>
         public AcquireTokenForManagedIdentityParameterBuilder AcquireTokenForManagedIdentity(string resource)
@@ -59,9 +63,20 @@ namespace Microsoft.Identity.Client
         /// Detects and returns the managed identity source available on the environment.
         /// </summary>
         /// <returns>Managed identity source detected on the environment if any.</returns>
+        [Obsolete("GetManagedIdentitySource() is deprecated and will be removed in a future release. Use GetManagedIdentitySourceAsync() instead.")]
+
         public static ManagedIdentitySource GetManagedIdentitySource()
         {
             return ManagedIdentityClient.GetManagedIdentitySource();
+        }
+
+        /// <summary>
+        /// Detects and returns the managed identity source available on the environment asynchronously.
+        /// </summary>
+        /// <returns>Managed identity source detected on the environment if any.</returns>
+        public static async Task<ManagedIdentitySource> GetManagedIdentitySourceAsync(CancellationToken cancellationToken = default)
+        {
+            return await ManagedIdentityClient.GetManagedIdentitySourceAsync(s_serviceBundle, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -582,5 +582,21 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 TokenSource = TokenSource.Broker
             };
         }
+
+        public static void AddCredentialEndpointNotFoundHandlers(
+            ManagedIdentitySource managedIdentitySource,
+            MockHttpManager httpManager,
+            int count = 4)
+        {
+            if (managedIdentitySource != ManagedIdentitySource.Imds)
+            {
+                return; // Only add handlers for IMDS
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                httpManager.AddMockHandlerContentNotFound(HttpMethod.Post);
+            }
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using NSubstitute;
 using static Microsoft.Identity.Client.TelemetryCore.Internal.Events.ApiEvent;
+using Microsoft.Identity.Client.ManagedIdentity;
 
 namespace Microsoft.Identity.Test.Common
 {
@@ -45,6 +46,7 @@ namespace Microsoft.Identity.Test.Common
             OidcRetrieverWithCache.ResetCacheForTest();
             AuthorityManager.ClearValidationCache();
             SingletonThrottlingManager.GetInstance().ResetCache();
+            ManagedIdentityClient.ResetManagedIdentitySourceCache();
         }
 
         public static object GetPropValue(object src, string propName)

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow("http://127.0.0.1:41564/msi/token/", ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
         [DataRow(AppServiceEndpoint, ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, ManagedIdentitySource.MachineLearning)]
-        public void TestAppServiceUpgradeScenario(
+        public async Task TestAppServiceUpgradeScenarioAsync(
             string endpoint,
             ManagedIdentitySource managedIdentitySource,
             ManagedIdentitySource expectedManagedIdentitySource)
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             {
                 SetUpgradeScenarioEnvironmentVariables(managedIdentitySource, endpoint);
 
-                Assert.AreEqual(expectedManagedIdentitySource, ManagedIdentityApplication.GetManagedIdentitySource());
+                Assert.AreEqual(expectedManagedIdentitySource, await ManagedIdentityApplication.GetManagedIdentitySourceAsync().ConfigureAwait(false));
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsTests.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(ManagedIdentitySource.Imds, httpManager);
+
                 // Adding multiple mock handlers to simulate retries for GatewayTimeout
                 for (int i = 0; i < expectedAttempts; i++)
                 {

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry.Resources;
+using static Microsoft.Identity.Test.Common.Core.Helpers.ManagedIdentityTestUtil;
+
+namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
+{
+
+    [TestClass]
+    public class ImdsV2Tests : TestBase
+    {
+        private const string ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+        internal const string Resource = "https://management.azure.com";
+        internal const string CredentialEndpoint = "http://169.254.169.254/metadata/identity/credential";
+        internal const string MtlsEndpoint = "https://centraluseuap.mtlsauth.microsoft.com/" +
+            "72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token";
+
+        [TestInitialize]
+        public override void TestInitialize()
+        {
+            TestCommon.ResetInternalStaticCaches();
+        }
+
+        [TestMethod]
+        public async Task CredentialSourceFailedFallbackToImdsTestAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager(isManagedIdentity: true))
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+
+                var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager);
+
+                // Disabling shared cache options to avoid cross test pollution.
+                miBuilder.Config.AccessorOptions = null;
+
+                var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(ManagedIdentitySource.Imds, httpManager);
+
+                httpManager.AddManagedIdentityMockHandler(
+                ImdsEndpoint,
+                Resource,
+                MockHelpers.GetMsiSuccessfulResponse(),
+                ManagedIdentitySource.Imds);
+
+                var result = await mi.AcquireTokenForManagedIdentity(Resource).ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                result = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -47,16 +47,16 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(CloudShellEndpoint, ManagedIdentitySource.CloudShell, ManagedIdentitySource.CloudShell)]
         [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, ManagedIdentitySource.ServiceFabric)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, ManagedIdentitySource.MachineLearning)]
-        public void GetManagedIdentityTests(
+        public async Task GetManagedIdentityTestsAsync(
             string endpoint,
-            ManagedIdentitySource managedIdentitySource, 
+            ManagedIdentitySource managedIdentitySource,
             ManagedIdentitySource expectedManagedIdentitySource)
         {
             using (new EnvVariableContext())
             {
                 SetEnvironmentVariables(managedIdentitySource, endpoint);
 
-                Assert.AreEqual(expectedManagedIdentitySource, ManagedIdentityApplication.GetManagedIdentitySource());
+                Assert.AreEqual(expectedManagedIdentitySource, await ManagedIdentityApplication.GetManagedIdentitySourceAsync().ConfigureAwait(false));
             }
         }
 
@@ -91,7 +91,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
-                
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                 endpoint,
                 Resource,
@@ -121,7 +123,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(ImdsEndpoint, ManagedIdentitySource.Imds, TestConstants.MiResourceId, UserAssignedIdentityId.ResourceId)]
         [DataRow(ImdsEndpoint, ManagedIdentitySource.Imds, TestConstants.MiResourceId, UserAssignedIdentityId.ObjectId)]
         [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.ClientId, UserAssignedIdentityId.ClientId)]
-        [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.MiResourceId, UserAssignedIdentityId .ResourceId)]
+        [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.MiResourceId, UserAssignedIdentityId.ResourceId)]
         [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.MiResourceId, UserAssignedIdentityId.ObjectId)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, TestConstants.ClientId, UserAssignedIdentityId.ClientId)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, TestConstants.MiResourceId, UserAssignedIdentityId.ResourceId)]
@@ -138,10 +140,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(managedIdentitySource, endpoint);
 
                 ManagedIdentityApplicationBuilder miBuilder = CreateMIABuilder(userAssignedId, userAssignedIdentityId);
-                
+
                 miBuilder.WithHttpManager(httpManager);
 
                 IManagedIdentityApplication mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -191,6 +195,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -251,6 +257,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -314,6 +322,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
                     Resource,
@@ -375,6 +385,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -507,7 +519,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 foreach (var expectedErrorSubString in expectedInErrorResponse)
                 {
-                    Assert.IsTrue(ex.Message.Contains(expectedErrorSubString), 
+                    Assert.IsTrue(ex.Message.Contains(expectedErrorSubString),
                         $"Expected to contain string {expectedErrorSubString}. Actual error message: {ex.Message}");
                 }
             }
@@ -554,6 +566,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(endpoint, "scope", "",
                     managedIdentitySource, statusCode: HttpStatusCode.InternalServerError);
                 httpManager.AddManagedIdentityMockHandler(endpoint, "scope", "",
@@ -596,6 +610,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
                     Resource,
@@ -635,6 +651,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddFailingRequest(new HttpRequestException("A socket operation was attempted to an unreachable network.",
                     new SocketException(10051)));
@@ -676,6 +694,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
                     Resource,
@@ -715,7 +735,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             }
         }
 
-        [TestMethod] 
+        [TestMethod]
         public async Task SystemAssignedManagedIdentityApiIdTestAsync()
         {
             using (new EnvVariableContext())
@@ -946,7 +966,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 Assert.AreEqual(0, httpManager.QueueSize,
                     "MSAL should have refreshed the token because the original AT was marked for refresh");
-                
+
                 cacheAccess.WaitTo_AssertAcessCounts(1, 1);
 
                 Assert.AreEqual(CacheRefreshReason.ProactivelyRefreshed, result.AuthenticationResultMetadata.CacheRefreshReason);
@@ -956,7 +976,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 result = await mi.AcquireTokenForManagedIdentity(Resource)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
-                
+
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
             }
         }
@@ -1019,7 +1039,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [TestMethod]
         public async Task ParallelRequests_CallTokenEndpointOnceAsync()
         {
-            int numOfTasks = 10; 
+            int numOfTasks = 10;
             int identityProviderHits = 0;
             int cacheHits = 0;
 
@@ -1114,6 +1134,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                      endpoint,
                      "scope",
@@ -1138,9 +1160,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(Resource, "https://graph.microsoft.com", ManagedIdentitySource.ServiceFabric, ServiceFabricEndpoint)]
         [DataRow(Resource, "https://graph.microsoft.com", ManagedIdentitySource.MachineLearning, MachineLearningEndpoint)]
         public async Task ManagedIdentityRequestTokensForDifferentScopesTestAsync(
-            string initialResource, 
-            string newResource, 
-            ManagedIdentitySource source, 
+            string initialResource,
+            string newResource,
+            ManagedIdentitySource source,
             string endpoint)
         {
             using (new EnvVariableContext())
@@ -1156,6 +1178,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 IManagedIdentityApplication mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(source, httpManager);
 
                 // Mock handler for the initial resource request
                 httpManager.AddManagedIdentityMockHandler(endpoint, initialResource,
@@ -1299,6 +1323,37 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // Verify the ClientId for each cached entry
                 Assert.AreEqual(UserAssignedClientId, userAssignedTokens[0].ClientId, "User-assigned ClientId mismatch in cache.");
                 Assert.AreEqual(SystemAssignedClientId, systemAssignedTokens[0].ClientId, "System-assigned ClientId mismatch in cache.");
+            }
+        }
+
+        [TestMethod]
+        public async Task ManagedIdentitySourceCachingWorksAsExpectedAsync()
+        {
+            // Create ApplicationConfiguration and ServiceBundle
+            var config = new ApplicationConfiguration(MsalClientType.ManagedIdentityClient);
+            var serviceBundle = new ServiceBundle(config);
+
+            using (new EnvVariableContext())
+            {
+                // Set environment variables to resolve as ServiceFabric
+                Environment.SetEnvironmentVariable("IDENTITY_ENDPOINT", "http://localhost:40342/metadata/identity/oauth2/token");
+                Environment.SetEnvironmentVariable("IDENTITY_HEADER", "dummy-header");
+                Environment.SetEnvironmentVariable("IDENTITY_SERVER_THUMBPRINT", "dummy-thumbprint");
+
+                // First call to populate the cache
+                ManagedIdentitySource firstSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle).ConfigureAwait(false);
+                Assert.AreEqual(ManagedIdentitySource.ServiceFabric, firstSource, "Initial resolution failed to detect ServiceFabric.");
+
+                // Change environment variables to mimic a different identity source (shouldn't affect cached value)
+                Environment.SetEnvironmentVariable("IDENTITY_ENDPOINT", "http://localhost/other/metadata/identity/oauth2/token");
+                Environment.SetEnvironmentVariable("IDENTITY_SERVER_THUMBPRINT", null);
+
+                // Second call should return the cached value
+                ManagedIdentitySource cachedSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle).ConfigureAwait(false);
+                Assert.AreEqual(ManagedIdentitySource.ServiceFabric, cachedSource, "Cached value should remain as ServiceFabric.");
+
+                // Ensure the cache was not recomputed 
+                Assert.AreEqual(firstSource, cachedSource, "The cache was unexpectedly recomputed.");
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -1332,6 +1332,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             // Create ApplicationConfiguration and ServiceBundle
             var config = new ApplicationConfiguration(MsalClientType.ManagedIdentityClient);
             var serviceBundle = new ServiceBundle(config);
+            var cancellationToken = CancellationToken.None;
 
             using (new EnvVariableContext())
             {
@@ -1341,7 +1342,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Environment.SetEnvironmentVariable("IDENTITY_SERVER_THUMBPRINT", "dummy-thumbprint");
 
                 // First call to populate the cache
-                ManagedIdentitySource firstSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle).ConfigureAwait(false);
+                ManagedIdentitySource firstSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle, cancellationToken).ConfigureAwait(false);
                 Assert.AreEqual(ManagedIdentitySource.ServiceFabric, firstSource, "Initial resolution failed to detect ServiceFabric.");
 
                 // Change environment variables to mimic a different identity source (shouldn't affect cached value)
@@ -1349,7 +1350,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Environment.SetEnvironmentVariable("IDENTITY_SERVER_THUMBPRINT", null);
 
                 // Second call should return the cached value
-                ManagedIdentitySource cachedSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle).ConfigureAwait(false);
+                ManagedIdentitySource cachedSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle, cancellationToken).ConfigureAwait(false);
                 Assert.AreEqual(ManagedIdentitySource.ServiceFabric, cachedSource, "Cached value should remain as ServiceFabric.");
 
                 // Ensure the cache was not recomputed 

--- a/tests/devapps/Managed Identity apps/ManagedIdentityAppVM/Program.cs
+++ b/tests/devapps/Managed Identity apps/ManagedIdentityAppVM/Program.cs
@@ -7,9 +7,15 @@ using Microsoft.IdentityModel.Abstractions;
 
 IIdentityLogger identityLogger = new IdentityLogger();
 
-IManagedIdentityApplication mi = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
-                .WithLogging(identityLogger, true)
-                .Build();
+var managedIdentitySource = await ManagedIdentityApplication.
+    GetManagedIdentitySourceAsync().ConfigureAwait(false);
+
+Console.WriteLine($"Managed identity source detected: {managedIdentitySource}");
+
+IManagedIdentityApplication mi = ManagedIdentityApplicationBuilder
+    .Create(ManagedIdentityId.SystemAssigned)
+    .WithLogging(identityLogger, true)
+    .Build();
 
 string? scope = "https://management.azure.com";
 


### PR DESCRIPTION
Fixes [#5115](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5115)

Please refer to the above task for more details. This is PR is part of a feature branch. 

This pull request introduces several changes to the `Microsoft.Identity.Client` library, focusing on enhancing managed identity support, particularly with the addition of a new `ImdsV2` managed identity source. The changes include creating new classes, updating existing methods, and adding new methods to support asynchronous operations.

Key changes include:

### Enhancements to Managed Identity Support:
* Introduced `ImdsV2ManagedIdentitySource` class to handle the new `ImdsV2` managed identity source. (`src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsV2ManagedIdentitySource.cs`)
* Added `ImdsCredentialProbeManager` class to probe the IMDS credential endpoint and determine its support. (`src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs`)
* Updated `ManagedIdentitySource` enum to include the new `ImdsV2` value. (`src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs`)

### Asynchronous Method Updates:
* Modified `ManagedIdentityClient` to use asynchronous methods for creating instances and selecting managed identity sources. (`src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs`) [[1]](diffhunk://#diff-13058fddef4867b4d36dca3120b5b961ae64b039b32bcf5ad410a364b36fbfa8R23-R93) [[2]](diffhunk://#diff-13058fddef4867b4d36dca3120b5b961ae64b039b32bcf5ad410a364b36fbfa8R140-R261)
* Updated `SendTokenRequestForManagedIdentityAsync` method to use the new asynchronous `CreateAsync` method for `ManagedIdentityClient`. (`src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs`)

### Public API Updates:
* Deprecated the synchronous `GetManagedIdentitySource` method and introduced an asynchronous `GetManagedIdentitySourceAsync` method in `ManagedIdentityApplication`. (`src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs`)
* Added new public API entries for the `ImdsV2` managed identity source and the asynchronous method in various `PublicAPI.Unshipped.txt` files. (`src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt`, `src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt`, `src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt`)