### PR TITLE
Fixing IsCommonOrOrganizationsTenant check to not return true for consumers

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/AadAuthority.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AadAuthority.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Identity.Client.Instance
 
         internal static bool IsCommonOrOrganizationsTenant(string tenantId)
         {
-            return !string.IsNullOrEmpty(tenantId) && 
+            return !string.IsNullOrEmpty(tenantId) &&
+                   !IsConsumers(tenantId) &&
                 s_tenantlessTenantNames.Contains(tenantId);
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -334,6 +334,34 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         }
 
         [TestMethod]
+        public void IsCommonOrOrganizationsTenantTest()
+        {
+            //Test for common tenant
+            AadAuthority aadAuthorityInstance = new AadAuthority(Authority.CreateAuthority("https://login.microsoftonline.com/common").AuthorityInfo);
+
+            Assert.IsNotNull(aadAuthorityInstance);
+            Assert.AreEqual(aadAuthorityInstance.AuthorityInfo.AuthorityType, AuthorityType.Aad);
+
+            Assert.IsTrue(aadAuthorityInstance.IsCommonOrOrganizationsTenant());
+
+            //Test for common Organizations tenant
+            aadAuthorityInstance = new AadAuthority(Authority.CreateAuthority("https://login.microsoftonline.com/organizations").AuthorityInfo);
+
+            Assert.IsNotNull(aadAuthorityInstance);
+            Assert.AreEqual(aadAuthorityInstance.AuthorityInfo.AuthorityType, AuthorityType.Aad);
+
+            Assert.IsTrue(aadAuthorityInstance.IsCommonOrOrganizationsTenant());
+
+            //Test for common Organizations tenant
+            aadAuthorityInstance = new AadAuthority(Authority.CreateAuthority("https://login.microsoftonline.com/consumers").AuthorityInfo);
+
+            Assert.IsNotNull(aadAuthorityInstance);
+            Assert.AreEqual(aadAuthorityInstance.AuthorityInfo.AuthorityType, AuthorityType.Aad);
+
+            Assert.IsFalse(aadAuthorityInstance.IsCommonOrOrganizationsTenant());
+        }
+
+        [TestMethod]
         public async Task CreateAuthorityForRequestAsync_MSAPassthroughAsync()
         {
             var testAccount = new Account("TEST_ID.9188040d-6c67-4c5b-b112-36a304b66dad", "username", Authority.CreateAuthority("https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad").AuthorityInfo.Host);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1898,7 +1898,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(httpManager)
                     .WithLogging((LogLevel _, string message, bool _) => log += message)
-                    .WithAuthority(TestConstants.AuthorityCommonTenant, true)
+                    .WithAuthority(tenant, true)
                     .BuildConcrete();
 
                 var result = await app

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1881,72 +1881,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         }
 
         [TestMethod]
-        public async Task AcquireTokenForClientAuthorityCheckTestAsync()
-        {
-            using (var httpManager = new MockHttpManager())
-            {
-                httpManager.AddInstanceDiscoveryMockHandler();
-                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
-
-                string log = string.Empty;
-
-                //Check common authority
-                var app = ConfidentialClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .WithClientSecret(TestConstants.ClientSecret)
-                    .WithHttpManager(httpManager)
-                    .WithLogging((LogLevel _, string message, bool _) => log += message)
-                    .WithAuthority(TestConstants.AuthorityCommonTenant, true)
-                    .BuildConcrete();
-
-                var result = await app
-                    .AcquireTokenForClient(TestConstants.s_scope)
-                    .ExecuteAsync(CancellationToken.None)
-                    .ConfigureAwait(false);
-
-                Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
-
-                //check organizations authority
-                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
-                log = string.Empty;
-
-                app = ConfidentialClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .WithClientSecret(TestConstants.ClientSecret)
-                    .WithHttpManager(httpManager)
-                    .WithLogging((LogLevel _, string message, bool _) => log += message)
-                    .WithAuthority(TestConstants.AuthorityOrganizationsTenant, true)
-                    .BuildConcrete();
-
-                result = await app
-                    .AcquireTokenForClient(TestConstants.s_scope)
-                    .ExecuteAsync(CancellationToken.None)
-                    .ConfigureAwait(false);
-
-                Assert.IsTrue(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
-
-                //check consumers authority
-                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
-                log = string.Empty;
-
-                app = ConfidentialClientApplicationBuilder
-                    .Create(TestConstants.ClientId)
-                    .WithClientSecret(TestConstants.ClientSecret)
-                    .WithHttpManager(httpManager)
-                    .WithLogging((LogLevel _, string message, bool _) => log += message)
-                    .WithAuthority(TestConstants.AuthorityConsumersTenant, true)
-                    .BuildConcrete();
-
-                result = await app
-                    .AcquireTokenForClient(TestConstants.s_scope)
-                    .ExecuteAsync(CancellationToken.None)
-                    .ConfigureAwait(false);
-
-                Assert.IsFalse(log.Contains(MsalErrorMessage.ClientCredentialWrongAuthority));
-            }
-        }
-
-        [TestMethod]
         [DataRow(TestConstants.AuthorityCommonTenant)]
         [DataRow(TestConstants.AuthorityOrganizationsTenant)]
         [DataRow(TestConstants.AuthorityConsumersTenant)]
@@ -1959,7 +1893,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 string log = string.Empty;
 
-                //Check common authority
                 var app = ConfidentialClientApplicationBuilder
                     .Create(TestConstants.ClientId)
                     .WithClientSecret(TestConstants.ClientSecret)


### PR DESCRIPTION
Fixes #
[Fix for5184](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5184)

**Changes proposed in this request**
Fixing IsCommonOrOrganizationsTenant check to not return true for consumers by adding back the consumers check. This will prevent this api from returning true.

**Testing**
Unit testing

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
