### PR TITLE
update the deprecated openURL(:) api to openURL(:options:completionHandler)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
             // this needs to be case sensitive because the AppBundle is case sensitive
             brokerRequest.Add(
-                BrokerParameter.RedirectUri, 
+                BrokerParameter.RedirectUri,
                 authenticationRequestParameters.RedirectUri.OriginalString);
 
             if (authenticationRequestParameters.ExtraQueryParameters?.Any() == true)
@@ -167,7 +167,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             {
                 brokerRequest.Add(BrokerParameter.Prompt, acquireTokenInteractiveParameters.Prompt.PromptValue);
             }
-            
+
             if (!string.IsNullOrEmpty(authenticationRequestParameters.Claims))
             {
                 brokerRequest.Add(BrokerParameter.Claims, authenticationRequestParameters.Claims);
@@ -181,7 +181,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1422:Validate platform compatibility", Justification = "<Pending>")]
         public void HandleInstallUrl(string appLink)
         {
-            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.OpenUrl(new NSUrl(appLink)));
+            DispatchQueue.MainQueue.DispatchAsync(() => UIApplication.SharedApplication.OpenUrl(new NSUrl(appLink), new UIApplicationOpenUrlOptions(), null));
 
             throw new MsalClientException(
                 MsalError.BrokerApplicationRequired,

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/Broker/iOSBroker.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
 
             // this needs to be case sensitive because the AppBundle is case sensitive
             brokerRequest.Add(
-                BrokerParameter.RedirectUri,
+                BrokerParameter.RedirectUri, 
                 authenticationRequestParameters.RedirectUri.OriginalString);
 
             if (authenticationRequestParameters.ExtraQueryParameters?.Any() == true)
@@ -167,7 +167,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS
             {
                 brokerRequest.Add(BrokerParameter.Prompt, acquireTokenInteractiveParameters.Prompt.PromptValue);
             }
-
+            
             if (!string.IsNullOrEmpty(authenticationRequestParameters.Claims))
             {
                 brokerRequest.Add(BrokerParameter.Claims, authenticationRequestParameters.Claims);

--- a/src/client/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Identity.Client.Platforms.iOS.EmbeddedWebview
 
 #pragma warning disable CA1422 // Validate platform compatibility
                 DispatchQueue.MainQueue.DispatchAsync(
-                    () => UIApplication.SharedApplication.OpenUrl(new NSUrl(requestUrlString)));
+                    () => UIApplication.SharedApplication.OpenUrl(new NSUrl(requestUrlString), new UIApplicationOpenUrlOptions(), null));
 #pragma warning restore CA1422 // Validate platform compatibility
                 _authenticationAgentUIViewController.DismissViewController(true, null);
                 decisionHandler(WKNavigationActionPolicy.Cancel);


### PR DESCRIPTION
update the api openURL(:) to open(:options:completionHandler) as openURL(:) is deprecated in iOS 18.

https://developer.apple.com/documentation/uikit/uiapplication/openurl(_:)/