### PR TITLE
Update CHANGELOG for MSAL 4.70.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+4.70.2
+=======
+
+### Bug fixes
+
+- Fixed MSIv1 Token Revocation's `token_sha256_to_refresh` parameter to use SHA256's HEX representation. See [Issue #5228](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5228)
+
 4.70.1
 =======
 


### PR DESCRIPTION
Update CHANGELOG for MSAL 4.70.2

This pull request includes a bug fix to the `CHANGELOG.md` file, specifically addressing an issue with the MSIv1 Token Revocation.

Bug Fixes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R7): Fixed the `token_sha256_to_refresh` parameter in MSIv1 Token Revocation to use SHA256's HEX representation.