### PR TITLE
Set Build Env variables to skip MSI E2E tests if needed

### DIFF
--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -96,10 +96,11 @@ jobs: #Build and stage projects
   - template: template-test-on-linux.yaml
   
 - job: 'RunManagedIdentityE2ETestsOnAzureArc'
-  displayName: 'Managed Identity E2E Tests – Azure ARC Agent'
+  displayName: 'Managed Identity E2E Tests â€“ Azure ARC Agent'
   dependsOn: ['BuildAndStageProjects']
   pool:
     name: 'MSALMSIAZUREARC'
+  condition: and(succeeded(), eq(variables['RunManagedIdentityE2EArcTests'], 'true'))
 
   steps:
   - template: template-run-mi-e2e-azurearc.yaml
@@ -108,10 +109,11 @@ jobs: #Build and stage projects
       TargetFramework: 'net8.0'
 
 - job: 'RunManagedIdentityE2ETestsOnImds'
-  displayName: 'Managed Identity E2E Tests – VM / IMDS'
+  displayName: 'Managed Identity E2E Tests â€“ VM / IMDS'
   dependsOn: ['BuildAndStageProjects']
   pool:
     name: 'ID4SMSIHostedAgent'
+  condition: and(succeeded(), eq(variables['RunManagedIdentityE2EVmTests'], 'true'))
 
   steps:
   - template: template-run-mi-e2e-imds.yaml


### PR DESCRIPTION
Fixes #5284

**Changes proposed in this request**
This pull request updates the `build/template-build-and-run-all-tests.yaml` file to improve the configuration of end-to-end tests for Managed Identity. The main changes include fixing display name formatting and adding conditional execution for specific test jobs.

### Updates to Managed Identity E2E Test Jobs:

* **Display Name Formatting:**
  - Fixed the display name encoding issue by replacing `�` with a proper en dash (`–`) in the `RunManagedIdentityE2ETestsOnAzureArc` and `RunManagedIdentityE2ETestsOnImds` jobs. [[1]](diffhunk://#diff-079281cae4bba8321b08ba4c9fd4707530a978b7c0f8ec66ab6072171ce428a7L99-R103) [[2]](diffhunk://#diff-079281cae4bba8321b08ba4c9fd4707530a978b7c0f8ec66ab6072171ce428a7L111-R116)

* **Conditional Execution:**
  - Added conditions to only run the `RunManagedIdentityE2ETestsOnAzureArc` job if the pipeline succeeds and the `RunManagedIdentityE2EArcTests` variable is set to `true`.
  - Added conditions to only run the `RunManagedIdentityE2ETestsOnImds` job if the pipeline succeeds and the `RunManagedIdentityE2EVmTests` variable is set to `true`.

Build pipeline injects these as TRUE by default. You can set it to false, if you need manual control over E2E test execution.

**Testing**
PR builds

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
