### PR TITLE
For Mtls, throw exception when service config region is set to null.

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -165,6 +165,7 @@ namespace Microsoft.Identity.Client
         }
 
         /// <inheritdoc/>
+        /// <seealso cref="ConfidentialClientApplicationBuilder.Validate"/> for a comment inside this function for AzureRegion.
         protected override void Validate()
         {
             if (CommonParameters.MtlsCertificate != null)
@@ -187,8 +188,10 @@ namespace Microsoft.Identity.Client
                 }
 
                 // Check for Azure region only if the authority is AAD
+                // AzureRegion is by default set to null or set to null when the application is created
+                // with region set to DisableForceRegion (see ConfidentialClientApplicationBuilder.Validate)
                 if (ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType == AuthorityType.Aad &&
-                    string.IsNullOrWhiteSpace(ServiceBundle.Config.AzureRegion))
+                    ServiceBundle.Config.AzureRegion == null)
                 {
                     throw new MsalClientException(
                         MsalError.MtlsPopWithoutRegion,

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Identity.Client
 
                 // Check for Azure region only if the authority is AAD
                 if (ServiceBundle.Config.Authority.AuthorityInfo.AuthorityType == AuthorityType.Aad &&
-                    string.IsNullOrEmpty(ServiceBundle.Config.AzureRegion))
+                    string.IsNullOrWhiteSpace(ServiceBundle.Config.AzureRegion))
                 {
                     throw new MsalClientException(
                         MsalError.MtlsPopWithoutRegion,

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
@@ -129,12 +129,15 @@ namespace Microsoft.Identity.Test.Unit
             Assert.AreEqual(MsalError.MtlsCertificateNotProvided, ex.ErrorCode);
         }
 
-        [TestMethod]
-        public async Task MtlsPopWithoutRegionAsync()
+        [DataTestMethod]
+        [DataRow(null, DisplayName = "Region is null")]
+        [DataRow("", DisplayName = "Region is empty string")]
+        [DataRow("   ", DisplayName = "Region is whitespace")]
+        public async Task MtlsPopWithoutRegionAsync(string region)
         {
             using (var envContext = new EnvVariableContext())
             {
-                Environment.SetEnvironmentVariable("REGION_NAME", null); // Ensure no region is set
+                Environment.SetEnvironmentVariable("REGION_NAME", region); // Ensure no region is set
 
                 IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                                 .Create(TestConstants.ClientId)
@@ -151,6 +154,7 @@ namespace Microsoft.Identity.Test.Unit
                     .ConfigureAwait(false);
 
                 Assert.AreEqual(MsalError.MtlsPopWithoutRegion, ex.ErrorCode);
+                Assert.AreEqual(MsalErrorMessage.MtlsPopWithoutRegion, ex.Message);
             }
         }
 


### PR DESCRIPTION
This PR fixes throwing exception when service config region is set to null for Mtls.

Fixes #5181 
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
- Replaced `string.IsNullOrEmpty` with `null` in `AcquireTokenForClientParameterBuilder.cs` for Azure region check when the authority is AAD.
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
- Updates existing unit tests to cover another case for this case when service config region is set to null and fixes existing tests.
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->
N/A

**Documentation**
- [ ] All relevant documentation is updated.
