### PR TITLE
Update MSAL to send "fmi-bearer" client assertion type based on the client id

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CertificateAndClaimsClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CertificateAndClaimsClientCredential.cs
@@ -65,7 +65,9 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
 
                 string assertion = jwtToken.Sign(Certificate, requestParameters.SendX5C, useSha2);
 
-                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
+                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType,
+                                                                string.Equals(clientId, Constants.FmiUrnClientId) ? 
+                                                                OAuth2AssertionType.FmiBearer : OAuth2AssertionType.JwtBearer);
                 oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, assertion);
             }
             else

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionClientCredential.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
             string tokenEndpoint,
             CancellationToken cancellationToken)
         {
-            oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
+            oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType,
+                                                            string.Equals(requestParameters.AppConfig.ClientId, Constants.FmiUrnClientId) ?
+                                                            OAuth2AssertionType.FmiBearer : OAuth2AssertionType.JwtBearer);
             oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, _signedAssertion);
             return Task.CompletedTask;
         }

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionClientCredential.cs
@@ -30,9 +30,7 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
             string tokenEndpoint,
             CancellationToken cancellationToken)
         {
-            oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType,
-                                                            string.Equals(requestParameters.AppConfig.ClientId, Constants.FmiUrnClientId) ?
-                                                            OAuth2AssertionType.FmiBearer : OAuth2AssertionType.JwtBearer);
+            oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
             oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, _signedAssertion);
             return Task.CompletedTask;
         }

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
             {
                 // If no "AssertionRequestOptions" delegate is supplied
                 string signedAssertion = await _signedAssertionDelegate(cancellationToken).ConfigureAwait(false);
-                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
+
+                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType,
+                                                                requestParameters.AppConfig.ClientId == Constants.FmiUrnClientId ?
+                                                                OAuth2AssertionType.FmiBearer : OAuth2AssertionType.JwtBearer);
                 oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, signedAssertion);
             }
             else

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/SignedAssertionDelegateClientCredential.cs
@@ -38,15 +38,14 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
             string tokenEndpoint,
             CancellationToken cancellationToken)
         {
+            string assertionType = requestParameters.AppConfig.ClientId == Constants.FmiUrnClientId ?
+                                   OAuth2AssertionType.FmiBearer :
+                                   OAuth2AssertionType.JwtBearer;
+            string signedAssertion;
             if (_signedAssertionDelegate != null)
             {
                 // If no "AssertionRequestOptions" delegate is supplied
-                string signedAssertion = await _signedAssertionDelegate(cancellationToken).ConfigureAwait(false);
-
-                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType,
-                                                                requestParameters.AppConfig.ClientId == Constants.FmiUrnClientId ?
-                                                                OAuth2AssertionType.FmiBearer : OAuth2AssertionType.JwtBearer);
-                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, signedAssertion);
+                signedAssertion = await _signedAssertionDelegate(cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -69,13 +68,14 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
 
                 //Set claims
                 assertionOptions.Claims = requestParameters.Claims;
-            
-                // Delegate that uses AssertionRequestOptions
-                string signedAssertion = await _signedAssertionWithInfoDelegate(assertionOptions).ConfigureAwait(false);
 
-                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, OAuth2AssertionType.JwtBearer);
-                oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, signedAssertion);
+                // Delegate that uses AssertionRequestOptions
+                signedAssertion = await _signedAssertionWithInfoDelegate(assertionOptions).ConfigureAwait(false);
+
             }
+
+            oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertionType, assertionType);
+            oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientAssertion, signedAssertion);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Constants.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Identity.Client.Internal
         public const int CallerSdkIdMaxLength = 10;
         public const int CallerSdkVersionMaxLength = 20;
 
+        public const string FmiUrnClientId = "urn:microsoft:identity:fmi";
+
         public static string FormatEnterpriseRegistrationOnPremiseUri(string domain)
         {
             return $"https://enterpriseregistration.{domain}/enrollmentserver/contract";

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuthConstants.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Identity.Client.OAuth2
     internal static class OAuth2AssertionType
     {
         public const string JwtBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+        public const string FmiBearer = "urn:ietf:params:oauth:client-assertion-type:fmi-bearer";
     }
 
     internal static class OAuth2RequestedTokenUse

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/FmiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/FmiTests.cs
@@ -64,7 +64,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [DataRow("urn:microsoft:identity:fmi", "SignedAssertionDelegate")]
         [DataRow(TestConstants.ClientId, "Cert")]
         [DataRow(TestConstants.ClientId, "SignedAssertionDelegate")]
-        public async Task FmiEnsureWithFmiPathUsesCorrectClientAssertion(string clientId, string ClientAssertionType)
+        [DataRow("urn:microsoft:identity:fmi", "SignedAssertionDelegate2")]
+        [DataRow(TestConstants.ClientId, "SignedAssertionDelegate2")]
+        public async Task FmiEnsureWithFmiPathUsesCorrectClientAssertion(string clientId, string clientAssertionType)
         {
             using (var httpManager = new MockHttpManager())
             {
@@ -76,7 +78,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                                               .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
                                               .WithRedirectUri(TestConstants.RedirectUri);
 
-                switch (ClientAssertionType)
+                switch (clientAssertionType)
                 {
                     case "Cert":
                         builder.WithCertificate(certificate);
@@ -84,6 +86,15 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     case "SignedAssertionDelegate":
                         builder.WithClientAssertion(() => { return TestConstants.DefaultClientAssertion; });
                         break;
+                    case "SignedAssertionDelegate2":
+                        Func<AssertionRequestOptions, Task<string>> func = (AssertionRequestOptions options) =>
+                        {
+                            return Task.FromResult(TestConstants.DefaultClientAssertion);
+                        };
+                        builder.WithClientAssertion(func);
+                        break;
+                    default:
+                        throw new NotImplementedException();
                 }
 
                 var app = builder.WithHttpManager(httpManager)

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/FmiTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/FmiTests.cs
@@ -58,5 +58,77 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.AreEqual(fmiClientId, app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().First().ClientId);
             }
         }
+
+        [TestMethod]
+        [DataRow("urn:microsoft:identity:fmi", "Cert")]
+        [DataRow("urn:microsoft:identity:fmi", "SignedAssertionDelegate")]
+        [DataRow(TestConstants.ClientId, "Cert")]
+        [DataRow(TestConstants.ClientId, "SignedAssertionDelegate")]
+        public async Task FmiEnsureWithFmiPathUsesCorrectClientAssertion(string clientId, string ClientAssertionType)
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var jwtClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                var fmiClientAssertionType = "urn:ietf:params:oauth:client-assertion-type:fmi-bearer";
+
+                var certificate = CertHelper.GetOrCreateTestCert();
+                var builder = ConfidentialClientApplicationBuilder.Create(clientId)
+                                              .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                                              .WithRedirectUri(TestConstants.RedirectUri);
+
+                switch (ClientAssertionType)
+                {
+                    case "Cert":
+                        builder.WithCertificate(certificate);
+                        break;
+                    case "SignedAssertionDelegate":
+                        builder.WithClientAssertion(() => { return TestConstants.DefaultClientAssertion; });
+                        break;
+                }
+
+                var app = builder.WithHttpManager(httpManager)
+                .WithExperimentalFeatures()
+                .BuildConcrete();
+
+                var appCacheAccess = app.AppTokenCache.RecordAccess();
+
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                if (string.Equals(clientId, TestConstants.ClientId))
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                                expectedPostData: new Dictionary<string, string>()
+                                { { OAuth2Parameter.ClientAssertionType, jwtClientAssertionType } });
+                }
+                else
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                                expectedPostData: new Dictionary<string, string>()
+                                { { OAuth2Parameter.ClientAssertionType, fmiClientAssertionType } });
+                }
+
+                //Ensure that the FMI path is set correctly and token is retrieved
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                        .WithFmiPath("fmiPath")
+                                        .ExecuteAsync(CancellationToken.None)
+                                        .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual("header.payload.signature", result.AccessToken);
+                Assert.AreEqual(clientId, app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().First().ClientId);
+
+                //Assert token can be acquired from cache
+                result = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                        .WithFmiPath("fmiPath")
+                                        .ExecuteAsync(CancellationToken.None)
+                                        .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual("header.payload.signature", result.AccessToken);
+                Assert.AreEqual(clientId, app.AppTokenCacheInternal.Accessor.GetAllAccessTokens().First().ClientId);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3166310

**Changes proposed in this request**
Update MSAL to send "fmi-bearer" client assertion type based on the provided client id.
If Client id = "urn:microsoft:identity:fmi" Assertion type = "uurn:ietf:params:oauth:client-assertion-type:fmi-bearer"
If Client id != "urn:microsoft:identity:fmi" Assertion type = "uurn:ietf:params:oauth:client-assertion-type:jwt-bearer"

This will occur when using the `WithCertificate()` and `WithClientAssertion(func<>)` methods

**Testing**
Unit testing

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
