### PR TITLE
Run Client Credentials Mtls Pop Sni Tests against PROD

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult authResult = await confidentialApp
                 .AcquireTokenForClient(settings.AppScopes)
                 .WithMtlsProofOfPossession()
-                .WithExtraQueryParameters("dc=ESTSR-PUB-WUS3-AZ1-TEST1&slice=TestSlice") //Feature in test slice 
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes - Test SNI against PROD 

**Changes proposed in this request**
This pull request includes a minor change to the `public async Task Sni_Gets_Pop_Token_Successfully_TestAsync()` test method. The change removes an extra query parameter that was previously used for testing purposes.

* [`tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs`](diffhunk://#diff-99c80006e86a371e433178287365a7fef77cf82ef0187aaaa37ec37cfe4d9ffcL50): Removed the `.WithExtraQueryParameters("dc=ESTSR-PUB-WUS3-AZ1-TEST1&slice=TestSlice")` line, which was used to specify a test slice in the query parameters.

**Testing**
unit, integration

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
