### PR TITLE
Delete flaky/deprecated Kerberos test

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
@@ -398,15 +398,6 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
             }, TestContext);
         }
 
-        #region Azure AD Kerberos Feature Tests
-        [IgnoreOnOneBranch]
-        public async Task Kerberos_Interactive_AADAsync()
-        {
-            LabResponse labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
-            await KerberosRunTestForUserAsync(labResponse, KerberosTicketContainer.IdToken).ConfigureAwait(false);
-            await KerberosRunTestForUserAsync(labResponse, KerberosTicketContainer.AccessToken).ConfigureAwait(false);
-        }
-
         private async Task<AuthenticationResult> KerberosRunTestForUserAsync(
             LabResponse labResponse,
             KerberosTicketContainer ticketContainer)


### PR DESCRIPTION
The Kerberos feature is being removed soon. This PR removes a flaky Kerberos test so that we can get the builds to pass.

See [here](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5357#issuecomment-2992520872) for more discussion.