### PR TITLE
Remove experimental flag on the new MTLS POP API on CCA + SNI Flows

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -96,8 +96,6 @@ namespace Microsoft.Identity.Client
         /// <returns>The current instance of <see cref="AcquireTokenForClientParameterBuilder"/> to enable method chaining.</returns>
         public AcquireTokenForClientParameterBuilder WithMtlsProofOfPossession()
         {
-            ValidateUseOfExperimentalFeature();
-
             if (ServiceBundle.Config.ClientCredential is not CertificateClientCredential certificateCredential)
             {
                 throw new MsalClientException(

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
@@ -38,9 +38,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // Build Confidential Client Application with SNI certificate at App level
             IConfidentialClientApplication confidentialApp = ConfidentialClientApplicationBuilder.Create(MsiAllowListedAppIdforSNI)
                 .WithAuthority("https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c")
-                .WithAzureRegion("westus3") //test slice region 
-                .WithCertificate(cert, true)  
-                .WithExperimentalFeatures()
+                .WithAzureRegion("westus3") //test slice region
+                .WithCertificate(cert, true)
                 .WithTestLogging()
                 .Build();
 
@@ -65,7 +64,8 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                .ConfigureAwait(false);
 
             // Assert: Verify that the token was fetched from cache on the second request
-            Assert.AreEqual(TokenSource.Cache, authResult.AuthenticationResultMetadata.TokenSource, "Token should be retrieved from cache");
+            Assert.AreEqual(TokenSource.Cache, authResult.AuthenticationResultMetadata.TokenSource, 
+                "Token should be retrieved from cache");
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
@@ -17,21 +17,5 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
     [TestClass]
     public class ExperimentalFeatureTests
     {
-        private static readonly string[] s_scopes = ["scope"];
-#if NETFRAMEWORK
-        [TestMethod]
-        public async Task ExperimentalFeatureExceptionAsync()
-        {
-            IConfidentialClientApplication cca = ConfidentialClientApplicationBuilder
-                .Create(Guid.NewGuid().ToString())
-                .WithCertificate(CertHelper.GetOrCreateTestCert()).Build();
-
-            MsalClientException ex = await AssertException.TaskThrowsAsync<MsalClientException>(
-                () => cca.AcquireTokenForClient(s_scopes).WithMtlsProofOfPossession().ExecuteAsync())
-                .ConfigureAwait(false);
-
-            Assert.AreEqual(MsalError.ExperimentalFeature, ex.ErrorCode);
-        }
-#endif
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
-                            .WithExperimentalFeatures()
                             .Build();
 
             MsalClientException ex = await AssertException.TaskThrowsAsync<MsalClientException>(() =>
@@ -73,7 +72,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithClientSecret(TestConstants.ClientSecret)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request without a certificate
@@ -97,7 +95,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithClientClaims(s_testCertificate, ipAddress)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Expecting an exception because MTLS PoP requires a certificate to sign the claims
@@ -116,7 +113,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithClientAssertion(() => { return TestConstants.DefaultClientAssertion; })
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Expecting an exception because MTLS PoP requires a certificate to sign the claims
@@ -154,7 +150,6 @@ namespace Microsoft.Identity.Test.Unit
                                     .Create(TestConstants.ClientId)
                                     .WithAuthority(TestConstants.AuthorityTenant)
                                     .WithCertificate(s_testCertificate)
-                                    .WithExperimentalFeatures()
                                     .Build();
                 }
 
@@ -176,7 +171,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithCertificate(s_testCertificate)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request without specifying an authority
@@ -247,7 +241,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -299,7 +292,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithTenantId("123456-1234-2345-1234561234")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -346,7 +338,6 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(authorityUrl)
                     .WithAzureRegion(region)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures()
                     .BuildConcrete();
 
                 AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
@@ -387,7 +378,6 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAzureRegion(region)
                     .WithAuthority(authority)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures()
                     .BuildConcrete();
 
                 var memoryTokenCache = new InMemoryTokenCache();
@@ -430,7 +420,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -458,7 +447,6 @@ namespace Microsoft.Identity.Test.Unit
                             .Create(TestConstants.ClientId)
                             .WithCertificate(s_testCertificate)
                             .WithAuthority(authorityUrl)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request with a non-AAD authority
@@ -497,7 +485,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithAuthority($"{authorityUrl}/{nonTenantValue}")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -554,7 +541,6 @@ namespace Microsoft.Identity.Test.Unit
                                  .WithHttpManager(harness.HttpManager)
                                  .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
                                  .WithCertificate(s_testCertificate)
-                                 .WithExperimentalFeatures(true)
                                  .Build();
 
                     // Act
@@ -602,7 +588,6 @@ namespace Microsoft.Identity.Test.Unit
                                         .WithHttpManager(harness.HttpManager)
                                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
                                         .WithCertificate(s_testCertificate)
-                                        .WithExperimentalFeatures(true)
                                         .Build();
 
                     AuthenticationResult result = await app
@@ -665,7 +650,6 @@ namespace Microsoft.Identity.Test.Unit
                                     .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
                                     .WithCertificate(s_testCertificate)
                                     .WithInstanceDiscovery(false)
-                                    .WithExperimentalFeatures(true)
                                     .Build();
 
                     AuthenticationResult result = await app
@@ -714,7 +698,6 @@ namespace Microsoft.Identity.Test.Unit
                 var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                     .WithCertificate(s_testCertificate)
                     .WithAuthority(authorityUrl)
-                    .WithExperimentalFeatures()
                     .WithHttpManager(httpManager)
                     .BuildConcrete();
 
@@ -750,7 +733,6 @@ namespace Microsoft.Identity.Test.Unit
                             .Create(TestConstants.ClientId)
                             .WithAuthority(authorityUrl)
                             .WithCertificate(s_testCertificate)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request specifying an authority

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -432,11 +432,7 @@ namespace NetCoreTestApp
                 .WithAuthority("https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c")
                 .WithAzureRegion(region);
 
-
             ccaBuilder = ccaBuilder.WithCertificate(s_confidentialClientCertificate, true);
-
-            //Add Experimental feature for MTLS PoP
-            ccaBuilder = ccaBuilder.WithExperimentalFeatures();
 
             IConfidentialClientApplication ccapp = ccaBuilder.Build();
 


### PR DESCRIPTION
Fixes #5352

**Changes proposed in this request**
This pull request removes the use of the `WithExperimentalFeatures` method across multiple files and tests in the codebase. The method was previously used to enable experimental features, but its removal indicates these features are now stable or no longer needed. Additionally, some minor formatting adjustments were made in test assertions.

### Removal of `WithExperimentalFeatures`:

* [`src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs`](diffhunk://#diff-66e58df1ddbe7bfef74ce08f426e8ebbdb78e7258838c181d5d497bd6c7236eeL99-L100): Removed the call to `ValidateUseOfExperimentalFeature` in the `WithMtlsProofOfPossession` method, reflecting that the feature is no longer experimental.
* [`tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs`](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL57): Removed multiple instances of `.WithExperimentalFeatures()` across various test methods, simplifying the test setup for MTLS PoP scenarios. [[1]](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL57) [[2]](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL179) [[3]](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL557) etc.)
* [`tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs`](diffhunk://#diff-c3c0d577f3efc4760d8fd4264394a0ecf611c642d0c5b4a3e9f3ace447d8bd0cL20-L35): Removed the `ExperimentalFeatureExceptionAsync` test, which was verifying the behavior of experimental features.
* [`tests/devapps/NetCoreTestApp/Program.cs`](diffhunk://#diff-68eff184dc4c1d3a61488bc239dabfafc7fe7dad0fad4c020bbc933314e5e310L435-L440): Removed the `WithExperimentalFeatures` call in the `CreateCcaForMtlsPop` method, aligning with the removal of experimental feature handling.

### Minor Test Formatting Adjustments:

* [`tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs`](diffhunk://#diff-99c80006e86a371e433178287365a7fef77cf82ef0187aaaa37ec37cfe4d9ffcL68-R68): Adjusted a test assertion to improve readability by splitting a long line.

**Testing**
unit tests and integration tests

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
