### PR TITLE
Update MSIv1 Token Revocation's token_sha256_to_refresh param to use sha256's HEX representation

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         /// <returns></returns>
         private bool IsMatchingTokenHash(string tokenSecret, string accessTokenHashToRefresh)
         {
-            string cachedTokenHash = _cryptoManager.CreateSha256Hash(tokenSecret);
+            string cachedTokenHash = _cryptoManager.CreateSha256HashHex(tokenSecret);
             return string.Equals(cachedTokenHash, accessTokenHashToRefresh, StringComparison.Ordinal);
         }
 

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Interfaces/ICryptographyManager.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Interfaces/ICryptographyManager.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Interfaces
         string CreateBase64UrlEncodedSha256Hash(string input);
         string GenerateCodeVerifier();
         string CreateSha256Hash(string input);
+        string CreateSha256HashHex(string input);
         byte[] CreateSha256HashBytes(string input);
         byte[] SignWithCertificate(string message, X509Certificate2 certificate, RSASignaturePadding signaturePadding);
     }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/CommonCryptographyManager.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/CommonCryptographyManager.cs
@@ -65,14 +65,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 
             byte[] hashBytes = CreateSha256HashBytes(input);
 
-            // Convert to hex (e.g., "a1b2c3...")
-            var sb = new StringBuilder(hashBytes.Length * 2);
-            foreach (byte b in hashBytes)
-            {
-                sb.Append(b.ToString("x2"));
-            }
-
-            return sb.ToString();
+            // Convert to hex using BitConverter, removing dashes and forcing lowercase
+            return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
         }
 
         /// <remarks>AAD only supports RSA certs for client credentials </remarks>

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/CommonCryptographyManager.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/CommonCryptographyManager.cs
@@ -56,6 +56,25 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             }
         }
 
+        public string CreateSha256HashHex(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return null;
+            }
+
+            byte[] hashBytes = CreateSha256HashBytes(input);
+
+            // Convert to hex (e.g., "a1b2c3...")
+            var sb = new StringBuilder(hashBytes.Length * 2);
+            foreach (byte b in hashBytes)
+            {
+                sb.Append(b.ToString("x2"));
+            }
+
+            return sb.ToString();
+        }
+
         /// <remarks>AAD only supports RSA certs for client credentials </remarks>
         public virtual byte[] SignWithCertificate(string message, X509Certificate2 certificate, RSASignaturePadding signaturePadding)
         {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -2164,8 +2164,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         [TestMethod]
         public async Task WithAccessTokenSha256ToRefresh_MatchingHash_GetsTokenFromIdp_Async()
         {
-            const string accessToken = "access-token";
-            const string accessTokenHash = "3f16bed7089f4653e5ef21bfd2824d7f3aaaecc7a598e7e89c580e1606a9cc52";
+            const string accessToken = "test_token";
+            const string accessTokenHash = "cc0af97287543b65da2c7e1476426021826cab166f1e063ed012b855ff819656";
 
             // Arrange
             using (var httpManager = new MockHttpManager())

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -2351,24 +2351,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
         private static string ComputeSHA256Hex(string token)
         {
-#if NET6_0_OR_GREATER
-    byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(token));
-#else
-            byte[] hashBytes;
-            using (var sha256 = SHA256.Create())
-            {
-                hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(token));
-            }
-#endif
-
-            // Convert to lowercase hex string (e.g. "a1b2c3...")
-            var sb = new StringBuilder(hashBytes.Length * 2);
-            foreach (byte b in hashBytes)
-            {
-                sb.Append(b.ToString("x2"));
-            }
-
-            return sb.ToString();
+            var cryptoMgr = new CommonCryptographyManager();
+            return cryptoMgr.CreateSha256HashHex(token);
         }
     }
 }


### PR DESCRIPTION
Fixes #5228

**Changes proposed in this request**
This pull request introduces a new method for creating SHA256 hashes in hexadecimal format and updates various parts of the codebase to utilize this new method. The most important changes include adding the new method to the cryptography manager interface, implementing the method, and updating relevant tests to use the hexadecimal hash method.

### New Method Addition:

* [`src/client/Microsoft.Identity.Client/PlatformsCommon/Interfaces/ICryptographyManager.cs`](diffhunk://#diff-7736527ce2bf61a9eb62e73d8785842efe27ebf94de620d5f757389df9d34874R14): Added `CreateSha256HashHex` method to the `ICryptographyManager` interface.

### Implementation of New Method:

* [`src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/CommonCryptographyManager.cs`](diffhunk://#diff-49bdf0a5cd26d0edc922e07676c2ad3f842671afa1611fd6fe56e08882df1aa8R59-R77): Implemented the `CreateSha256HashHex` method which converts SHA256 hash bytes to a hexadecimal string.

### Updates to Existing Code:

* [`src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs`](diffhunk://#diff-655d5868568553085143b1c4df713cb7baf07c35ab78610a8ac73da1e467ce43L259-R259): Updated `IsMatchingTokenHash` method to use `CreateSha256HashHex` instead of `CreateSha256Hash`.

### Test Updates:

* `tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs`: 
  - Added a hardcoded hexadecimal hash for testing purposes.
  - Updated tests to use `ComputeSHA256Hex` instead of `ComputeSHA256` for hash comparisons. [[1]](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6L2193-R2199) [[2]](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6L2234-R2233) [[3]](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6L2292-R2291) [[4]](diffhunk://#diff-70ac5f29a11d58d5ce20b3cfc1f0024e6b02b2bbf6fc2b79d01a5b2a7c99c0a6L2337-R2336)
  - Renamed `ComputeSHA256` to `ComputeSHA256Hex` and updated its implementation to return a hexadecimal string.

**Testing**
unit testing

**Performance impact**
n/a

**Documentation**
- [ ] All relevant documentation is updated.
