### PR TITLE
Update MSI V2 SDK Guidance 

### DIFF
--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** will leverage the `IMtlsHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
+To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** will leverage the `IMsalHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
 
 _This section covers:_
 - How Azure SDK uses **`IMtlsHttpClientFactory`** for MTLS authentication.

--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -2,59 +2,26 @@
 
 ## Overview
 
-To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** leverages the `IMsalMtlsHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
+To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** will continue to leverage the `IMtlsHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
 
 _This section covers:_
-- How Azure SDK uses **`IMsalMtlsHttpClientFactory`** for MTLS authentication.
-- How SDKs interact with the **certificate APIs** to obtain the binding certificate certificates.
+- How Azure SDK uses **`IMtlsHttpClientFactory`** for MTLS authentication.
+- How SDKs interact with the **certificate APIs** to obtain information about binding certificate.
 - The **new `CertificateRefreshed` event**, which notifies when a binding certificate is updated.
 
 ---
 
-## **Handling Certificate Rotation for Long-Lived Clients**
-
-**_The Problem: Certificate Expiry and Rotation_**
-- mTLS Proof of Possession (PoP) tokens are signed by a binding certificate.
-- The binding certificate is valid for 90 days.
-- A new certificate is made available 5 days before expiration.
-- The SDKs consuming MSAL (customizing httpclient) must ensure that its HttpClient uses the latest certificate.
-
-**_Proposed Solution_**
-- SDK clients must monitor certificate updates and refresh their HttpClient dynamically.
-- MSAL exposes an event-driven model to notify when the binding certificate is refreshed.
-
-## **New Interface: `IMsalMtlsHttpClientFactory`**
-
-MSAL introduces the `IMsalMtlsHttpClientFactory` interface to facilitate **mTLS-based authentication** in Azure SDKs. This ensures:
-- Secure token acquisition by enabling **mTLS authentication**.
-- **Reusable `HttpClient` instances** to prevent socket exhaustion.
-- Optimized **Azure SDK integration** for managing identities securely.
-
-### **Interface Definition**
-
-```csharp
-public interface IMsalMtlsHttpClientFactory : IMsalHttpClientFactory
-{
-    /// <summary>
-    /// Returns an HttpClient configured with a certificate for mutual TLS authentication.
-    /// </summary>
-    /// <param name="x509Certificate2">The certificate to be used for MTLS authentication.</param>
-    /// <returns>An HttpClient instance configured with the specified certificate.</returns>
-    HttpClient GetHttpClient(X509Certificate2 x509Certificate2);
-}
-```
-
 ## **Binding Certificate**
 
-SDKs customizing the httpclient factory will need a way to get the binding certificate for MTLS authentication. MSAL exposes a few different APIs to help SDKs manage certificates.
+SDKs customizing the httpclient factory will continue to use the old `IMtlsHttpClientFactory` interface. MSAL will use the customized httpclient factory to, 
 
-- Retrieving existing certificates from the OS store or memory.
-- Notifying SDKs when a certificate is updated via the CertificateRefreshed event.
+- call into `platformmetadata` endpoint to form the CSR.
+- Use the CSR and call into `issuecredential` endpoint to get the Certificate.
+- Once. MSAL acquires a certificate, MSAL will will call the mTLS endpoint using this certificate. MSAL will not use the customized factory for this call. 
 
 | API Name                             | Purpose                                                                            |
 |--------------------------------------|------------------------------------------------------------------------------------|
 | `GetManagedIdentitySourceAsync()`    | Will expose the MSI Source including the new `IMDSV2` source                       |
-| `GetBindingCertificate()`            | Helper method to get the binding certificate when source is `IMDSV2`.              |
 | `BindingCertificateRefreshed`        | Event to notify SDKs when the binding certificate is updated.                      |
 | `IsPopSupported()`                   | Helper method to check if POP is supported.                                        |
 | `IsCaeSupported()`                   | Helper method to check if CAE is supported.                                        |

--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** will continue to leverage the `IMtlsHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
+To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** will leverage the `IMtlsHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
 
 _This section covers:_
 - How Azure SDK uses **`IMtlsHttpClientFactory`** for MTLS authentication.

--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -13,7 +13,7 @@ _This section covers:_
 
 ## **Binding Certificate**
 
-SDKs customizing the httpclient factory will continue to use the old `IMtlsHttpClientFactory` interface. MSAL will use the customized httpclient factory to, 
+SDKs customizing the httpclient factory will continue to use the old `IMsalHttpClientFactory` interface. MSAL will use the customized httpclient factory to, 
 
 - call into `platformmetadata` endpoint to form the CSR.
 - Use the CSR and call into `issuecredential` endpoint to get the Certificate.

--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -51,11 +51,14 @@ SDKs customizing the httpclient factory will need a way to get the binding certi
 - Retrieving existing certificates from the OS store or memory.
 - Notifying SDKs when a certificate is updated via the CertificateRefreshed event.
 
-| API Name                         | Purpose                                                                            |
-|----------------------------------|------------------------------------------------------------------------------------|
-| `GetManagedIdentitySourceAsync()`| Will expose the MSI Source including the new `IMDSV2` source                       |
-| `GetBindingCertificate()`        | Helper method to get the binding certificate when source is `IMDSV2`.              |
-| `BindingCertificateRefreshed`    | Event to notify SDKs when the binding certificate is updated.                      |
+| API Name                             | Purpose                                                                            |
+|--------------------------------------|------------------------------------------------------------------------------------|
+| `GetManagedIdentitySourceAsync()`    | Will expose the MSI Source including the new `IMDSV2` source                       |
+| `GetBindingCertificate()`            | Helper method to get the binding certificate when source is `IMDSV2`.              |
+| `BindingCertificateRefreshed`        | Event to notify SDKs when the binding certificate is updated.                      |
+| `IsPopSupported()`                   | Helper method to check if POP is supported.                                        |
+| `IsCaeSupported()`                   | Helper method to check if CAE is supported.                                        |
+| `ResetInternalStaticCachesForTest()` | Helper method to reset internal static caches.                                     |
 
 
 

--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -5,7 +5,7 @@
 To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** will leverage the `IMsalHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
 
 _This section covers:_
-- How Azure SDK uses **`IMtlsHttpClientFactory`** for MTLS authentication.
+- How Azure SDK uses **`IMsalHttpClientFactory`** for MTLS authentication.
 - How SDKs interact with the **certificate APIs** to obtain information about binding certificate.
 - The **new `CertificateRefreshed` event**, which notifies when a binding certificate is updated.
 

--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-To support MSI V2 authentication with the `/credential` endpoint, the **Azure SDK** leverages the `IMsalMtlsHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
+To support MSI V2 authentication with the new `/issuecredential` endpoint, the **Azure SDK** leverages the `IMsalMtlsHttpClientFactory` interface and **certificate management APIs** for secure communication with Azure AD using **mutual TLS (mTLS)**.
 
-This section covers:
+_This section covers:_
 - How Azure SDK uses **`IMsalMtlsHttpClientFactory`** for MTLS authentication.
 - How SDKs interact with the **certificate APIs** to obtain the binding certificate certificates.
 - The **new `CertificateRefreshed` event**, which notifies when a binding certificate is updated.
@@ -13,14 +13,13 @@ This section covers:
 
 ## **Handling Certificate Rotation for Long-Lived Clients**
 
-The Problem: Certificate Expiry and Rotation
-
+**_The Problem: Certificate Expiry and Rotation_**
 - mTLS Proof of Possession (PoP) tokens are signed by a binding certificate.
 - The binding certificate is valid for 90 days.
 - A new certificate is made available 5 days before expiration.
 - The SDKs consuming MSAL (customizing httpclient) must ensure that its HttpClient uses the latest certificate.
 
-Proposed Solution
+**_Proposed Solution_**
 - SDK clients must monitor certificate updates and refresh their HttpClient dynamically.
 - MSAL exposes an event-driven model to notify when the binding certificate is refreshed.
 

--- a/docs/msi_v2/guidance_for_sdks_consuming_msal.md
+++ b/docs/msi_v2/guidance_for_sdks_consuming_msal.md
@@ -24,7 +24,6 @@ SDKs customizing the httpclient factory will continue to use the old `IMtlsHttpC
 | `GetManagedIdentitySourceAsync()`    | Will expose the MSI Source including the new `IMDSV2` source                       |
 | `BindingCertificateRefreshed`        | Event to notify SDKs when the binding certificate is updated.                      |
 | `IsPopSupported()`                   | Helper method to check if POP is supported.                                        |
-| `IsCaeSupported()`                   | Helper method to check if CAE is supported.                                        |
 | `ResetInternalStaticCachesForTest()` | Helper method to reset internal static caches.                                     |
 
 


### PR DESCRIPTION
Fixes - design doc

**Changes proposed in this request**
This pull request updates the documentation for MSI V2 authentication in the Azure SDK to reflect changes in endpoint naming and improves formatting for clarity. The most important changes include updating the endpoint name to `/issuecredential` and enhancing section headings for better readability.

### Documentation updates:

This pull request updates the documentation for MSI V2 authentication in the Azure SDK to reflect changes in the `/issuecredential` endpoint and simplifies the explanation of certificate handling. The most important changes include updating endpoint references, clarifying the role of the `IMtlsHttpClientFactory` interface, and revising certificate management details.

### Updates to MSI V2 Authentication Documentation:

* Updated references to the `/credential` endpoint, replacing it with the new `/issuecredential` endpoint for MSI V2 authentication. Adjusted the description to reflect continued use of the `IMtlsHttpClientFactory` interface for mTLS communication.
* Revised the explanation of certificate handling:
  - Removed detailed sections on certificate rotation and the `IMsalMtlsHttpClientFactory` interface.
  - Clarified that MSAL will now handle certificate acquisition and mTLS endpoint calls directly, without using the customized factory for the latter.

### API Updates in Documentation:

* Added new helper methods (`IsPopSupported`, `IsCaeSupported`, and `ResetInternalStaticCachesForTest`) to the API table, providing additional functionality for SDKs.

**Testing**
n/a

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
