### PR TITLE
Add mac broker console app support

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityManager.cs
@@ -47,7 +47,15 @@ namespace Microsoft.Identity.Client.Instance
 
         public async Task RunInstanceDiscoveryAndValidationAsync()
         {
-            if (!_instanceDiscoveryAndValidationExecuted)
+            if (_requestContext.ServiceBundle.Config.IsBrokerEnabled)
+            {
+                // For broker flows we should avoid authority validation. Internally, we should avoid any network requests to prevent context switch.
+                // On macOS, interactive calls need to happen in the main thread, making network calls will switch to another thread and not easy to go back.
+                _metadata = _requestContext.ServiceBundle.InstanceDiscoveryManager.GetMetadataEntryAvoidNetwork(
+                                _initialAuthority.AuthorityInfo,
+                                _requestContext);
+            }
+            else if (!_instanceDiscoveryAndValidationExecuted)
             {
                 // This will make a network call unless instance discovery is cached, but this OK
                 // GetAccounts and AcquireTokenSilent do not need this

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/IInstanceDiscoveryManager.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Identity.Client.Instance.Discovery
     /// </summary>
     internal interface IInstanceDiscoveryManager
     {
+        InstanceDiscoveryMetadataEntry GetMetadataEntryAvoidNetwork(
+            AuthorityInfo authorityInfo,
+            RequestContext requestContext);
         Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryTryAvoidNetworkAsync(
             AuthorityInfo authorityinfo,
             IEnumerable<string> existingEnvironmentsInCache,

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
@@ -80,6 +80,25 @@ namespace Microsoft.Identity.Client.Instance.Discovery
             }
         }
 
+        public InstanceDiscoveryMetadataEntry GetMetadataEntryAvoidNetwork(
+            AuthorityInfo authorityInfo,
+            RequestContext requestContext)
+        {
+            string environment = authorityInfo.Host;
+            InstanceDiscoveryMetadataEntry entry = null;
+            if (requestContext.ServiceBundle.Config.IsInstanceDiscoveryEnabled)
+            {
+                entry = _networkCacheMetadataProvider.GetMetadata(environment, requestContext.Logger) ??
+                    _knownMetadataProvider.GetMetadata(environment, null, requestContext.Logger);
+            }
+            if (entry == null)
+            {
+                requestContext.Logger.Info(() => $"Skipping Instance discovery for {authorityInfo.AuthorityType} authority and use single authority.");
+                entry = CreateEntryForSingleAuthority(authorityInfo.CanonicalAuthority);
+            }
+            return entry;
+        }
+
         public async Task<InstanceDiscoveryMetadataEntry> GetMetadataEntryTryAvoidNetworkAsync(
             AuthorityInfo authorityInfo,
             IEnumerable<string> existingEnvironmentsInCache,

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -725,7 +725,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             using (var harness = CreateBrokerHelper())
             {
                 var tokenResponse = CreateTokenResponseForTest();
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 IBroker broker = Substitute.For<IBroker>();
                 _acquireTokenSilentParameters.Account = PublicClientApplication.OperatingSystemAccount;
                 var brokerSilentAuthStrategy =
@@ -828,9 +827,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             using (var harness = CreateBrokerHelper())
             {
-                // Arrange
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
-
                 var builder = PublicClientApplicationBuilder
                    .Create(TestConstants.ClientId)
                    .WithAuthority("https://login.microsoftonline.com/common")

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/RuntimeBrokerTests.cs
@@ -100,7 +100,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
         {
             using (var handle = base.CreateTestHarness())
             {
-                handle.HttpManager.AddInstanceDiscoveryMockHandler();
                 var pcaBuilder = PublicClientApplicationBuilder
                    .Create(TestConstants.ClientId)
                    .WithHttpManager(handle.HttpManager)

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/WamGetAccountsTests.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             // Arrange
             using (var httpManager = new MockHttpManager())
             {
-                httpManager.AddInstanceDiscoveryMockHandler();
-
                 var mockBroker = Substitute.For<IBroker>();
                 mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
@@ -74,8 +72,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             using (var httpManager = new MockHttpManager())
             {
                 var cache = new InMemoryTokenCache();
-                httpManager.AddInstanceDiscoveryMockHandler();
-
                 var mockBroker = Substitute.For<IBroker>();
                 mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
 
@@ -131,7 +127,6 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
             // Arrange
             using (var httpManager = new MockHttpManager())
             {
-                httpManager.AddInstanceDiscoveryMockHandler();
                 string commonAccId = $"{TestConstants.Uid}.{TestConstants.Utid}";
                 Account brokerAccount1 = new Account(commonAccId, "commonAccount", "login.windows.net");
                 Account brokerAccount2 = new Account("other.account", "brokerAcc2", "login.windows.net");

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationOperationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationOperationTests.cs
@@ -104,8 +104,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             // Arrange
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
-
                 var mockBroker = Substitute.For<IBroker>();
                 mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
                 mockBroker.IsPopSupported.Returns(true);

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/InteractiveRequestOrchestrationTests.cs
@@ -108,8 +108,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             // Arrange - common stuff
             using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
-                MockInstanceDiscovery(harness.HttpManager);
-
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle, false);
 
                 var requestParams = harness.CreateAuthenticationRequestParameters(
@@ -167,8 +165,6 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
             // Arrange - common stuff
             using (MockHttpAndServiceBundle harness = CreateTestHarness())
             {
-                MockInstanceDiscovery(harness.HttpManager);
-
                 ITokenCacheInternal cache = new TokenCache(harness.ServiceBundle, false);
 
                 var requestParams = harness.CreateAuthenticationRequestParameters(

--- a/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/pop/PoPTests.cs
@@ -192,8 +192,6 @@ namespace Microsoft.Identity.Test.Unit.Pop
             // Arrange
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
-
                 var mockBroker = Substitute.For<IBroker>();
                 mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(false);
                 mockBroker.IsPopSupported.Returns(true);
@@ -298,8 +296,6 @@ namespace Microsoft.Identity.Test.Unit.Pop
             // Arrange
             using (var harness = CreateTestHarness())
             {
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
-
                 var mockBroker = Substitute.For<IBroker>();
                 mockBroker.IsBrokerInstalledAndInvokable(AuthorityType.Aad).Returns(true);
                 mockBroker.IsPopSupported.Returns(true);
@@ -349,8 +345,6 @@ namespace Microsoft.Identity.Test.Unit.Pop
                 mockBroker.AcquireTokenSilentAsync(
                     Arg.Any<AuthenticationRequestParameters>(),
                     Arg.Any<AcquireTokenSilentParameters>()).Returns(CreateMsalPopTokenResponse(brokerAccessToken));
-
-                harness.HttpManager.AddInstanceDiscoveryMockHandler();
 
                 var pcaBuilder = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
                                 .WithTestBroker(mockBroker)

--- a/tests/devapps/MacConsoleAppWithBroker/MacConsoleAppWithBroker.cs
+++ b/tests/devapps/MacConsoleAppWithBroker/MacConsoleAppWithBroker.cs
@@ -1,0 +1,231 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Broker;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+
+class MacConsoleAppWithBroker
+{
+    private static readonly int MainThreadId = Thread.CurrentThread.ManagedThreadId;
+
+    private static readonly ConcurrentQueue<(Action Action, TaskCompletionSource<bool> Completion, bool IsAsyncAction)> MainThreadActions = 
+        new ConcurrentQueue<(Action, TaskCompletionSource<bool>, bool)>();
+    
+    private static volatile bool _workerFinished = false;
+    
+    static async Task Main(string[] args)
+    {
+
+        _ = Task.Run(() => BackgroundWorker());
+
+        while (!_workerFinished)
+        {
+            while (MainThreadActions.TryDequeue(out var actionItem))
+            {
+                try
+                {
+                    actionItem.Action();
+                    if (!actionItem.IsAsyncAction)
+                    {
+                        actionItem.Completion.TrySetResult(true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    actionItem.Completion.TrySetException(ex);
+                }
+            }
+
+            Thread.Sleep(10);
+        }
+        
+        Console.WriteLine("Background worker completed. Application exiting.");
+    }
+
+    public static Task RunOnMainThreadAsync(Func<Task> asyncAction)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        Action wrapper = async () => 
+        {
+            try 
+            {
+                await asyncAction().ConfigureAwait(false);
+                tcs.TrySetResult(true);
+            }
+            catch (Exception ex) 
+            {
+                tcs.TrySetException(ex);
+            }
+        };
+        MainThreadActions.Enqueue((wrapper, tcs, true));
+        return tcs.Task;
+    }
+
+    private static string TruncateToken(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            return string.Empty;
+            
+        return token.Length <= 50 ? token : token.Substring(0, 50) + "...";
+    }
+
+    private static async Task SwitchToBackgroundThreadViaHttpRequest()
+    {
+        Console.WriteLine($"Current thread ID before HTTP request: {Thread.CurrentThread.ManagedThreadId}");
+        using (HttpClient client = new HttpClient())
+        {
+            try
+            {
+                // Make a simple HTTP request to switch context
+                HttpResponseMessage response = await client.GetAsync("https://httpbin.org/get").ConfigureAwait(false);
+                string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                Console.WriteLine("HTTP request completed successfully");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"HTTP request failed: {ex.Message}");
+            }
+        }
+        
+        Console.WriteLine($"Current thread ID (after HTTP request): {Thread.CurrentThread.ManagedThreadId}");
+    }
+
+    private static async Task BackgroundWorker()
+    {
+        try
+        {
+            PublicClientApplicationBuilder builder = PublicClientApplicationBuilder
+                .Create("04b07795-8ddb-461a-bbee-02f9e1bf7b46") // Azure CLI client id
+                .WithRedirectUri("msauth.com.msauth.unsignedapp://auth")  // Unsigned app redirect, required by broker team.
+                .WithAuthority("https://login.microsoftonline.com/organizations");
+
+            builder = builder.WithLogging(SampleLogging);
+
+            builder = builder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.OSX)
+            {
+                ListOperatingSystemAccounts = false,
+                MsaPassthrough = false,
+                Title = "MSAL Dev App .NET FX"
+            }
+            );
+
+            IPublicClientApplication pca = builder.Build();
+
+            AcquireTokenInteractiveParameterBuilder interactiveBuilder = pca.AcquireTokenInteractive(new string[] { "https://graph.microsoft.com/.default" });
+
+            AuthenticationResult result = null;
+
+            // Acquire token interactively on main thread
+            await RunOnMainThreadAsync(async () =>
+            {
+                try
+                {
+                    // Execute the authentication request on the main thread
+                    result = await interactiveBuilder.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+                    Console.WriteLine("Interactive authentication completed successfully.");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Interactive authentication error: {ex}");
+                    throw;
+                }
+            }).ConfigureAwait(false);
+
+
+            Console.WriteLine($"Interactive call. Access token: {TruncateToken(result.AccessToken)}");
+            Console.WriteLine($"Expires on: {result.ExpiresOn}");
+            
+            // Make an HTTP request to switch to a background thread
+            await SwitchToBackgroundThreadViaHttpRequest().ConfigureAwait(false);
+            
+            IAccount account = result.Account;
+            AcquireTokenSilentParameterBuilder silentBuilder = pca.AcquireTokenSilent(new string[] { "https://graph.microsoft.com/.default" }, account);
+
+            // Silent call on main thread
+            await RunOnMainThreadAsync(async () =>
+            {
+                try
+                {
+                    // Execute the silent authentication request on the main thread
+                    result = await silentBuilder.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+                    Console.WriteLine("Second interactive authentication completed successfully.");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Second interactive authentication error: {ex}");
+                    throw;
+                }
+            }).ConfigureAwait(false);
+
+            Console.WriteLine($"Silent Call. Access token: {TruncateToken(result.AccessToken)}");
+            Console.WriteLine($"Expires on: {result.ExpiresOn}");
+
+            // Make an HTTP request to switch to a background thread
+            await SwitchToBackgroundThreadViaHttpRequest().ConfigureAwait(false);
+
+            // Second interactive call on main thread
+            await RunOnMainThreadAsync(async () =>
+            {
+                try
+                {
+                    // Execute the authentication request on the main thread
+                    result = await interactiveBuilder.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+                    Console.WriteLine("Second interactive authentication completed successfully.");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Second interactive authentication error: {ex}");
+                    throw;
+                }
+            }).ConfigureAwait(false);
+
+            Console.WriteLine($"Second interactive call. Access token: {TruncateToken(result.AccessToken)}");
+            Console.WriteLine($"Expires on: {result.ExpiresOn}");
+
+            // Make an HTTP request to switch to a background thread
+            await SwitchToBackgroundThreadViaHttpRequest().ConfigureAwait(false);
+
+            try
+            {
+                // Execute the authentication request on the main thread
+                result = await interactiveBuilder.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+                Console.WriteLine("Third interactive call should not succeed.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Third interactive authentication error: {ex}");
+
+                Console.WriteLine($"\nNotice! The third interactive call fails with status ApiContractViolation is expected. The interactive call should happen in the main thread.\n");
+            }
+        }
+        finally
+        {
+            // Signal that the worker has finished, regardless of success or failure
+            _workerFinished = true;
+        }
+    }
+
+	private static void SampleLogging(LogLevel level, string message, bool containsPii)
+	{
+		try
+        {
+			string homeDirectory = Environment.GetEnvironmentVariable("HOME");
+            string filePath = Path.Combine(homeDirectory, "msalnet.log");
+			using (StreamWriter writer = new StreamWriter(filePath, append: true))
+			{
+				writer.WriteLine($"{level} {message}");
+			}
+		}
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to write log: {ex.Message}");
+        }
+	}
+
+}

--- a/tests/devapps/MacConsoleAppWithBroker/MacConsoleAppWithBroker.csproj
+++ b/tests/devapps/MacConsoleAppWithBroker/MacConsoleAppWithBroker.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="../../../src/client/Microsoft.Identity.Client.Broker/Microsoft.Identity.Client.Broker.csproj" />
+
+    <!-- <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.68.6-internal-preview" /> -->
+
+    <!-- <ProjectReference Include="../../../../OneAuth/msal/msalruntime/interop/net/Microsoft.Identity.Client.NativeInterop.csproj" />
+    <None Include="../../../../OneAuth/msal/_builds/macOS/msalruntime/lib/Debug/libmsalruntime.dylib">
+      <Link>msalruntime.dylib</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>msalruntime_arm64.dylib</TargetPath>
+    </None> -->
+
+		<PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.19.0" />
+
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
NativeInterop 0.19.0 from nuget already contains mac console app support code.
This PR enables console app support from MSAL.dotnet side, and add a sample app.

Internally, this PR removed authority validation if it is a broker flow. Brokers have their own authority validation processes, and making http requests will switch to a background thread, which will break the main thread context for broker ineractive flows.

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
