### PR TITLE
Fix support versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following table lists MSAL.NET versions currently supported and receiving se
 
 | Major Version | Last Release | Patch Release Date  | Support Phase|End of Support |
 | --------------|--------------|--------|------------|--------|
-| 4.x           | [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)   |Monthly| Active | Not planned.<br/>✅Supported versions: from 4.71.2 to [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)<br/>⚠️Unsupported versions &lt; `4.71.2`.|
+| 4.x           | [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)   |Monthly| Active | Not planned.<br/>✅Supported versions: from 4.72.1 to [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)<br/>⚠️Unsupported versions &lt; `4.72.1`.|
 
 ### Performance perspectives
 

--- a/supportPolicy.md
+++ b/supportPolicy.md
@@ -1,20 +1,20 @@
 # MSAL.NET Support Policy
 
-_Last updated May 14, 2025_
+_Last updated July 15, 2025_
 
 ## Supported versions
 The following table lists MSAL.NET versions currently supported and receiving security fixes.
 
 | Major Version | Last Release | Patch Release Date  | Support Phase|End of Support |
 | --------------|--------------|--------|------------|--------|
-| 4.x           | [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)   |Monthly| Active | Not planned.<br/>✅Supported versions: from 4.61.2 to [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)<br/>⚠️Unsupported versions `< 4.61.2`.|
+| 4.x           | [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)   |Monthly| Active | Not planned.<br/>✅Supported versions: from 4.72.1 to [![NuGet](https://img.shields.io/nuget/v/microsoft.identity.client.svg?style=flat-square&label=nuget&colorB=00b200)](https://www.nuget.org/packages/Microsoft.Identity.Client/)<br/>⚠️Unsupported versions `< 4.72.1`.|
 
 ## Out of support versions
 The following table lists MSAL.NET versions no longer supported and no longer receiving security fixes.
 
 | Major Version | Latest Patch Version| Patch Release Date | End of Support Date|
 | --------------|--------------|--------|--------|
-| 4.x           |    4.61.1      | August 23, 2024        | May 15, 2025    |
+| 4.x           |    4.72.0      | May 12, 2025        | July 11, 2025    |
 | 3.x           |    3.0.9       | July 31, 2019          | May 15, 2025    |
 | 2.x           |    2.7.1       | February 21, 2019      | May 15, 2025    |
 | 1.x           |    1.1.4-preview0002      | June 1, 2018         | May 15, 2025   |


### PR DESCRIPTION
Update supportPolicy.md
This pull request updates the MSAL.NET support policy and documentation to reflect changes in supported and unsupported versions. The updates include adjustments to version ranges, release dates, and end-of-support dates for MSAL.NET.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22): Updated the supported version range for MSAL.NET 4.x from `4.71.2` to `4.72.1` and clarified that versions `< 4.72.1` are unsupported.

### Support Policy Updates:

* `supportPolicy.md`: 
  - Updated the supported version range for MSAL.NET 4.x from `4.61.2` to `4.72.1` and clarified unsupported versions `< 4.72.1`.
  - Adjusted the latest patch version and end-of-support date for unsupported MSAL.NET 4.x versions to `4.72.0` with an end-of-support date of July 11, 2025.
  - Updated the "Last updated" date to July 15, 2025.