### PR TITLE
Update msiv1_token_revocation.md to specify MIRP api-version

### DIFF
--- a/docs/msiv1_token_revocation.md
+++ b/docs/msiv1_token_revocation.md
@@ -47,6 +47,8 @@ Steps 5-9 are new and show how the RP propagates the revocation signal.
 6. **MITS** is basically a proxy, forwarding the query to **SFRP**.
 7. **SFRP** uses MSAL again to get a **new** token from eSTS.
 
+> [!IMPORTANT]
+> This design is only applicable to MIRP api-version=2025-03-30 (for App Service). api-version for service fabric will be soon made available. 
 
 > [!NOTE]  
 >  ClientCapabilities is an array of capabilities. In case the app developer sends multiple capabilities, these will be sent to the RP as `MITS_endpoint?xms_cc=cp1,cp2,cp3`. The RP MUST pass "cp1" (i.e. the CAE capabilitiy) if it is included.


### PR DESCRIPTION
Fixes - spec clarity

**Changes proposed in this request**
This pull request includes a small update to the `docs/msiv1_token_revocation.md` file. The change adds an important note about the applicability of the design to specific API versions.

Documentation update:

* [`docs/msiv1_token_revocation.md`](diffhunk://#diff-708928b0ae864249d92886b9476987f030e1ffa83a0f529e2f6df380c06a7676R50-R51): Added a note specifying that the design is only applicable to MIRP api-version=2025-03-30 for App Service, with the service fabric API version to be made available soon.

