### PR TITLE
Use the actual client IDs for FOCI

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -240,10 +240,6 @@ namespace Microsoft.Identity.Test.Unit
         public const string MsalOBOKeyVaultSecretName = "IdentityDivisionDotNetOBOServiceSecret";
         public const string MsalArlingtonOBOKeyVaultUri = "https://msidlabs.vault.azure.net:443/secrets/ARLMSIDLAB1-IDLASBS-App-CC-Secret";
         public const string MsalArlingtonOBOKeyVaultSecretName = "ARLMSIDLAB1-IDLASBS-App-CC-Secret";
-        public const string FociApp1 = "https://buildautomation.vault.azure.net/secrets/automation-foci-app1/";
-        public const string FociApp1KeyVaultSecretName = "automation-foci-app1";
-        public const string FociApp2 = "https://buildautomation.vault.azure.net/secrets/automation-foci-app2/";
-        public const string FociApp2KeyVaultSecretName = "automation-foci-app2";
         public const string MsalArlingtonCCAKeyVaultUri = "https://msidlabs.vault.azure.net:443/secrets/ARLMSIDLAB1-IDLASBS-App-CC-Secret";
         public const string MsalArlingtonCCAKeyVaultSecretName = "ARLMSIDLAB1-IDLASBS-App-CC-Secret";
 

--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/FociTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/FociTests.cs
@@ -115,8 +115,8 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         private static void CreateFamilyApps(LabResponse labResponse, string cacheFilePath, out IPublicClientApplication pca_fam1, out IPublicClientApplication pca_fam2, out IPublicClientApplication pca_nonFam)
         {
             var keyvault = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
-            var clientId1 = keyvault.GetSecretByName(TestConstants.FociApp1KeyVaultSecretName).Value;
-            var clientId2 = keyvault.GetSecretByName(TestConstants.FociApp2KeyVaultSecretName).Value;
+            var clientId1 = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
+            var clientId2 = "1950a258-227b-4e31-a9cf-717495945fc2";
 
             pca_fam1 = PublicClientApplicationBuilder
                .Create(clientId1)


### PR DESCRIPTION
Fixes an internal repair item - reduces dependency on a KeyVault which is on a deprecation path.