### PR TITLE
update to langVersion 13

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>13</LangVersion>
     <!-- This is strong naming, not signing-->
     <SignAssembly>true</SignAssembly>
     <!-- The MSAL.snk has both private and public keys -->

--- a/tests/devapps/WAM/NetWSLWam/test.csproj
+++ b/tests/devapps/WAM/NetWSLWam/test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>13</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Downlevel "latest" maps to pre-13. In the future, we'll want to either keep this up-to-date (e.g. update it to 14 when .NET 10 ships) or change it to preview, which will always be up-to-date.

note: I haven't tested anything 