### PR TITLE
Fix Machine Learning Source to Use "clientid" Instead of "client_id"

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Constants.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Identity.Client.Internal
         public const string SshCertAuthHeaderPrefix = "SshCert";
 
         public const string ManagedIdentityClientId = "client_id";
+        public const string ManagedIdentityClientId2017 = "clientid";
         public const string ManagedIdentityObjectId = "object_id";
         public const string ManagedIdentityResourceId = "mi_res_id";
         public const string ManagedIdentityDefaultClientId = "system_assigned_managed_identity";

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/MachineLearningManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/MachineLearningManagedIdentitySource.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             {
                 case AppConfig.ManagedIdentityIdType.ClientId:
                     _requestContext.Logger.Info("[Managed Identity] Adding user assigned client id to the request.");
-                    request.QueryParameters[Constants.ManagedIdentityClientId] = _requestContext.ServiceBundle.Config.ManagedIdentityId.UserAssignedId;
+                    // Use the new 2017 constant for older ML-based environment
+                    request.QueryParameters[Constants.ManagedIdentityClientId2017] = _requestContext.ServiceBundle.Config.ManagedIdentityId.UserAssignedId;
                     break;
 
                 case AppConfig.ManagedIdentityIdType.ResourceId:

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs
@@ -378,7 +378,16 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
 
             if (userAssignedIdentityId == UserAssignedIdentityId.ClientId)
             {
-                httpMessageHandler.ExpectedQueryParams.Add(Constants.ManagedIdentityClientId, userAssignedId);
+                if (managedIdentitySourceType == ManagedIdentitySource.MachineLearning)
+                {
+                    // For Machine Learning (App Service 2017), the param is "clientid"
+                    httpMessageHandler.ExpectedQueryParams.Add(Constants.ManagedIdentityClientId2017, userAssignedId);
+                }
+                else
+                {
+                    // For App Service 2019, Azure Arc, IMDS, etc., the param is "client_id"
+                    httpMessageHandler.ExpectedQueryParams.Add(Constants.ManagedIdentityClientId, userAssignedId);
+                }
             }
 
             if (userAssignedIdentityId == UserAssignedIdentityId.ResourceId)

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
@@ -190,5 +190,31 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
             }
         }
+
+        /// <summary>
+        /// Verifies that if no token type is specified, the default is 'Bearer',
+        /// and CreateAuthorizationHeader() uses it.
+        /// </summary>
+        [TestMethod]
+        public void DefaultTokenType_IsBearer_Test()
+        {
+            DateTime now = DateTime.UtcNow;
+
+            var ar = new AuthenticationResult(
+                accessToken: "some-access-token",
+                isExtendedLifeTimeToken: false,
+                uniqueId: "unique-id",
+                expiresOn: now.AddMinutes(15),
+                extendedExpiresOn: now.AddMinutes(30),
+                tenantId: "tid",
+                account: new Account("aid", "user", "env"),
+                idToken: "my-id-token",
+                scopes: new[] { "scope" },
+                correlationId: Guid.NewGuid()
+            );
+
+            Assert.AreEqual("Bearer", ar.TokenType, "Expected default token type to be 'Bearer'");
+            Assert.AreEqual("Bearer some-access-token", ar.CreateAuthorizationHeader());
+        }
     }
 }


### PR DESCRIPTION
Fixes #5183

**Changes proposed in this request**
This pull request includes several changes to the Microsoft Identity Client library to support different managed identity configurations and improve test coverage. The most important changes include adding a new constant for the 2017 managed identity client ID, updating the request creation logic for older machine learning environments, and adding a new unit test to verify the default token type.

### Support for different managed identity configurations:

* [`src/client/Microsoft.Identity.Client/Internal/Constants.cs`](diffhunk://#diff-69a69c54931b0896394c0c0ba76f1642cd6931ce882c112675804793bea7a5daR45): Added a new constant `ManagedIdentityClientId2017` for the 2017 managed identity client ID.
* [`src/client/Microsoft.Identity.Client/ManagedIdentity/MachineLearningManagedIdentitySource.cs`](diffhunk://#diff-a8294b48db4b9d9920dea44df8f04f7e90d5704aa0e02fd6f60467f5f6ce714fL78-R79): Updated the `CreateRequest` method to use the new `ManagedIdentityClientId2017` constant for older ML-based environments.
* [`tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManagerExtensions.cs`](diffhunk://#diff-b5cbc5bfefa33d39f979adca0369b61dfc99c7100434c6785ce15cab5a1e9bd7R381-R391): Modified the `AddManagedIdentityMockHandler` method to handle both the 2017 and 2019 managed identity client ID parameters based on the source type.

### Improved test coverage:

* [`tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs`](diffhunk://#diff-a38cae874977b1de652fa165a0c0e7952919eb3eb099fa888c5a2508499a2645R193-R218): Added a new test method `DefaultTokenType_IsBearer_Test` to verify that the default token type is 'Bearer' and that `CreateAuthorizationHeader` uses it correctly.

**Testing**
Unit tests

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
