### PR TITLE
Test the token requests sent from MSAL

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="System.Xml.XDocument" Version="4.3.0" />
     <PackageVersion Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageVersion Include="Xamarin.AndroidX.Browser" Version="1.4.0" PrivateAssets="All" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Analyzers and dev packages -->
@@ -80,7 +81,6 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="System.Windows.Forms" Version="4.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.8.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0"/>
-
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/LibsAndSamples.sln
+++ b/LibsAndSamples.sln
@@ -185,6 +185,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ManagedIdentityTokenRevocat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Test.E2E.MSI", "tests\Microsoft.Identity.Test.E2e\Microsoft.Identity.Test.E2E.MSI.csproj", "{97995B86-AA0F-3AF9-DA40-85A6263E4391}"
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MacMauiAppWithBroker", "tests\devapps\MacMauiAppWithBroker\MacMauiAppWithBroker.csproj", "{AEF6BB00-931F-4638-955D-24D735625C34}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Test.Smile", "tests\Microsoft.Identity.Test.Smile\Microsoft.Identity.Test.Smile.csproj", "{7C8485C9-C7D2-452B-8DA5-635D336B4992}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1866,6 +1867,48 @@ Global
 		{AEF6BB00-931F-4638-955D-24D735625C34}.Release|x64.Build.0 = Release|Any CPU
 		{AEF6BB00-931F-4638-955D-24D735625C34}.Release|x86.ActiveCfg = Release|Any CPU
 		{AEF6BB00-931F-4638-955D-24D735625C34}.Release|x86.Build.0 = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|Any CPU.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|ARM.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|ARM.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|ARM64.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|ARM64.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|iPhone.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|iPhone.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|x64.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|x64.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|x86.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug + MobileApps|x86.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|ARM.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|x64.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Debug|x86.Build.0 = Debug|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|ARM.ActiveCfg = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|ARM.Build.0 = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|ARM64.Build.0 = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|iPhone.Build.0 = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|x64.ActiveCfg = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|x64.Build.0 = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1921,6 +1964,7 @@ Global
 		{DA9C3258-DEF6-7794-9762-20CF7B826839} = {BCAEE9AE-8D3E-4C77-A2E4-134E1552D5F8}
 		{97995B86-AA0F-3AF9-DA40-85A6263E4391} = {9B0B5396-4D95-4C15-82ED-DC22B5A3123F}
 		{AEF6BB00-931F-4638-955D-24D735625C34} = {34BE693E-3496-45A4-B1D2-D3A0E068EEDB}
+		{7C8485C9-C7D2-452B-8DA5-635D336B4992} = {9B0B5396-4D95-4C15-82ED-DC22B5A3123F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {020399A9-DC27-4B82-9CAA-EF488665AC27}

--- a/tests/Microsoft.Identity.Test.Smile/Microsoft.Identity.Test.Smile.csproj
+++ b/tests/Microsoft.Identity.Test.Smile/Microsoft.Identity.Test.Smile.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+    <PackageReference Include="Microsoft.Identity.Client" />
+    -->
+    <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
+
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Microsoft.Identity.Test.Smile/Program.cs
+++ b/tests/Microsoft.Identity.Test.Smile/Program.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SmileTestRunner
+{
+    class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            try
+            {
+                if (args.Length == 0)
+                {
+                    Console.Error.WriteLine("Error: Please provide a test case url");
+                    return 1;
+                }
+
+                string testcaseUrl = args[0];
+                var executor = new SmileTestExecutor(testcaseUrl);
+                var results = await executor.RunTestAsync().ConfigureAwait(false);
+
+                // Output results in a more structured format
+                Console.WriteLine($"Test results for: {testcaseUrl}");
+                Console.WriteLine($"Total steps executed: {results.Count}");
+
+                for (int i = 0; i < results.Count; i++)
+                {
+                    string resultStatus = results[i] ? "Passed" : "Failed";
+                    Console.WriteLine($"\nStep {i + 1} result: {resultStatus}");
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error executing test: {ex.Message}");
+                Console.Error.WriteLine(ex.StackTrace);
+                return 1;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Smile/Program.cs
+++ b/tests/Microsoft.Identity.Test.Smile/Program.cs
@@ -16,20 +16,39 @@ namespace SmileTestRunner
                 }
 
                 string testcaseUrl = args[0];
-                var executor = new SmileTestExecutor(testcaseUrl);
-                var results = await executor.RunTestAsync().ConfigureAwait(false);
-
-                // Output results in a more structured format
-                Console.WriteLine($"Test results for: {testcaseUrl}");
-                Console.WriteLine($"Total steps executed: {results.Count}");
-
-                for (int i = 0; i < results.Count; i++)
+                // For now we assume that if it ends with .json, it is a batch file
+                if (testcaseUrl.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
                 {
-                    string resultStatus = results[i] ? "Passed" : "Failed";
-                    Console.WriteLine($"\nStep {i + 1} result: {resultStatus}");
-                }
+                    var executor = new SmileTestBatchExecutor(testcaseUrl);
+                    var results = await executor.RunTestsAsync().ConfigureAwait(false);
 
-                return 0;
+                    Console.WriteLine("Summary of test results:");
+                    // Loop through the results and print them
+                    foreach (var result in results)
+                    {
+                        string status = result.Value ? "Passed" : "Failed";
+                        Console.WriteLine($"Test case: {result.Key} - Status: {status}");
+                    }
+                    // Return 0 if all tests passed, otherwise return 1
+                    return results.Values.All(r => r) ? 0 : 1;
+                }
+                else
+                {
+                    var executor = new SmileTestExecutor(testcaseUrl);
+                    var results = await executor.RunTestAsync().ConfigureAwait(false);
+
+                    // Output results in a more structured format
+                    Console.WriteLine($"Test results for: {testcaseUrl}");
+                    Console.WriteLine($"Total steps executed: {results.Count}");
+
+                    for (int i = 0; i < results.Count; i++)
+                    {
+                        string resultStatus = results[i] ? "Passed" : "Failed";
+                        Console.WriteLine($"\nStep {i + 1} result: {resultStatus}");
+                    }
+                    // Return 0 if all steps passed, otherwise return 1
+                    return results.All(r => r) ? 0 : 1;
+                }
             }
             catch (Exception ex)
             {

--- a/tests/Microsoft.Identity.Test.Smile/Properties/launchSettings.json
+++ b/tests/Microsoft.Identity.Test.Smile/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Microsoft.Identity.Test.Smile": {
       "commandName": "Project",
-      "commandLineArgs": "token_sha256_to_refresh.sml"
+      "commandLineArgs": "https://smile-test.azurewebsites.net/testcases.json"
     }
   }
 }

--- a/tests/Microsoft.Identity.Test.Smile/Properties/launchSettings.json
+++ b/tests/Microsoft.Identity.Test.Smile/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Microsoft.Identity.Test.Smile": {
+      "commandName": "Project",
+      "commandLineArgs": "token_sha256_to_refresh.sml"
+    }
+  }
+}

--- a/tests/Microsoft.Identity.Test.Smile/SmileTestBatchExecutor.cs
+++ b/tests/Microsoft.Identity.Test.Smile/SmileTestBatchExecutor.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SmileTestRunner
+{
+    /// <summary>
+    /// Executes a batch of Smile tests from a JSON file containing a list of test URLs
+    /// </summary>
+    public class SmileTestBatchExecutor
+    {
+        private readonly string _batchUrl;
+        private static readonly HttpClient _httpClient = new HttpClient();
+
+        /// <summary>
+        /// Creates a new instance of SmileTestBatchExecutor
+        /// </summary>
+        /// <param name="batchUrl">URL pointing to a JSON file containing test URLs</param>
+        public SmileTestBatchExecutor(string batchUrl)
+        {
+            _batchUrl = batchUrl ?? throw new ArgumentNullException(nameof(batchUrl));
+        }
+
+        /// <summary>
+        /// Runs all tests specified in the batch file
+        /// </summary>
+        /// <returns>A dictionary mapping each test URL to its result</returns>
+        public async Task<Dictionary<string, bool>> RunTestsAsync()
+        {
+            var testUrls = await GetTestUrlsAsync().ConfigureAwait(false);
+            var results = new Dictionary<string, bool>();
+
+            foreach (string testUrl in testUrls)
+            {
+                try
+                {
+                    Console.WriteLine($"Test {testUrl}: Spawning separate process...");
+                    var processResult = await RunTestInSeparateProcessAsync(testUrl).ConfigureAwait(false);
+                    results[testUrl] = processResult.Success;
+
+                    Console.WriteLine($"Test {testUrl}: {(processResult.Success ? "PASSED" : "FAILED")}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error executing test {testUrl}: {ex.Message}");
+                    results[testUrl] = false;
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Retrieves the list of test URLs from the batch file
+        /// </summary>
+        /// <returns>A list of test URLs</returns>
+        private async Task<List<string>> GetTestUrlsAsync()
+        {
+            if (!Uri.IsWellFormedUriString(_batchUrl, UriKind.Absolute))
+            {
+                throw new ArgumentException($"Invalid batch URL: {_batchUrl}");
+            }
+
+            HttpResponseMessage response = await _httpClient.GetAsync(_batchUrl).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            
+            string jsonContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using JsonDocument doc = JsonDocument.Parse(jsonContent);
+            
+            if (!doc.RootElement.TryGetProperty("testcases", out JsonElement testcasesElement) || 
+                testcasesElement.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidOperationException("Batch file does not contain a valid 'testcases' array");
+            }
+
+            var testUrls = new List<string>();
+            foreach (JsonElement element in testcasesElement.EnumerateArray())
+            {
+                if (element.ValueKind == JsonValueKind.String)
+                {
+                    string? url = element.GetString();
+                    if (!string.IsNullOrWhiteSpace(url))
+                    {
+                        testUrls.Add(url);
+                    }
+                }
+            }
+
+            return testUrls;
+        }
+
+        /// <summary>
+        /// Runs a single test in a separate process
+        /// </summary>
+        /// <param name="testUrl">URL of the test to run</param>
+        /// <returns>The result of the test execution</returns>
+        private async Task<(bool Success, string Output)> RunTestInSeparateProcessAsync(string testUrl)
+        {
+            // Create a temporary file to store the test result
+            string resultFile = Path.GetTempFileName();
+            
+            try
+            {
+                // Create process info
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    // Run the test using the existing Microsoft.Identity.Test.Smile.csproj
+                    Arguments = $"run --project \"{Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "Microsoft.Identity.Test.Smile.csproj")}\" -- \"{testUrl}\" --output-file \"{resultFile}\"",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+
+                // Start the process
+                using var process = new Process { StartInfo = startInfo };
+                var outputBuilder = new StringBuilder();
+                
+                process.OutputDataReceived += (sender, args) => 
+                {
+                    if (args.Data != null)
+                    {
+                        outputBuilder.AppendLine(args.Data);
+                        Console.WriteLine($"[Test Process] {args.Data}");
+                    }
+                };
+                
+                process.ErrorDataReceived += (sender, args) => 
+                {
+                    if (args.Data != null)
+                    {
+                        outputBuilder.AppendLine($"[ERROR] {args.Data}");
+                        Console.WriteLine($"[Test Process Error] {args.Data}");
+                    }
+                };
+                
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                
+                await process.WaitForExitAsync().ConfigureAwait(false);
+
+                /*
+                // Read result from file
+                if (File.Exists(resultFile))
+                {
+                    string resultJson = await File.ReadAllTextAsync(resultFile).ConfigureAwait(false);
+                    var result = JsonSerializer.Deserialize<TestResult>(resultJson);
+                    return (result?.Success ?? false, outputBuilder.ToString());
+                }
+                */
+                
+                return (process.ExitCode == 0, outputBuilder.ToString());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error running test in separate process: {ex.Message}");
+                return (false, ex.ToString());
+            }
+            finally
+            {
+                // Clean up temp file
+                try { if (File.Exists(resultFile)) File.Delete(resultFile); } catch { }
+            }
+        }
+
+        private class TestResult
+        {
+            public bool Success { get; set; }
+            public string[] StepResults { get; set; } = Array.Empty<string>();
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Smile/SmileTestExecutor.cs
+++ b/tests/Microsoft.Identity.Test.Smile/SmileTestExecutor.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SmileTestRunner
+{
+    public class SmileTestExecutor
+    {
+        private readonly string _testSource;
+        private TestFileContent? _testContent;  // Nullable since it is initialized asynchronously and cannot be guaranteed to be non-null at the end of the constructor.
+
+        private Dictionary<string, object> _variables = new Dictionary<string, object>();
+        private static readonly HttpClient _httpClient = new HttpClient();
+
+        /// <summary>
+        /// Creates a new instance of SmileTestExecutor using either a file path or URL
+        /// </summary>
+        /// <param name="testSource">Path to a local file or a URL pointing to YAML content</param>
+        public SmileTestExecutor(string testSource)
+        {
+            _testSource = testSource;
+        }
+
+        /// <summary>
+        /// Initializes the test content by loading from either a file or URL
+        /// </summary>
+        private async Task InitializeTestContentAsync()
+        {
+            string yamlContent = await GetYamlContentAsync().ConfigureAwait(false);
+
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+
+            _testContent = deserializer.Deserialize<TestFileContent>(yamlContent);
+        }
+
+        /// <summary>
+        /// Gets the YAML content from either a file or URL
+        /// </summary>
+        /// <returns>The YAML content as a string</returns>
+        private async Task<string> GetYamlContentAsync()
+        {
+            if (Uri.IsWellFormedUriString(_testSource, UriKind.Absolute))
+            {
+                // Get content from URL
+                HttpResponseMessage response = await _httpClient.GetAsync(_testSource).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode(); // Throw if not successful
+                return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                // Get content from local file
+                if (!File.Exists(_testSource))
+                {
+                    throw new FileNotFoundException($"Test file '{_testSource}' not found");
+                }
+
+                return await File.ReadAllTextAsync(_testSource).ConfigureAwait(false);
+            }
+        }
+
+        public async Task<List<bool>> RunTestAsync()
+        {
+            await InitializeTestContentAsync().ConfigureAwait(false);
+            SetupEnvironment();
+            CreateArrangeVariables();
+            return await ExecuteStepsAsync().ConfigureAwait(false);
+            // TODO: Do we need to handle unsetting env variables?
+        }
+
+        private void SetupEnvironment()
+        {
+            if (_testContent?.Env != null) // Use null conditional operator to ensure _testContent is not null
+            {
+                foreach (var entry in _testContent.Env)
+                {
+                    Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+                }
+            }
+        }
+
+        private void CreateArrangeVariables()
+        {
+            if (_testContent?.Arrange == null)
+                return;
+
+            foreach (var entry in _testContent.Arrange)
+            {
+                string variableName = entry.Key;
+                object variableValue = CreateObjectFromConfig(entry.Value);
+                _variables[variableName] = variableValue;
+            }
+        }
+
+        private object CreateObjectFromConfig(Dictionary<string, object> config)
+        {
+            var entry = config.First();
+            return CreateMsalObject(entry.Key, JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(entry.Value)));
+        }
+
+        private object CreateMsalObject(string className, JsonElement parameters)
+        {
+            if (className == "ManagedIdentityClient")
+            {
+                if (parameters.TryGetProperty("managed_identity", out _))
+                {
+                    // TODO: Properly parse the parameters and set up SAMI or UAMI accordingly
+                    var appBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned);
+                    if (parameters.TryGetProperty("client_capabilities", out JsonElement clientCapabilitiesElement))
+                    {
+                        var clientCapabilities = JsonSerializer.Deserialize<string[]>(clientCapabilitiesElement.GetRawText());
+                        appBuilder = appBuilder.WithClientCapabilities(clientCapabilities);
+                    }
+                    IManagedIdentityApplication managedIdentityApp = appBuilder.Build();
+                    return managedIdentityApp;
+                }
+            }
+            throw new NotImplementedException($"{className} is not implemented yet.");
+        }
+
+        private async Task<List<bool>> ExecuteStepsAsync()
+        {
+            var results = new List<bool>();
+
+            if (_testContent?.Steps == null)
+                return results;
+
+            foreach (var step in _testContent.Steps)
+            {
+                if (step.Act == null)
+                    continue;
+
+                var actionResult = await ExecuteActionAsync(step.Act).ConfigureAwait(false);
+                bool stepPassed = actionResult != null && (
+                    step.Assert != null ? AreAssertionsPassed(actionResult, step.Assert) : true);
+                results.Add(stepPassed);
+            }
+
+            return results;
+        }
+
+        private async Task<Dictionary<string, object>?> ExecuteActionAsync(Dictionary<string, object> actionConfig)
+        {
+            var actionEntry = actionConfig.First();
+            string actionString = actionEntry.Key;
+            var parameters = JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(actionEntry.Value));
+
+            string[] parts = actionString.Split('.');
+            string variableName = parts[0];
+            string methodName = parts[1];
+
+            if (!_variables.TryGetValue(variableName, out object? obj))
+                throw new InvalidOperationException($"Variable '{variableName}' not found");
+
+            // Convert method parameters
+            var methodParams = new Dictionary<string, object>();
+            if (parameters.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var param in parameters.EnumerateObject())
+                {
+                    methodParams[param.Name] = param.Value.Deserialize<object>()!;
+                }
+            }
+
+            // Match obj via reflection
+            if (obj is IManagedIdentityApplication managedIdentityApp)
+            {
+                if (methodName == "AcquireTokenForManagedIdentity")
+                {
+                    try
+                    {
+                        var acquireTokenBuilder = managedIdentityApp.AcquireTokenForManagedIdentity(
+                           parameters.GetProperty("resource").GetString()
+                        );
+
+                        if (parameters.TryGetProperty("claims_challenge", out JsonElement claimsChallengeElement))
+                        {
+                            acquireTokenBuilder = acquireTokenBuilder.WithClaims(claimsChallengeElement.GetString());
+                        }
+
+                        var result = await acquireTokenBuilder
+                           .ExecuteAsync()
+                           .ConfigureAwait(false);
+                        return new Dictionary<string, object>
+                        {
+                            ["access_token"] = result.AccessToken,
+                            ["token_type"] = result.TokenType,
+                            ["token_source"] = TokenSourceHelper.ToSmileString(result.AuthenticationResultMetadata.TokenSource),
+                        };
+                    }
+                    catch (MsalException msalEx)
+                    {
+                        Console.WriteLine($"{variableName}.{methodName}: MSAL Exception: " +
+                            $"\n - Message: {msalEx.Message}" +
+                            $"\n - ErrorCode: {msalEx.ErrorCode}" +
+                            $"\n - StackTrace: {msalEx.StackTrace}");
+                        return null;
+                    }
+                }
+                throw new NotImplementedException($"Method '{methodName}' not implemented for '{variableName}'");
+            }
+            throw new NotImplementedException($"Variable '{variableName}' not arranged");
+        }
+
+        private bool AreAssertionsPassed(Dictionary<string, object> result, Dictionary<string, object> assertions)
+        {
+            bool allAssertionsPassed = true;
+            foreach (KeyValuePair<string, object> assertion in assertions)
+            {
+                if (!result.TryGetValue(assertion.Key, out object? actualValue) ||
+                    !actualValue.Equals(assertion.Value))
+                {
+                    Console.WriteLine($"Assertion failed for {assertion.Key}. Expected: {assertion.Value}, Got: {actualValue}");
+                    allAssertionsPassed = false;
+                }
+            }
+            return allAssertionsPassed;
+        }
+    }
+
+    public class TestFileContent
+    {
+        public required string Type { get; set; }
+        public string? Ver { get; set; }
+        public Dictionary<string, string>? Env { get; set; }
+        public Dictionary<string, Dictionary<string, object>>? Arrange { get; set; }
+        public required List<TestStep> Steps { get; set; }
+    }
+
+    public class TestStep
+    {
+        public required Dictionary<string, object> Act { get; set; }
+        public Dictionary<string, object>? Assert { get; set; }
+    }
+
+    public static class TokenSourceHelper
+    {
+        public static string ToSmileString(TokenSource tokenSource)
+        {
+            return tokenSource switch
+            {
+                TokenSource.IdentityProvider => "identity_provider",
+                TokenSource.Cache => "cache",
+                TokenSource.Broker => "broker",
+                _ => "unknown"
+            };
+        }
+    }
+}


### PR DESCRIPTION
This is a proof-of-concept described in a recent internal discussion.

Currently this PR contains the test runner as a command line application, so that the human user can manually run it with a parameter which is the url of the centrally hosted test case. We can integrate it as a new test case alongside with other existing tests later.