### PR TITLE
Update benchmark-action.yml to use NET 8

### DIFF
--- a/.github/workflows/benchmark-action.yml
+++ b/.github/workflows/benchmark-action.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.418'
+          dotnet-version: '8.0.x'
       - name: Run benchmark
-        run: cd tests/Microsoft.Identity.Test.Performance && dotnet run -c release -f net6.0 --exporters json 
+        run: cd tests/Microsoft.Identity.Test.Performance && dotnet run -c release -f net8.0 --exporters json 
 
       - name: Download previous benchmark data
         uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3

--- a/.github/workflows/benchmark-action.yml
+++ b/.github/workflows/benchmark-action.yml
@@ -31,7 +31,7 @@ jobs:
         run: cd tests/Microsoft.Identity.Test.Performance && dotnet run -c release -f net8.0 --exporters json 
 
       - name: Download previous benchmark data
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@v3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark


### PR DESCRIPTION
Fixes #5159

**Changes proposed in this request**
This pull request includes updates to the `.github/workflows/benchmark-action.yml` file to ensure compatibility with the latest .NET version.

Updates to `.github/workflows/benchmark-action.yml`:

* Updated the `dotnet-version` from `6.0.418` to `8.0.x` to use the latest .NET version.
* Changed the target framework in the benchmark run command from `net6.0` to `net8.0` to align with the updated .NET version.

**Testing**
build

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
