### PR TITLE
Removal of `WithExperimentalFeatures` on `WithMtlsProofOfPossession` API:

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -96,8 +96,6 @@ namespace Microsoft.Identity.Client
         /// <returns>The current instance of <see cref="AcquireTokenForClientParameterBuilder"/> to enable method chaining.</returns>
         public AcquireTokenForClientParameterBuilder WithMtlsProofOfPossession()
         {
-            ValidateUseOfExperimentalFeature();
-
             if (ServiceBundle.Config.ClientCredential is not CertificateClientCredential certificateCredential)
             {
                 throw new MsalClientException(

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .WithAuthority("https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c")
                 .WithAzureRegion("westus3") //test slice region 
                 .WithCertificate(cert, true)  
-                .WithExperimentalFeatures()
                 .WithTestLogging()
                 .Build();
 

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/ExperimentalFeatureTests.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -22,12 +24,16 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
         [TestMethod]
         public async Task ExperimentalFeatureExceptionAsync()
         {
+            PoPAuthenticationConfiguration popConfig = new PoPAuthenticationConfiguration(new Uri("https://www.contoso.com/path1/path2?queryParam1=a&queryParam2=b"));
+            popConfig.HttpMethod = HttpMethod.Get;
+
             IConfidentialClientApplication cca = ConfidentialClientApplicationBuilder
                 .Create(Guid.NewGuid().ToString())
                 .WithCertificate(CertHelper.GetOrCreateTestCert()).Build();
 
             MsalClientException ex = await AssertException.TaskThrowsAsync<MsalClientException>(
-                () => cca.AcquireTokenForClient(s_scopes).WithMtlsProofOfPossession().ExecuteAsync())
+                () => cca.AcquireTokenForClient(s_scopes)
+                .WithSignedHttpRequestProofOfPossession(popConfig).ExecuteAsync())
                 .ConfigureAwait(false);
 
             Assert.AreEqual(MsalError.ExperimentalFeature, ex.ErrorCode);

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -369,7 +369,6 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(managedIdentitySource, endpoint);
 
                 var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
-                    .WithExperimentalFeatures(true)
                     .WithHttpManager(httpManager);
 
                 // Disabling shared cache options to avoid cross test pollution.
@@ -811,7 +810,6 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(ManagedIdentitySource.AppService, AppServiceEndpoint);
 
                 var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
-                    .WithExperimentalFeatures()
                     .WithHttpManager(httpManager);
 
                 // Disabling shared cache options to avoid cross test pollution.

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
-                            .WithExperimentalFeatures()
                             .Build();
 
             MsalClientException ex = await AssertException.TaskThrowsAsync<MsalClientException>(() =>
@@ -74,7 +73,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithClientSecret(TestConstants.ClientSecret)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request without a certificate
@@ -98,7 +96,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithClientClaims(s_testCertificate, ipAddress)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Expecting an exception because MTLS PoP requires a certificate to sign the claims
@@ -117,7 +114,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithClientAssertion(() => { return TestConstants.DefaultClientAssertion; })
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Expecting an exception because MTLS PoP requires a certificate to sign the claims
@@ -146,7 +142,6 @@ namespace Microsoft.Identity.Test.Unit
                                     .WithCertificate(s_testCertificate)
                                     // Setting Azure region to ConfidentialClientApplicationBuilder.DisableForceRegion overrides the AzureRegion to null.
                                     .WithAzureRegion(ConfidentialClientApplicationBuilder.DisableForceRegion)
-                                    .WithExperimentalFeatures()
                                     .Build();
                 }
                 else
@@ -155,7 +150,6 @@ namespace Microsoft.Identity.Test.Unit
                                     .Create(TestConstants.ClientId)
                                     .WithAuthority(TestConstants.AuthorityTenant)
                                     .WithCertificate(s_testCertificate)
-                                    .WithExperimentalFeatures()
                                     .Build();
                 }
 
@@ -177,7 +171,6 @@ namespace Microsoft.Identity.Test.Unit
             IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                             .Create(TestConstants.ClientId)
                             .WithCertificate(s_testCertificate)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request without specifying an authority
@@ -220,7 +213,7 @@ namespace Microsoft.Identity.Test.Unit
         public void GetTokenRequestParams_ExpectedValues()
         {
             var scheme = new MtlsPopAuthenticationOperation(s_testCertificate);
-            System.Collections.Generic.IReadOnlyDictionary<string, string> parameters = scheme.GetTokenRequestParams();
+            IReadOnlyDictionary<string, string> parameters = scheme.GetTokenRequestParams();
 
             Assert.AreEqual(Constants.MtlsPoPTokenType, parameters[OAuth2Parameter.TokenType]);
         }
@@ -248,7 +241,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -308,7 +300,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithTenantId("123456-1234-2345-1234561234")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -355,7 +346,6 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAuthority(authorityUrl)
                     .WithAzureRegion(region)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures()
                     .BuildConcrete();
 
                 AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
@@ -388,7 +378,6 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAzureRegion(region)
                     .WithAuthority(authority)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures()
                     .BuildConcrete();
 
                 IConfidentialClientApplication regionalApp2 = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
@@ -396,7 +385,6 @@ namespace Microsoft.Identity.Test.Unit
                     .WithAzureRegion(region)
                     .WithAuthority(authority)
                     .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures()
                     .BuildConcrete();
 
                 var memoryTokenCache = new InMemoryTokenCache();
@@ -443,7 +431,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -471,7 +458,6 @@ namespace Microsoft.Identity.Test.Unit
                             .Create(TestConstants.ClientId)
                             .WithCertificate(s_testCertificate)
                             .WithAuthority(authorityUrl)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request with a non-AAD authority
@@ -510,7 +496,6 @@ namespace Microsoft.Identity.Test.Unit
                         .WithCertificate(s_testCertificate)
                         .WithAuthority($"{authorityUrl}/{nonTenantValue}")
                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                        .WithExperimentalFeatures()
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
@@ -567,7 +552,6 @@ namespace Microsoft.Identity.Test.Unit
                                  .WithHttpManager(harness.HttpManager)
                                  .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
                                  .WithCertificate(s_testCertificate)
-                                 .WithExperimentalFeatures(true)
                                  .Build();
 
                     // Act
@@ -615,7 +599,6 @@ namespace Microsoft.Identity.Test.Unit
                                         .WithHttpManager(harness.HttpManager)
                                         .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
                                         .WithCertificate(s_testCertificate)
-                                        .WithExperimentalFeatures(true)
                                         .Build();
 
                     AuthenticationResult result = await app
@@ -678,7 +661,6 @@ namespace Microsoft.Identity.Test.Unit
                                     .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
                                     .WithCertificate(s_testCertificate)
                                     .WithInstanceDiscovery(false)
-                                    .WithExperimentalFeatures(true)
                                     .Build();
 
                     AuthenticationResult result = await app
@@ -727,7 +709,6 @@ namespace Microsoft.Identity.Test.Unit
                 var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
                     .WithCertificate(s_testCertificate)
                     .WithAuthority(authorityUrl)
-                    .WithExperimentalFeatures()
                     .WithHttpManager(httpManager)
                     .BuildConcrete();
 
@@ -763,7 +744,6 @@ namespace Microsoft.Identity.Test.Unit
                             .Create(TestConstants.ClientId)
                             .WithAuthority(authorityUrl)
                             .WithCertificate(s_testCertificate)
-                            .WithExperimentalFeatures()
                             .Build();
 
             // Set WithMtlsProofOfPossession on the request specifying an authority
@@ -793,7 +773,6 @@ namespace Microsoft.Identity.Test.Unit
                     .WithCertificate(s_testCertificate)
                     .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
                     .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                    .WithExperimentalFeatures()
                     .WithHttpManager(httpManager)
                     .BuildConcrete();
 

--- a/tests/devapps/NetCoreTestApp/Program.cs
+++ b/tests/devapps/NetCoreTestApp/Program.cs
@@ -437,9 +437,6 @@ namespace NetCoreTestApp
 
             ccaBuilder = ccaBuilder.WithCertificate(s_confidentialClientCertificate, true);
 
-            //Add Experimental feature for MTLS PoP
-            ccaBuilder = ccaBuilder.WithExperimentalFeatures();
-
             IConfidentialClientApplication ccapp = ccaBuilder.Build();
 
             // Optionally set cache settings or other configurations if needed


### PR DESCRIPTION
Fixes #5352

**Changes proposed in this request**
This pull request removes the use of the `WithExperimentalFeatures` method across the codebase, indicating that the associated features are no longer considered experimental. It also updates the test cases to reflect these changes and introduces some minor refactoring in related code.

### Removal of `WithExperimentalFeatures` on `WithMtlsProofOfPossession` API:

* The `WithExperimentalFeatures` method has been removed from various test cases in the `MtlsPopTests`, `ManagedIdentityTests`, and other test files, aligning the code with the updated feature status. [[1]](diffhunk://#diff-99c80006e86a371e433178287365a7fef77cf82ef0187aaaa37ec37cfe4d9ffcL43) [[2]](diffhunk://#diff-19a0a81f3b134202f8cf3c47e96e3641f889aa6a03288d2da27d950d2fadf2eaL372) [[3]](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL58) [[4]](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL251) [[5]](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL570) [[6]](diffhunk://#diff-d28b262c73a75d470d135b56896790e41634f61f5d3ed9016f0d444d4b08e94cL796) and others)

### Refactoring and Updates:

* Removed the `ValidateUseOfExperimentalFeature` call in the `WithMtlsProofOfPossession` method in `AcquireTokenForClientParameterBuilder`, simplifying the method implementation.
* Updated the `ExperimentalFeatureTests` to use `WithSignedHttpRequestProofOfPossession` instead of `WithMtlsProofOfPossession`, reflecting the removal of experimental status.
* Minor refactoring in `MtlsPopTests` to simplify variable declarations and improve readability.

These changes ensure that the codebase is consistent with the updated feature status and improve maintainability by removing experimental flags and redundant code.

**Testing**
tests

**Performance impact**
n/a

**Documentation**
- [x] All relevant documentation is updated.
