### PR TITLE
Hide ListOperatingSystemAccounts in intellisense

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/BrokerOptions.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/BrokerOptions.cs
@@ -80,9 +80,10 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Currently supported on Windows, Linux and macOS
-        /// Allows the Windows broker to list Work and School accounts as part of the <see cref="ClientApplicationBase.GetAccountsAsync()"/>
+        /// Allows the Windows broker to list MSA, Work and School accounts as part of the <see cref="ClientApplicationBase.GetAccountsAsync()"/>
         /// Linux and macOS broker will discover accounts as part of the <see cref="ClientApplicationBase.GetAccountsAsync()"/>
-        /// </summary>        
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool ListOperatingSystemAccounts { get; set; }
 
         internal bool IsBrokerEnabledOnCurrentOs()


### PR DESCRIPTION
Fixes #4945

**Changes proposed in this request**
Hide ListOperatingSystemAccounts in intellisense so that developers are discouraged to use this. 
Eventually this will be deprecated.

