### PR TITLE
Added missing param in arrow 8, also refined headers

### DIFF
--- a/docs/msiv1_token_revocation.md
+++ b/docs/msiv1_token_revocation.md
@@ -13,10 +13,10 @@
 ```mermaid
 sequenceDiagram
     participant Resource
-    actor Client/Caller (CX)
-    participant MSAL (Leaf)
-    participant MITS (Proxy)
-    participant SFRP (RP)
+    actor CX as Client/Caller
+    participant MSAL as MSAL on Leaf
+    participant MITS as MITS (Proxy)
+    participant SFRP as SFRP (RP)
     participant eSTS
 
 rect rgb(173, 216, 230)
@@ -30,7 +30,7 @@ rect rgb(215, 234, 132)
     MSAL->>MSAL: 5. Looks up old token T in local cache
     MSAL->>MITS: 6. MITS_endpoint?xms_cc=cp1&token_sha256_to_refresh=SHA256(T)
     MITS->>SFRP: 7. (Forward request w/ cc=cp1, hash=SHA256(T))
-    SFRP->>SFRP: 8. Another MSAL call AcquireTokenForClient(...).WithClientCapabilities(cp1)
+    SFRP->>SFRP: 8. Another MSAL call AcquireTokenForClient(...).WithClientCapabilities(cp1).WithAccessTokenSha256ToRefresh(hash)
     SFRP->>eSTS: 9. eSTS issues a new token
 end
 ```


### PR DESCRIPTION
Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->
The first diagram introduced in [MSI v1 token revocation specification #5137](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5137) missed a parameter that the Resource Provider needs to use.

**Changes proposed in this request**
Added missing param in arrow 8, also refined headers

**Testing**
This is a diagram change. Let's just visually check the diagrams, [before](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/622fa2a/docs/msiv1_token_revocation.md#flow-diagram---revocation-event) and [after](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/rayluo/refine-MSIv1-token-revocation-diagram/docs/msiv1_token_revocation.md#flow-diagram---revocation-event).

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->
N/A

**Documentation**
- [x] All relevant documentation is updated.
