### PR TITLE
Prevent PublicAPI File Additions using a workflow 

### DIFF
--- a/.github/workflows/prevent-publicapi-addition.yml
+++ b/.github/workflows/prevent-publicapi-addition.yml
@@ -9,15 +9,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Scan for accidental PublicAPI text file references
+      - name: Scan for accidental PublicAPI references
         run: |
           set -e  # Stop on first error
-          
+
           # Find all .csproj files and check for unwanted lines
           if find . -name "*.csproj" -exec grep -q "PublicAPI.Shipped.txt" {} \; || \
-             find . -name "*.csproj" -exec grep -q "PublicAPI.Unshipped.txt" {} \; then
+             find . -name "*.csproj" -exec grep -q "PublicAPI.Unshipped.txt" {} \; 
+          then
             echo "Error: PublicAPI.Shipped.txt or PublicAPI.Unshipped.txt detected in a .csproj file."
             exit 1
-          else
-            echo "All good - No PublicAPI references found."
           fi
+          
+          echo "All good - No PublicAPI references found."

--- a/.github/workflows/prevent-publicapi-addition.yml
+++ b/.github/workflows/prevent-publicapi-addition.yml
@@ -1,0 +1,23 @@
+name: Prevent PublicAPI File Additions
+
+on: [pull_request]
+
+jobs:
+  check-publicapi-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Scan for accidental PublicAPI text file references
+        run: |
+          set -e  # Stop on first error
+          
+          # Find all .csproj files and check for unwanted lines
+          if find . -name "*.csproj" -exec grep -q "PublicAPI.Shipped.txt" {} \; || \
+             find . -name "*.csproj" -exec grep -q "PublicAPI.Unshipped.txt" {} \; then
+            echo "Error: PublicAPI.Shipped.txt or PublicAPI.Unshipped.txt detected in a .csproj file."
+            exit 1
+          else
+            echo "All good - No PublicAPI references found."
+          fi


### PR DESCRIPTION
Fixes #

**Changes proposed in this request**
This PR introduces a GitHub Actions workflow that automatically detects and blocks accidental additions of PublicAPI.Shipped.txt and PublicAPI.Unshipped.txt in .csproj files. This ensures that these files are not mistakenly committed, preventing unintended changes to the csproj structure.

Given that this is a commonly edited file this workflow should catch it. 

This pull request introduces a new GitHub Actions workflow to prevent the addition of `PublicAPI` files in `.csproj` project files. The most important change is the creation of the `prevent-publicapi-addition.yml` workflow file.

New GitHub Actions workflow:

* [`.github/workflows/prevent-publicapi-addition.yml`](diffhunk://#diff-fe7feea6b350bc8f308c81d4e3e5c19a20439bba1fc756c9f39866f162f48762R1-R24): Added a workflow named "Prevent PublicAPI File Additions" that runs on pull requests. It checks out the code and scans for accidental references to `PublicAPI.Shipped.txt` or `PublicAPI.Unshipped.txt` in `.csproj` files, and fails the check if any are found.

**Testing**
build

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
