### PR TITLE
[MSI V2 Feature] Adding Credential as a Managed Identity Source

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ManagedIdentityExecutor.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Executors/ManagedIdentityExecutor.cs
@@ -33,21 +33,40 @@ namespace Microsoft.Identity.Client.ApiConfig.Executors
             AcquireTokenForManagedIdentityParameters managedIdentityParameters,
             CancellationToken cancellationToken)
         {
-            var requestContext = CreateRequestContextAndLogVersionInfo(commonParameters.CorrelationId, commonParameters.MtlsCertificate, cancellationToken);
+            RequestContext requestContext = CreateRequestContextAndLogVersionInfo(
+                commonParameters.CorrelationId, 
+                commonParameters.MtlsCertificate, 
+                cancellationToken);
 
-            var requestParams = await _managedIdentityApplication.CreateRequestParametersAsync(
+            AuthenticationRequestParameters requestParams = await _managedIdentityApplication.CreateRequestParametersAsync(
                 commonParameters,
                 requestContext,
                 _managedIdentityApplication.AppTokenCacheInternal).ConfigureAwait(false);
 
-            var handler = new ManagedIdentityAuthRequest(
-                ServiceBundle,
-                requestParams,
-                managedIdentityParameters);
+            // Determine the Managed Identity Source
+            ManagedIdentitySource managedIdentitySource =
+                await ManagedIdentityClient.GetManagedIdentitySourceAsync(ServiceBundle, cancellationToken)
+                .ConfigureAwait(false);
 
-            return await handler.RunAsync(cancellationToken).ConfigureAwait(false);
+            ManagedIdentityAuthRequest authRequest;
+
+            if (managedIdentitySource == ManagedIdentitySource.ImdsV2)
+            {
+                authRequest = new CredentialManagedIdentityAuthRequest(
+                    ServiceBundle,
+                    requestParams,
+                    managedIdentityParameters);
+            }
+            else
+            {
+                authRequest = new LegacyManagedIdentityAuthRequest(
+                    ServiceBundle,
+                    requestParams,
+                    managedIdentityParameters);
+            }
+
+            // Execute the request
+            return await authRequest.RunAsync(cancellationToken).ConfigureAwait(false);
         }
-
-     
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/IMsalMtlsHttpClientFactory.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/IMsalMtlsHttpClientFactory.cs
@@ -7,8 +7,8 @@ using System.Security.Cryptography.X509Certificates;
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// Internal factory responsible for creating HttpClient instances configured for mutual TLS (MTLS).
-    /// This factory is specifically intended for use within the MSAL library for secure communication with Azure AD using MTLS.
+    /// Factory responsible for creating HttpClient instances configured for mutual TLS (MTLS).
+    /// This factory is specifically intended for use with the MSAL library for secure communication with Azure AD using MTLS.
     /// For more details on HttpClient instancing, see https://learn.microsoft.com/dotnet/api/system.net.http.httpclient?view=net-7.0#instancing.
     /// </summary>
     /// <remarks>
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client
     /// If your application requires Integrated Windows Authentication, set <see cref="HttpClientHandler.UseDefaultCredentials"/> to true.
     /// This interface is intended for internal use by MSAL only and is designed to support MTLS scenarios.
     /// </remarks>
-    internal interface IMsalMtlsHttpClientFactory : IMsalHttpClientFactory
+    public interface IMsalMtlsHttpClientFactory : IMsalHttpClientFactory
     {
         /// <summary>
         /// Returns an HttpClient configured with a certificate for mutual TLS authentication.

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/CredentialBasedMsiAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/CredentialBasedMsiAuthRequest.cs
@@ -1,0 +1,271 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Client.ManagedIdentity;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Identity.Client.Internal.Utilities;
+
+namespace Microsoft.Identity.Client.Internal.Requests
+{
+    internal class CredentialManagedIdentityAuthRequest : ManagedIdentityAuthRequest
+    {
+        internal const string IdentityUnavailableError = "[Managed Identity] Authentication unavailable. " +
+            "Either the requested identity has not been assigned to this resource, or other errors could " +
+            "be present. Ensure the identity is correctly assigned and check the inner exception for more " +
+            "details. For more information, visit https://aka.ms/msal-managed-identity.";
+
+        internal const string GatewayError = "[Managed Identity] Authentication unavailable. " +
+            "The request failed due to a gateway error.";
+
+        private readonly Uri _credentialEndpoint = new ("http://169.254.169.254/metadata/identity/credential?cred-api-version=1.0");
+        private readonly X509Certificate2 _certificate; 
+
+        public CredentialManagedIdentityAuthRequest(
+            IServiceBundle serviceBundle,
+            AuthenticationRequestParameters authenticationRequestParameters,
+            AcquireTokenForManagedIdentityParameters managedIdentityParameters)
+            : base(serviceBundle, authenticationRequestParameters, managedIdentityParameters)
+        {
+            _certificate = ManagedIdentityCertificateManager.GetOrCreateCertificate();
+        }
+
+        protected override async Task<AuthenticationResult> GetAccessTokenAsync(
+            CancellationToken cancellationToken,
+            ILoggerAdapter logger)
+        {
+            await ResolveAuthorityAsync().ConfigureAwait(false);
+
+            //calls sent to app token provider
+            AuthenticationResult authResult = null;
+            MsalAccessTokenCacheItem cachedAccessTokenItem = null;
+
+            //allow only one call to the provider 
+            logger.Verbose(() => "[CredentialManagedIdentityAuthRequest] Entering acquire token for managed identity credential request semaphore.");
+            await s_semaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
+            logger.Verbose(() => "[CredentialManagedIdentityAuthRequest] Entered acquire token for managed identity credential request semaphore.");
+
+            try
+            {
+                // Bypass cache and send request to token endpoint, when 
+                // 1. Force refresh is requested, or
+                // 2. Claims are passed, or 
+                // 3. If the AT needs to be refreshed pro-actively 
+                if (_managedIdentityParameters.ForceRefresh ||
+                    !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims) ||
+                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo == CacheRefreshReason.ProactivelyRefreshed)
+                {
+                    authResult = await GetAccessTokenFromTokenEndpointAsync(cancellationToken, logger).ConfigureAwait(false);
+                }
+                else
+                {
+                    cachedAccessTokenItem = await GetCachedAccessTokenAsync().ConfigureAwait(false);
+
+                    if (cachedAccessTokenItem == null)
+                    {
+                        authResult = await GetAccessTokenFromTokenEndpointAsync(cancellationToken, logger).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        logger.Verbose(() => "[CredentialManagedIdentityAuthRequest] Getting Access token from cache ...");
+                        authResult = CreateAuthenticationResultFromCache(cachedAccessTokenItem);
+                    }
+                }
+
+                return authResult;
+            }
+            finally
+            {
+                s_semaphoreSlim.Release();
+                logger.Verbose(() => "[CredentialManagedIdentityAuthRequest] Released acquire token for managed identity credential request semaphore.");
+            }
+        }
+
+        private async Task<AuthenticationResult> GetAccessTokenFromTokenEndpointAsync(
+            CancellationToken cancellationToken,
+            ILoggerAdapter logger)
+        {
+            string message;
+            Exception exception = null;
+
+            try
+            {
+                logger.Verbose(() => $"[CredentialManagedIdentityAuthRequest] Getting token from the managed identity endpoint using certificate: " +
+                     $"Subject: {_certificate.Subject}, " +
+                     $"Expiration: {_certificate.NotAfter}, " +
+                     $"Thumbprint: {_certificate.Thumbprint}, " +
+                     $"Issuer: {_certificate.Issuer}");
+
+                ManagedIdentityCredentialResponse credentialResponse =
+                    await GetCredentialAssertionAsync(_certificate, logger, cancellationToken).ConfigureAwait(false);
+
+                var baseUri = new Uri(credentialResponse.RegionalTokenUrl);
+                var tokenUrl = new Uri(baseUri, $"{credentialResponse.TenantId}/oauth2/v2.0/token");
+
+                logger.Verbose(() => $"[CredentialManagedIdentityAuthRequest] Token endpoint : {tokenUrl}.");
+
+                OAuth2Client client = CreateClientRequest(
+                    AuthenticationRequestParameters.RequestContext.ServiceBundle.HttpManager,
+                    credentialResponse);
+
+                MsalTokenResponse msalTokenResponse = await client
+                        .GetTokenAsync(tokenUrl,
+                        AuthenticationRequestParameters.RequestContext,
+                        true,
+                        AuthenticationRequestParameters.OnBeforeTokenRequestHandler).ConfigureAwait(false);
+
+                msalTokenResponse.Scope = AuthenticationRequestParameters.Scope.AsSingleString();
+
+                logger.Info("[CredentialManagedIdentityAuthRequest] Successful response received.");
+
+                return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse)
+                    .ConfigureAwait(false);
+            }
+            catch (MsalClientException ex)
+            {
+                logger.Verbose(() => $"[CredentialManagedIdentityAuthRequest] Caught an exception. {ex.Message}");
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                exception = MsalServiceExceptionFactory.CreateManagedIdentityException(
+                MsalError.ManagedIdentityRequestFailed,
+                ex.Message,
+                ex,
+                ManagedIdentitySource.ImdsV2,
+                null);
+
+                logger.Verbose(() => $"[CredentialManagedIdentityAuthRequest] Caught an exception. {ex.Message}");
+
+                throw exception;
+            }
+            catch (MsalServiceException ex)
+            {
+                logger.Verbose(() => $"[CredentialManagedIdentityAuthRequest] Caught an exception. {ex.Message}. Error Code : {ex.ErrorCode} Status Code : {ex.StatusCode}");
+
+                exception = MsalServiceExceptionFactory.CreateManagedIdentityException(
+                    ex.ErrorCode,
+                    ex.Message,
+                    ex,
+                    ManagedIdentitySource.ImdsV2,
+                    ex.StatusCode);
+
+                throw exception;
+            }
+            catch (Exception e) when (e is not MsalServiceException)
+            {
+                logger.Error($"[CredentialManagedIdentityAuthRequest] Exception: {e.Message}");
+                exception = e;
+                message = MsalErrorMessage.CredentialEndpointNoResponseReceived;
+            }
+
+            MsalException msalException = MsalServiceExceptionFactory.CreateManagedIdentityException(
+                MsalError.ManagedIdentityRequestFailed,
+                message,
+                exception,
+                ManagedIdentitySource.ImdsV2,
+                null);
+
+            throw msalException;
+        }
+
+        private async Task<ManagedIdentityCredentialResponse> GetCredentialAssertionAsync(
+            X509Certificate2 credentialCertificate,
+            ILoggerAdapter logger,
+            CancellationToken cancellationToken
+            )
+        {
+            // Create a Managed Identity request dynamically using the provided resource.
+            string resource = GetOverriddenScopes(AuthenticationRequestParameters.Scope).AsSingleString();
+            ManagedIdentityRequest miRequest = CreateManagedIdentityRequest(resource);
+
+            var msiCredentialService = new ManagedIdentityCredentialService(
+                miRequest,
+                credentialCertificate,
+                AuthenticationRequestParameters.RequestContext,
+                cancellationToken);
+
+            ManagedIdentityCredentialResponse credentialResponse = await msiCredentialService.GetCredentialAsync().ConfigureAwait(false);
+
+            logger.Verbose(() => "[CredentialManagedIdentityAuthRequest] A credential was successfully fetched.");
+
+            return credentialResponse;
+        }
+
+        /// <summary>
+        /// Creates a Managed Identity request dynamically, including user-assigned identity if needed.
+        /// </summary>
+        private ManagedIdentityRequest CreateManagedIdentityRequest(string resource)
+        {
+            var request = new ManagedIdentityRequest(HttpMethod.Post, _credentialEndpoint);
+
+            switch (AuthenticationRequestParameters.RequestContext.ServiceBundle.Config.ManagedIdentityId.IdType)
+            {
+                case AppConfig.ManagedIdentityIdType.ClientId:
+                    AuthenticationRequestParameters.RequestContext.Logger.Info("[Managed Identity] Adding user-assigned client ID to the request.");
+                    request.QueryParameters[Constants.ManagedIdentityClientId] = AuthenticationRequestParameters.RequestContext.ServiceBundle.Config.ManagedIdentityId.UserAssignedId;
+                    break;
+
+                case AppConfig.ManagedIdentityIdType.ResourceId:
+                    AuthenticationRequestParameters.RequestContext.Logger.Info("[Managed Identity] Adding user-assigned resource ID to the request.");
+                    request.QueryParameters[Constants.ManagedIdentityResourceId] = AuthenticationRequestParameters.RequestContext.ServiceBundle.Config.ManagedIdentityId.UserAssignedId;
+                    break;
+
+                case AppConfig.ManagedIdentityIdType.ObjectId:
+                    AuthenticationRequestParameters.RequestContext.Logger.Info("[Managed Identity] Adding user-assigned object ID to the request.");
+                    request.QueryParameters[Constants.ManagedIdentityObjectId] = AuthenticationRequestParameters.RequestContext.ServiceBundle.Config.ManagedIdentityId.UserAssignedId;
+                    break;
+            }
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates an OAuth2 client request for fetching the managed identity credential.
+        /// </summary>
+        /// <param name="httpManager"></param>
+        /// <param name="credentialResponse"></param>
+        /// <returns></returns>
+        private OAuth2Client CreateClientRequest(
+            IHttpManager httpManager,
+            ManagedIdentityCredentialResponse credentialResponse)
+        {
+            // Initialize an OAuth2 client with logger, HTTP manager, and binding certificate.
+            var client = new OAuth2Client(
+                AuthenticationRequestParameters.RequestContext.Logger,
+                httpManager,
+                _certificate);
+
+            // Convert overridden scopes to a single string.
+            string scopes = GetOverriddenScopes(AuthenticationRequestParameters.Scope).AsSingleString();
+
+            //credential flows must have a scope value with /.default suffixed to the resource identifier (application ID URI)
+            scopes += "/.default";
+
+            // Add required parameters for client credentials grant request.
+            client.AddBodyParameter(OAuth2Parameter.GrantType, OAuth2GrantType.ClientCredentials);
+            client.AddBodyParameter(OAuth2Parameter.Scope, scopes);
+            client.AddBodyParameter(OAuth2Parameter.ClientId, credentialResponse.ClientId);
+            client.AddBodyParameter(OAuth2Parameter.ClientAssertion, credentialResponse.Credential);
+            client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
+
+            // Add optional claims and client capabilities parameter if provided.
+            if (!string.IsNullOrWhiteSpace(AuthenticationRequestParameters.ClaimsAndClientCapabilities))
+            {
+                client.AddBodyParameter(OAuth2Parameter.Claims, AuthenticationRequestParameters.ClaimsAndClientCapabilities);
+            }
+
+            // Return the configured OAuth2 client.
+            return client;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/LegacyManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/LegacyManagedIdentityAuthRequest.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Client.Internal.Requests
+{
+    internal class LegacyManagedIdentityAuthRequest : ManagedIdentityAuthRequest
+    {
+        public LegacyManagedIdentityAuthRequest(
+            IServiceBundle serviceBundle,
+            AuthenticationRequestParameters authenticationRequestParameters,
+            AcquireTokenForManagedIdentityParameters managedIdentityParameters)
+            : base(serviceBundle, authenticationRequestParameters, managedIdentityParameters)
+        {
+        }
+
+        protected override async Task<AuthenticationResult> GetAccessTokenAsync(
+            CancellationToken cancellationToken,
+            ILoggerAdapter logger)
+        {
+            AuthenticationResult authResult;
+            MsalAccessTokenCacheItem cachedAccessTokenItem = null;
+
+            logger.Verbose(() => "[ManagedIdentityRequest] Entering managed identity request semaphore.");
+            await s_semaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
+            logger.Verbose(() => "[ManagedIdentityRequest] Entered managed identity request semaphore.");
+
+            try
+            {
+                if (_managedIdentityParameters.ForceRefresh ||
+                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo == CacheRefreshReason.ProactivelyRefreshed ||
+                    !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
+                {
+                    authResult = await SendTokenRequestForManagedIdentityAsync(logger, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    logger.Info("[ManagedIdentityRequest] Checking for a cached access token.");
+                    cachedAccessTokenItem = await GetCachedAccessTokenAsync().ConfigureAwait(false);
+
+                    if (cachedAccessTokenItem != null)
+                    {
+                        authResult = CreateAuthenticationResultFromCache(cachedAccessTokenItem);
+                    }
+                    else
+                    {
+                        authResult = await SendTokenRequestForManagedIdentityAsync(logger, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                return authResult;
+            }
+            finally
+            {
+                s_semaphoreSlim.Release();
+                logger.Verbose(() => "[ManagedIdentityRequest] Released managed identity request semaphore.");
+            }
+        }
+
+        private async Task<AuthenticationResult> SendTokenRequestForManagedIdentityAsync(ILoggerAdapter logger, CancellationToken cancellationToken)
+        {
+            logger.Info("[ManagedIdentityRequest] Acquiring a token from the managed identity endpoint.");
+
+            await ResolveAuthorityAsync().ConfigureAwait(false);
+
+            ManagedIdentityClient managedIdentityClient =
+                await ManagedIdentityClient.CreateAsync(AuthenticationRequestParameters.RequestContext)
+                .ConfigureAwait(false);
+
+            ManagedIdentityResponse managedIdentityResponse =
+                await managedIdentityClient
+                .SendTokenRequestForManagedIdentityAsync(_managedIdentityParameters, cancellationToken)
+                .ConfigureAwait(false);
+
+            var msalTokenResponse = MsalTokenResponse.CreateFromManagedIdentityResponse(managedIdentityResponse);
+            msalTokenResponse.Scope = AuthenticationRequestParameters.Scope.AsSingleString();
+
+            return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);
+        }
+
+        protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
+        {
+            return null;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (_managedIdentityParameters.ForceRefresh || !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ForceRefreshOrClaims;
-                
+
                 logger.Info("[ManagedIdentityRequest] Skipped looking for a cached access token because ForceRefresh or Claims were set. " +
                     "This means either a force refresh was requested or claims were present.");
 
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 logger.Info("[ManagedIdentityRequest] Access token retrieved from cache.");
 
                 try
-                {  
+                {
                     var proactivelyRefresh = SilentRequestHelper.NeedsRefresh(cachedAccessTokenItem);
 
                     // If needed, refreshes token in the background
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         }
 
         private async Task<AuthenticationResult> GetAccessTokenAsync(
-            CancellationToken cancellationToken, 
+            CancellationToken cancellationToken,
             ILoggerAdapter logger)
         {
             AuthenticationResult authResult;
@@ -115,7 +115,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // Bypass cache and send request to token endpoint, when
                 // 1. Force refresh is requested, or
                 // 2. If the access token needs to be refreshed proactively.
-                if (_managedIdentityParameters.ForceRefresh || 
+                if (_managedIdentityParameters.ForceRefresh ||
                     AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo == CacheRefreshReason.ProactivelyRefreshed ||
                     !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
                 {
@@ -152,8 +152,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             await ResolveAuthorityAsync().ConfigureAwait(false);
 
-            ManagedIdentityClient managedIdentityClient = 
-                new ManagedIdentityClient(AuthenticationRequestParameters.RequestContext);
+            ManagedIdentityClient managedIdentityClient =
+                await ManagedIdentityClient.CreateAsync(AuthenticationRequestParameters.RequestContext)
+                .ConfigureAwait(false);
 
             ManagedIdentityResponse managedIdentityResponse =
                 await managedIdentityClient

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -2,24 +2,20 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.ManagedIdentity;
-using Microsoft.Identity.Client.OAuth2;
-using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {
-    internal class ManagedIdentityAuthRequest : RequestBase
+    internal abstract class ManagedIdentityAuthRequest : RequestBase
     {
-        private readonly AcquireTokenForManagedIdentityParameters _managedIdentityParameters;
-        private static readonly SemaphoreSlim s_semaphoreSlim = new SemaphoreSlim(1, 1);
+        protected readonly AcquireTokenForManagedIdentityParameters _managedIdentityParameters;
+        protected static readonly SemaphoreSlim s_semaphoreSlim = new(1, 1);
 
-        public ManagedIdentityAuthRequest(
+        protected ManagedIdentityAuthRequest(
             IServiceBundle serviceBundle,
             AuthenticationRequestParameters authenticationRequestParameters,
             AcquireTokenForManagedIdentityParameters managedIdentityParameters)
@@ -30,51 +26,52 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         protected override async Task<AuthenticationResult> ExecuteAsync(CancellationToken cancellationToken)
         {
-            AuthenticationResult authResult = null;
-            ILoggerAdapter logger = AuthenticationRequestParameters.RequestContext.Logger;
+            if (AuthenticationRequestParameters.Scope == null || AuthenticationRequestParameters.Scope.Count == 0)
+            {
+                throw new MsalClientException(
+                    MsalError.ScopesRequired,
+                    MsalErrorMessage.ScopesRequired);
+            }
 
-            // Skip checking cache when force refresh or claims is specified
+            ILoggerAdapter logger = AuthenticationRequestParameters.RequestContext.Logger;
+            AuthenticationResult authResult = null;
+
+            // Skip checking cache for force refresh or when claims are present
             if (_managedIdentityParameters.ForceRefresh || !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ForceRefreshOrClaims;
-
-                logger.Info("[ManagedIdentityRequest] Skipped looking for a cached access token because ForceRefresh or Claims were set. " +
-                    "This means either a force refresh was requested or claims were present.");
+                logger.Info("[ManagedIdentityRequest] Skipped looking for a cached access token because ForceRefresh or Claims was set.");
 
                 authResult = await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);
                 return authResult;
             }
 
+            // Check cache for AT 
             MsalAccessTokenCacheItem cachedAccessTokenItem = await GetCachedAccessTokenAsync().ConfigureAwait(false);
 
-            // No access token or cached access token needs to be refreshed 
             if (cachedAccessTokenItem != null)
             {
                 authResult = CreateAuthenticationResultFromCache(cachedAccessTokenItem);
-
                 logger.Info("[ManagedIdentityRequest] Access token retrieved from cache.");
 
                 try
                 {
                     var proactivelyRefresh = SilentRequestHelper.NeedsRefresh(cachedAccessTokenItem);
 
-                    // If needed, refreshes token in the background
+                    // Proactive refresh logic 
                     if (proactivelyRefresh)
                     {
-                        logger.Info("[ManagedIdentityRequest] Initiating a proactive refresh.");
-
                         AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ProactivelyRefreshed;
 
                         SilentRequestHelper.ProcessFetchInBackground(
-                        cachedAccessTokenItem,
-                        () =>
-                        {
-                            // Use a linked token source, in case the original cancellation token source is disposed before this background task completes.
-                            using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                            return GetAccessTokenAsync(tokenSource.Token, logger);
-                        }, logger, ServiceBundle, AuthenticationRequestParameters.RequestContext.ApiEvent,
-                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkApiId,
-                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion);
+                            cachedAccessTokenItem,
+                            () =>
+                            {
+                                using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                                return GetAccessTokenAsync(tokenSource.Token, logger);
+                            }, logger, ServiceBundle, AuthenticationRequestParameters.RequestContext.ApiEvent,
+                            AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkApiId,
+                            AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion);
                     }
                 }
                 catch (MsalServiceException e)
@@ -84,7 +81,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
             else
             {
-                //  No AT in the cache 
+                // No AT in cache
                 if (AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo != CacheRefreshReason.Expired)
                 {
                     AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.NoCachedAccessToken;
@@ -97,91 +94,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return authResult;
         }
 
-        private async Task<AuthenticationResult> GetAccessTokenAsync(
-            CancellationToken cancellationToken,
-            ILoggerAdapter logger)
-        {
-            AuthenticationResult authResult;
-            MsalAccessTokenCacheItem cachedAccessTokenItem = null;
-
-            // Requests to a managed identity endpoint must be throttled; 
-            // otherwise, the endpoint will throw a HTTP 429.
-            logger.Verbose(() => "[ManagedIdentityRequest] Entering managed identity request semaphore.");
-            await s_semaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
-            logger.Verbose(() => "[ManagedIdentityRequest] Entered managed identity request semaphore.");
-
-            try
-            {
-                // Bypass cache and send request to token endpoint, when
-                // 1. Force refresh is requested, or
-                // 2. If the access token needs to be refreshed proactively.
-                if (_managedIdentityParameters.ForceRefresh ||
-                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo == CacheRefreshReason.ProactivelyRefreshed ||
-                    !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
-                {
-                    authResult = await SendTokenRequestForManagedIdentityAsync(logger, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    logger.Info("[ManagedIdentityRequest] Checking for a cached access token.");
-                    cachedAccessTokenItem = await GetCachedAccessTokenAsync().ConfigureAwait(false);
-
-                    // Check the cache again after acquiring the semaphore in case the previous request cached a new token.
-                    if (cachedAccessTokenItem != null)
-                    {
-                        authResult = CreateAuthenticationResultFromCache(cachedAccessTokenItem);
-                    }
-                    else
-                    {
-                        authResult = await SendTokenRequestForManagedIdentityAsync(logger, cancellationToken).ConfigureAwait(false);
-                    }
-                }
-
-                return authResult;
-            }
-            finally
-            {
-                s_semaphoreSlim.Release();
-                logger.Verbose(() => "[ManagedIdentityRequest] Released managed identity request semaphore.");
-            }
-        }
-
-        private async Task<AuthenticationResult> SendTokenRequestForManagedIdentityAsync(ILoggerAdapter logger, CancellationToken cancellationToken)
-        {
-            logger.Info("[ManagedIdentityRequest] Acquiring a token from the managed identity endpoint.");
-
-            await ResolveAuthorityAsync().ConfigureAwait(false);
-
-            ManagedIdentityClient managedIdentityClient =
-                await ManagedIdentityClient.CreateAsync(AuthenticationRequestParameters.RequestContext)
-                .ConfigureAwait(false);
-
-            ManagedIdentityResponse managedIdentityResponse =
-                await managedIdentityClient
-                .SendTokenRequestForManagedIdentityAsync(_managedIdentityParameters, cancellationToken)
-                .ConfigureAwait(false);
-
-            var msalTokenResponse = MsalTokenResponse.CreateFromManagedIdentityResponse(managedIdentityResponse);
-            msalTokenResponse.Scope = AuthenticationRequestParameters.Scope.AsSingleString();
-
-            return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse).ConfigureAwait(false);
-        }
-
-        private async Task<MsalAccessTokenCacheItem> GetCachedAccessTokenAsync()
-        {
-            MsalAccessTokenCacheItem cachedAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
-
-            if (cachedAccessTokenItem != null)
-            {
-                AuthenticationRequestParameters.RequestContext.ApiEvent.IsAccessTokenCacheHit = true;
-                Metrics.IncrementTotalAccessTokensFromCache();
-                return cachedAccessTokenItem;
-            }
-
-            return null;
-        }
-
-        private AuthenticationResult CreateAuthenticationResultFromCache(MsalAccessTokenCacheItem cachedAccessTokenItem)
+        internal AuthenticationResult CreateAuthenticationResultFromCache(MsalAccessTokenCacheItem cachedAccessTokenItem)
         {
             AuthenticationResult authResult = new AuthenticationResult(
                                                             cachedAccessTokenItem,
@@ -196,9 +109,32 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return authResult;
         }
 
+        internal async Task<MsalAccessTokenCacheItem> GetCachedAccessTokenAsync()
+        {
+            MsalAccessTokenCacheItem cachedAccessTokenItem = await CacheManager.FindAccessTokenAsync().ConfigureAwait(false);
+
+            if (cachedAccessTokenItem != null)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.IsAccessTokenCacheHit = true;
+                Metrics.IncrementTotalAccessTokensFromCache();
+                return cachedAccessTokenItem;
+            }
+
+            return null;
+        }
+
+        protected abstract Task<AuthenticationResult> GetAccessTokenAsync(CancellationToken cancellationToken, ILoggerAdapter logger);
+
         protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
             return null;
+        }
+
+        // Override method to return a sorted set of scopes based on the input set.
+        protected override SortedSet<string> GetOverriddenScopes(ISet<string> inputScopes)
+        {
+            // Create a new SortedSet from the inputScopes to ensure a consistent and sorted order.
+            return new SortedSet<string>(inputScopes);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             _logger.Info($"[Credential Probe] Response received from the server. Status Code: {response.StatusCode}");
 
             // 3. Evaluate IMDS header
-            if (response.HeadersAsDictionary.TryGetValue("server", out string serverHeader) &&
+            if (response.HeadersAsDictionary.TryGetValue("Server", out string serverHeader) &&
                 serverHeader.TrimStart().StartsWith(ImdsHeader, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.Info("[Credential Probe] Credential endpoint supported. Server Header contains IMDS.");

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsCredentialProbeManager.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    internal class ImdsCredentialProbeManager
+    {
+        private const string CredentialEndpoint = "http://169.254.169.254/metadata/identity/credential";
+        private const string ProbeBody = ".";
+        private const string ImdsHeader = "IMDS/";
+        private readonly IHttpManager _httpManager;
+        private readonly ILoggerAdapter _logger;
+
+        public ImdsCredentialProbeManager(IHttpManager httpManager, ILoggerAdapter logger)
+        {
+            _httpManager = httpManager ?? throw new ArgumentNullException(nameof(httpManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<bool> ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            _logger.Info("[Credential Probe] Initiating probe to IMDS credential endpoint.");
+
+            var request = new ManagedIdentityRequest(HttpMethod.Post, new Uri($"{CredentialEndpoint}?cred-api-version=1.0"))
+            {
+                Content = ProbeBody
+            };
+
+            HttpContent httpContent = request.CreateHttpContent();
+
+            _logger.Info($"[Credential Probe] Sending request to {CredentialEndpoint}");
+
+            try
+            {
+                HttpResponse response = await _httpManager.SendRequestAsync(
+                    request.ComputeUri(),
+                    request.Headers,
+                    httpContent,
+                    request.Method,
+                    _logger,
+                    doNotThrow: true,
+                    mtlsCertificate: null,
+                    customHttpClient: null,
+                    cancellationToken).ConfigureAwait(false);
+
+                return EvaluateProbeResponse(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.Info($"[Credential Probe] Exception during probe: {ex.Message}");
+                return false;
+            }
+        }
+
+        private bool EvaluateProbeResponse(HttpResponse response)
+        {
+            // 1. Handle null response
+            if (response == null)
+            {
+                _logger.Error("[Credential Probe] No response received from the server.");
+                return false;
+            }
+
+            // 2. Log basic details
+            _logger.Info($"[Credential Probe] Response received from the server. Status Code: {response.StatusCode}");
+
+            // 3. Evaluate IMDS header
+            if (response.HeadersAsDictionary.TryGetValue("server", out string serverHeader) &&
+                serverHeader.TrimStart().StartsWith(ImdsHeader, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.Info("[Credential Probe] Credential endpoint supported. Server Header contains IMDS.");
+                return true;
+            }
+
+            _logger.Warning($"[Credential Probe] Credential endpoint not supported. Status Code: {response.StatusCode}");
+            return false;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsV2ManagedIdentitySource.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    internal class ImdsV2ManagedIdentitySource : AbstractManagedIdentity
+    {
+        /// <summary>
+        /// Factory method to create an instance of `CredentialManagedIdentitySource`.
+        /// </summary>
+        public static AbstractManagedIdentity Create(RequestContext requestContext)
+        {
+            requestContext.Logger.Info(() => "[Managed Identity] Using credential based managed identity.");
+
+            return new ImdsV2ManagedIdentitySource(requestContext);
+        }
+
+        private ImdsV2ManagedIdentitySource(RequestContext requestContext) :
+            base(requestContext, ManagedIdentitySource.ImdsV2)
+        {
+        }
+
+        /// <summary>
+        /// Even though the Credential flow does not use this request, we need to satisfy the abstract contract.
+        /// Return a minimal, valid ManagedIdentityRequest using the fixed credential endpoint.
+        /// </summary>
+        /// <param name="resource">The resource identifier (ignored in this flow).</param>
+        /// <returns>A ManagedIdentityRequest instance using the credential endpoint.</returns>
+        protected override ManagedIdentityRequest CreateRequest(string resource)
+        {
+            // Return a minimal request with the fixed credential endpoint.
+            return new ManagedIdentityRequest(
+                HttpMethod.Post,
+                new Uri("http://169.254.169.254/metadata/identity/credential?cred-api-version=1.0"));
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -9,6 +9,7 @@ using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.PlatformsCommon.Shared;
 using System.IO;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
 
 namespace Microsoft.Identity.Client.ManagedIdentity
 {
@@ -19,38 +20,77 @@ namespace Microsoft.Identity.Client.ManagedIdentity
     {
         private const string WindowsHimdsFilePath = "%Programfiles%\\AzureConnectedMachineAgent\\himds.exe";
         private const string LinuxHimdsFilePath = "/opt/azcmagent/bin/himds";
+
+        // Cache for the managed identity source
+        private static ManagedIdentitySource? s_cachedManagedIdentitySource;
+        private static readonly SemaphoreSlim s_credentialSemaphore = new(1, 1);
         private readonly AbstractManagedIdentity _identitySource;
 
-        public ManagedIdentityClient(RequestContext requestContext)
+        internal static async Task<ManagedIdentityClient> CreateAsync(RequestContext requestContext)
         {
-            using (requestContext.Logger.LogMethodDuration())
-            {
-                _identitySource = SelectManagedIdentitySource(requestContext);
-            }
+            requestContext.Logger?.Info("[ManagedIdentityClient] Creating ManagedIdentityClient.");
+
+            AbstractManagedIdentity identitySource = await SelectManagedIdentitySourceAsync(
+                requestContext,
+                requestContext.UserCancellationToken)
+                .ConfigureAwait(false);
+
+            requestContext.Logger?.Info($"[ManagedIdentityClient] Managed identity source selected: {identitySource.GetType().Name}.");
+
+            return new ManagedIdentityClient(identitySource);
         }
 
-        internal Task<ManagedIdentityResponse> SendTokenRequestForManagedIdentityAsync(AcquireTokenForManagedIdentityParameters parameters, CancellationToken cancellationToken)
+        private ManagedIdentityClient(AbstractManagedIdentity identitySource)
+        {
+            _identitySource = identitySource ?? throw new ArgumentNullException(nameof(identitySource), "Identity source cannot be null.");
+        }
+
+        /// <summary>
+        /// Resets the cached managed identity source. Used only for testing purposes.
+        /// </summary>
+        internal static void ResetManagedIdentitySourceCache()
+        {
+            s_cachedManagedIdentitySource = null;
+        }
+
+        internal Task<ManagedIdentityResponse> SendTokenRequestForManagedIdentityAsync(
+            AcquireTokenForManagedIdentityParameters parameters, CancellationToken cancellationToken)
         {
             return _identitySource.AuthenticateAsync(parameters, cancellationToken);
         }
 
-        // This method tries to create managed identity source for different sources, if none is created then defaults to IMDS.
-        private static AbstractManagedIdentity SelectManagedIdentitySource(RequestContext requestContext)
+        /// <summary>
+        /// This method tries to create managed identity source for different sources. 
+        /// If none is created then defaults to IMDS.
+        /// </summary>
+        /// <param name="requestContext"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private static async Task<AbstractManagedIdentity> SelectManagedIdentitySourceAsync(
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
         {
-            return GetManagedIdentitySource(requestContext.Logger) switch
+            ManagedIdentitySource source = await GetManagedIdentitySourceAsync(
+                requestContext.ServiceBundle,
+                cancellationToken).ConfigureAwait(false);
+
+            return source switch
             {
                 ManagedIdentitySource.ServiceFabric => ServiceFabricManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.AppService => AppServiceManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.MachineLearning => MachineLearningManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.CloudShell => CloudShellManagedIdentitySource.Create(requestContext),
                 ManagedIdentitySource.AzureArc => AzureArcManagedIdentitySource.Create(requestContext),
+                ManagedIdentitySource.ImdsV2 => ImdsV2ManagedIdentitySource.Create(requestContext),
                 _ => new ImdsManagedIdentitySource(requestContext)
             };
         }
 
-        // Detect managed identity source based on the availability of environment variables.
-        // The result of this method is not cached because reading environment variables is cheap. 
-        // This method is perf sensitive any changes should be benchmarked.
+        /// <summary>
+        /// Compute the managed identity source based on the environment variables.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <returns></returns>
         internal static ManagedIdentitySource GetManagedIdentitySource(ILoggerAdapter logger = null)
         {
             string identityEndpoint = EnvironmentVariables.IdentityEndpoint;
@@ -97,6 +137,128 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             }
         }
 
+        /// <summary>
+        /// Compute the managed identity source based on the environment variables and the probe.
+        /// </summary>
+        /// <param name="serviceBundle"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        internal static async Task<ManagedIdentitySource> GetManagedIdentitySourceAsync(
+            IServiceBundle serviceBundle,
+            CancellationToken cancellationToken)
+        {
+            if (serviceBundle == null)
+            {
+                throw new ArgumentNullException(nameof(serviceBundle), "ServiceBundle is required to initialize the probe manager.");
+            }
+
+            ILoggerAdapter logger = serviceBundle.ApplicationLogger;
+
+            logger.Verbose(() => s_cachedManagedIdentitySource.HasValue
+                ? "[Managed Identity] Using cached managed identity source."
+                : "[Managed Identity] Computing managed identity source asynchronously.");
+
+            if (s_cachedManagedIdentitySource.HasValue)
+            {
+                return s_cachedManagedIdentitySource.Value;
+            }
+
+            // Using SemaphoreSlim to prevent multiple threads from computing at the same time
+            logger.Verbose(() => "[Managed Identity] Entering managed identity source semaphore.");
+            await s_credentialSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            logger.Verbose(() => "[Managed Identity] Entered managed identity source semaphore.");
+
+            try
+            {
+                // Ensure another thread didn't set this while waiting on semaphore
+                if (s_cachedManagedIdentitySource.HasValue)
+                {
+                    return s_cachedManagedIdentitySource.Value;
+                }
+
+                // Initialize probe manager
+                var probeManager = new ImdsCredentialProbeManager(
+                    serviceBundle.HttpManager,
+                    serviceBundle.ApplicationLogger);
+
+                // Compute the managed identity source
+                s_cachedManagedIdentitySource = await ComputeManagedIdentitySourceAsync(
+                    probeManager,
+                    serviceBundle.ApplicationLogger,
+                    cancellationToken).ConfigureAwait(false);
+
+                logger.Info($"[Managed Identity] Managed identity source determined: {s_cachedManagedIdentitySource.Value}.");
+
+                return s_cachedManagedIdentitySource.Value;
+            }
+            finally
+            {
+                s_credentialSemaphore.Release();
+                logger.Verbose(() => "[Managed Identity] Released managed identity source semaphore.");
+            }
+        }
+
+        /// <summary>
+        /// Compute the managed identity source based on the environment variables and the probe.
+        /// </summary>
+        /// <param name="imdsCredentialProbeManager"></param>
+        /// <param name="logger"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private static async Task<ManagedIdentitySource> ComputeManagedIdentitySourceAsync(
+            ImdsCredentialProbeManager imdsCredentialProbeManager,
+            ILoggerAdapter logger,
+            CancellationToken cancellationToken)
+        {
+            string identityEndpoint = EnvironmentVariables.IdentityEndpoint;
+            string identityHeader = EnvironmentVariables.IdentityHeader;
+            string identityServerThumbprint = EnvironmentVariables.IdentityServerThumbprint;
+            string msiEndpoint = EnvironmentVariables.MsiEndpoint;
+            string imdsEndpoint = EnvironmentVariables.ImdsEndpoint;
+            string msiSecretMachineLearning = EnvironmentVariables.MsiSecret;
+
+            if (!string.IsNullOrEmpty(identityEndpoint) && !string.IsNullOrEmpty(identityHeader))
+            {
+                if (!string.IsNullOrEmpty(identityServerThumbprint))
+                {
+                    return ManagedIdentitySource.ServiceFabric;
+                }
+                else
+                {
+                    return ManagedIdentitySource.AppService;
+                }
+            }
+            else if (!string.IsNullOrEmpty(msiSecretMachineLearning) && !string.IsNullOrEmpty(msiEndpoint))
+            {
+                return ManagedIdentitySource.MachineLearning;
+            }
+            else if (!string.IsNullOrEmpty(msiEndpoint))
+            {
+                return ManagedIdentitySource.CloudShell;
+            }
+            else if (ValidateAzureArcEnvironment(identityEndpoint, imdsEndpoint, logger))
+            {
+                return ManagedIdentitySource.AzureArc;
+            }
+            else
+            {
+                logger?.Info("[Managed Identity] Probing for credential endpoint.");
+                bool isSuccess = await imdsCredentialProbeManager.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+
+                if (isSuccess)
+                {
+                    logger?.Info("[Managed Identity] Credential endpoint detected.");
+                    return ManagedIdentitySource.ImdsV2;
+                }
+                else
+                {
+                    logger?.Verbose(() => "[Managed Identity] Defaulting to IMDS as credential endpoint not detected.");
+                    return ManagedIdentitySource.DefaultToImds;
+                }
+            }
+        }
+
         // Method to return true if a file exists and is not empty to validate the Azure arc environment.
         private static bool ValidateAzureArcEnvironment(string identityEndpoint, string imdsEndpoint, ILoggerAdapter logger)
         {
@@ -118,8 +280,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             {
                 logger?.Verbose(() => "[Managed Identity] Azure Arc managed identity is available through file detection.");
                 return true;
-            } 
-            
+            }
+
             logger?.Verbose(() => "[Managed Identity] Azure Arc managed identity is not available.");
             return false;
         }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityCredentialResponse.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityCredentialResponse.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+#if SUPPORTS_SYSTEM_TEXT_JSON
+using Microsoft.Identity.Client.Platforms.net;
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Microsoft.Identity.Json;
+#endif
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    [JsonObject]
+    [Preserve(AllMembers = true)]
+    internal class ManagedIdentityCredentialResponse
+    {
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
+
+        [JsonProperty("credential")]
+        public string Credential { get; set; }
+
+        [JsonProperty("expires_on")]
+        public long ExpiresOn { get; set; }
+
+        [JsonProperty("identity_type")]
+        public string IdentityType { get; set; }
+
+        [JsonProperty("refresh_in")]
+        public long RefreshIn { get; set; }
+
+        [JsonProperty("regional_token_url")]
+        public string RegionalTokenUrl { get; set; }
+
+        [JsonProperty("tenant_id")]
+        public string TenantId { get; set; }
+
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityCredentialService .cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityCredentialService .cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Utils;
+using Microsoft.Identity.Client.OAuth2;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    internal class ManagedIdentityCredentialService
+    {
+        private readonly ManagedIdentityRequest _request;
+        private readonly X509Certificate2 _bindingCertificate;
+        private readonly RequestContext _requestContext;
+        private readonly CancellationToken _cancellationToken;
+        internal const string TimeoutError = "[Managed Identity] Authentication unavailable. The request to the managed identity endpoint timed out.";
+
+        // New constructor that accepts a ManagedIdentityRequest
+        public ManagedIdentityCredentialService(
+            ManagedIdentityRequest request,
+            X509Certificate2 bindingCertificate,
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            _request = request;
+            _bindingCertificate = bindingCertificate;
+            _requestContext = requestContext;
+            _cancellationToken = cancellationToken;
+        }
+
+        /// <summary>
+        /// Gets or fetches the Managed Identity credential from the cache or the service.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="MsalServiceException"></exception>
+        public async Task<ManagedIdentityCredentialResponse> GetCredentialAsync()
+        {
+            ManagedIdentityCredentialResponse credentialResponse = await FetchFromServiceAsync(
+                _requestContext.ServiceBundle.HttpManager,
+                _cancellationToken)
+                .ConfigureAwait(false);
+
+            ValidateCredentialResponse(credentialResponse);
+
+            return credentialResponse;
+        }
+
+        /// <summary>
+        /// Validates the properties of a CredentialResponse to ensure it meets the necessary criteria for authentication.
+        /// </summary>
+        /// <param name="credentialResponse">The CredentialResponse to be validated.</param>
+        private void ValidateCredentialResponse(ManagedIdentityCredentialResponse credentialResponse)
+        {
+            var errorMessages = new List<string>();
+
+            // Check if the CredentialResponse is null or if any required property is missing or invalid
+            if (credentialResponse == null)
+            {
+                errorMessages.Add("CredentialResponse is null. ");
+            }
+            else
+            {
+                if (credentialResponse.Credential.IsNullOrEmpty())
+                {
+                    errorMessages.Add("Credential is missing or empty. ");
+                }
+
+                if (credentialResponse.RegionalTokenUrl.IsNullOrEmpty())
+                {
+                    errorMessages.Add("RegionalTokenUrl is missing or empty. ");
+                }
+
+                if (credentialResponse.ClientId.IsNullOrEmpty())
+                {
+                    errorMessages.Add("ClientId is missing or empty. ");
+                }
+
+                if (credentialResponse.TenantId.IsNullOrEmpty())
+                {
+                    errorMessages.Add("TenantId is missing or empty. ");
+                }
+            }
+
+            // Check if any error messages were added
+            if (errorMessages.Any())
+            {
+                // Log an error message indicating the missing or insufficient fields
+                _requestContext.Logger.Error("[Managed Identity] " + string.Join(" ", errorMessages) +
+                    " and/or insufficient for authentication.");
+
+                // Throw an exception indicating that the CredentialResponse is invalid
+                MsalException exception = MsalServiceExceptionFactory.CreateManagedIdentityException(
+                    MsalError.ManagedIdentityRequestFailed,
+                    MsalErrorMessage.ManagedIdentityInvalidResponse,
+                    null,
+                    ManagedIdentitySource.ImdsV2,
+                    null);
+
+                throw exception;
+            }
+        }
+
+        /// <summary>
+        /// Fetches a new managed identity credential from the IMDS endpoint.
+        /// </summary>
+        /// <param name="httpManager"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task<ManagedIdentityCredentialResponse> FetchFromServiceAsync(
+            IHttpManager httpManager,
+            CancellationToken cancellationToken)
+        {
+            _requestContext.Logger.Info("[Managed Identity] Fetching new managed identity credential from IMDS endpoint.");
+
+            OAuth2Client client = CreateClientRequest(httpManager);
+
+            Uri requestUri = _request.ComputeUri();
+
+            ManagedIdentityCredentialResponse credentialResponse = await client
+                .GetCredentialResponseAsync(requestUri, _requestContext, cancellationToken)
+                .ConfigureAwait(false);
+
+            return credentialResponse;
+        }
+
+        /// <summary>
+        /// Creates an OAuth2 client request for fetching the managed identity credential.
+        /// </summary>
+        /// <param name="httpManager"></param>
+        /// <returns></returns>
+        private OAuth2Client CreateClientRequest(IHttpManager httpManager)
+        {
+            var client = new OAuth2Client(_requestContext.Logger, httpManager, null);
+
+            client.AddHeader("metadata", "true");
+            client.AddHeader("x-ms-client-request-id", _requestContext.CorrelationId.ToString("D"));
+            string jsonPayload = GetCredentialPayload();
+            client.AddBodyContent(new StringContent(jsonPayload, System.Text.Encoding.UTF8, "application/json"));
+
+            return client;
+        }
+
+        /// <summary>
+        /// Creates the payload for the managed identity credential request.
+        /// </summary>
+        private string GetCredentialPayload()
+        {
+            _requestContext.Logger.Verbose(() => $"[CredentialManagedIdentityAuthRequest] Creating credential payload using using certificate: " +
+                     $"Subject: {_bindingCertificate.Subject}, " +
+                     $"Expiration: {_bindingCertificate.NotAfter}, " +
+                     $"Issuer: {_bindingCertificate.Issuer}");
+
+            string certificateBase64 = Convert.ToBase64String(_bindingCertificate.Export(X509ContentType.Cert));
+
+            return @"{""cnf"":{""jwk"":{""kty"":""RSA"",""use"":""sig"",""alg"":""RS256"",""kid"":""" + _bindingCertificate.Thumbprint +
+                @""",""x5c"":[""" + certificateBase64 + @"""]}},""latch_key"":false}";
+
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityRequest.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityRequest.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
         public IDictionary<string, string> QueryParameters { get; }
 
+        public string Content { get; internal set; }
+
         public ManagedIdentityRequest(HttpMethod method, Uri endpoint)
         {
             Method = method;
@@ -38,6 +40,22 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             uriBuilder.AppendQueryParameters(QueryParameters);
 
             return uriBuilder.Uri;
+        }
+
+        public HttpContent CreateHttpContent()
+        {
+            if (!string.IsNullOrEmpty(Content))
+            {
+                return new StringContent(Content, Encoding.UTF8, "application/json");
+            }
+
+            if (BodyParameters.Count > 0)
+            {
+                var formData = new FormUrlEncodedContent(BodyParameters);
+                return formData;
+            }
+
+            return null; // No body content
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
@@ -53,6 +53,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         /// <summary>
         /// The source to acquire token for managed identity is Machine Learning Service.
         /// </summary>
-        MachineLearning
+        MachineLearning,
+
+        /// <summary>
+        /// Indicates that the source is credential endpoint based on the probe.
+        /// This is used to detect the new managed identity credential source.
+        /// </summary>
+        ImdsV2
     }
 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -36,11 +36,15 @@ namespace Microsoft.Identity.Client
 
             AppTokenCacheInternal = configuration.AppTokenCacheInternalForTest ?? new TokenCache(ServiceBundle, true);
 
-            this.ServiceBundle.ApplicationLogger.Verbose(()=>$"ManagedIdentityApplication {configuration.GetHashCode()} created");
+            s_serviceBundle = this.ServiceBundle;
+
+            s_serviceBundle.ApplicationLogger.Verbose(() => $"ManagedIdentityApplication {configuration.GetHashCode()} created");
         }
 
         // Stores all app tokens
         internal ITokenCacheInternal AppTokenCacheInternal { get; }
+
+        private static IServiceBundle s_serviceBundle;
 
         /// <inheritdoc/>
         public AcquireTokenForManagedIdentityParameterBuilder AcquireTokenForManagedIdentity(string resource)
@@ -59,9 +63,20 @@ namespace Microsoft.Identity.Client
         /// Detects and returns the managed identity source available on the environment.
         /// </summary>
         /// <returns>Managed identity source detected on the environment if any.</returns>
+        [Obsolete("GetManagedIdentitySource() is deprecated and will be removed in a future release. Use GetManagedIdentitySourceAsync() instead.")]
+
         public static ManagedIdentitySource GetManagedIdentitySource()
         {
             return ManagedIdentityClient.GetManagedIdentitySource();
+        }
+
+        /// <summary>
+        /// Detects and returns the managed identity source available on the environment asynchronously.
+        /// </summary>
+        /// <returns>Managed identity source detected on the environment if any.</returns>
+        public static async Task<ManagedIdentitySource> GetManagedIdentitySourceAsync(CancellationToken cancellationToken = default)
+        {
+            return await ManagedIdentityClient.GetManagedIdentitySourceAsync(s_serviceBundle, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -85,6 +85,7 @@
     <None Include="Platforms\net\JsonObjectAttribute.cs" />
     <None Include="Platforms\net\JsonStringConverter.cs" />
     <None Include="Platforms\net\MsalJsonSerializerContext.cs" />
+    <None Include="Utils\ManagedIdentityCertificateManager.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
@@ -162,5 +163,9 @@
   <ItemGroup Label="For public api analyzer support">
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Utils\ManagedIdentityCertificateManager.cs" />
   </ItemGroup>
 </Project>

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -268,6 +268,10 @@ namespace Microsoft.Identity.Client
 
         public const string CustomWebUiReturnedInvalidUri = "ICustomWebUi returned an invalid URI - it is empty or has no query. ";
 
+        public const string CredentialEndpointNoResponseReceived = "[Managed Identity] Authentication unavailable. No response received from the managed identity credential endpoint.";
+
+        public const string CredentialResponseMissingHeader = "[Managed Identity] Did not receive expected Server header in the response from Credential Endpoint.";
+
         public static string RedirectUriMismatch(string expectedUri, string actualUri)
         {
             return $"Redirect Uri mismatch.  Expected ({expectedUri}) Actual ({actualUri}). ";

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -17,7 +17,8 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Client.Internal.Broker;
 using System.Security.Cryptography.X509Certificates;
-
+using Microsoft.Identity.Client.ManagedIdentity;
+using System.Threading;
 #if SUPPORTS_SYSTEM_TEXT_JSON
 using System.Text.Json;
 #else
@@ -41,6 +42,7 @@ namespace Microsoft.Identity.Client.OAuth2
         private readonly IDictionary<string, string> _bodyParameters = new Dictionary<string, string>();
         private readonly IHttpManager _httpManager;
         private readonly X509Certificate2 _mtlsCertificate;
+        private StringContent _stringContent;
 
         public OAuth2Client(ILoggerAdapter logger, IHttpManager httpManager, X509Certificate2 mtlsCertificate)
         {
@@ -68,6 +70,14 @@ namespace Microsoft.Identity.Client.OAuth2
         internal void AddHeader(string key, string value)
         {
             _headers[key] = value;
+        }
+
+        public void AddBodyContent(StringContent content)
+        {
+            if (content != null)
+            {
+                _stringContent = content;
+            }
         }
 
         internal IReadOnlyDictionary<string, string> GetBodyParameters()
@@ -98,6 +108,16 @@ namespace Microsoft.Identity.Client.OAuth2
                 false,
                 addCommonHeaders,
                 onBeforePostRequestHandler);
+        }
+
+        public async Task<ManagedIdentityCredentialResponse> GetCredentialResponseAsync(
+            Uri endpoint,
+            RequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            return await ExecuteRequestAsync<ManagedIdentityCredentialResponse>(
+                endpoint, HttpMethod.Post, requestContext)
+                       .ConfigureAwait(false);
         }
 
         internal async Task<T> ExecuteRequestAsync<T>(
@@ -134,7 +154,7 @@ namespace Microsoft.Identity.Client.OAuth2
                         response = await _httpManager.SendRequestAsync(
                             endpointUri,
                             _headers,
-                            body: new FormUrlEncodedContent(_bodyParameters),
+                            body: _stringContent == null ? new FormUrlEncodedContent(_bodyParameters) : _stringContent,
                             HttpMethod.Post,
                             logger: requestContext.Logger,
                             doNotThrow: false,

--- a/src/client/Microsoft.Identity.Client/Platforms/net/MsalJsonSerializerContext.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net/MsalJsonSerializerContext.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Identity.Client.Platforms.net
     [JsonSerializable(typeof(ManagedIdentityResponse))]
     [JsonSerializable(typeof(ManagedIdentityErrorResponse))]
     [JsonSerializable(typeof(OidcMetadata))]
+    [JsonSerializable(typeof(ManagedIdentityCredentialResponse))]
     [JsonSourceGenerationOptions]
     internal partial class MsalJsonSerializerContext : JsonSerializerContext
     {

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Mi
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory.GetHttpClient(System.Security.Cryptography.X509Certificates.X509Certificate2 x509Certificate2) -> System.Net.Http.HttpClient

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Mi
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory.GetHttpClient(System.Security.Cryptography.X509Certificates.X509Certificate2 x509Certificate2) -> System.Net.Http.HttpClient

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Mi
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory.GetHttpClient(System.Security.Cryptography.X509Certificates.X509Certificate2 x509Certificate2) -> System.Net.Http.HttpClient

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Mi
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory.GetHttpClient(System.Security.Cryptography.X509Certificates.X509Certificate2 x509Certificate2) -> System.Net.Http.HttpClient

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Mi
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory.GetHttpClient(System.Security.Cryptography.X509Certificates.X509Certificate2 x509Certificate2) -> System.Net.Http.HttpClient

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.ImdsV2 = 8 -> Mi
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory
+Microsoft.Identity.Client.IMsalMtlsHttpClientFactory.GetHttpClient(System.Security.Cryptography.X509Certificates.X509Certificate2 x509Certificate2) -> System.Net.Http.HttpClient

--- a/src/client/Microsoft.Identity.Client/Utils/ManagedIdentityCertificateManager.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/ManagedIdentityCertificateManager.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Identity.Client.PlatformsCommon.Shared;
+
+namespace Microsoft.Identity.Client.Internal.Utilities
+{
+    internal static class ManagedIdentityCertificateManager
+    {
+        private const string CertificateName = "devicecert.mtlsauth.local";
+        private static readonly object s_lock = new object();
+        private static X509Certificate2 s_cachedCertificate;
+        private static bool s_isInMemoryCertificate;
+
+        /// <summary>
+        /// Event triggered when a new certificate is created.
+        /// </summary>
+        internal static event Action<X509Certificate2> CertificateUpdated;
+
+        /// <summary>
+        /// Main entry point for retrieving a certificate. Splits logic between Linux (always in-memory)
+        /// and Windows/macOS (attempt platform store first, else create in-memory).
+        /// </summary>
+        /// <param name="forceUpdate">If true, forces renewal of an in-memory certificate.</param>
+        /// <returns>An X509Certificate2 valid for 90 days.</returns>
+        public static X509Certificate2 GetOrCreateCertificate(bool forceUpdate = false)
+        {
+            lock (s_lock)
+            {
+                // Determine if running on Linux
+                bool isLinux = DesktopOsHelper.IsLinux();
+
+                if (isLinux)
+                {
+                    return GetOrCreateLinuxCertificate(forceUpdate);
+                }
+                else
+                {
+                    return GetOrCreateWindowsCertificate(forceUpdate);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Convenience method for Azure SDK to force update the in-memory certificate.
+        /// Not for final release. For platform certificates, this is a no-op.
+        /// </summary>
+        /// <returns>The renewed certificate.</returns>
+        public static X509Certificate2 ForceUpdateInMemoryCertificate()
+        {
+            return GetOrCreateCertificate(forceUpdate: true);
+        }
+
+        /// <summary>
+        /// Creates a new self-signed certificate valid for 90 days.
+        /// Uses ECDSA (NIST P-256 curve).
+        /// </summary>
+        /// <param name="certificateName">The subject name of the certificate.</param>
+        /// <returns>A newly created self-signed certificate.</returns>
+        private static X509Certificate2 CreateNewCertificate(string certificateName)
+        {
+#if SUPPORTS_MTLS
+            using (var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256))
+            {
+                var req = new CertificateRequest($"CN={certificateName}",
+                    ecdsa,
+                    HashAlgorithmName.SHA256);
+
+                req.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+                req.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true));
+
+                X509Certificate2 cert = req.CreateSelfSigned(
+                    DateTimeOffset.Now,
+                    DateTimeOffset.Now.AddDays(90));
+
+                bool isWindows = DesktopOsHelper.IsWindows();
+
+                X509KeyStorageFlags flags = isWindows
+                    ? X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable
+                    : X509KeyStorageFlags.EphemeralKeySet;
+
+                // Export as PFX 
+                return new X509Certificate2(
+                    cert.Export(X509ContentType.Pfx),
+                    (string)null,
+                    flags);
+            }
+#else
+            return null;
+#endif
+        }
+
+        /// <summary>
+        /// Retrieves a certificate from the store using the certificate's subject name.
+        /// </summary>
+        /// <param name="certificateName">The subject name of the certificate.</param>
+        /// <returns>The certificate if found, otherwise null.</returns>
+        private static X509Certificate2 GetCertificateFromStore(string certificateName)
+        {
+            // Search in the LocalMachine store.
+            using (var store = new X509Store(StoreLocation.LocalMachine))
+            {
+                store.Open(OpenFlags.ReadOnly);
+                var certificates = store.Certificates.Find(
+                    X509FindType.FindBySubjectName, certificateName, validOnly: false);
+
+                if (certificates.Count > 0)
+                {
+                    return certificates[0];
+                }
+            }
+
+            // Search in the CurrentUser store.
+            using (var store = new X509Store(StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadOnly);
+                var certificates = store.Certificates.Find(
+                    X509FindType.FindBySubjectName, certificateName, validOnly: false);
+
+                if (certificates.Count > 0)
+                {
+                    return certificates[0];
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// On Windows: Attempt to retrieve from store, then create in-memory cert if none found.
+        /// Renews ephemeral cert if nearly expired or forced to update.
+        /// </summary>
+        private static X509Certificate2 GetOrCreateWindowsCertificate(bool forceUpdate)
+        {
+            // Try to get from store if not cached
+            if (s_cachedCertificate == null)
+            {
+                s_cachedCertificate = GetCertificateFromStore(CertificateName);
+
+                if (s_cachedCertificate != null)
+                {
+                    // Found a platform certificate
+                    s_isInMemoryCertificate = false;
+                }
+            }
+
+            // If cached is ephemeral
+            if (s_cachedCertificate != null && s_isInMemoryCertificate)
+            {
+                if (forceUpdate)
+                {
+                    s_cachedCertificate = CreateNewCertificate(CertificateName);
+                    CertificateUpdated?.Invoke(s_cachedCertificate);
+                }
+                else
+                {
+                    // Renew if less than 5 days remain
+                    TimeSpan timeLeft = s_cachedCertificate.NotAfter - DateTimeOffset.Now;
+                    if (timeLeft < TimeSpan.FromDays(5))
+                    {
+                        s_cachedCertificate = CreateNewCertificate(CertificateName);
+                        CertificateUpdated?.Invoke(s_cachedCertificate);
+                    }
+                }
+            }
+
+            // If still no certificate, create ephemeral
+            if (s_cachedCertificate == null)
+            {
+                s_cachedCertificate = CreateNewCertificate(CertificateName);
+                s_isInMemoryCertificate = true;
+                CertificateUpdated?.Invoke(s_cachedCertificate);
+            }
+
+            return s_cachedCertificate;
+        }
+
+        /// <summary>
+        /// On Linux: Always uses an in-memory certificate.
+        /// Renews ephemeral cert if nearly expired or forced to update.
+        /// </summary>
+        private static X509Certificate2 GetOrCreateLinuxCertificate(bool forceUpdate)
+        {
+            // If no certificate or forced update, create ephemeral
+            if (s_cachedCertificate == null || forceUpdate)
+            {
+                s_cachedCertificate = CreateNewCertificate(CertificateName);
+                s_isInMemoryCertificate = true;
+                CertificateUpdated?.Invoke(s_cachedCertificate);
+                return s_cachedCertificate;
+            }
+
+            // If ephemeral cert is near expiration, renew it
+            if (s_isInMemoryCertificate)
+            {
+                TimeSpan timeLeft = s_cachedCertificate.NotAfter - DateTimeOffset.Now;
+                if (timeLeft < TimeSpan.FromDays(5))
+                {
+                    s_cachedCertificate = CreateNewCertificate(CertificateName);
+                    CertificateUpdated?.Invoke(s_cachedCertificate);
+                }
+                return s_cachedCertificate;
+            }
+
+            // Fallback if we somehow have a non-in-memory cert on Linux (unlikely)
+            s_cachedCertificate = CreateNewCertificate(CertificateName);
+            s_isInMemoryCertificate = true;
+            CertificateUpdated?.Invoke(s_cachedCertificate);
+            return s_cachedCertificate;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHelpers.cs
@@ -582,5 +582,21 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 TokenSource = TokenSource.Broker
             };
         }
+
+        public static void AddCredentialEndpointNotFoundHandlers(
+            ManagedIdentitySource managedIdentitySource,
+            MockHttpManager httpManager,
+            int count = 4)
+        {
+            if (managedIdentitySource != ManagedIdentitySource.Imds)
+            {
+                return; // Only add handlers for IMDS
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                httpManager.AddMockHandlerContentNotFound(HttpMethod.Post);
+            }
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/TestCommon.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestCommon.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using NSubstitute;
 using static Microsoft.Identity.Client.TelemetryCore.Internal.Events.ApiEvent;
+using Microsoft.Identity.Client.ManagedIdentity;
 
 namespace Microsoft.Identity.Test.Common
 {
@@ -45,6 +46,7 @@ namespace Microsoft.Identity.Test.Common
             OidcRetrieverWithCache.ResetCacheForTest();
             AuthorityManager.ClearValidationCache();
             SingletonThrottlingManager.GetInstance().ResetCache();
+            ManagedIdentityClient.ResetManagedIdentitySourceCache();
         }
 
         public static object GetPropValue(object src, string propName)

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow("http://127.0.0.1:41564/msi/token/", ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
         [DataRow(AppServiceEndpoint, ManagedIdentitySource.AppService, ManagedIdentitySource.AppService)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, ManagedIdentitySource.MachineLearning)]
-        public void TestAppServiceUpgradeScenario(
+        public async Task TestAppServiceUpgradeScenarioAsync(
             string endpoint,
             ManagedIdentitySource managedIdentitySource,
             ManagedIdentitySource expectedManagedIdentitySource)
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             {
                 SetUpgradeScenarioEnvironmentVariables(managedIdentitySource, endpoint);
 
-                Assert.AreEqual(expectedManagedIdentitySource, ManagedIdentityApplication.GetManagedIdentitySource());
+                Assert.AreEqual(expectedManagedIdentitySource, await ManagedIdentityApplication.GetManagedIdentitySourceAsync().ConfigureAwait(false));
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsTests.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(ManagedIdentitySource.Imds, httpManager);
+
                 // Adding multiple mock handlers to simulate retries for GatewayTimeout
                 for (int i = 0; i < expectedAttempts; i++)
                 {

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTelemetry.Resources;
+using static Microsoft.Identity.Test.Common.Core.Helpers.ManagedIdentityTestUtil;
+
+namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
+{
+
+    [TestClass]
+    public class ImdsV2Tests : TestBase
+    {
+        private const string ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+        internal const string Resource = "https://management.azure.com";
+        internal const string CredentialEndpoint = "http://169.254.169.254/metadata/identity/credential";
+        internal const string MtlsEndpoint = "https://centraluseuap.mtlsauth.microsoft.com/" +
+            "72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token";
+
+        [TestInitialize]
+        public override void TestInitialize()
+        {
+            TestCommon.ResetInternalStaticCaches();
+        }
+
+        [TestMethod]
+        public async Task CredentialSourceFailedFallbackToImdsTestAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager(isManagedIdentity: true))
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+
+                var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager);
+
+                // Disabling shared cache options to avoid cross test pollution.
+                miBuilder.Config.AccessorOptions = null;
+
+                var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(ManagedIdentitySource.Imds, httpManager);
+
+                httpManager.AddManagedIdentityMockHandler(
+                ImdsEndpoint,
+                Resource,
+                MockHelpers.GetMsiSuccessfulResponse(),
+                ManagedIdentitySource.Imds);
+
+                var result = await mi.AcquireTokenForManagedIdentity(Resource).ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                result = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -47,16 +47,16 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(CloudShellEndpoint, ManagedIdentitySource.CloudShell, ManagedIdentitySource.CloudShell)]
         [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, ManagedIdentitySource.ServiceFabric)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, ManagedIdentitySource.MachineLearning)]
-        public void GetManagedIdentityTests(
+        public async Task GetManagedIdentityTestsAsync(
             string endpoint,
-            ManagedIdentitySource managedIdentitySource, 
+            ManagedIdentitySource managedIdentitySource,
             ManagedIdentitySource expectedManagedIdentitySource)
         {
             using (new EnvVariableContext())
             {
                 SetEnvironmentVariables(managedIdentitySource, endpoint);
 
-                Assert.AreEqual(expectedManagedIdentitySource, ManagedIdentityApplication.GetManagedIdentitySource());
+                Assert.AreEqual(expectedManagedIdentitySource, await ManagedIdentityApplication.GetManagedIdentitySourceAsync().ConfigureAwait(false));
             }
         }
 
@@ -91,7 +91,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
-                
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                 endpoint,
                 Resource,
@@ -121,7 +123,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(ImdsEndpoint, ManagedIdentitySource.Imds, TestConstants.MiResourceId, UserAssignedIdentityId.ResourceId)]
         [DataRow(ImdsEndpoint, ManagedIdentitySource.Imds, TestConstants.MiResourceId, UserAssignedIdentityId.ObjectId)]
         [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.ClientId, UserAssignedIdentityId.ClientId)]
-        [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.MiResourceId, UserAssignedIdentityId .ResourceId)]
+        [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.MiResourceId, UserAssignedIdentityId.ResourceId)]
         [DataRow(ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric, TestConstants.MiResourceId, UserAssignedIdentityId.ObjectId)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, TestConstants.ClientId, UserAssignedIdentityId.ClientId)]
         [DataRow(MachineLearningEndpoint, ManagedIdentitySource.MachineLearning, TestConstants.MiResourceId, UserAssignedIdentityId.ResourceId)]
@@ -138,10 +140,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(managedIdentitySource, endpoint);
 
                 ManagedIdentityApplicationBuilder miBuilder = CreateMIABuilder(userAssignedId, userAssignedIdentityId);
-                
+
                 miBuilder.WithHttpManager(httpManager);
 
                 IManagedIdentityApplication mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -191,6 +195,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -251,6 +257,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -314,6 +322,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
                     Resource,
@@ -375,6 +385,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
@@ -507,7 +519,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 foreach (var expectedErrorSubString in expectedInErrorResponse)
                 {
-                    Assert.IsTrue(ex.Message.Contains(expectedErrorSubString), 
+                    Assert.IsTrue(ex.Message.Contains(expectedErrorSubString),
                         $"Expected to contain string {expectedErrorSubString}. Actual error message: {ex.Message}");
                 }
             }
@@ -554,6 +566,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(endpoint, "scope", "",
                     managedIdentitySource, statusCode: HttpStatusCode.InternalServerError);
                 httpManager.AddManagedIdentityMockHandler(endpoint, "scope", "",
@@ -596,6 +610,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
                     Resource,
@@ -635,6 +651,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 var mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
 
                 httpManager.AddFailingRequest(new HttpRequestException("A socket operation was attempted to an unreachable network.",
                     new SocketException(10051)));
@@ -676,6 +694,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                     endpoint,
                     Resource,
@@ -715,7 +735,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             }
         }
 
-        [TestMethod] 
+        [TestMethod]
         public async Task SystemAssignedManagedIdentityApiIdTestAsync()
         {
             using (new EnvVariableContext())
@@ -946,7 +966,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 Assert.AreEqual(0, httpManager.QueueSize,
                     "MSAL should have refreshed the token because the original AT was marked for refresh");
-                
+
                 cacheAccess.WaitTo_AssertAcessCounts(1, 1);
 
                 Assert.AreEqual(CacheRefreshReason.ProactivelyRefreshed, result.AuthenticationResultMetadata.CacheRefreshReason);
@@ -956,7 +976,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 result = await mi.AcquireTokenForManagedIdentity(Resource)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
-                
+
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
             }
         }
@@ -1019,7 +1039,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [TestMethod]
         public async Task ParallelRequests_CallTokenEndpointOnceAsync()
         {
-            int numOfTasks = 10; 
+            int numOfTasks = 10;
             int identityProviderHits = 0;
             int cacheHits = 0;
 
@@ -1114,6 +1134,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 var mi = miBuilder.Build();
 
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(managedIdentitySource, httpManager);
+
                 httpManager.AddManagedIdentityMockHandler(
                      endpoint,
                      "scope",
@@ -1138,9 +1160,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(Resource, "https://graph.microsoft.com", ManagedIdentitySource.ServiceFabric, ServiceFabricEndpoint)]
         [DataRow(Resource, "https://graph.microsoft.com", ManagedIdentitySource.MachineLearning, MachineLearningEndpoint)]
         public async Task ManagedIdentityRequestTokensForDifferentScopesTestAsync(
-            string initialResource, 
-            string newResource, 
-            ManagedIdentitySource source, 
+            string initialResource,
+            string newResource,
+            ManagedIdentitySource source,
             string endpoint)
         {
             using (new EnvVariableContext())
@@ -1156,6 +1178,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 miBuilder.Config.AccessorOptions = null;
 
                 IManagedIdentityApplication mi = miBuilder.Build();
+
+                MockHelpers.AddCredentialEndpointNotFoundHandlers(source, httpManager);
 
                 // Mock handler for the initial resource request
                 httpManager.AddManagedIdentityMockHandler(endpoint, initialResource,
@@ -1299,6 +1323,38 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // Verify the ClientId for each cached entry
                 Assert.AreEqual(UserAssignedClientId, userAssignedTokens[0].ClientId, "User-assigned ClientId mismatch in cache.");
                 Assert.AreEqual(SystemAssignedClientId, systemAssignedTokens[0].ClientId, "System-assigned ClientId mismatch in cache.");
+            }
+        }
+
+        [TestMethod]
+        public async Task ManagedIdentitySourceCachingWorksAsExpectedAsync()
+        {
+            // Create ApplicationConfiguration and ServiceBundle
+            var config = new ApplicationConfiguration(MsalClientType.ManagedIdentityClient);
+            var serviceBundle = new ServiceBundle(config);
+            var cancellationToken = CancellationToken.None;
+
+            using (new EnvVariableContext())
+            {
+                // Set environment variables to resolve as ServiceFabric
+                Environment.SetEnvironmentVariable("IDENTITY_ENDPOINT", "http://localhost:40342/metadata/identity/oauth2/token");
+                Environment.SetEnvironmentVariable("IDENTITY_HEADER", "dummy-header");
+                Environment.SetEnvironmentVariable("IDENTITY_SERVER_THUMBPRINT", "dummy-thumbprint");
+
+                // First call to populate the cache
+                ManagedIdentitySource firstSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle, cancellationToken).ConfigureAwait(false);
+                Assert.AreEqual(ManagedIdentitySource.ServiceFabric, firstSource, "Initial resolution failed to detect ServiceFabric.");
+
+                // Change environment variables to mimic a different identity source (shouldn't affect cached value)
+                Environment.SetEnvironmentVariable("IDENTITY_ENDPOINT", "http://localhost/other/metadata/identity/oauth2/token");
+                Environment.SetEnvironmentVariable("IDENTITY_SERVER_THUMBPRINT", null);
+
+                // Second call should return the cached value
+                ManagedIdentitySource cachedSource = await ManagedIdentityClient.GetManagedIdentitySourceAsync(serviceBundle, cancellationToken).ConfigureAwait(false);
+                Assert.AreEqual(ManagedIdentitySource.ServiceFabric, cachedSource, "Cached value should remain as ServiceFabric.");
+
+                // Ensure the cache was not recomputed 
+                Assert.AreEqual(firstSource, cachedSource, "The cache was unexpectedly recomputed.");
             }
         }
     }

--- a/tests/devapps/Managed Identity apps/ManagedIdentityAppVM/Program.cs
+++ b/tests/devapps/Managed Identity apps/ManagedIdentityAppVM/Program.cs
@@ -7,13 +7,8 @@ using Microsoft.IdentityModel.Abstractions;
 
 IIdentityLogger identityLogger = new IdentityLogger();
 
-var managedIdentitySource = await ManagedIdentityApplication.
-    GetManagedIdentitySourceAsync().ConfigureAwait(false);
-
-Console.WriteLine($"Managed identity source detected: {managedIdentitySource}");
-
 IManagedIdentityApplication mi = ManagedIdentityApplicationBuilder
-    .Create(ManagedIdentityId.SystemAssigned)
+    .Create(ManagedIdentityId.WithUserAssignedClientId("5bcd1685-b002-4fd1-8ebd-1ec3e1e4ca4d"))
     .WithLogging(identityLogger, true)
     .Build();
 

--- a/tests/devapps/Managed Identity apps/ManagedIdentityAppVM/Program.cs
+++ b/tests/devapps/Managed Identity apps/ManagedIdentityAppVM/Program.cs
@@ -7,9 +7,15 @@ using Microsoft.IdentityModel.Abstractions;
 
 IIdentityLogger identityLogger = new IdentityLogger();
 
-IManagedIdentityApplication mi = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
-                .WithLogging(identityLogger, true)
-                .Build();
+var managedIdentitySource = await ManagedIdentityApplication.
+    GetManagedIdentitySourceAsync().ConfigureAwait(false);
+
+Console.WriteLine($"Managed identity source detected: {managedIdentitySource}");
+
+IManagedIdentityApplication mi = ManagedIdentityApplicationBuilder
+    .Create(ManagedIdentityId.SystemAssigned)
+    .WithLogging(identityLogger, true)
+    .Build();
 
 string? scope = "https://management.azure.com";
 


### PR DESCRIPTION
Fixes [#5117](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5117)

**Changes proposed in this request**
This adds a new credential source to Managed Identity sources. We call it IMDSV2 source. 

This pull request introduces significant changes to the Managed Identity authentication flow in the Microsoft Identity Client library. The most important changes include refactoring the `ManagedIdentityAuthRequest` class into an abstract class, adding new classes for handling different Managed Identity sources, and modifying the visibility of the `IMsalMtlsHttpClientFactory` interface.

### Refactoring and new classes:

* [`src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs`](diffhunk://#diff-a1260a45bdc4ac7ab60d4a348996be6b69c5a48fa6f484fa41daa390c7e69ca8L5-R18): Refactored `ManagedIdentityAuthRequest` into an abstract class to support different Managed Identity sources.
* [`src/client/Microsoft.Identity.Client/Internal/Requests/CredentialBasedMsiAuthRequest.cs`](diffhunk://#diff-384a38def4c11cd9777756cbb47591dfa4f1871b6b612f8b6aeb92d3a7444f66R1-R271): Added `CredentialManagedIdentityAuthRequest` class to handle Managed Identity authentication using certificates.
* [`src/client/Microsoft.Identity.Client/Internal/Requests/LegacyManagedIdentityAuthRequest.cs`](diffhunk://#diff-484c9c96332690b5ff6af04086d893e06e1c8304148ec61d26df329a53218114R1-R96): Added `LegacyManagedIdentityAuthRequest` class to handle legacy Managed Identity authentication.

### Modifications in existing methods:

* [`src/client/Microsoft.Identity.Client/ApiConfig/Executors/ManagedIdentityExecutor.cs`](diffhunk://#diff-c173d517556b1e1f07ea7c662830e81eb30fea2ca39c4ad5e7ace1849cf623f0L36-R70): Updated `ExecuteAsync` method to determine the Managed Identity source and use the appropriate authentication request class.

### Visibility changes:

* [`src/client/Microsoft.Identity.Client/AppConfig/IMsalMtlsHttpClientFactory.cs`](diffhunk://#diff-57a9635e81b059ca6b8ab06b220484b58842705663b081f3b7c04a4cd49adc34L21-R21): Changed the visibility of `IMsalMtlsHttpClientFactory` from internal to public.

**Testing**
tests will be added in a new PR 

**Performance impact**
none

**Documentation**
Have a separate task for docs 
