### PR TITLE
MSAL 4.70.0 Public API updates

### DIFF
--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
@@ -1032,3 +1032,7 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> Syst
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
 static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
-const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
@@ -1032,3 +1032,7 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> Syst
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
 static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
-const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
@@ -998,3 +998,7 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> Syst
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
 static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
-const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
@@ -1000,3 +1000,7 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> Syst
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
 static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
-const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
@@ -994,3 +994,7 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> Syst
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
 static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
-const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -994,3 +994,7 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.get -> Syst
 Microsoft.Identity.Client.AssertionRequestOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders
 static Microsoft.Identity.Client.RP.ConfidentialClientApplicationBuilderForResourceProviders.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool sendX5C, bool associateTokensWithCertificateSerialNumber) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
+Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
+const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
+Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
+static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get -> string
-const Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash = "force_refresh_and_token_hash_not_compatible" -> string
-Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders
-static Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string hash) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder


### PR DESCRIPTION

**Changes proposed in this request**
This pull request includes changes to the public API shipped and unshipped files across multiple frameworks and platforms. The main changes involve adding new methods and constants related to token cache notifications and token acquisition, and removing them from the unshipped files.

### Additions to Public API:

* Added `Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get` method. [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R1001-R1004) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R1003-R1006) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR997-R1000) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R997-R1000)
* Added constant `Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash`. [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R1001-R1004) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R1003-R1006) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR997-R1000) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R997-R1000)
* Added `Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders` class. [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R1001-R1004) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R1003-R1006) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR997-R1000) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R997-R1000)
* Added `Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh` method. [[1]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[2]](diffhunk://#diff-cbf7ceab1866a87ca05ef66c7a043bce3f21b454700e64c182b403f3884ad195R1035-R1038) [[3]](diffhunk://#diff-ba02fd692f23584ac367416f93f025aafe3ee9535e714b7ad1f46486a18c81c7R1001-R1004) [[4]](diffhunk://#diff-521cf91ecf46f87e497e10f087b1a619fa9cdf96c4698ae336c7dd47324092e1R1003-R1006) [[5]](diffhunk://#diff-ffdc781f3ef8f95fb6c862704d1835c18d30398d487f8bba40c46091311be10aR997-R1000) [[6]](diffhunk://#diff-9f88cae51dd278939a6c4dd17a5f89c65e7bd3560ab630ed505b869500463cd5R997-R1000)

### Removals from Unshipped API:

* Removed `Microsoft.Identity.Client.TokenCacheNotificationArgs.NoDistributedCacheUseReason.get` method.
* Removed constant `Microsoft.Identity.Client.MsalError.ForceRefreshNotCompatibleWithTokenHash`.
* Removed `Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders` class.
* Removed `Microsoft.Identity.Client.RP.AcquireTokenForClientParameterBuilderForResourceProviders.WithAccessTokenSha256ToRefresh` method.
