### PR TITLE
Adding regional tests for FMI

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/FmiIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/FmiIntegrationTests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
     public class FmiIntegrationTests
     {
         private byte[] _serializedCache;
+        private const string _testslice1 = "dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1"; //Enables MSAL to target ESTS Test slice
+        private const string _testslice2 = "dc=ESTSR-PUB-WUS-LZ1-TEST"; //Updated slice for regional tests
 
         [TestMethod]
         //RMA getting FMI cred for a leaf entity or sub-RMA
@@ -52,7 +54,7 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             var confidentialApp = ConfidentialClientApplicationBuilder
                         .Create(clientId)
                         .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
-                        .WithExtraQueryParameters("dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1") //Enables MSAL to target ESTS Test slice
+                        .WithExtraQueryParameters(_testslice1) //Enables MSAL to target ESTS Test slice
                         .WithCertificate(cert, sendX5C: true) //sendX5c enables SN+I auth which is required for FMI flows
                         .BuildConcrete();
 
@@ -104,7 +106,7 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             var confidentialApp = ConfidentialClientApplicationBuilder
                         .Create(clientId)
                         .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
-                        .WithExtraQueryParameters("dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1") //Enables MSAL to target ESTS Test slice
+                        .WithExtraQueryParameters(_testslice1) //Enables MSAL to target ESTS Test slice
                         .WithCertificate(cert, sendX5C: true) //sendX5c enables SN+I auth which is required for FMI flows
                         .BuildConcrete();
 
@@ -156,8 +158,8 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             var confidentialApp = ConfidentialClientApplicationBuilder
                         .Create(clientId)
                         .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
-                        .WithExtraQueryParameters("dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1") //Enables MSAL to target ESTS Test slice
-                        .WithClientAssertion((options) => GetParentCredential(options)) //This api acquires the FMI credential needed to authenticate
+                        .WithExtraQueryParameters(_testslice1) //Enables MSAL to target ESTS Test slice
+                        .WithClientAssertion((options) => GetParentCredential(options, _testslice1)) //This api acquires the FMI credential needed to authenticate
                         .BuildConcrete();
 
             //FOR TESTING ONLY: Configure token cache serialization
@@ -184,7 +186,7 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
 
         [TestMethod]
         //Sub-RMA getting FIC for leaf entity.
-        [Ignore("Waiting for ESTS Implementation. Also requires Coorp net to run")]
+        [Ignore("Requires Coorp net to run")]
         public async Task Flow4_SubRma_FmiCredential_For_leaf()
         {
             //Arrange
@@ -208,8 +210,8 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             var confidentialApp = ConfidentialClientApplicationBuilder
                         .Create(clientId)
                         .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
-                        .WithExtraQueryParameters("dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1") //Enables MSAL to target ESTS Test slice
-                        .WithClientAssertion((options) => GetParentCredential(options)) //This api acquires the FMI credential needed to authenticate
+                        .WithExtraQueryParameters(_testslice1) //Enables MSAL to target ESTS Test slice
+                        .WithClientAssertion((options) => GetParentCredential(options, _testslice1)) //This api acquires the FMI credential needed to authenticate
                         .BuildConcrete();
 
             //Configure token cache serialization
@@ -229,8 +231,8 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             //Assert
             AssertResults(authResult,
                           confidentialApp,
-                          "expectedInternalCacheKey",
-                          "expectedAudience",
+                          "-login.windows.net-atext-urn:microsoft:identity:fmi-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-3091264c-7afb-45d4-b527-39737ee86187/.default-7cx57q63os7benq6er0sxgjptnqsv7tgb5zexcidfoi",
+                          "3091264c-7afb-45d4-b527-39737ee86187",
                           "SomeFmiPath/Path");
         }
 
@@ -260,8 +262,8 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             var confidentialApp = ConfidentialClientApplicationBuilder
                         .Create(clientId)
                         .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
-                        .WithExtraQueryParameters("dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1") //Enables MSAL to target ESTS Test slice
-                        .WithClientAssertion((options) => GetParentCredential(options)) //This api acquires the FMI credential needed to authenticate
+                        .WithExtraQueryParameters(_testslice1) //Enables MSAL to target ESTS Test slice
+                        .WithClientAssertion((options) => GetParentCredential(options, _testslice1)) //This api acquires the FMI credential needed to authenticate
                         .BuildConcrete();
 
             //Configure token cache serialization
@@ -286,7 +288,7 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
                           "SomeFmiPath/Path");
         }
 
-        private static async Task<string> GetParentCredential(AssertionRequestOptions options)
+        private static async Task<string> GetParentCredential(AssertionRequestOptions options, string eqParameters)
         {
             //Fmi app/scenario parameters
             var clientId = "4df2cbbb-8612-49c1-87c8-f334d6d065ad";
@@ -298,7 +300,7 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             var confidentialApp = ConfidentialClientApplicationBuilder
                         .Create(clientId)
                         .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
-                        .WithExtraQueryParameters("dc=ESTS-PUB-SCUS-LZ1-FD000-TEST1") //Enables MSAL to target ESTS Test slice
+                        .WithExtraQueryParameters(eqParameters) //Enables MSAL to target ESTS Test slice
                         .WithCertificate(cert, sendX5C: true) //sendX5c enables SN+I auth which is required for FMI flows
                         .BuildConcrete();
 
@@ -339,5 +341,272 @@ namespace Microsoft.Identity.Test.Integration.NetCore.HeadlessTests
             Assert.IsTrue(subject.Contains(expectedFmiPath));
             Assert.AreEqual(expectedInternalCacheKey, token.CacheKey);
         }
+
+        #region Regional Tests
+        [TestMethod]
+        //RMA getting FMI cred for a leaf entity or sub-RMA
+        [Ignore("Requires Coorp net to run")]
+        public async Task Flow1_RmaCredential_From_CertTestRegionalAsync()
+        {
+            //Arrange
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+            string expectedExternalCacheKey = null;
+
+            Action<TokenCacheNotificationArgs> extCacheKeyEvaluator = (args) =>
+            {
+                if (expectedExternalCacheKey != null)
+                {
+                    Assert.IsTrue(args.SuggestedCacheKey.Contains(expectedExternalCacheKey));
+                }
+            };
+
+            //Fmi app/scenario parameters
+            var clientId = "4df2cbbb-8612-49c1-87c8-f334d6d065ad";
+            var scope = "api://AzureFMITokenExchange/.default";
+
+            //Act
+            //Create application
+            var confidentialApp = ConfidentialClientApplicationBuilder
+                        .Create(clientId)
+                        .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
+                        .WithExtraQueryParameters(_testslice2) //Enables MSAL to target ESTS Test slice
+                        .WithCertificate(cert, sendX5C: true) //sendX5c enables SN+I auth which is required for FMI flows
+                        .WithAzureRegion("westus3")
+                        .BuildConcrete();
+
+            //Configure token cache serialization
+            confidentialApp.AppTokenCache.SetBeforeAccess(BeforeCacheAccess);
+            confidentialApp.AppTokenCache.SetAfterAccess(AfterCacheAccess);
+
+            //Recording test data for Asserts
+            var appCacheAccess = confidentialApp.AppTokenCache.RecordAccess(extCacheKeyEvaluator);
+            expectedExternalCacheKey = "zm2n0E62zwTsnNsozptLsoOoB_C7i-GfpxHYQQINJUw";
+
+            //Acquire Fmi Cred
+            var authResult = await confidentialApp.AcquireTokenForClient(new[] { scope })
+                                                    .WithFmiPath("SomeFmiPath/FmiCredentialPath") //Sets fmi path in client credential request.
+                                                    .ExecuteAsync()
+                                                    .ConfigureAwait(false);
+
+            //Assert
+            AssertResults(authResult,
+                          confidentialApp,
+                          "-login.microsoftonline.com-atext-4df2cbbb-8612-49c1-87c8-f334d6d065ad-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-api://azurefmitokenexchange/.default-zm2n0e62zwtsnnsozptlsooob_c7i-gfpxhyqqinjuw",
+                          "a9dd8a2a-df54-4ae0-84f9-38c8d57e5265",
+                          "SomeFmiPath/FmiCredentialPath");
+        }
+
+        [TestMethod]
+        //RMA getting FMI token for a leaf entity
+        [Ignore("Requires Coorp net to run")]
+        public async Task Flow2_RmaToken_From_CertTestRegionalAsync()
+        {
+            //Arrange
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+            string expectedExternalCacheKey = null;
+
+            Action<TokenCacheNotificationArgs> extCacheKeyEvaluator = (args) =>
+            {
+                if (expectedExternalCacheKey != null)
+                {
+                    Assert.IsTrue(args.SuggestedCacheKey.Contains(expectedExternalCacheKey));
+                }
+            };
+
+            //Fmi app/scenario parameters
+            var clientId = "4df2cbbb-8612-49c1-87c8-f334d6d065ad";
+            var scope = "3091264c-7afb-45d4-b527-39737ee86187/.default"; //Guid for api://AzureFMITokenExchange
+
+            //Act
+            //Create application
+            var confidentialApp = ConfidentialClientApplicationBuilder
+                        .Create(clientId)
+                        .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
+                        .WithExtraQueryParameters(_testslice2) //Enables MSAL to target ESTS Test slice
+                        .WithCertificate(cert, sendX5C: true) //sendX5c enables SN+I auth which is required for FMI flows
+                        .WithAzureRegion("westus3")
+                        .BuildConcrete();
+
+            //Configure token cache serialization
+            confidentialApp.AppTokenCache.SetBeforeAccess(BeforeCacheAccess);
+            confidentialApp.AppTokenCache.SetAfterAccess(AfterCacheAccess);
+
+            //Recording test data for Asserts
+            var appCacheAccess = confidentialApp.AppTokenCache.RecordAccess(extCacheKeyEvaluator);
+            expectedExternalCacheKey = "zm2n0E62zwTsnNsozptLsoOoB_C7i-GfpxHYQQINJUw";
+
+            //Acquire Token
+            var authResult = await confidentialApp.AcquireTokenForClient(new[] { scope })
+                                                    .WithFmiPath("SomeFmiPath/FmiCredentialPath") //Sets fmi path in client credential request.
+                                                    .ExecuteAsync()
+                                                    .ConfigureAwait(false);
+
+            //Assert
+            AssertResults(authResult,
+                          confidentialApp,
+                          "-login.microsoftonline.com-atext-4df2cbbb-8612-49c1-87c8-f334d6d065ad-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-3091264c-7afb-45d4-b527-39737ee86187/.default-zm2n0e62zwtsnnsozptlsooob_c7i-gfpxhyqqinjuw",
+                          "3091264c-7afb-45d4-b527-39737ee86187",
+                          "SomeFmiPath/FmiCredentialPath");
+        }
+
+        [TestMethod]
+        //Sub-RMA getting FMI cred for a child sub-RMA
+        [Ignore("Requires Coorp net to run")]
+        public async Task Flow3_FmiCredential_From_RmaCredentialRegional()
+        {
+            //Arrange
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+            string expectedExternalCacheKey = null;
+
+            Action<TokenCacheNotificationArgs> extCacheKeyEvaluator = (args) =>
+            {
+                if (expectedExternalCacheKey != null)
+                {
+                    Assert.IsTrue(args.SuggestedCacheKey.Contains(expectedExternalCacheKey));
+                }
+            };
+
+            //Fmi app/scenario parameters
+            var clientId = "urn:microsoft:identity:fmi";
+            var scope = "api://AzureFMITokenExchange/.default";
+
+            //Act
+            //Create application
+            var confidentialApp = ConfidentialClientApplicationBuilder
+                        .Create(clientId)
+                        .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
+                        .WithExtraQueryParameters(_testslice2) //Enables MSAL to target ESTS Test slice
+                        .WithClientAssertion((options) => GetParentCredential(options, _testslice2)) //This api acquires the FMI credential needed to authenticate
+                        .WithAzureRegion("westus3")
+                        .BuildConcrete();
+
+            //FOR TESTING ONLY: Configure token cache serialization
+            confidentialApp.AppTokenCache.SetBeforeAccess(BeforeCacheAccess);
+            confidentialApp.AppTokenCache.SetAfterAccess(AfterCacheAccess);
+
+            //Recording test data for Asserts
+            var appCacheAccess = confidentialApp.AppTokenCache.RecordAccess(extCacheKeyEvaluator);
+            expectedExternalCacheKey = "7CX57Q63os7benQ6ER0sxgJPtNQSv7TGb5zexcidFoI";
+
+            //Acquire Fmi Cred
+            var authResult = await confidentialApp.AcquireTokenForClient(new[] { scope })
+                                                    .WithFmiPath("SomeFmiPath/Path") //Sets fmi path in client credential request.
+                                                    .ExecuteAsync()
+                                                    .ConfigureAwait(false);
+
+            //Assert
+            AssertResults(authResult,
+                          confidentialApp,
+                          "-login.microsoftonline.com-atext-urn:microsoft:identity:fmi-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-api://azurefmitokenexchange/.default-7cx57q63os7benq6er0sxgjptnqsv7tgb5zexcidfoi",
+                          "a9dd8a2a-df54-4ae0-84f9-38c8d57e5265",
+                          "SomeFmiPath/Path");
+        }
+
+        [TestMethod]
+        //Sub-RMA getting FIC for leaf entity.
+        [Ignore("Requires Coorp net to run")]
+        public async Task Flow4_SubRma_FmiCredential_For_leafRegional()
+        {
+            //Arrange
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+            string expectedExternalCacheKey = null;
+
+            Action<TokenCacheNotificationArgs> extCacheKeyEvaluator = (args) =>
+            {
+                if (expectedExternalCacheKey != null)
+                {
+                    Assert.IsTrue(args.SuggestedCacheKey.Contains(expectedExternalCacheKey));
+                }
+            };
+
+            //Fmi app/scenario parameters
+            var clientId = "urn:microsoft:identity:fmi";
+            var scope = "3091264c-7afb-45d4-b527-39737ee86187/.default"; //Guid for api://AzureFMITokenExchange
+
+            //Act
+            //Create application
+            var confidentialApp = ConfidentialClientApplicationBuilder
+                        .Create(clientId)
+                        .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
+                        .WithExtraQueryParameters(_testslice2) //Enables MSAL to target ESTS Test slice
+                        .WithClientAssertion((options) => GetParentCredential(options, _testslice2)) //This api acquires the FMI credential needed to authenticate
+                        .WithAzureRegion("westus3")
+                        .BuildConcrete();
+
+            //Configure token cache serialization
+            confidentialApp.AppTokenCache.SetBeforeAccess(BeforeCacheAccess);
+            confidentialApp.AppTokenCache.SetAfterAccess(AfterCacheAccess);
+
+            //Recording test data for Asserts
+            var appCacheAccess = confidentialApp.AppTokenCache.RecordAccess(extCacheKeyEvaluator);
+            expectedExternalCacheKey = "";
+
+            //Acquire Fmi Cred
+            var authResult = await confidentialApp.AcquireTokenForClient(new[] { scope })
+                                                    .WithFmiPath("SomeFmiPath/Path") //Sets fmi path in client credential request.
+                                                    .ExecuteAsync()
+                                                    .ConfigureAwait(false);
+
+            //Assert
+            AssertResults(authResult,
+                          confidentialApp,
+                          "-login.microsoftonline.com-atext-urn:microsoft:identity:fmi-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-3091264c-7afb-45d4-b527-39737ee86187/.default-7cx57q63os7benq6er0sxgjptnqsv7tgb5zexcidfoi",
+                          "3091264c-7afb-45d4-b527-39737ee86187",
+                          "SomeFmiPath/Path");
+        }
+
+        [TestMethod]
+        //Sub-RMA getting FMI token for leaf entity
+        [Ignore("Requires Coorp net to run")]
+        public async Task Flow5_SubRma_FmiToken_From_FmiCred_For_leafTestRegionalAsync()
+        {
+            //Arrange
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+            string expectedExternalCacheKey = null;
+
+            Action<TokenCacheNotificationArgs> extCacheKeyEvaluator = (args) =>
+            {
+                if (expectedExternalCacheKey != null)
+                {
+                    Assert.IsTrue(args.SuggestedCacheKey.Contains(expectedExternalCacheKey));
+                }
+            };
+
+            //Fmi app/scenario parameters
+            var clientId = "urn:microsoft:identity:fmi";
+            var scope = "3091264c-7afb-45d4-b527-39737ee86187/.default"; //Guid for api://AzureFMITokenExchange
+
+            //Act
+            //Create application
+            var confidentialApp = ConfidentialClientApplicationBuilder
+                        .Create(clientId)
+                        .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
+                        .WithExtraQueryParameters(_testslice2) //Enables MSAL to target ESTS Test slice
+                        .WithClientAssertion((options) => GetParentCredential(options, _testslice2)) //This api acquires the FMI credential needed to authenticate
+                        .WithAzureRegion("westus3")
+                        .BuildConcrete();
+
+            //Configure token cache serialization
+            confidentialApp.AppTokenCache.SetBeforeAccess(BeforeCacheAccess);
+            confidentialApp.AppTokenCache.SetAfterAccess(AfterCacheAccess);
+
+            //Recording test data for Asserts
+            var appCacheAccess = confidentialApp.AppTokenCache.RecordAccess(extCacheKeyEvaluator);
+            expectedExternalCacheKey = "7CX57Q63os7benQ6ER0sxgJPtNQSv7TGb5zexcidFoI";
+
+            //Acquire Fmi Cred
+            var authResult = await confidentialApp.AcquireTokenForClient(new[] { scope })
+                                                    .WithFmiPath("SomeFmiPath/Path") //Sets fmi path in client credential request.
+                                                    .ExecuteAsync()
+                                                    .ConfigureAwait(false);
+
+            //Assert
+            AssertResults(authResult,
+                          confidentialApp,
+                          "-login.microsoftonline.com-atext-urn:microsoft:identity:fmi-f645ad92-e38d-4d1a-b510-d1b09a74a8ca-3091264c-7afb-45d4-b527-39737ee86187/.default-7cx57q63os7benq6er0sxgjptnqsv7tgb5zexcidfoi",
+                          "3091264c-7afb-45d4-b527-39737ee86187",
+                          "SomeFmiPath/Path");
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5275

**Changes proposed in this request**
Adding regional versions of FMI tests
These tests are intended to demonstrate how to use FMI tests with regions. therefore, the code is not consolidated.

**Testing**
Unit

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
