### PR TITLE
Deprecate AcquireTokenByIntegratedWindowsAuth API

### DIFF
--- a/src/client/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/src/client/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -77,8 +77,9 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// <para>
-        /// This API is no longer recommended and will be deprecated in future versions in favor of 
-        /// similar functionality via <see href="https://aka.ms/msal-net-wam">the Windows broker (WAM)</see>.
+        /// This API is no longer recommended. If your applicaiton requires single sign-on (SSO) with the Windows OS's default account, 
+        /// please transition to using WAM, which provides similar functionality 
+        /// via <see href="https://aka.ms/msal-net-wam">the Windows broker (WAM)</see>.
         /// WAM does not require any setup for desktop apps to login with the Windows account.
         /// </para>
         /// <para>
@@ -94,6 +95,9 @@ namespace Microsoft.Identity.Client
         /// <remarks>
         /// See <see href="https://aka.ms/msal-net-iwa">our documentation</see> for more details.
         /// </remarks>
+
+        [Obsolete("This API is no longer recommended. For scenarios requiring SSO with the Windows OS's default account, please transition to using WAM.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         AcquireTokenByIntegratedWindowsAuthParameterBuilder AcquireTokenByIntegratedWindowsAuth(
             IEnumerable<string> scopes);
 

--- a/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs
@@ -98,8 +98,7 @@ namespace Microsoft.Identity.Client.WsTrust
             };
 
             var body = new StringContent(
-                // CodeQL [SM00417] False Positive: wsTrustRequest is a body parameter for HttpRequest that follows WsTrust protocol
-                wsTrustRequest,
+                wsTrustRequest, // CodeQL [SM00417] False Positive: wsTrustRequest is a body parameter for HttpRequest that follows WsTrust protocol
                 Encoding.UTF8, "application/soap+xml");
 
             IRetryPolicyFactory retryPolicyFactory = requestContext.ServiceBundle.Config.RetryPolicyFactory;


### PR DESCRIPTION
This API is no longer recommended. 
Aslo suppress a CodeQL issue which is a false positive.
