### PR TITLE
Expose client capabilities in AssertionRequestOptions for MSI FIC scenarios

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading;
 namespace Microsoft.Identity.Client
 {
@@ -30,5 +31,11 @@ namespace Microsoft.Identity.Client
         /// Claims to be included in the client assertion
         /// </summary>
         public string Claims { get; set; }
+
+        /// <summary>
+        /// Capabilities that the client application declares in the assertion.
+        /// The service may require or interpret these capabilities in advanced scenarios.
+        /// </summary>
+        public IEnumerable<string> ClientCapabilities { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
@@ -33,8 +33,9 @@ namespace Microsoft.Identity.Client
         public string Claims { get; set; }
 
         /// <summary>
-        /// Capabilities that the client application declares in the assertion.
-        /// The service may require or interpret these capabilities in advanced scenarios.
+        /// Capabilities that the client application has declared. 
+        /// If the callback implementer calls the token issuer using another client application object 
+        /// (e.g. ManagedIdentityApplication or ConfidentialClientApplication), the same capabilities should be used there.
         /// </summary>
         public IEnumerable<string> ClientCapabilities { get; set; }
     }

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
 
         public SignedAssertionDelegateClientCredential(Func<AssertionRequestOptions, Task<string>> signedAssertionDelegate)
         {
-            _signedAssertionWithInfoDelegate = signedAssertionDelegate;
+            _signedAssertionWithInfoDelegate = signedAssertionDelegate ?? throw new ArgumentNullException(nameof(signedAssertionDelegate),
+                    "Signed assertion delegate cannot be null.");
         }
 
         public async Task AddConfidentialClientParametersAsync(

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -858,6 +858,30 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         }
 
         [TestMethod]
+        public void Constructor_NullDelegate_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Func<AssertionRequestOptions, Task<string>> nullDelegate = null;
+
+            // Act & Assert
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                new SignedAssertionDelegateClientCredential(nullDelegate));
+        }
+
+        [TestMethod]
+        public void Constructor_ValidDelegate_DoesNotThrow()
+        {
+            // Arrange
+            Func<AssertionRequestOptions, Task<string>> validDelegate =
+                (options) => Task.FromResult("fake_assertion");
+
+            // Act & Assert
+            // Should not throw
+            var credential = new SignedAssertionDelegateClientCredential(validDelegate);
+            Assert.IsNotNull(credential);
+        }
+
+        [TestMethod]
         public async Task GetAuthorizationRequestUrlNoRedirectUriTestAsync()
         {
             using (var httpManager = new MockHttpManager())


### PR DESCRIPTION
Fixes #4948

**Changes proposed in this request**
This pull request introduces new functionality to handle client capabilities in the `Microsoft.Identity.Client` library. The changes include updates to the `AssertionRequestOptions` class, modifications to the `SignedAssertionDelegateClientCredential` class to utilize these capabilities, and corresponding updates to the public API and unit tests.

### New functionality for client capabilities:

* [`src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs`](diffhunk://#diff-b48cd0f220d91dbc6af2b3db8a7c7c9ba353d1bf24fe9a90bba7e19e48d60f62R34-R39): Added a new property, `ClientCapabilities`, to the `AssertionRequestOptions` class. This property allows client applications to declare capabilities in the assertion.

### Modifications to handle client capabilities:

* [`src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs`](diffhunk://#diff-a748b78c034c87d7a7fc04df5974cdbb703ce39a7ef692b02ebb79a141afbd83L39-R75): Updated the `AddConfidentialClientParametersAsync` method to conditionally set the `ClientCapabilities` property in the `AssertionRequestOptions` object if they exist and are not empty.

### Public API updates:

* [`src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt`](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5R1-R2): Added getter and setter entries for the new `ClientCapabilities` property.
* [`src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt`](diffhunk://#diff-bd56040c15b8f2ff8e9a0dfab3a1f0ee73f3e9165f3f23e87a850a990cfc2ed4R1-R2): Added getter and setter entries for the new `ClientCapabilities` property.
* [`src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt`](diffhunk://#diff-bd56040c15b8f2ff8e9a0dfab3a1f0ee73f3e9165f3f23e87a850a990cfc2ed4R1-R2): Added getter and setter entries for the new `ClientCapabilities` property.
* [`src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt`](diffhunk://#diff-bd56040c15b8f2ff8e9a0dfab3a1f0ee73f3e9165f3f23e87a850a990cfc2ed4R1-R2): Added getter and setter entries for the new `ClientCapabilities` property.
* [`src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt`](diffhunk://#diff-bd56040c15b8f2ff8e9a0dfab3a1f0ee73f3e9165f3f23e87a850a990cfc2ed4R1-R2): Added getter and setter entries for the new `ClientCapabilities` property.
* [`src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt`](diffhunk://#diff-bd56040c15b8f2ff8e9a0dfab3a1f0ee73f3e9165f3f23e87a850a990cfc2ed4R1-R2): Added getter and setter entries for the new `ClientCapabilities` property.

### Unit tests:

* [`tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs`](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6L496-R507): Updated the `CreateConfidentialClient` method to accept a `withClientCapability` parameter and conditionally set the client capabilities. Added a new test method, `SignedAssertionWithClientCapabilitiesTestAsync`, to verify the functionality when client capabilities are set. [[1]](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6L496-R507) [[2]](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6R535-R566) [[3]](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6R800-R828)

**Testing**
unit tests

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
