### PR TITLE
Update to the `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` files across multiple target frameworks

### DIFF
--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
@@ -1027,3 +1027,8 @@ const Microsoft.Identity.Client.MsalError.MtlsPopWithoutRegion = "mtls_pop_witho
 const Microsoft.Identity.Client.MsalError.RegionRequiredForMtlsPop = "region_required_for_mtls_pop" -> string
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.MachineLearning = 7 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithFmiPath(string pathSuffix) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
-Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
@@ -1027,3 +1027,8 @@ const Microsoft.Identity.Client.MsalError.MtlsPopWithoutRegion = "mtls_pop_witho
 const Microsoft.Identity.Client.MsalError.RegionRequiredForMtlsPop = "region_required_for_mtls_pop" -> string
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.MachineLearning = 7 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithFmiPath(string pathSuffix) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
-Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
@@ -993,3 +993,8 @@ const Microsoft.Identity.Client.MsalError.MtlsPopWithoutRegion = "mtls_pop_witho
 const Microsoft.Identity.Client.MsalError.RegionRequiredForMtlsPop = "region_required_for_mtls_pop" -> string
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.MachineLearning = 7 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithFmiPath(string pathSuffix) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
-Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
@@ -995,3 +995,8 @@ const Microsoft.Identity.Client.MsalError.MtlsPopWithoutRegion = "mtls_pop_witho
 const Microsoft.Identity.Client.MsalError.RegionRequiredForMtlsPop = "region_required_for_mtls_pop" -> string
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.MachineLearning = 7 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithFmiPath(string pathSuffix) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
-Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
@@ -989,3 +989,8 @@ const Microsoft.Identity.Client.MsalError.MtlsPopWithoutRegion = "mtls_pop_witho
 const Microsoft.Identity.Client.MsalError.RegionRequiredForMtlsPop = "region_required_for_mtls_pop" -> string
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.MachineLearning = 7 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithFmiPath(string pathSuffix) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
-Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -989,3 +989,8 @@ const Microsoft.Identity.Client.MsalError.MtlsPopWithoutRegion = "mtls_pop_witho
 const Microsoft.Identity.Client.MsalError.RegionRequiredForMtlsPop = "region_required_for_mtls_pop" -> string
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource.MachineLearning = 7 -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithFmiPath(string pathSuffix) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
+Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
+Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux = 2 -> Microsoft.Identity.Client.BrokerOptions.OperatingSystems
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string>
-Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
-Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder


### PR DESCRIPTION
Fixes - post release updates

**Changes proposed in this request**
This pull request includes updates to the `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` files across multiple target frameworks. The changes primarily focus on adding new API members to the shipped files and removing them from the unshipped files, reflecting their new shipped status.

### API Updates:

* Added new API members to `PublicAPI.Shipped.txt` files:
  * `Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux` [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R996-R1000) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R998-R1002) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR992-R996) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R992-R996)
  * `Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get` [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R996-R1000) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R998-R1002) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR992-R996) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R992-R996)
  * `Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set` [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R996-R1000) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R998-R1002) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR992-R996) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R992-R996)
  * `Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders` [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R996-R1000) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R998-R1002) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR992-R996) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R992-R996)
  * `Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate` [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1030-R1034) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R996-R1000) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R998-R1002) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR992-R996) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R992-R996)

* Removed corresponding API members from `PublicAPI.Unshipped.txt` files:
  * `Microsoft.Identity.Client.BrokerOptions.OperatingSystems.Linux` [[1]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[2]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[3]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[4]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[5]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[6]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5)
  * `Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get` [[1]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[2]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[3]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[4]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[5]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[6]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5)
  * `Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set` [[1]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[2]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[3]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[4]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[5]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[6]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5)
  * `Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders` [[1]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[2]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[3]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[4]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[5]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[6]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5)
  * `Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate` [[1]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[2]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[3]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[4]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[5]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5) [[6]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5L1-L5)

**Testing**
n/a

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated. - n/a
