### PR TITLE
IMDSv2: Created a retry policy for the CSR Metadata Probe

### DIFF
--- a/src/client/Microsoft.Identity.Client/Http/Retry/CsrMetadataProbeRetryPolicy.cs
+++ b/src/client/Microsoft.Identity.Client/Http/Retry/CsrMetadataProbeRetryPolicy.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Identity.Client.Http.Retry
+{
+    internal class CsrMetadataProbeRetryPolicy : ImdsRetryPolicy
+    {
+        protected override bool ShouldRetry(HttpResponse response, Exception exception)
+        {
+            return HttpRetryConditions.CsrMetadataProbe(response, exception);
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Http/Retry/HttpRetryCondition.cs
+++ b/src/client/Microsoft.Identity.Client/Http/Retry/HttpRetryCondition.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Client.Http.Retry
         }
 
         /// <summary>
-        /// Retry policy specific to Region Discovery.
+        /// Retry policy specific to CSR Metadata Probe.
         /// Extends Imds retry policy but excludes 404 and 408 status codes.
         /// </summary>
         public static bool CsrMetadataProbe(HttpResponse response, Exception exception)
@@ -73,7 +73,7 @@ namespace Microsoft.Identity.Client.Http.Retry
                 return false;
             }
 
-            // If Imds would retry but the status code is 404 or 408, don't retry
+            // If Imds would retry but the status code is 404, don't retry
             return (int)response.StatusCode is not 404;
         }
 

--- a/src/client/Microsoft.Identity.Client/Http/Retry/HttpRetryCondition.cs
+++ b/src/client/Microsoft.Identity.Client/Http/Retry/HttpRetryCondition.cs
@@ -63,6 +63,21 @@ namespace Microsoft.Identity.Client.Http.Retry
         }
 
         /// <summary>
+        /// Retry policy specific to Region Discovery.
+        /// Extends Imds retry policy but excludes 404 and 408 status codes.
+        /// </summary>
+        public static bool CsrMetadataProbe(HttpResponse response, Exception exception)
+        {
+            if (!Imds(response, exception))
+            {
+                return false;
+            }
+
+            // If Imds would retry but the status code is 404 or 408, don't retry
+            return (int)response.StatusCode is not 404;
+        }
+
+        /// <summary>
         /// Retry condition for /token and /authorize endpoints
         /// </summary>
         /// <param name="response"></param>

--- a/src/client/Microsoft.Identity.Client/Http/Retry/ImdsRetryPolicy.cs
+++ b/src/client/Microsoft.Identity.Client/Http/Retry/ImdsRetryPolicy.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Identity.Client.Http.Retry
             return Task.Delay(milliseconds);
         }
 
+        protected virtual bool ShouldRetry(HttpResponse response, Exception exception)
+        {
+            return HttpRetryConditions.Imds(response, exception);
+        }
+
         public async Task<bool> PauseForRetryAsync(HttpResponse response, Exception exception, int retryCount, ILoggerAdapter logger)
         {
             int httpStatusCode = (int)response.StatusCode;
@@ -46,7 +51,7 @@ namespace Microsoft.Identity.Client.Http.Retry
             }
 
             // Check if the status code is retriable and if the current retry count is less than max retries
-            if (HttpRetryConditions.Imds(response, exception) &&
+            if (ShouldRetry(response, exception) &&
                 retryCount < _maxRetries)
             {
                 int retryAfterDelay = httpStatusCode == (int)HttpStatusCode.Gone

--- a/src/client/Microsoft.Identity.Client/Http/Retry/RetryPolicyFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Http/Retry/RetryPolicyFactory.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Identity.Client.Http.Retry
                     return new ImdsRetryPolicy();
                 case RequestType.RegionDiscovery:
                     return new RegionDiscoveryRetryPolicy();
+                case RequestType.CsrMetadataProbe:
+                    return new CsrMetadataProbeRetryPolicy();
                 default:
                     throw new ArgumentOutOfRangeException(nameof(requestType), requestType, "Unknown request type.");
             }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsV2ManagedIdentitySource.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             };
 
             IRetryPolicyFactory retryPolicyFactory = requestContext.ServiceBundle.Config.RetryPolicyFactory;
-            IRetryPolicy retryPolicy = retryPolicyFactory.GetRetryPolicy(RequestType.ManagedIdentityDefault);
+            IRetryPolicy retryPolicy = retryPolicyFactory.GetRetryPolicy(RequestType.CsrMetadataProbe);
 
             // CSR metadata GET request
             HttpResponse response = null;

--- a/src/client/Microsoft.Identity.Client/RequestType.cs
+++ b/src/client/Microsoft.Identity.Client/RequestType.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Region Discovery request, used for region discovery operations with exponential backoff retry strategy.
         /// </summary>
-        RegionDiscovery
+        RegionDiscovery,
+
+        /// <summary>
+        /// CSR Metadata Probe request, used to probe an IMDSv2 managed identity for metadata to be used in acquiring a token.
+        /// </summary>
+        CsrMetadataProbe
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/Helpers/TestRetryPolicies.cs
+++ b/tests/Microsoft.Identity.Test.Unit/Helpers/TestRetryPolicies.cs
@@ -39,4 +39,15 @@ namespace Microsoft.Identity.Test.Unit.Helpers
             return Task.CompletedTask;
         }
     }
+
+    internal class TestCsrMetadataProbeRetryPolicy : CsrMetadataProbeRetryPolicy
+    {
+        public TestCsrMetadataProbeRetryPolicy() : base() { }
+
+        internal override Task DelayAsync(int milliseconds)
+        {
+            // No delay for tests
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/tests/Microsoft.Identity.Test.Unit/Helpers/TestRetryPolicyFactory.cs
+++ b/tests/Microsoft.Identity.Test.Unit/Helpers/TestRetryPolicyFactory.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Identity.Test.Unit.Helpers
                     return new TestImdsRetryPolicy();
                 case RequestType.RegionDiscovery:
                     return new TestRegionDiscoveryRetryPolicy();
+                case RequestType.CsrMetadataProbe:
+                    return new TestCsrMetadataProbeRetryPolicy();
                 default:
                     throw new ArgumentOutOfRangeException(nameof(requestType), requestType, "Unknown request type.");
             }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         {
             using (var httpManager = new MockHttpManager())
             {
-                // First attempt fails with NOT_FOUND (404)
-                httpManager.AddMockHandler(MockHelpers.MockCsrResponse(HttpStatusCode.NotFound));
+                // First attempt fails with INTERNAL_SERVER_ERROR (500)
+                httpManager.AddMockHandler(MockHelpers.MockCsrResponse(HttpStatusCode.InternalServerError));
 
                 // Second attempt succeeds
                 httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
@@ -108,17 +108,17 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithRetryPolicyFactory(_testRetryPolicyFactory)
                     .Build();
 
-                const int Num404Errors = 1 + TestDefaultRetryPolicy.DefaultManagedIdentityMaxRetries;
-                for (int i = 0; i < Num404Errors; i++)
+                const int Num500Errors = 1 + TestCsrMetadataProbeRetryPolicy.ExponentialStrategyNumRetries;
+                for (int i = 0; i < Num500Errors; i++)
                 {
-                    httpManager.AddMockHandler(MockHelpers.MockCsrResponse(HttpStatusCode.NotFound));
+                    httpManager.AddMockHandler(MockHelpers.MockCsrResponse(HttpStatusCode.InternalServerError));
                 }
 
                 var miSource = await (managedIdentityApp as ManagedIdentityApplication).GetManagedIdentitySourceAsync().ConfigureAwait(false);
                 Assert.AreEqual(ManagedIdentitySource.DefaultToImds, miSource);
 
-                int requestsMade = Num404Errors - httpManager.QueueSize;
-                Assert.AreEqual(Num404Errors, requestsMade);
+                int requestsMade = Num500Errors - httpManager.QueueSize;
+                Assert.AreEqual(Num500Errors, requestsMade);
             }
         }
     }


### PR DESCRIPTION
This new retry policy is almost the exact same as the IMDS retry policy, except it doesn't retry on 404.