### PR TITLE
Add Concurrency Test for Multi-Tenant AcquireTokenForClient Scenario

### DIFF
--- a/tests/Microsoft.Identity.Test.Unit/ParallelRequestsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ParallelRequestsTests.cs
@@ -86,6 +86,138 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
+        public async Task AcquireTokenForClient_ConcurrentTenantRequests_Test()
+        {
+            // Arrange
+            const int NumberOfRequests = 1000;
+
+            // Custom HTTP manager that counts the number of requests
+            ParallelRequestMockHandler httpManager = new();
+
+            var cca = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithAuthority("https://login.microsoftonline.com/common")
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithHttpManager(httpManager)
+                .Build();
+
+            var tasks = new List<Task<AuthenticationResult>>();
+
+            for (int i = 0; i < NumberOfRequests; i++)
+            {
+                tasks.Add(Task.Run(async () =>
+                {
+                    string tid = $"tidtid_{i}";
+                    AuthenticationResult res = await cca.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithTenantId(tid)
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    Assert.IsFalse(
+                        string.IsNullOrEmpty(res.AuthenticationResultMetadata.TokenEndpoint),
+                        "TokenEndpoint is null/empty!"
+                    );
+                    Assert.IsTrue(
+                        res.AuthenticationResultMetadata.TokenEndpoint.Contains(tid),
+                        "TokenEndpoint should contain the tenant ID."
+                    );
+                    Assert.AreEqual($"token_{tid}", res.AccessToken, "Access token did not match the expected value.");
+
+                    return res;
+                }));
+            }
+
+            // Wait for all tasks to complete
+            AuthenticationResult[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // Assert the total tasks
+            Assert.AreEqual(NumberOfRequests, results.Length, "Number of AuthenticationResult objects does not match the number of requests.");
+        }
+
+        [TestMethod]
+        public async Task AcquireTokenForClient_PerTenantCaching_Test()
+        {
+            const int NumberOfRequests = 5000;
+
+            var httpManager = new ParallelRequestMockHandler();
+            IConfidentialClientApplication cca = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithAuthority("https://login.microsoftonline.com/common")
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithHttpManager(httpManager)
+                .Build();
+
+            // First pass: tokens should come from the network
+            var tasksFirstPass = new List<Task<AuthenticationResult>>();
+            for (int i = 0; i < NumberOfRequests; i++)
+            {
+                string tid = $"tidtid_{i}";
+                tasksFirstPass.Add(Task.Run(async () =>
+                {
+                    AuthenticationResult result = await cca
+                        .AcquireTokenForClient(TestConstants.s_scope)
+                        .WithTenantId(tid)
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    Assert.IsNotNull(result, $"First-pass result is null for TID '{tid}'.");
+                    Assert.IsFalse(
+                        string.IsNullOrEmpty(result.AccessToken),
+                        $"First-pass access token is null/empty for TID '{tid}'.");
+                    Assert.AreEqual(
+                        $"token_{tid}",
+                        result.AccessToken,
+                        $"First-pass AccessToken mismatch for TID '{tid}'.");
+                    Assert.IsTrue(
+                        result.AuthenticationResultMetadata.TokenEndpoint.Contains(tid),
+                        $"First-pass TokenEndpoint '{result.AuthenticationResultMetadata.TokenEndpoint}' does not contain TID '{tid}'.");
+
+                    return result;
+                }));
+            }
+
+            AuthenticationResult[] firstPassResults = await Task.WhenAll(tasksFirstPass).ConfigureAwait(false);
+            int firstPassRequestsMade = httpManager.RequestsMade;
+
+            // Second pass: tokens should come from the cache
+            var tasksSecondPass = new List<Task<AuthenticationResult>>();
+            for (int i = 0; i < NumberOfRequests; i++)
+            {
+                string tid = $"tidtid_{i}";
+                tasksSecondPass.Add(Task.Run(async () =>
+                {
+                    AuthenticationResult result = await cca
+                        .AcquireTokenForClient(TestConstants.s_scope)
+                        .WithTenantId(tid)
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    Assert.IsNotNull(result, $"Second-pass result is null for TID '{tid}'.");
+                    Assert.IsFalse(
+                        string.IsNullOrEmpty(result.AccessToken),
+                        $"Second-pass access token is null/empty for TID '{tid}'.");
+                    Assert.AreEqual(
+                        $"token_{tid}",
+                        result.AccessToken,
+                        $"Second-pass AccessToken mismatch for TID '{tid}'.");
+
+                    return result;
+                }));
+            }
+
+            AuthenticationResult[] secondPassResults = await Task.WhenAll(tasksSecondPass).ConfigureAwait(false);
+            int totalRequestsMade = httpManager.RequestsMade;
+            int secondPassRequestsMade = totalRequestsMade - firstPassRequestsMade;
+
+            // Verifying no new network calls on the second pass if caching is working properly
+            Assert.AreEqual(
+                0,
+                secondPassRequestsMade,
+                $"Expected zero new requests in second pass, but found {secondPassRequestsMade}."
+            );
+        }
+
+        [TestMethod]
         public async Task AcquireTokenSilent_ValidATs_ParallelRequests_Async()
         {
             // Arrange

--- a/tests/Microsoft.Identity.Test.Unit/ParallelRequestsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ParallelRequestsTests.cs
@@ -105,9 +105,10 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
 
             for (int i = 0; i < NumberOfRequests; i++)
             {
+                int tempI = i; // Capture the current value of i
                 tasks.Add(Task.Run(async () =>
                 {
-                    string tid = $"tidtid_{i}";
+                    string tid = $"tidtid_{tempI}";
                     AuthenticationResult res = await cca.AcquireTokenForClient(TestConstants.s_scope)
                         .WithTenantId(tid)
                         .ExecuteAsync()
@@ -151,7 +152,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             var tasksFirstPass = new List<Task<AuthenticationResult>>();
             for (int i = 0; i < NumberOfRequests; i++)
             {
-                string tid = $"tidtid_{i}";
+                int tempI = i; // Capture the current value of i
+                string tid = $"tidtid_{tempI}";
                 tasksFirstPass.Add(Task.Run(async () =>
                 {
                     AuthenticationResult result = await cca
@@ -183,7 +185,8 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             var tasksSecondPass = new List<Task<AuthenticationResult>>();
             for (int i = 0; i < NumberOfRequests; i++)
             {
-                string tid = $"tidtid_{i}";
+                int tempI = i; // Capture the current value of i
+                string tid = $"tidtid_{tempI}";
                 tasksSecondPass.Add(Task.Run(async () =>
                 {
                     AuthenticationResult result = await cca


### PR DESCRIPTION
Fixes #5191

**Changes proposed in this request**
This pull request introduces enhancements to the `ParallelRequestMockHandler` class and adds new unit tests to validate concurrent tenant requests and per-tenant caching in the `ParallelRequestsTests` class. The most important changes include adding request counting functionality, modifying token endpoint handling, and adding new test methods to ensure proper handling of concurrent requests and caching.

Enhancements to `ParallelRequestMockHandler`:

* Added `_requestCount` field and `RequestsMade` property to track the number of requests made.
* Incremented `_requestCount` in `SendRequestAsync` method to count each request made.
* Modified the endpoint comparison to use `EndsWith` for better flexibility.
* Enhanced token generation to include tenant ID in the token for `client_credentials` grant type.

New unit tests in `ParallelRequestsTests`:

* Added `AcquireTokenForClient_ConcurrentTenantRequests_Test` to validate handling of concurrent tenant requests.
* Added `AcquireTokenForClient_PerTenantCaching_Test` to ensure tokens are cached per tenant and no new network calls are made on subsequent requests.

There is no bug in MSAL code, but this enhances some test coverage. 

**Testing**
unit tests

**Performance impact**
none

**Documentation**
n/a
