### PR TITLE
Restore public AuthenticationResult constructor

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -43,8 +43,6 @@ namespace Microsoft.Identity.Client
         /// <param name="claimsPrincipal">Claims from the ID token</param>
         /// <param name="spaAuthCode">Auth Code returned by the Microsoft identity platform when you use AcquireTokenByAuthorizationCode.WithSpaAuthorizationCode(). This auth code is meant to be redeemed by the frontend code. See https://aka.ms/msal-net/spa-auth-code</param>
         /// <param name="additionalResponseParameters">Other properties from the token response.</param>
-        [Obsolete("Direct constructor use is deprecated.", error: false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public AuthenticationResult( // for backwards compat with 4.16-
             string accessToken,
             bool isExtendedLifeTimeToken,
@@ -98,8 +96,6 @@ namespace Microsoft.Identity.Client
         /// <param name="authenticationResultMetadata">Contains metadata related to the Authentication Result.</param>
         /// <param name="tokenType">The token type, defaults to Bearer. Note: this property is experimental and may change in future versions of the library.</param>
         /// <remarks>For backwards compatibility with MSAL 4.17-4.20 </remarks>
-        [Obsolete("Direct constructor use is deprecated.", error: false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public AuthenticationResult(
           string accessToken,
           bool isExtendedLifeTimeToken,

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs
@@ -19,9 +19,31 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
     {
 
         [TestMethod]
+        public void PublicTestConstructorCoversAllProperties()
+        {
+            // The first public ctor that is meant only for tests (“for-test”)
+            var ctorParameters = typeof(AuthenticationResult)
+                .GetConstructors()
+                .First(ctor => ctor.GetParameters().Length > 3)
+                .GetParameters();
+
+            var classProperties = typeof(AuthenticationResult)
+                .GetProperties()
+                .Where(p => p.GetCustomAttribute(typeof(ObsoleteAttribute)) == null)
+                .Where(p => p.SetMethod == null || p.SetMethod.IsPublic)
+                .Where(p => p.Name != nameof(AuthenticationResult.BindingCertificate));
+
+            // +2 for the 2 obsolete ExtendedExpires* props that are deliberately
+            // not represented in the ctor.
+            Assert.AreEqual(
+                ctorParameters.Length,
+                classProperties.Count() + 2,
+                "The <for-test> constructor should include all public-settable or read-only properties of AuthenticationResult (except BindingCertificate and the obsolete ExtendedExpires* pair).");
+        }
+
+        [TestMethod]
         public void GetAuthorizationHeader()
         {
-#pragma warning disable CS0618 // exercising obsolete constructors until full deprecation
             var ar = new AuthenticationResult(
                 "at",
                 false,
@@ -64,7 +86,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             "one for backwards compat with 4.17+ and one for 4.16 and below")]
         public void AuthenticationResult_PublicApi()
         {
-#pragma warning disable CS0618 // exercising obsolete constructors until full deprecation
             // old constructor, before 4.16
             var ar1 = new AuthenticationResult(
                 "at",


### PR DESCRIPTION
Fixes #5392

**Changes proposed in this request**
This pull request focuses on cleaning up deprecated code and improving test coverage for the `AuthenticationResult` class in the Microsoft Identity Client library. The most notable changes include the removal of `[Obsolete]` attributes from certain constructors and the addition of a comprehensive unit test to validate the consistency of the "for-test" constructor.

### Removal of deprecated attributes:

* Removed `[Obsolete]` and `[EditorBrowsable(EditorBrowsableState.Never)]` attributes from two constructors in the `AuthenticationResult` class to make them publicly accessible again. These constructors were previously marked as deprecated but are now intended for continued use. (`src/client/Microsoft.Identity.Client/AuthenticationResult.cs`, [[1]](diffhunk://#diff-6e9f3460583c54b690e5d7d155cb337653c519dd7cd5f513cc36ff82c3417849L46-L47) [[2]](diffhunk://#diff-6e9f3460583c54b690e5d7d155cb337653c519dd7cd5f513cc36ff82c3417849L101-L102)

### Improvements in test coverage:

* Added a new unit test, `PublicTestConstructorCoversAllProperties`, in `AuthenticationResultTests` to ensure that the "for-test" constructor includes all public-settable or read-only properties of `AuthenticationResult`, excluding specific exceptions (e.g., obsolete properties and `BindingCertificate`). (`tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs`, [tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.csR21-L24](diffhunk://#diff-a38cae874977b1de652fa165a0c0e7952919eb3eb099fa888c5a2508499a2645R21-L24))
* Removed obsolete constructor usage from the `GetHybridSpaAuthCode` test, aligning with the cleanup of deprecated constructors. (`tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.cs`, [tests/Microsoft.Identity.Test.Unit/PublicApiTests/AuthenticationResultTests.csL67](diffhunk://#diff-a38cae874977b1de652fa165a0c0e7952919eb3eb099fa888c5a2508499a2645L67))

**Testing**
unit

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
