### PR TITLE
Add the missing claims in SignedAssertion With AssertionRequestOptions Delegate 

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
@@ -67,6 +67,14 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
                     assertionOptions.ClientCapabilities = configuredCapabilities;
                 }
 
+                // Only set claims if they exist and are not empty
+                var configuredClaims = requestParameters.Claims;
+
+                if (!string.IsNullOrWhiteSpace(configuredClaims))
+                {
+                    assertionOptions.Claims = configuredClaims;
+                }
+
                 // Delegate that uses AssertionRequestOptions
                 string signedAssertion = await _signedAssertionWithInfoDelegate(assertionOptions).ConfigureAwait(false);
 

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
@@ -55,26 +55,18 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
                     TokenEndpoint = tokenEndpoint
                 };
 
-                // Only set client capabilities if they exist and are not empty
+                // Set client capabilities 
                 var configuredCapabilities = requestParameters
                     .RequestContext
                     .ServiceBundle
                     .Config
                     .ClientCapabilities;
 
-                if (configuredCapabilities != null && configuredCapabilities.Any())
-                {
-                    assertionOptions.ClientCapabilities = configuredCapabilities;
-                }
+                assertionOptions.ClientCapabilities = configuredCapabilities;
 
-                // Only set claims if they exist and are not empty
-                var configuredClaims = requestParameters.Claims;
-
-                if (!string.IsNullOrWhiteSpace(configuredClaims))
-                {
-                    assertionOptions.Claims = configuredClaims;
-                }
-
+                //Set claims
+                assertionOptions.Claims = requestParameters.Claims;
+            
                 // Delegate that uses AssertionRequestOptions
                 string signedAssertion = await _signedAssertionWithInfoDelegate(assertionOptions).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes #5143

**Changes proposed in this request**
This pull request introduces changes to the `SignedAssertionDelegateClientCredential` class to handle client capabilities and claims more effectively, and adds corresponding unit tests to verify these changes.

Improvements to handling client capabilities and claims:

* [`src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs`](diffhunk://#diff-a748b78c034c87d7a7fc04df5974cdbb703ce39a7ef692b02ebb79a141afbd83L58-R68): Simplified the logic for setting client capabilities and added a new section to set claims within the `AddConfidentialClientParametersAsync` method.

Unit tests for new functionality:

* [`tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs`](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6R2022-R2118): Added three new test methods (`SignedAssertionDelegateClientCredential_Claims_TestAsync`, `SignedAssertionDelegateClientCredential_NoClaims_TestAsync`, and `SignedAssertionDelegateClientCredential_WithClaims_TestAsync`) to ensure that claims are correctly handled when acquiring tokens with or without claims.

**Testing**
Unit tests 

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
