### PR TITLE
Split CacheRefreshReason.ForceRefreshOrClaims into ForceRefresh and WithClaims

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Identity.Client
         /// </summary>
         NotApplicable = 0,
         /// <summary>
-        /// When the token request goes to the identity provider because force_refresh was set to true. Also occurs if WithClaims() is used.
+        /// When the token request goes to the identity provider because force_refresh was set to true.
         /// </summary>
-        ForceRefreshOrClaims = 1,
+        ForceRefresh = 1,
         /// <summary>
         /// When the token request goes to the identity provider because no cached access token exists
         /// </summary>
@@ -27,6 +27,14 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// When the token request goes to the identity provider because refresh_in was used and the existing token needs to be refreshed
         /// </summary>
-        ProactivelyRefreshed = 4
+        ProactivelyRefreshed = 4,
+        /// <summary>
+        /// When the token request goes to the identity provider because WithClaims() was used.
+        /// </summary>
+        WithClaims = 5,
+        /// <summary>
+        /// When the token request goes to the identity provider because WithAccessTokenSha256ToRefresh() is used AND the hash matches.
+        /// </summary>
+        TokenRejected = 6
     }
 }

--- a/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Identity.Client
 {
     /// <summary>
@@ -13,28 +15,33 @@ namespace Microsoft.Identity.Client
         /// </summary>
         NotApplicable = 0,
         /// <summary>
+        /// When the token request goes to the identity provider because force_refresh was set to true. Also occurs if WithClaims() is used.
+        /// </summary>
+        [Obsolete("Use ForceRefresh or WithClaims instead.")]
+        ForceRefreshOrClaims = 1,
+        /// <summary>
         /// When the token request goes to the identity provider because force_refresh was set to true.
         /// </summary>
-        ForceRefresh = 1,
+        ForceRefresh = 2,
         /// <summary>
         /// When the token request goes to the identity provider because no cached access token exists
         /// </summary>
-        NoCachedAccessToken = 2,
+        NoCachedAccessToken = 3,
         /// <summary>
         /// When the token request goes to the identity provider because cached access token expired
         /// </summary>
-        Expired = 3,
+        Expired = 4,
         /// <summary>
         /// When the token request goes to the identity provider because refresh_in was used and the existing token needs to be refreshed
         /// </summary>
-        ProactivelyRefreshed = 4,
+        ProactivelyRefreshed = 5,
         /// <summary>
         /// When the token request goes to the identity provider because WithClaims() was used.
         /// </summary>
-        WithClaims = 5,
+        WithClaims = 6,
         /// <summary>
-        /// When the token request goes to the identity provider because WithAccessTokenSha256ToRefresh() is used AND the hash matches.
+        /// Indicates that the resource (e.g., Microsoft Graph) has rejected the provided token. 
         /// </summary>
-        TokenRejected = 6
+        TokenRejectedByResource = 7
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             AuthenticationResult authResult;
 
-            // Determine the cache refresh reason and log
+            // Determine if there is a cache refresh reason and log
             if (_clientParameters.ForceRefresh || !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo =

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -47,11 +47,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             AuthenticationResult authResult;
 
-            // Skip checking cache when force refresh or claims are specified
+            // Determine the cache refresh reason and log
             if (_clientParameters.ForceRefresh || !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
-                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ForceRefreshOrClaims;
-                logger.Info("[ClientCredentialRequest] Skipped looking for a cached access token because ForceRefresh or Claims were set.");
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo =
+                    _clientParameters.ForceRefresh ? CacheRefreshReason.ForceRefresh : CacheRefreshReason.WithClaims;
+
+                logger.Info($"[ClientCredentialRequest] Skipped looking for a cached access token because " +
+                            $"{(_clientParameters.ForceRefresh ? "ForceRefresh" : "Claims")} was set.");
+
                 authResult = await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);
                 return authResult;
             }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             AuthenticationResult authResult = null;
             ILoggerAdapter logger = AuthenticationRequestParameters.RequestContext.Logger;
 
-            // Determine the cache refresh reason and log
+            // Determine the cache refresh reason, skip the cache if force refresh or claims is used and log
             if (_managedIdentityParameters.ForceRefresh || !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo =

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -33,13 +33,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
             AuthenticationResult authResult = null;
             ILoggerAdapter logger = AuthenticationRequestParameters.RequestContext.Logger;
 
-            // Skip checking cache when force refresh or claims is specified
+            // Determine the cache refresh reason and log
             if (_managedIdentityParameters.ForceRefresh || !string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
-                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ForceRefreshOrClaims;
-                
-                logger.Info("[ManagedIdentityRequest] Skipped looking for a cached access token because ForceRefresh or Claims were set. " +
-                    "This means either a force refresh was requested or claims were present.");
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo =
+                    _managedIdentityParameters.ForceRefresh ? CacheRefreshReason.ForceRefresh : CacheRefreshReason.WithClaims;
+
+                logger.Info($"[ManagedIdentityRequest] Skipped looking for a cached access token because " +
+                            $"{(_managedIdentityParameters.ForceRefresh ? "ForceRefresh" : "Claims")} was set.");
 
                 authResult = await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);
                 return authResult;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -103,8 +103,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
             else
             {
-                logger.Info("[OBO Request] Skipped looking for an Access Token in the cache because ForceRefresh or Claims were set. ");
-                cacheInfoTelemetry = CacheRefreshReason.ForceRefreshOrClaims;
+                cacheInfoTelemetry = _onBehalfOfParameters.ForceRefresh ? CacheRefreshReason.ForceRefresh : CacheRefreshReason.WithClaims;
+
+                logger.Info($"[OBO Request] Skipped looking for an Access Token in the cache because " +
+                            $"{(_onBehalfOfParameters.ForceRefresh ? "ForceRefresh" : "Claims")} was set.");
             }
 
             if (AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo == CacheRefreshReason.NotApplicable)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -66,8 +66,10 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             }
             else
             {
-                cacheInfoTelemetry = CacheRefreshReason.ForceRefreshOrClaims;
-                logger.Info("Skipped looking for an Access Token because ForceRefresh or Claims were set. ");
+                cacheInfoTelemetry = _silentParameters.ForceRefresh ? CacheRefreshReason.ForceRefresh : CacheRefreshReason.WithClaims;
+
+                logger.Info($"[OBO Request] Skipped looking for an Access Token in the cache because " +
+                            $"{(_silentParameters.ForceRefresh ? "ForceRefresh" : "Claims")} was set.");
             }
 
             if (AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo == CacheRefreshReason.NotApplicable)

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
@@ -436,10 +436,7 @@ Microsoft.Identity.Client.CacheOptions.CacheOptions(bool useSharedCache) -> void
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.ClientApplicationBase
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
@@ -437,7 +437,6 @@ Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.Expired = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 2 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 3 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejectedByResource = 7 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 6 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
@@ -436,10 +436,7 @@ Microsoft.Identity.Client.CacheOptions.CacheOptions(bool useSharedCache) -> void
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.ClientApplicationBase
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
@@ -437,7 +437,6 @@ Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.Expired = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 2 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 3 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejectedByResource = 7 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 6 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
@@ -440,7 +440,6 @@ Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
@@ -439,10 +439,7 @@ Microsoft.Identity.Client.CacheOptions.CacheOptions(bool useSharedCache) -> void
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.ClientApplicationBase
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.Expired = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 2 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 3 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejectedByResource = 7 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 6 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
@@ -442,7 +442,6 @@ Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
@@ -441,10 +441,7 @@ Microsoft.Identity.Client.CacheOptions.CacheOptions(bool useSharedCache) -> void
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.ClientApplicationBase
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.Expired = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 2 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 3 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejectedByResource = 7 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 6 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
@@ -433,10 +433,7 @@ Microsoft.Identity.Client.CacheOptions.CacheOptions(bool useSharedCache) -> void
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.ClientApplicationBase
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
@@ -434,7 +434,6 @@ Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.Expired = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 2 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 3 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejectedByResource = 7 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 6 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -433,10 +433,7 @@ Microsoft.Identity.Client.CacheOptions.CacheOptions(bool useSharedCache) -> void
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.ClientApplicationBase
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, Microsoft.Identity.Client.IAccount account) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
 Microsoft.Identity.Client.ClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable<string> scopes, string loginHint) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -434,7 +434,6 @@ Microsoft.Identity.Client.CacheOptions.UseSharedCache.get -> bool
 Microsoft.Identity.Client.CacheOptions.UseSharedCache.set -> void
 Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.Expired = 3 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefreshOrClaims = 1 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 2 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 4 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
-Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 1 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.TokenRejected = 6 -> Microsoft.Identity.Client.CacheRefreshReason
-Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.Expired = 4 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ForceRefresh = 2 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NoCachedAccessToken = 3 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.NotApplicable = 0 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.ProactivelyRefreshed = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.TokenRejectedByResource = 7 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.CacheRefreshReason.WithClaims = 6 -> Microsoft.Identity.Client.CacheRefreshReason

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/HttpTelemetryRecorder.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/HttpTelemetryRecorder.cs
@@ -23,9 +23,18 @@ namespace Microsoft.Identity.Test.Integration.Infrastructure
         {
             string[] splitCsv = telemetryCsv.Split('|');
             string[] splitApiIdAndCacheInfo = splitCsv[1].Split(',');
+
             ApiId.Add(splitApiIdAndCacheInfo[0]);
-            Enum.TryParse(splitApiIdAndCacheInfo[1], out CacheRefreshReason cacheInfoTelemetry);
-            ForceRefresh = CacheRefreshReason.ForceRefreshOrClaims == cacheInfoTelemetry;
+
+            if (Enum.TryParse(splitApiIdAndCacheInfo[1], out CacheRefreshReason cacheInfoTelemetry))
+            {
+                ForceRefresh = cacheInfoTelemetry == CacheRefreshReason.ForceRefresh ||
+                               cacheInfoTelemetry == CacheRefreshReason.WithClaims;
+            }
+            else
+            {
+                ForceRefresh = false;
+            }
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/HttpTelemetryRecorder.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/HttpTelemetryRecorder.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Identity.Test.Integration.Infrastructure
 
             if (Enum.TryParse(splitApiIdAndCacheInfo[1], out CacheRefreshReason cacheInfoTelemetry))
             {
-                ForceRefresh = cacheInfoTelemetry == CacheRefreshReason.ForceRefresh ||
-                               cacheInfoTelemetry == CacheRefreshReason.WithClaims;
+                ForceRefresh = cacheInfoTelemetry == 
+                    CacheRefreshReason.ForceRefresh || cacheInfoTelemetry == CacheRefreshReason.WithClaims;
             }
             else
             {


### PR DESCRIPTION
Fixes #5186

**Changes proposed in this request**
This pull request includes several changes to the `CacheRefreshReason` enum and updates to the related logic and tests across multiple files. The changes focus on refining the reasons for cache refresh and improving the logging and handling of these reasons.

### Enum and Logic Updates:

* [`src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs`](diffhunk://#diff-dd548256ab53963ad65e75170deba2ff00da77c5ca6192415ff6b38f9048d93eL16-R18): Updated `CacheRefreshReason` enum by removing `ForceRefreshOrClaims` and adding `WithClaims` and `TokenRejected` reasons. [[1]](diffhunk://#diff-dd548256ab53963ad65e75170deba2ff00da77c5ca6192415ff6b38f9048d93eL16-R18) [[2]](diffhunk://#diff-dd548256ab53963ad65e75170deba2ff00da77c5ca6192415ff6b38f9048d93eL30-R38)
* [`src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs`](diffhunk://#diff-655d5868568553085143b1c4df713cb7baf07c35ab78610a8ac73da1e467ce43L50-R58): Updated cache refresh reason logic to distinguish between `ForceRefresh` and `WithClaims`.
* [`src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs`](diffhunk://#diff-a1260a45bdc4ac7ab60d4a348996be6b69c5a48fa6f484fa41daa390c7e69ca8L36-R43): Similar update to cache refresh reason logic.
* [`src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs`](diffhunk://#diff-bf467b9439792137a4965d3a9b52423cf088346687d966681557d134a6ef1b10L106-R109): Updated to log specific cache refresh reasons.
* [`src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs`](diffhunk://#diff-04f82f33c9cf802268c7c48a869ca80b26839db606a0d729bd739887c7593bfaL69-R72): Updated to log specific cache refresh reasons.

### Public API Updates:

* [`src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt`](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195L440): Removed `ForceRefreshOrClaims` from the shipped API.
* [`src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt`](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5R1-R3): Added `ForceRefresh`, `WithClaims`, and `TokenRejected` to the unshipped API.
* Similar updates were made to other `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` files for different frameworks. [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195L440) [[2]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7L443) [[3]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1L445) [[4]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aL437) [[5]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5L437)

### Test Updates:

* [`tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/HttpTelemetryRecorder.cs`](diffhunk://#diff-e560c22d3e206c40340cfa15a35dc7c161384a5820ec978a148eb01c062ad807R26-R37): Updated to handle new cache refresh reasons.
* [`tests/Microsoft.Identity.Test.Unit/RequestsTests/LongRunningOnBehalfOfTests.cs`](diffhunk://#diff-1cd803db17cc6016844d5ee7bc809e58ac9b8695236bac89405edda7d5b8bf1aL334-R334): Added a new test for `WithClaims` and updated existing tests to reflect the new enum values. [[1]](diffhunk://#diff-1cd803db17cc6016844d5ee7bc809e58ac9b8695236bac89405edda7d5b8bf1aL334-R334) [[2]](diffhunk://#diff-1cd803db17cc6016844d5ee7bc809e58ac9b8695236bac89405edda7d5b8bf1aR931-R972)
* [`tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs`](diffhunk://#diff-606c6cb88f2f7be52cfb5bdeee91051feba0dc6135aca2786dd869867b174004L105-R105): Updated telemetry test to use `ForceRefresh` instead of `ForceRefreshOrClaims`.

These changes collectively enhance the granularity and clarity of cache refresh reasons, improving both logging and functionality.

**Testing**
unit testing

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated. Need to check documentation, 
