### PR TITLE
Set a generous startup timeout of 120 seconds for the `ChromeDriver` to accommodate slower environments.

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/SeleniumExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/SeleniumExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Test.Integration.Infrastructure
             // ---------- Chrome launch flags ----------
             var options = new ChromeOptions();
             options.AddArguments(
-                "--headless=new",          // modern headless mode (works on GUI-less agents)
+                "--headless=new",          // modern headless mode (remove this for debugging)
                 "--disable-gpu",
                 "--window-size=1920,1080",
                 "--remote-allow-origins=*",
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Test.Integration.Infrastructure
             }
             catch (WebDriverException e)
             {
-                Trace.WriteLine("Failed to maximize: " + e.Message);
+                Trace.WriteLine("Failed to maximize the window : " + e.Message);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/SeleniumExtensions.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/SeleniumExtensions.cs
@@ -24,35 +24,54 @@ namespace Microsoft.Identity.Test.Integration.Infrastructure
 
         public static IWebDriver CreateDefaultWebDriver()
         {
-            ChromeOptions options = new ChromeOptions();
-            ChromeDriver driver;
+            // ---------- Chrome launch flags ----------
+            var options = new ChromeOptions();
+            options.AddArguments(
+                "--headless=new",          // modern headless mode (works on GUI-less agents)
+                "--disable-gpu",
+                "--window-size=1920,1080",
+                "--remote-allow-origins=*",
+                "--disable-dev-shm-usage"); // avoids crashes in low-memory containers
 
-            // ~2x faster, no visual rendering
-            // remove when debugging to see the UI automation
-            options.AddArguments("headless");
+            // ---------- Pick a driver binary ----------
+            // 1) Prefer explicit env-var so devs can override locally
+            var driverDir = Environment.GetEnvironmentVariable("CHROMEWEBDRIVER");
 
-            var env = Environment.GetEnvironmentVariable("CHROMEWEBDRIVER");
-            if (string.IsNullOrEmpty(env))
+            // 2) Otherwise use the folder where CI drops a matching chromedriver
+            if (string.IsNullOrEmpty(driverDir))
             {
-                driver = new ChromeDriver(options);
+                driverDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "drivers");
             }
-            else
-            {
-                driver = new ChromeDriver(env, options);
-            }
+
+            // 3) Fallback: let Selenium look on PATH
+            ChromeDriverService service = string.IsNullOrEmpty(driverDir)
+                ? ChromeDriverService.CreateDefaultService()
+                : ChromeDriverService.CreateDefaultService(driverDir);
+
+            service.HideCommandPromptWindow = true;
+            service.EnableVerboseLogging = true;
+
+            var driver = new ChromeDriver(
+                service,
+                options,
+                TimeSpan.FromSeconds(120));       // generous startup timeout
 
             driver.Manage().Timeouts().ImplicitWait = ImplicitTimespan;
 
+            TryMaximize(driver);
+            return driver;
+        }
+
+        private static void TryMaximize(IWebDriver driver)
+        {
             try
             {
                 driver.Manage().Window.Maximize();
             }
             catch (WebDriverException e)
             {
-                Trace.WriteLine("Failed to maximize the window: " + e.Message);
+                Trace.WriteLine("Failed to maximize: " + e.Message);
             }
-            
-            return driver;
         }
 
         #region ScreenShot support


### PR DESCRIPTION
Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
This pull request refactors the `CreateDefaultWebDriver` method in `SeleniumExtensions` to improve configurability, enhance debugging options, and ensure better compatibility with CI environments. Additionally, it introduces a helper method for window maximization and removes redundant code.

### Refactoring of `CreateDefaultWebDriver`:

* Enhanced Chrome options:
  - Added modern headless mode (`--headless=new`) and other flags for improved performance and compatibility in CI environments.
  
* Improved driver binary selection:
  - Introduced a prioritized approach to locate the ChromeDriver binary:
    1. Explicit environment variable (`CHROMEWEBDRIVER`) for local overrides.
    2. Default fallback to a predefined `drivers` folder in the application directory for CI.
    3. Final fallback to the system `PATH`.

* Configured `ChromeDriverService`:
  - Enabled verbose logging and hid the command prompt window for cleaner output.

* Adjusted driver initialization:
  - Set a generous startup timeout of 120 seconds for the `ChromeDriver` to accommodate slower environments.

### Code simplification and helper method:

* Introduced `TryMaximize` method:
  - Extracted window maximization logic into a separate method to improve readability and maintainability. [[1]](diffhunk://#diff-7d1151e2b437f33b7343b0894a242e312f75bc4b1413bc9c0170435c5b233f65L27-R66) [[2]](diffhunk://#diff-7d1151e2b437f33b7343b0894a242e312f75bc4b1413bc9c0170435c5b233f65L54-L55)

* Removed redundant return statement from the original `CreateDefaultWebDriver` method.

**Testing**
Build - https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1489714&view=logs&j=309407d2-99a6-50bb-5f2b-1c3d160dddc9&t=094e3a64-4c2a-5d4a-9d73-c72bee49987f

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
