### PR TITLE
Retry policies are now pre request instead of per HttpManager.

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/HttpManagerFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManagerFactory.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.Identity.Client.Http
 {
     /// <summary>
@@ -16,17 +10,10 @@ namespace Microsoft.Identity.Client.Http
     {
         public static IHttpManager GetHttpManager(
             IMsalHttpClientFactory httpClientFactory,
-            bool withRetry,
-            bool isManagedIdentity)
+            bool isManagedIdentity = false,
+            bool withRetry = true)
         {
-            if (!withRetry)
-            {
-                return new HttpManager(httpClientFactory, new NoRetryPolicy());
-            }
-
-            return isManagedIdentity ?
-                new HttpManager(httpClientFactory, new LinearRetryPolicy(1000, 3, HttpRetryConditions.ManagedIdentity)) :
-                new HttpManager(httpClientFactory, new LinearRetryPolicy(1000, 1, HttpRetryConditions.Sts));
+            return new HttpManager(httpClientFactory, isManagedIdentity, withRetry);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Http/IHttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/IHttpManager.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Identity.Client.Http
         /// <param name="mtlsCertificate">Certificate used for MTLS authentication.</param>
         /// <param name="validateServerCertificate">Callback to validate the server cert for service fabric managed identity flow.</param>
         /// <param name="cancellationToken"></param>
+        /// <param name="retryPolicy">Retry policy to be used for the request.</param>
         /// <param name="retryCount">Number of retries to be attempted in case of retriable status codes.</param>
         /// <returns></returns>
         Task<HttpResponse> SendRequestAsync(
@@ -40,6 +41,7 @@ namespace Microsoft.Identity.Client.Http
            X509Certificate2 mtlsCertificate,
            Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> validateServerCertificate,
            CancellationToken cancellationToken,
+           IRetryPolicy retryPolicy = null,
            int retryCount = 0);
     }
 }

--- a/src/client/Microsoft.Identity.Client/Http/LinearRetryPolicy.cs
+++ b/src/client/Microsoft.Identity.Client/Http/LinearRetryPolicy.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Identity.Client.Http
 {
     internal class LinearRetryPolicy : IRetryPolicy
     {
-        
+        // referenced in unit tests, cannot be private
+        public static int numRetries { get; private set; } = 0;
+
         private int _maxRetries;
         private readonly Func<HttpResponse, Exception, bool> _retryCondition;
         public int DelayInMilliseconds { private set; get; }
@@ -23,6 +25,9 @@ namespace Microsoft.Identity.Client.Http
 
         public bool pauseForRetry(HttpResponse response, Exception exception, int retryCount)
         {
+            // referenced in the unit tests
+            numRetries = retryCount + 1;
+
             return retryCount < _maxRetries && _retryCondition(response, exception);
         }
     }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                             doNotThrow: true,
                             mtlsCertificate: null,
                             validateServerCertificate: ValidateServerCertificate, 
-                            cancellationToken: cancellationToken).ConfigureAwait(false);
+                            cancellationToken: cancellationToken,
+                            retryPolicy: request.RetryPolicy).ConfigureAwait(false);
                 }
                 else
                 {
@@ -80,7 +81,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                             doNotThrow: true,
                             mtlsCertificate: null,
                             validateServerCertificate: ValidateServerCertificate, 
-                            cancellationToken: cancellationToken)
+                            cancellationToken: cancellationToken,
+                            retryPolicy: request.RetryPolicy)
                         .ConfigureAwait(false);
 
                 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
@@ -82,6 +82,9 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     break;
             }
 
+            // uncomment in follow-up IMDS retry policy PR
+            // request.RetryPolicy = new ImdsRetryPolicy();
+
             return request;
         }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityRequest.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityRequest.cs
@@ -3,16 +3,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Identity.Client.Http;
 using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.ManagedIdentity
 {
     internal class ManagedIdentityRequest
     {
+        // referenced in unit tests, cannot be private
+        public const int DEFAULT_MANAGED_IDENTITY_MAX_RETRIES = 3;
+        // this will be overridden in the unit tests so that they run faster
+        public static int DEFAULT_MANAGED_IDENTITY_RETRY_DELAY_MS { get; set; } = 1000;
+
         private readonly Uri _baseEndpoint;
 
         public HttpMethod Method { get; }
@@ -23,13 +26,21 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
         public IDictionary<string, string> QueryParameters { get; }
 
-        public ManagedIdentityRequest(HttpMethod method, Uri endpoint)
+        public IRetryPolicy RetryPolicy { get; set; }
+
+        public ManagedIdentityRequest(HttpMethod method, Uri endpoint, IRetryPolicy retryPolicy = null)
         {
             Method = method;
             _baseEndpoint = endpoint;
             Headers = new Dictionary<string, string>();
             BodyParameters = new Dictionary<string, string>();
             QueryParameters = new Dictionary<string, string>();
+
+            IRetryPolicy defaultRetryPolicy = new LinearRetryPolicy(
+                DEFAULT_MANAGED_IDENTITY_RETRY_DELAY_MS,
+                DEFAULT_MANAGED_IDENTITY_MAX_RETRIES,
+                HttpRetryConditions.ManagedIdentity);
+            RetryPolicy = retryPolicy ?? defaultRetryPolicy;
         }
 
         public Uri ComputeUri()

--- a/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManager.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Mocks/MockHttpManager.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
             X509Certificate2 mtlsCertificate,
             Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> validateServerCert,
             CancellationToken cancellationToken,
+            IRetryPolicy retryPolicy = null,
             int retryCount = 0)
         {
             return _httpManager.SendRequestAsync(
@@ -127,6 +128,7 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                 doNotThrow,
                 mtlsCertificate,
                 validateServerCert, cancellationToken,
+                retryPolicy,
                 retryCount);
         }
     }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/MsiProxyHttpManager.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/MsiProxyHttpManager.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Identity.Test.Integration.NetFx.Infrastructure
             X509Certificate2 mtlsCertificate,
             Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> validateServerCert,
             CancellationToken cancellationToken,
+            IRetryPolicy retryPolicy = null,
             int retryCount = 0)
         {
             //Get token for the MSIHelperService

--- a/tests/Microsoft.Identity.Test.Unit/Helpers/ParallelRequestMockHandler.cs
+++ b/tests/Microsoft.Identity.Test.Unit/Helpers/ParallelRequestMockHandler.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Identity.Test.Unit.Helpers
             X509Certificate2 mtlsCertificate,
             Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> validateServerCert,
             CancellationToken cancellationToken,
+            IRetryPolicy retryPolicy = null,
             int retryCount = 0)
         {
             Interlocked.Increment(ref _requestCount);


### PR DESCRIPTION
The same retry policy was previously being used for all Managed Identity sources and requests.

The retry policy will now be based on the Managed Identity source, and therefore will be per-request.