### PR TITLE
Implement DoNotRunFederatedTestsAttribute to gate federated tests

### DIFF
--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Identity.Client
                 if (accessToken.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase) &&
                     environmentAliases.Contains(accessToken.Environment) &&
                     string.Equals(accessToken.TokenType ?? "", tokenType ?? "", StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(accessToken.TenantId, tenantId, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(accessToken.TenantId ?? "", tenantId ?? "", StringComparison.OrdinalIgnoreCase) &&
                     accessToken.ScopeSet.Overlaps(scopeSet))
                 {
                     requestParams.RequestContext.Logger.Verbose(() => $"Intersecting scopes found: {scopeSet}");

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Identity.Client
                 if (accessToken.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase) &&
                     environmentAliases.Contains(accessToken.Environment) &&
                     string.Equals(accessToken.TokenType ?? "", tokenType ?? "", StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(accessToken.TenantId ?? "", tenantId ?? "", StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(accessToken.TenantId, tenantId, StringComparison.OrdinalIgnoreCase) &&
                     accessToken.ScopeSet.Overlaps(scopeSet))
                 {
                     requestParams.RequestContext.Logger.Verbose(() => $"Intersecting scopes found: {scopeSet}");

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,4 +6,7 @@
   <PropertyGroup Condition="'$(PipelineType)' == 'OneBranch'">
     <DefineConstants>$(DefineConstants);ONEBRANCH_BUILD</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MSAL_SKIP_FEDERATED_TESTS)' == 'True'">
+    <DefineConstants>$(DefineConstants);IGNORE_FEDERATED</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsTests.NetFwk.cs
@@ -89,8 +89,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [DataTestMethod]
         [DataRow(Cloud.Public, TargetFrameworks.NetFx | TargetFrameworks.NetCore)]
+#if !IGNORE_FEDERATED
         [DataRow(Cloud.Adfs, TargetFrameworks.NetFx | TargetFrameworks.NetCore)]
-        //[DataRow(Cloud.PPE, TargetFrameworks.NetFx)]      
+#endif
         [DataRow(Cloud.Public, TargetFrameworks.NetCore, true)]
         //[DataRow(Cloud.Arlington)] - cert not setup
         public async Task WithCertificate_TestAsync(Cloud cloud, TargetFrameworks runOn, bool useAppIdUri = false)
@@ -101,9 +102,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [DataTestMethod]
         [DataRow(Cloud.Public, TargetFrameworks.NetCore)]
+#if !IGNORE_FEDERATED
         [DataRow(Cloud.Adfs, TargetFrameworks.NetFx)]
+#endif
         [DataRow(Cloud.Arlington, TargetFrameworks.NetCore)]
-        //[DataRow(Cloud.PPE)] - secret not setup
         public async Task WithSecret_TestAsync(Cloud cloud, TargetFrameworks runOn)
         {
             runOn.AssertFramework();
@@ -112,8 +114,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [DataTestMethod]
         [DataRow(Cloud.Public, TargetFrameworks.NetCore)]
+#if !IGNORE_FEDERATED
         [DataRow(Cloud.Adfs, TargetFrameworks.NetCore)]
-        //[DataRow(Cloud.PPE, TargetFrameworks.NetCore)]
+#endif
         // [DataRow(Cloud.Arlington)] - cert not setup
         public async Task WithClientAssertion_Manual_TestAsync(Cloud cloud, TargetFrameworks runOn)
         {
@@ -123,8 +126,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [DataTestMethod]
         [DataRow(Cloud.Public, TargetFrameworks.NetFx)]
+#if !IGNORE_FEDERATED
         [DataRow(Cloud.Adfs, TargetFrameworks.NetFx)]
-        //[DataRow(Cloud.PPE, TargetFrameworks.NetCore)]
+#endif
         // [DataRow(Cloud.Arlington)] - cert not setup
         public async Task WithClientAssertion_Wilson_TestAsync(Cloud cloud, TargetFrameworks runOn)
         {
@@ -143,7 +147,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [DataTestMethod]
         [DataRow(Cloud.Public, TargetFrameworks.NetFx)]
+#if !IGNORE_FEDERATED
         [DataRow(Cloud.Adfs, TargetFrameworks.NetCore)]
+#endif
         // [DataRow(Cloud.Arlington)] - cert not setup
         public async Task WithClientClaims_OverrideClaims_TestAsync(Cloud cloud, TargetFrameworks runOn)
         {
@@ -162,7 +168,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [DataTestMethod]
         [DataRow(Cloud.Public, TargetFrameworks.NetFx)]
+#if !IGNORE_FEDERATED
         [DataRow(Cloud.Adfs, TargetFrameworks.NetCore)]
+#endif
         // [DataRow(Cloud.Arlington)] - cert not setup
         public async Task WithClientClaims_SendX5C_OverrideClaims_TestAsync(Cloud cloud, TargetFrameworks runOn)
         {
@@ -223,12 +231,12 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .WithAuthority(labResponse.Lab.Authority, "organizations")
                 .BuildConcrete();
 
-            #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             AuthenticationResult authResult = await msalPublicClient
                 .AcquireTokenByUsernamePassword(s_scopes, labResponse.User.Upn, labResponse.User.GetOrFetchPassword())
                 .ExecuteAsync(CancellationToken.None)
                 .ConfigureAwait(false);
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
 
             var confidentialApp = ConfidentialClientApplicationBuilder
                 .Create(labResponse.App.AppId)

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/OnBehalfOfTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/OnBehalfOfTests.cs
@@ -226,6 +226,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task WithMultipleUsers_TestAsync()
         {
             var aadUser1 = (await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false)).User;

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/UsernamePasswordIntegrationTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/UsernamePasswordIntegrationTests.NetFwk.cs
@@ -82,6 +82,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [RunOn(TargetFrameworks.NetCore)]
         [TestCategory(TestCategories.Arlington)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task ARLINGTON_ROPC_ADFS_Async()
         {
             var labResponse = await LabUserHelper.GetArlingtonADFSUserAsync().ConfigureAwait(false);
@@ -89,6 +92,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task ROPC_ADFSv4Federated_Async()
         {
             var labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.AdfsV4, true).ConfigureAwait(false);
@@ -96,6 +102,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task ROPC_ADFSv4Federated_WithMetadata_Async()
         {
             var labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.AdfsV4, true).ConfigureAwait(false);
@@ -105,6 +114,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         [RunOn(TargetFrameworks.NetCore)]
         [TestCategory(TestCategories.ADFS)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task AcquireTokenFromAdfsUsernamePasswordAsync()
         {
             LabResponse labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.ADFSv2019, true).ConfigureAwait(false);
@@ -182,7 +194,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
-        public async Task AcquireTokenWithFederatedUsernameIncorrectPasswordAsync()
+        public async Task AcquireTokenDefaultUserIncorrectPasswordAsync()
         {
             var labResponse = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
             var user = labResponse.User;
@@ -475,6 +487,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [IgnoreOnOneBranch]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task Kerberos_ROPC_ADFSv4Federated_Async()
         {
             var labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.AdfsV4, true).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/IgnoreFederatedTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/IgnoreFederatedTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Integration.Infrastructure
+{
+    internal class IgnoreFederatedTestsAttribute : TestMethodAttribute
+    {
+        public override TestResult[] Execute(ITestMethod testMethod)
+        {
+#if IGNORE_FEDERATED
+            return new[]
+            {
+                    new TestResult
+                    {
+                        Outcome = UnitTestOutcome.Inconclusive,
+                        TestFailureException = new AssertInconclusiveException(
+                            $"Skipped on OneBranch pipeline")
+                    }
+                };
+#else
+            return base.Execute(testMethod);
+#endif
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/DeviceCodeFlowIntegrationTest.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/DeviceCodeFlowIntegrationTest.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         [TestMethod]
         [Timeout(2 * 60 * 1000)] // 2 min timeout
         [TestCategory(TestCategories.ADFS)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task DeviceCodeFlowAdfsTestAsync()
         {
             LabResponse labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.ADFSv2019, true).ConfigureAwait(false);
@@ -75,6 +78,9 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         [TestMethod]
         [Timeout(2 * 60 * 1000)] // 2 min timeout
         [TestCategory(TestCategories.Arlington)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task ArlingtonDeviceCodeFlowAdfsTestAsync()
         {
             LabResponse labResponse = await LabUserHelper.GetArlingtonADFSUserAsync().ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
@@ -71,6 +71,9 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task Interactive_AdfsV4_FederatedAsync()
         {
             LabResponse labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.AdfsV4, true).ConfigureAwait(false);
@@ -87,6 +90,9 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task Interactive_AdfsV2019_FederatedAsync()
         {
             LabResponse labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.ADFSv2019, true).ConfigureAwait(false);
@@ -95,6 +101,9 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
 
         [RunOn(TargetFrameworks.NetCore)]
         [TestCategory(TestCategories.Arlington)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task Arlington_Interactive_AdfsV2019_FederatedAsync()
         {
             LabResponse labResponse = await LabUserHelper.GetArlingtonADFSUserAsync().ConfigureAwait(false);
@@ -156,6 +165,9 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
 
         [RunOn(TargetFrameworks.NetCore)]
         [TestCategory(TestCategories.ADFS)]
+#if IGNORE_FEDERATED
+        [Ignore]
+#endif
         public async Task Interactive_AdfsV2019_DirectAsync()
         {
             LabResponse labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.ADFSv2019, true).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #5416

**Changes proposed in this request**
This pull request introduces a mechanism to conditionally ignore federated tests in the test suite when a specific pipeline configuration is set. The main changes include adding a new property to define the condition, modifying test methods to support conditional ignoring, and creating a custom attribute for handling ignored tests.

### Federated Test Ignoring Mechanism:

* **New property for conditional test ignoring**:
  - Added a property group in `tests/Directory.Build.props` to define the `IGNORE_FEDERATED` constant when the `MSAL_SKIP_FEDERATED_TESTS` environment variable is set to `True`. (`[tests/Directory.Build.propsR9-R11](diffhunk://#diff-ab383adf9c3ae4ff1108d67217eb0fed97889109451be090a231e1091fba8d17R9-R11)`)

* **Custom attribute for ignoring tests**:
  - Introduced a new `IgnoreFederatedTestsAttribute` in `tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/IgnoreFederatedTests.cs`. This attribute skips tests by marking them as inconclusive when the `IGNORE_FEDERATED` constant is defined. (`[tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/IgnoreFederatedTests.csR1-R32](diffhunk://#diff-d905945ac01eddd0506c9b910b70360556c6d9fc4cc58bdbaaac7a38ca8c877eR1-R32)`)

### Updates to Test Methods:

* **Conditional ignoring in test methods**:
  - Updated various test methods across multiple files to conditionally use the `[Ignore]` attribute when `IGNORE_FEDERATED` is defined. This includes tests in:
    - `UsernamePasswordIntegrationTests.NetFwk.cs` (`[[1]](diffhunk://#diff-741d6f87ce1630adce944f96ad905f7e39ee2065b1e478704ecf8fe8b5865a7bR85-R107)`, `[[2]](diffhunk://#diff-741d6f87ce1630adce944f96ad905f7e39ee2065b1e478704ecf8fe8b5865a7bR117-R119)`, `[[3]](diffhunk://#diff-741d6f87ce1630adce944f96ad905f7e39ee2065b1e478704ecf8fe8b5865a7bL185-R197)`, `[[4]](diffhunk://#diff-741d6f87ce1630adce944f96ad905f7e39ee2065b1e478704ecf8fe8b5865a7bR490-R492)`)
    - `DeviceCodeFlowIntegrationTest.cs` (`[[1]](diffhunk://#diff-3084b0c0ccb8f3efaf2193e699bef81f82be05852ac4d87dd71b9f423b7fd392R68-R70)`, `[[2]](diffhunk://#diff-3084b0c0ccb8f3efaf2193e699bef81f82be05852ac4d87dd71b9f423b7fd392R81-R83)`)
    - `InteractiveFlowTests.NetFwk.cs` (`[[1]](diffhunk://#diff-14f496148329d28d512e22af551983503611b00a520402e9ad8613db75356249R74-R76)`, `[[2]](diffhunk://#diff-14f496148329d28d512e22af551983503611b00a520402e9ad8613db75356249R93-R95)`, `[[3]](diffhunk://#diff-14f496148329d28d512e22af551983503611b00a520402e9ad8613db75356249R104-R106)`)

* **Renamed a test method**:
  - Renamed `AcquireTokenWithFederatedUsernameIncorrectPasswordAsync` to `AcquireTokenDefaultUserIncorrectPasswordAsync` to better reflect its purpose. (`[tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/UsernamePasswordIntegrationTests.NetFwk.csL185-R197](diffhunk://#diff-741d6f87ce1630adce944f96ad905f7e39ee2065b1e478704ecf8fe8b5865a7bL185-R197)`)

**Testing**
tests 

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
