### PR TITLE
Fix the build

### DIFF
--- a/tests/devapps/MacMauiAppWithBroker/MacMauiAppWithBroker.csproj
+++ b/tests/devapps/MacMauiAppWithBroker/MacMauiAppWithBroker.csproj
@@ -126,7 +126,7 @@ namespace MacMauiAppWithBroker
 
 	<!-- Display warning when building on non-Mac -->
 	<Target Name="WarnNonMacBuild" BeforeTargets="Build" Condition="!$([MSBuild]::IsOSPlatform('OSX'))">
-		<Warning Text="MacMauiAppWithBroker is designed for macOS only. Building an empty stub project on this platform." />
+		<Message Importance="high" Text="MacMauiAppWithBroker is designed for macOS only. Building an empty stub project on this platform." />
 	</Target>
 
 </Project>


### PR DESCRIPTION
Build is broken because it uses "warnings as errors" and a custom msbuild target is emitting a warning. I've made it a non-warning message.