### PR TITLE
Enhancing Token Refresh Control in MSAL: Introducing .WithAccessTokenSha256ToRefresh() in AcquireTokenForClient Flows

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Client
     public sealed class AcquireTokenForClientParameterBuilder :
         AbstractConfidentialClientAcquireTokenParameterBuilder<AcquireTokenForClientParameterBuilder>
     {
-        private AcquireTokenForClientParameters Parameters { get; } = new AcquireTokenForClientParameters();
+        internal AcquireTokenForClientParameters Parameters { get; } = new AcquireTokenForClientParameters();
 
         /// <inheritdoc/>
         internal AcquireTokenForClientParameterBuilder(IConfidentialClientApplicationExecutor confidentialClientApplicationExecutor)
@@ -154,26 +154,6 @@ namespace Microsoft.Identity.Client
 
             CommonParameters.FmiPathSuffix = pathSuffix;
 
-            return this;
-        }
-
-        /// <summary>
-        /// Specifies that the token refresh should only occur if the specified SHA-256 hash
-        /// of the previously issued access token matches a cached token.
-        /// If the hash does not match, the existing cached token is returned without refresh.
-        /// </summary>
-        /// <param name="hash">The SHA-256 hash of the access token to refresh.</param>
-        /// <returns>The builder to chain the .With methods</returns>
-        public AcquireTokenForClientParameterBuilder WithAccessTokenSha256ToRefresh(string hash)
-        {
-            ValidateUseOfExperimentalFeature();
-
-            if (string.IsNullOrWhiteSpace(hash))
-            {
-                throw new ArgumentNullException(nameof(hash), "Access token hash cannot be null or empty.");
-            }
-
-            Parameters.AccessTokenHashToRefresh = hash;
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 builder.AppendLine("=== AcquireTokenForClientParameters ===");
                 builder.AppendLine("SendX5C: " + SendX5C);
                 builder.AppendLine("ForceRefresh: " + ForceRefresh);
+                builder.AppendLine($"AccessTokenHashToRefresh: {!string.IsNullOrEmpty(AccessTokenHashToRefresh)}");
                 logger.Info(builder.ToString());
             }
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForClientParameters.cs
@@ -9,9 +9,13 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 {
     internal class AcquireTokenForClientParameters : AbstractAcquireTokenConfidentialClientParameters, IAcquireTokenParameters
     {
-        /// <summary>
-        /// </summary>
         public bool ForceRefresh { get; set; }
+
+        /// <summary>
+        /// The SHA-256 hash of the access token that should be refreshed.
+        /// If set, token refresh will occur only if a matching token is found in cache.
+        /// </summary>
+        public string AccessTokenHashToRefresh { get; set; }
 
         /// <inheritdoc/>
         public void LogParameters(ILoggerAdapter logger)

--- a/src/client/Microsoft.Identity.Client/Extensibility/RP/AcquireTokenForClientParameterBuilderForResourceProviders.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/RP/AcquireTokenForClientParameterBuilderForResourceProviders.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+
+namespace Microsoft.Identity.Client.RP
+{
+    /// <summary>
+    /// Resource Provider extensibility methods for AcquireTokenForClientParameterBuilder
+    /// </summary>
+    public static class AcquireTokenForClientParameterBuilderForResourceProviders
+    {
+        /// <summary>
+        /// Configures the SDK to not retrieve a token from the cache if it matches the SHA256 hash 
+        /// of the token configured. Similar to WithForceRefresh(bool) API, but instead of bypassing 
+        /// the cache for all tokens, the cache bypass only occurs for 1 token
+        /// </summary>
+        /// <param name="builder">The existing AcquireTokenForClientParameterBuilder instance.</param>
+        /// <param name="hash">
+        /// A Base64-encoded SHA-256 hash of the token (UTF-8). For example:
+        /// <c>Convert.ToBase64String(SHA256(Encoding.UTF8.GetBytes(accessToken)))</c>.
+        /// </param>
+        /// <returns>The builder to chain the .With methods.</returns>
+        public static AcquireTokenForClientParameterBuilder WithAccessTokenSha256ToRefresh(
+            this AcquireTokenForClientParameterBuilder builder,
+            string hash)
+        {
+            if (!string.IsNullOrWhiteSpace(hash))
+            {
+                builder.Parameters.AccessTokenHashToRefresh = hash;
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         }
 
         /// <summary>
-        /// Checks if the token should be used from the cache.
+        /// Checks if the token should be used from the cache and returns the cached access token if applicable.
         /// </summary>
         /// <returns></returns>
         private async Task<MsalAccessTokenCacheItem> GetCachedAccessTokenAsync()

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -202,6 +202,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return authResult;
         }
 
+        /// <summary>
+        /// Checks if the token should be used from the cache.
+        /// </summary>
+        /// <returns></returns>
         private async Task<MsalAccessTokenCacheItem> GetCachedAccessTokenAsync()
         {
             // Fetch the cache item (could be null if none found).
@@ -219,6 +223,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return cacheItem;
         }
 
+        /// <summary>
+        /// Checks if the token should be used from the cache.
+        /// </summary>
+        /// <param name="cacheItem"></param>
+        /// <returns></returns>
         private bool ShouldUseCachedToken(MsalAccessTokenCacheItem cacheItem)
         {
             // 1) No cached item 
@@ -239,18 +248,32 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return true;
         }
 
+        /// <summary>
+        /// Checks if the token hash matches the hash provided in AccessTokenHashToRefresh.
+        /// </summary>
+        /// <param name="tokenSecret"></param>
+        /// <param name="accessTokenHashToRefresh"></param>
+        /// <returns></returns>
         private bool IsMatchingTokenHash(string tokenSecret, string accessTokenHashToRefresh)
         {
             string cachedTokenHash = _cryptoManager.CreateSha256Hash(tokenSecret);
             return string.Equals(cachedTokenHash, accessTokenHashToRefresh, StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// Marks the request as a cache hit and increments the cache hit count.
+        /// </summary>
         private void MarkAccessTokenAsCacheHit()
         {
             AuthenticationRequestParameters.RequestContext.ApiEvent.IsAccessTokenCacheHit = true;
             Metrics.IncrementTotalAccessTokensFromCache();
         }
 
+        /// <summary>
+        /// returns the cached access token item 
+        /// </summary>
+        /// <param name="cachedAccessTokenItem"></param>
+        /// <returns></returns>
         private AuthenticationResult CreateAuthenticationResultFromCache(MsalAccessTokenCacheItem cachedAccessTokenItem)
         {
             AuthenticationResult authResult = new AuthenticationResult(
@@ -266,6 +289,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return authResult;
         }
 
+        /// <summary>
+        /// Gets overriden scopes for client credentials flow
+        /// </summary>
+        /// <param name="inputScopes"></param>
+        /// <returns></returns>
         protected override SortedSet<string> GetOverriddenScopes(ISet<string> inputScopes)
         {
             // Client credentials should not add the reserved scopes
@@ -274,6 +302,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return new SortedSet<string>(inputScopes);
         }
 
+        /// <summary>
+        /// Gets the body parameters for the client credentials flow
+        /// </summary>
+        /// <returns></returns>
         private Dictionary<string, string> GetBodyParameters()
         {
             var dict = new Dictionary<string, string>
@@ -285,6 +317,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return dict;
         }
 
+        /// <summary>
+        /// Gets the CCS header for the client credentials flow
+        /// </summary>
+        /// <param name="additionalBodyParameters"></param>
+        /// <returns></returns>
         protected override KeyValuePair<string, string>? GetCcsHeader(IDictionary<string, string> additionalBodyParameters)
         {
             return null;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     if (string.Equals(cachedTokenHash, _clientParameters.AccessTokenHashToRefresh, StringComparison.Ordinal))
                     {
                         AuthenticationRequestParameters.RequestContext.Logger.Info(
-                            "[ClientCredentialRequest] Found the 'bad' token in the cache. Skipping cache usage.");
+                            "[ClientCredentialRequest] A cached token was found, but it matches the AccessTokenHashToRefresh, so it is ignored");
                         return null; // triggers a new token acquisition
                     }
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (skipCache)
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ForceRefreshOrClaims;
-                logger.Info("[ClientCredentialRequest] Skipped looking for a cached access token because ForceRefresh or Claims were set.");
+                logger.Info("[ClientCredentialRequest] Skipped looking for a cached access token because either of ForceRefresh, Claims or AccessTokenHashToRefresh were set.");
                 authResult = await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);
                 return authResult;
             }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -231,10 +231,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
         /// </summary>
         private bool IsValidCachedToken(MsalAccessTokenCacheItem cachedAccessTokenItem)
         {
-            // Return false if:
-            // - The cache is empty
-            // - ForceRefresh is enabled
-            if (cachedAccessTokenItem == null || _clientParameters.ForceRefresh)
+            // Return false if the cache is empty
+            if (cachedAccessTokenItem == null)
             {
                 return false;
             }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1177,5 +1177,16 @@ namespace Microsoft.Identity.Client
         /// <para>Mitigation:</para> Ensure that the AzureRegion configuration is set when using mTLS PoP as it requires a regional endpoint.
         /// </summary>
         public const string RegionRequiredForMtlsPop = "region_required_for_mtls_pop";
+
+        /// <summary>
+        /// <para>What happened?</para> The operation attempted to force a token refresh while also using a token hash. 
+        /// These two options are incompatible because forcing a refresh bypasses token caching, 
+        /// which conflicts with token hash validation.
+        /// <para>Mitigation:</para>
+        /// - Ensure that `force_refresh` is not set to `true` when using a token hash.
+        /// - Review the request parameters to ensure they are not conflicting.
+        /// - If token hashing is required, allow the cached token to be used instead of forcing a refresh.
+        /// </summary>
+        public const string ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -437,5 +437,6 @@ namespace Microsoft.Identity.Client
         public const string MtlsInvalidAuthorityTypeMessage = "mTLS PoP is only supported for AAD authority type. See https://aka.ms/msal-net-pop for details.";
         public const string MtlsNonTenantedAuthorityNotAllowedMessage = "mTLS authentication requires a tenanted authority. Using 'common', 'organizations', or similar non-tenanted authorities is not allowed. Please provide an authority with a specific tenant ID (e.g., 'https://login.microsoftonline.com/{tenantId}'). See https://aka.ms/msal-net-pop for details.";
         public const string RegionRequiredForMtlsPopMessage = "Regional auto-detect failed. mTLS Proof-of-Possession requires a region to be specified, as there is no global endpoint for mTLS. See https://aka.ms/msal-net-pop for details.";
+        public const string ForceRefreshAndTokenHasNotCompatible = "Cannot specify ForceRefresh and AccessTokenSha256ToRefresh in the same request.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithAccessTokenSha256ToRefresh(string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -895,7 +895,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task ManagedIdentityIsProactivelyRefreshedAsync()
+        public async Task ManagedIdentityIsProActivelyRefreshedAsync()
         {
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager(isManagedIdentity: true))

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -2238,29 +2238,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             }
         }
 
-        public async Task WithAccessTokenSha256ToRefresh_NullOrEmpty_ThrowsArgumentNullException_Async()
-        {
-            ConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
-                .WithClientSecret(TestConstants.ClientSecret)
-                .WithExperimentalFeatures(true)
-                .BuildConcrete();
-
-            // 1) If hash is null, expect ArgumentNullException
-            await AssertException.TaskThrowsAsync<ArgumentNullException>(() =>
-                app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithAccessTokenSha256ToRefresh(null)  // Null hash
-                    .ExecuteAsync()
-            ).ConfigureAwait(false);
-
-            // 2) If hash is empty, expect ArgumentNullException
-            await AssertException.TaskThrowsAsync<ArgumentNullException>(() =>
-                app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithAccessTokenSha256ToRefresh("")  // Empty hash
-                    .ExecuteAsync()
-            ).ConfigureAwait(false);
-
-        }
-
         [TestMethod]
         public async Task ForceRefreshAndAccessTokenHash_ThrowsException_Async()
         {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.RP;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.ClientCredential;
@@ -2338,6 +2339,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 // First network call: populates the cache with "cache-token"
                 httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "cache-token");
+
                 var initialResult = await app.AcquireTokenForClient(TestConstants.s_scope)
                     .ExecuteAsync()
                     .ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -2168,7 +2168,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 ConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 // 1) First network call: populates the cache with "access-token"
@@ -2212,7 +2211,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 ConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 // 1) Populate the cache with "access-token"
@@ -2245,7 +2243,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             ConfidentialClientApplication cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                                                             .WithClientSecret(TestConstants.ClientSecret)
-                                                            .WithExperimentalFeatures(true)
                                                             .BuildConcrete();
 
             // Attempt to create a request that sets both ForceRefresh and an AccessTokenHash
@@ -2277,7 +2274,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .Create(TestConstants.ClientId)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: oldToken);
@@ -2318,7 +2314,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .Create(TestConstants.ClientId)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 // First network call: populates the cache with "cache-token"


### PR DESCRIPTION
Fixes #5111

**Specification -** https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/main/docs/msiv1_token_revocation.md

**Changes proposed in this request**
This pull request includes several changes to enhance token acquisition and revocation capabilities in the MSAL library. The most important changes focus on adding support for token hash-based refresh, improving cache handling, and updating error handling.

### Enhancements to Token Acquisition and Revocation:

* Added a new method `WithAccessTokenSha256ToRefresh` to the `AcquireTokenForClientParameterBuilder` for configuring the SDK to bypass the cache for a specific token based on its SHA-256 hash.
* Introduced a new property `AccessTokenHashToRefresh` in `AcquireTokenForClientParameters` to store the hash of the token to be refreshed.
* Updated `ClientCredentialRequest` to handle token hash-based refresh logic, including checking the cache for matching tokens and bypassing the cache if necessary. [[1]](diffhunk://#diff-655d5868568553085143b1c4df713cb7baf07c35ab78610a8ac73da1e467ce43R26) [[2]](diffhunk://#diff-655d5868568553085143b1c4df713cb7baf07c35ab78610a8ac73da1e467ce43L47-R68) [[3]](diffhunk://#diff-655d5868568553085143b1c4df713cb7baf07c35ab78610a8ac73da1e467ce43R209-R287)

### Error Handling Improvements:

* Added a new error `ForceRefreshNotCompatibleWithTokenHash` to indicate that force refresh and token hash cannot be used together. [[1]](diffhunk://#diff-e5c43e5cc8296950029f80cce9e2b350341fcdc994737931e50a2d43d310878eR1180-R1190) [[2]](diffhunk://#diff-5f7fcb836912bee0deb52d9dbdedafd36ce6fad65c20327ea497847edb7f2fdeR440) [[3]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5R1-R3)

### Internal Code Changes:

* Changed the visibility of the `Parameters` property in `AcquireTokenForClientParameterBuilder` from private to internal.
* Added validation in `AcquireTokenForClientParameterBuilder` to throw an exception if both force refresh and token hash are used together.

### Documentation Updates:

* Removed outdated documentation on MSI v1 token revocation and capabilities from `docs/msiv1_token_revocation.md`.

These changes collectively improve the flexibility and robustness of token handling in the MSAL library.

**Testing**
unit tests

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
