### PR TITLE
Update spellcheck.yml

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
       # 1️⃣  Built-in codespell action  → PR annotations
       ############################################################
       - name: Codespell (built-in dictionary)
-        uses: step-security/actions-codespell@8664d8537142419fa42d0a49dcb326d2cac4eeab
+        uses: codespell-project/actions-codespell@0c1b7db3ec1527186e897b0ebee1736475623fca
         with:
           check_filenames: true           # also scan file names
           ignore_words_file: .codespellignore

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
       # 1️⃣  Built-in codespell action  → PR annotations
       ############################################################
       - name: Codespell (built-in dictionary)
-        uses: codespell-project/actions-codespell@0c1b7db3ec1527186e897b0ebee1736475623fca
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630
         with:
           check_filenames: true           # also scan file names
           ignore_words_file: .codespellignore

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
       # 1️⃣  Built-in codespell action  → PR annotations
       ############################################################
       - name: Codespell (built-in dictionary)
-        uses: step-security/actions-codespell@b7401c5f16b3a0725ac2fa9d19252a0aecfba76
+        uses: step-security/actions-codespell@8664d8537142419fa42d0a49dcb326d2cac4eeab
         with:
           check_filenames: true           # also scan file names
           ignore_words_file: .codespellignore

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
       # 1️⃣  Built-in codespell action  → PR annotations
       ############################################################
       - name: Codespell (built-in dictionary)
-        uses: codespell-project/actions-codespell@v2
+        uses: step-security/actions-codespell@b7401c5f16b3a0725ac2fa9d19252a0aecfba76
         with:
           check_filenames: true           # also scan file names
           ignore_words_file: .codespellignore
@@ -28,7 +28,7 @@ jobs:
       # 2️⃣  Raw CLI pass  → enforces your custom typo pairs
       ############################################################
       - name: Install codespell
-        run: pip install --quiet codespell
+        run: pip install --quiet --no-deps "codespell==2.4.1"
 
       - name: Codespell (custom pair list)
         run: |


### PR DESCRIPTION
Fixes - eliminate the “moving-target” risk of unpinned actions and PyPI pulls

**Changes proposed in this request**
Goals are:

- eliminate the “moving-target” risk of unpinned actions and PyPI pulls
- switch to the hardened Step Security fork (fewer base-image CVEs, 10 / 10 score)
- grant the workflow only the permissions it needs
- keep the second “custom-pairs” pass in sync with the same Codespell version

**Testing**
build

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
