### PR TITLE
Ensure correlationId is added to request_timeout exception when available

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http.Retry;
+using Microsoft.Identity.Client.OAuth2;
 
 namespace Microsoft.Identity.Client.Http
 {
@@ -134,9 +135,14 @@ namespace Microsoft.Identity.Client.Http
             logger.Warning("Request retry failed.");
             if (timeoutException != null)
             {
+                //If the correlation id is available, include it in the exception message
+                string correlationId = headers.ContainsKey(OAuth2Header.CorrelationId) ?
+                    $" CorrelationId: {headers[OAuth2Header.CorrelationId]}" :
+                    string.Empty;
+
                 throw new MsalServiceException(
                     MsalError.RequestTimeout,
-                    "Request to the endpoint timed out.",
+                    $"Request to the endpoint timed out.{correlationId}",
                     timeoutException);
             }
 

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Identity.Client.Http
             if (timeoutException != null)
             {
                 //If the correlation id is available, include it in the exception message
-                string msg = "Request to the endpoint timed out.";
+                string msg = MsalErrorMessage.RequestTimeOut;
 
                 if (headers != null && headers.Count > 0)
                 {

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -140,16 +140,25 @@ namespace Microsoft.Identity.Client.Http
 
                 if (headers != null && headers.Count > 0)
                 {
-                    string correlationId = headers.ContainsKey(OAuth2Header.CorrelationId) ?
-                                                $" CorrelationId: {headers[OAuth2Header.CorrelationId]}" :
+                    var correlationId = headers[OAuth2Header.CorrelationId];
+                    string correlationIdMsg = headers.ContainsKey(OAuth2Header.CorrelationId) ?
+                                                $" CorrelationId: {correlationId}" :
                                                 string.Empty;
-                    msg += correlationId;
+
+                    var ex = new MsalServiceException(
+                                MsalError.RequestTimeout,
+                                msg + correlationIdMsg,
+                                timeoutException);
+
+                    ex.CorrelationId = correlationId;
+
+                    throw ex;
                 }
 
                 throw new MsalServiceException(
-                    MsalError.RequestTimeout,
-                    msg,
-                    timeoutException);
+                                MsalError.RequestTimeout,
+                                msg,
+                                timeoutException);
             }
 
             if (doNotThrow)

--- a/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
+++ b/src/client/Microsoft.Identity.Client/Http/HttpManager.cs
@@ -136,13 +136,19 @@ namespace Microsoft.Identity.Client.Http
             if (timeoutException != null)
             {
                 //If the correlation id is available, include it in the exception message
-                string correlationId = headers.ContainsKey(OAuth2Header.CorrelationId) ?
-                    $" CorrelationId: {headers[OAuth2Header.CorrelationId]}" :
-                    string.Empty;
+                string msg = "Request to the endpoint timed out.";
+
+                if (headers != null && headers.Count > 0)
+                {
+                    string correlationId = headers.ContainsKey(OAuth2Header.CorrelationId) ?
+                                                $" CorrelationId: {headers[OAuth2Header.CorrelationId]}" :
+                                                string.Empty;
+                    msg += correlationId;
+                }
 
                 throw new MsalServiceException(
                     MsalError.RequestTimeout,
-                    $"Request to the endpoint timed out.{correlationId}",
+                    msg,
                     timeoutException);
             }
 

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -438,5 +438,6 @@ namespace Microsoft.Identity.Client
         public const string MtlsNonTenantedAuthorityNotAllowedMessage = "mTLS authentication requires a tenanted authority. Using 'common', 'organizations', or similar non-tenanted authorities is not allowed. Please provide an authority with a specific tenant ID (e.g., 'https://login.microsoftonline.com/{tenantId}'). See https://aka.ms/msal-net-pop for details.";
         public const string RegionRequiredForMtlsPopMessage = "Regional auto-detect failed. mTLS Proof-of-Possession requires a region to be specified, as there is no global endpoint for mTLS. See https://aka.ms/msal-net-pop for details.";
         public const string ForceRefreshAndTokenHasNotCompatible = "Cannot specify ForceRefresh and AccessTokenSha256ToRefresh in the same request.";
+        public const string RequestTimeOut = "Request to the endpoint timed out.";
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
@@ -607,7 +607,6 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
                             .Create(TestConstants.ClientId)
                             .WithAuthority(TestConstants.AuthorityTestTenant)
                             .WithHttpManager(httpManager)
-                            .WithExperimentalFeatures(true)
                             .WithClientSecret(TestConstants.ClientSecret)
                             .Build();
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/HttpTests/HttpManagerTests.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http.Retry;
+using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
@@ -533,6 +534,56 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.HttpTests
 
                 int requestsMade = Num500Errors - httpManager.QueueSize;
                 Assert.AreEqual(Num500Errors, requestsMade);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task TestCorrelationIdWithRetryOnTimeoutFailureAsync(bool addCorrelationId)
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                // Simulate permanent errors (to trigger the maximum number of retries)
+                const int Num500Errors = 1 + TestDefaultRetryPolicy.DefaultStsMaxRetries; // initial request + maximum number of retries
+                for (int i = 0; i < Num500Errors; i++)
+                {
+                    httpManager.AddRequestTimeoutResponseMessageMockHandler(HttpMethod.Post);
+                }
+
+                Guid correlationId = Guid.NewGuid();
+                var headers = new Dictionary<string, string>();
+
+                if (addCorrelationId)
+                {
+                    headers.Add(OAuth2Header.CorrelationId, correlationId.ToString());
+                }
+
+                var exc = await AssertException.TaskThrowsAsync<MsalServiceException>(() =>
+                    httpManager.SendRequestAsync(
+                        new Uri(TestConstants.AuthorityHomeTenant + "oauth2/token"),
+                        headers: headers,
+                        body: new FormUrlEncodedContent(new Dictionary<string, string>()),
+                        method: HttpMethod.Post,
+                        logger: Substitute.For<ILoggerAdapter>(),
+                        doNotThrow: false,
+                        mtlsCertificate: null,
+                        validateServerCert: null,
+                        cancellationToken: default,
+                        retryPolicy: _stsRetryPolicy))
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.RequestTimeout, exc.ErrorCode);
+
+                if (addCorrelationId)
+                {
+                    Assert.AreEqual($"Request to the endpoint timed out. CorrelationId: {correlationId.ToString()}", exc.Message);
+                }
+                else
+                {
+                    Assert.AreEqual("Request to the endpoint timed out.", exc.Message);
+                }
+
             }
         }
 


### PR DESCRIPTION
Fixes #
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5255

**Changes proposed in this request**
Adds the correlation id when the request_timeout exception is thrown if it is available

**Testing**
Unit testing

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
