### PR TITLE
Update Directory.Packages.props to TreatWarningsAsErrors in DevApps

### DIFF
--- a/tests/devapps/Directory.Packages.props
+++ b/tests/devapps/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Disable central package management for dev apps -->
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #
Build errors

**Changes proposed in this request**
This pull request includes a single change to the `tests/devapps/Directory.Packages.props` file. The change updates the `TreatWarningsAsErrors` property to treat all warnings as errors, ensuring stricter code quality enforcement.

**Testing**
n/a

**Performance impact**
n/a

**Documentation**
- [x] All relevant documentation is updated.
