### PR TITLE
Adding a flag to TokenCacheNotificationArgs to signal that the clientId is an RMA node.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Constants.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Identity.Client.Internal
         public const string ManagedIdentityDefaultTenant = "managed_identity";
         public const string CiamAuthorityHostSuffix = ".ciamlogin.com";
         public const string CertSerialNumber = "cert_sn";
+        public const string FmiNodeClientId = "urn:microsoft:identity:fmi";
 
         public const int CallerSdkIdMaxLength = 10;
         public const int CallerSdkVersionMaxLength = 20;

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.IsFmiClientNode.get -> bool
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Identity.Client
         public TelemetryData TelemetryData { get; }
 
         /// <summary>
-        /// Determines if the client application authentication is an FMI node under an RMA.
+        /// Determines whether the client application authentication instance is classified as an FMI (Federated Managed Identity) node under a specified RMA (Resource Managed Authority).
         /// </summary>
         public bool IsFmiClientNode 
         {

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.TelemetryCore.TelemetryClient;
 using Microsoft.IdentityModel.Abstractions;
 
@@ -255,5 +256,13 @@ namespace Microsoft.Identity.Client
         /// Cache Details contains the details of L1/ L2 cache for telemetry logging.
         /// </summary>
         public TelemetryData TelemetryData { get; }
+
+        /// <summary>
+        /// Determines if the client application authentication is an FMI node under an RMA.
+        /// </summary>
+        public bool IsFmiClientNode 
+        {
+            get { return ClientId.Equals(Constants.FmiNodeClientId); }
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Identity.Client
                    hasTokens,
                    suggestedCacheExpiry,
                    cancellationToken,
-                   default, 
-                   default, 
+                   default,
+                   default,
                    default,
                    null,
                    default)
-            {
-            }
+        {
+        }
 
         /// <summary>
         /// This constructor is for test purposes only. It allows apps to unit test their MSAL token cache implementation code.
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Client
             bool hasTokens,
             DateTimeOffset? suggestedCacheExpiry,
             CancellationToken cancellationToken,
-            Guid correlationId)       
+            Guid correlationId)
            : this(tokenCache,
                    clientId,
                    account,
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client
                    default,
                    null,
                    default)
-        { 
+        {
         }
 
         /// <summary>
@@ -93,10 +93,10 @@ namespace Microsoft.Identity.Client
             bool hasTokens,
             DateTimeOffset? suggestedCacheExpiry,
             CancellationToken cancellationToken,
-            Guid correlationId, 
+            Guid correlationId,
             IEnumerable<string> requestScopes,
             string requestTenantId)
-            
+
         {
             TokenCache = tokenCache;
             ClientId = clientId;
@@ -146,7 +146,7 @@ namespace Microsoft.Identity.Client
             SuggestedCacheExpiry = suggestedCacheExpiry;
             IdentityLogger = identityLogger;
             PiiLoggingEnabled = piiLoggingEnabled;
-            TelemetryData = telemetryData?? new TelemetryData();
+            TelemetryData = telemetryData ?? new TelemetryData();
         }
 
         /// <summary>
@@ -260,9 +260,17 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Determines whether the client application authentication instance is classified as an FMI (Federated Managed Identity) node under a specified RMA (Resource Managed Authority).
         /// </summary>
-        public bool IsFmiClientNode 
+        public string NoDistributedCacheUseReason
         {
-            get { return ClientId.Equals(Constants.FmiNodeClientId); }
+            get
+            {
+                if (ClientId.Equals(Constants.FmiNodeClientId))
+                {
+                    return "The currently provided client id indicates that this is a RMA (Resource Managed Authority) node client. RMA node clients should not use a distributed cache, please use an in memory cache instead.";
+                }
+
+                return string.Empty;
+            }
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -216,6 +216,7 @@ namespace Microsoft.Identity.Test.Unit
 
         public const string Bearer = "Bearer";
         public const string Pop = "PoP";
+        public const string FmiNodeClientId = "urn:microsoft:identity:fmi";
 
         public static IDictionary<string, string> ExtraQueryParameters
         {

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheNotificationTests.cs
@@ -541,7 +541,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             using (var harness = CreateTestHarness())
             {
-                //Confirm that IsFmiClientNode is correct
+                // Confirm that NoDistributedCacheUseReason is correct
                 // Arrange
                 var cca = ConfidentialClientApplicationBuilder
                     .Create(clientId)
@@ -554,11 +554,13 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     Assert.AreEqual(clientId, args.ClientId);
                     if (clientId.Equals(TestConstants.FmiNodeClientId))
                     {
-                        Assert.IsTrue(args.IsFmiClientNode);
+                        // string should not be null or empty
+                        Assert.IsTrue(!string.IsNullOrEmpty(args.NoDistributedCacheUseReason));
                     }
                     else
                     {
-                        Assert.IsFalse(args.IsFmiClientNode);
+                        // string should be null or empty
+                        Assert.IsTrue(string.IsNullOrEmpty(args.NoDistributedCacheUseReason));
                     }
 
                     CollectionAssert.AreEquivalent(TestConstants.s_scope.ToArray(), args.RequestScopes.ToArray());


### PR DESCRIPTION
Fixes #
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3174516

**Changes proposed in this request**
Adding a flag to `TokenCacheNotificationArgs` to signal that the clientId is an RMA node.

**Testing**
Unit testing

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
