### PR TITLE
Use HTTP 2 on .NET

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Identity.Client.Http
             requestMessage.Headers.Accept.Clear();
 
 #if NET5_0_OR_GREATER
-            // On .NET 5.0 and later, HTTP2 is supported by default and Entra is HTTP2 compatible
+            // On .NET 5.0 and later, HTTP2 is supported through the SDK and Entra is HTTP2 compatible
             // Note that HttpClient.DefaultRequestVersion does not work when using HttpRequestMessage objects
             requestMessage.Version = HttpVersion.Version20; // Default to HTTP/2
             requestMessage.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower; // Allow fallback to HTTP/1.1
@@ -230,7 +230,7 @@ namespace Microsoft.Identity.Client.Http
             CancellationToken cancellationToken = default)
         {
             using (HttpRequestMessage requestMessage = CreateRequestMessage(endpoint, headers))
-            {                
+            {
                 requestMessage.Method = method;
                 requestMessage.Content = body;
 

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -199,7 +199,15 @@ namespace Microsoft.Identity.Client.Http
         private static HttpRequestMessage CreateRequestMessage(Uri endpoint, IDictionary<string, string> headers)
         {
             HttpRequestMessage requestMessage = new HttpRequestMessage { RequestUri = endpoint };
+            
             requestMessage.Headers.Accept.Clear();
+
+#if NET5_0_OR_GREATER
+            // On .NET 5.0 and later, HTTP2 is supported by default and Entra is HTTP2 compatible
+            // Note that HttpClient.DefaultRequestVersion does not work when using HttpRequestMessage objects
+            requestMessage.Version = HttpVersion.Version20; // Default to HTTP/2
+            requestMessage.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower; // Allow fallback to HTTP/1.1
+#endif
             if (headers != null)
             {
                 foreach (KeyValuePair<string, string> kvp in headers)
@@ -222,7 +230,7 @@ namespace Microsoft.Identity.Client.Http
             CancellationToken cancellationToken = default)
         {
             using (HttpRequestMessage requestMessage = CreateRequestMessage(endpoint, headers))
-            {
+            {                
                 requestMessage.Method = method;
                 requestMessage.Content = body;
 

--- a/tests/Microsoft.Identity.Test.Common/Core/Helpers/HttpSnifferClientFactory.cs
+++ b/tests/Microsoft.Identity.Test.Common/Core/Helpers/HttpSnifferClientFactory.cs
@@ -4,9 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Runtime.InteropServices;
 using Microsoft.Identity.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Common
 {
@@ -28,7 +31,24 @@ namespace Microsoft.Identity.Test.Common
                     req.Content.LoadIntoBufferAsync().GetAwaiter().GetResult();
                     LastHttpContentData = req.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                 }
+
+                // check the .net runtime
+                var framework = RuntimeInformation.FrameworkDescription;
+
+                // This will match ".NET 5.0", ".NET 6.0", ".NET 7.0", ".NET 8.0", etc.
+                if (framework.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Extract the version number
+                    var versionString = framework.Substring(5).Trim(); // e.g., "6.0.0"
+                    if (Version.TryParse(versionString, out var version) && version.Major >= 5)
+                    {
+                        Assert.AreEqual(new Version(2, 0), req.Version, $"Request version mismatch: {req.Version}. MSAL on NET 5+ expects HTTP/2.0 for all requests.");
+                        // ESTS-R endpoint does not support HTTP/2.0, so we don't assert this
+                    }
+                }
+
                 RequestsAndResponses.Add((req, res));
+                
                 Trace.WriteLine($"[MSAL][HTTP Request]: {req}");
                 Trace.WriteLine($"[MSAL][HTTP Response]: {res}");
             });

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http.Retry;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
@@ -555,7 +556,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
             var httpClientFactory = Substitute.For<IMsalHttpClientFactory>();
             httpClientFactory.GetHttpClient().Returns(httpClient);
 
-            var httpManager = new HttpManager(httpClientFactory, disableInternalRetries: true);
+            var httpManager = new Client.Http.HttpManager(httpClientFactory, disableInternalRetries: true);
 
             // Act
             await httpManager.SendRequestAsync(

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
@@ -575,7 +575,6 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
             Assert.IsNotNull(handler.CapturedRequest);
             Assert.AreEqual(HttpVersion.Version20, handler.CapturedRequest.Version);
             Assert.AreEqual(HttpVersionPolicy.RequestVersionOrLower, handler.CapturedRequest.VersionPolicy);
-            Assert.AreEqual("abc", handler.CapturedRequest.Headers.GetValues("X-Test").Single());
         }
 #endif
     }


### PR DESCRIPTION
Fixes #5209
