### PR TITLE
Fix logger message to accurately reflect skipCache condition

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (skipCache)
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.ForceRefreshOrClaims;
-                logger.Info("[ClientCredentialRequest] Skipped looking for a cached access token because either of ForceRefresh, Claims or AccessTokenHashToRefresh were set.");
+                logger.Info("[ClientCredentialRequest] Skipped looking for a cached access token because ForceRefresh was requested, or there are Claims but no AccessTokenHashToRefresh.");
                 authResult = await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);
                 return authResult;
             }


### PR DESCRIPTION
Fixes - The condition skipCache remains the same. We have not touched the functionality that determines whether the cache is skipped or not.

**Improved Clarity:**
The new log message precisely matches the condition in skipCache. That clarity helps developers and maintainers quickly understand why the cache was not used.

By removing misleading wording, we reduce confusion and potential troubleshooting errors.