### PR TITLE
Add test verifying custom user‐provided LR session key usage in OBO scenario

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/LongRunningOnBehalfOfTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/LongRunningOnBehalfOfTests.cs
@@ -169,6 +169,56 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.AreEqual(1, cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens().Count);
         }
 
+        [TestMethod]
+        public async Task InitiateLRWithCustomKey_ThenAcquireLRWithSameKey_Succeeds_TestAsync()
+        {
+            // Arrange
+            var user1 = (await LabUserHelper.GetSpecificUserAsync("idlab1@msidlab4.onmicrosoft.com").ConfigureAwait(false)).User;
+            var pca = PublicClientApplicationBuilder
+                .Create(PublicClientID)
+                .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                .Build();
+
+            // Acquire a token for the user via user name/password
+            var userAuthResult = await pca
+                .AcquireTokenByUsernamePassword(s_oboServiceScope, user1.Upn, user1.GetOrFetchPassword())
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Build the ConfidentialClient for OBO
+            var cca = BuildCCA(userAuthResult.TenantId);
+
+            // We'll use a *non-empty* custom key (NOT null, NOT empty).
+            // In raw MSAL, this means MSAL *will NOT* overwrite it with the assertion hash.
+            string oboCacheKey = "MyCustomKey";
+
+            // Act #1: Initiate the long running session.
+            // MSAL associates the "MyCustomKey" partition in its cache with the new LR token.
+            var initiateResult = await cca
+                .InitiateLongRunningProcessInWebApi(s_scopes, userAuthResult.AccessToken, ref oboCacheKey)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Assert #1: MSAL does NOT overwrite a non-empty key with the assertion hash.
+            // The user-provided key remains "MyCustomKey"
+            Assert.AreEqual("MyCustomKey", oboCacheKey,
+                "Expected MSAL to respect custom OBO key exactly, not to overwrite it.");
+
+            // Act #2: Acquire a token from that same long-running process,
+            // re-using the same custom key but passing *no* user assertion.
+            // Because we are in the same session, MSAL should find the token in
+            // the LR OBO partition or use the RT if the AT is expired.
+            var lrAcquireResult = await cca
+                .AcquireTokenInLongRunningProcess(s_scopes, oboCacheKey)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Assert #2: We should get a valid token and no exception
+            Assert.IsNotNull(lrAcquireResult.AccessToken,
+                "AcquireTokenInLongRunningProcess should succeed using the same custom key.");
+            Assert.AreNotEqual("", lrAcquireResult.AccessToken);
+        }
+
         /// <summary>
         /// Tests the behavior when calling both, long-running and normal OBO methods.
         /// Both methods should return the same tokens, since the cache key is the same.


### PR DESCRIPTION
This pull request introduces a new test case to validate the behavior of long-running On-Behalf-Of (OBO) token acquisition with a custom cache key. The test ensures that MSAL respects custom keys during token initiation and reuses them correctly during subsequent token acquisitions. Validates to confirm that MSAL respects a user‐provided, non‐empty key string during Long‐Running On‐Behalf‐Of (OBO) flows. Specifically, we verify that:

When a custom key (e.g. "MyCustomKey") is passed to InitiateLongRunningProcessInWebApi(...), MSAL does not overwrite it with an assertion hash 

Subsequent calls to AcquireTokenInLongRunningProcess(...) with the same custom key succeed without requiring a new user assertion.

### New Test Addition:

* `tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/LongRunningOnBehalfOfTests.cs`: Added `InitiateLRWithCustomKey_ThenAcquireLRWithSameKey_Succeeds_TestAsync()` to verify that:
  - MSAL respects a non-empty custom OBO cache key without overwriting it during token initiation.
  - Tokens can be acquired successfully using the same custom key in subsequent calls, even after access tokens are expired and refreshed.