### PR TITLE
Update CHANGELOG.md for MSAL 4.74.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
+4.74.0
+======
+
+### Features
+* Deprecate ROPC flow in Public Client Applications https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5355.
+* AuthenticationResult exposes a new BindingCertificate property that returns the X.509 certificate bound to the access token in mTLS-PoP scenarios. https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5370.
+
+### Bug fixes
+* MSAL now honors the DEFAULT_IDENTITY_CLIENT_ID environment variable when acquiring tokens from Azure Machine Learning managed-identity endpoint. https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5350.
+
+
 4.73.1
 ======
 
 ### Features
-Deprecate AcquireTokenByIntegratedWindowsAuth API in https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5345
+* Deprecate AcquireTokenByIntegratedWindowsAuth API in https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5345
 
 ### Bug fixes
-Update native interop to 0.19.2 by @fengga in https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5362 to solve broker bugs
+* Update native interop to 0.19.2 by @fengga in https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5362 to solve broker bugs
 update the deprecated openURL(:) api to openURL(:options:completionHandler) in https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5354
 
 4.73.0


### PR DESCRIPTION
Fixes - updates changelog

**Changes proposed in this request**
This pull request updates the `CHANGELOG.md` file to document changes for version 4.74.0, including new features and bug fixes.

### Version 4.74.0 updates:

#### Features:
* Deprecated the ROPC flow in Public Client Applications.
* Added a new `BindingCertificate` property to `AuthenticationResult` for returning the X.509 certificate bound to the access token in mTLS-PoP scenarios.

#### Bug fixes:
* Ensured MSAL honors the `DEFAULT_IDENTITY_CLIENT_ID` environment variable when acquiring tokens from the Azure Machine Learning managed-identity endpoint.

**Testing**
in the pipeline

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
