### PR TITLE
fixes typo in the example Entra ID authority URL in two builder classes XML comments.

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Identity.Client
         /// See https://openid.net/specs/openid-connect-core-1_0.html#Terminology
         /// </summary>
         /// <remarks>
-        /// Do not use this method with Entra ID authorities (e.g. https://login.microsfoftonline.com/common).
+        /// Do not use this method with Entra ID authorities (e.g. https://login.microsoftonline.com/common).
         /// Use WithAuthority(string) instead.
         /// </remarks>
         public ConfidentialClientApplicationBuilder WithOidcAuthority(string authorityUri)

--- a/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <remarks>
         /// Experimental on public clients.
-        /// Do not use this method with Entra ID authorities (e.g. https://login.microsfoftonline.com/common).
+        /// Do not use this method with Entra ID authorities (e.g. https://login.microsoftonline.com/common).
         /// Use WithAuthority(string) instead.
         /// </remarks>
         public PublicClientApplicationBuilder WithOidcAuthority(string authorityUri) 


### PR DESCRIPTION
Fixes #5277

**Changes proposed in this request**
This pull request includes minor documentation corrections in the `ConfidentialClientApplicationBuilder` and `PublicClientApplicationBuilder` classes to fix a typo in the example URL for Entra ID authorities.

Documentation fixes:

* Corrected the typo in the example URL for Entra ID authorities in the `WithGenericAuthority` method of `ConfidentialClientApplicationBuilder` (`https://login.microsfoftonline.com/common` → `https://login.microsoftonline.com/common`). (`src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs`, [src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.csL342-R342](diffhunk://#diff-e2e87b43b43d31cdb3c62ecf8c6e1a5a1985291f458f89737a1237136f9c4c82L342-R342))
* Corrected the same typo in the example URL for Entra ID authorities in the `WithParentFunc` method of `PublicClientApplicationBuilder`. (`src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.cs`, [src/client/Microsoft.Identity.Client/AppConfig/PublicClientApplicationBuilder.csL229-R229](diffhunk://#diff-2ea5d406315605dd075a3d32aacd53a1bc284e2fc59f034ecbb0415a3307c601L229-R229))

**Testing**
none - just comments

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
