### PR TITLE
Update DeviceCodeRequest/UsernamePasswordRequest to utilize OAuth2Value.ReservedScopes rather than individual constants

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/DeviceCodeRequest.cs
@@ -31,11 +31,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             var client = new OAuth2Client(ServiceBundle.ApplicationLogger, ServiceBundle.HttpManager, null);
 
-            var deviceCodeScopes = new HashSet<string>();
-            deviceCodeScopes.UnionWith(AuthenticationRequestParameters.Scope);
-            deviceCodeScopes.Add(OAuth2Value.ScopeOfflineAccess);
-            deviceCodeScopes.Add(OAuth2Value.ScopeProfile);
-            deviceCodeScopes.Add(OAuth2Value.ScopeOpenId);
+            var deviceCodeScopes = new HashSet<string>(AuthenticationRequestParameters.Scope);
+            deviceCodeScopes.UnionWith(OAuth2Value.ReservedScopes);
 
             client.AddBodyParameter(OAuth2Parameter.ClientId, AuthenticationRequestParameters.AppConfig.ClientId);
             client.AddBodyParameter(OAuth2Parameter.Scope, deviceCodeScopes.AsSingleString());

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/UsernamePasswordRequest.cs
@@ -187,14 +187,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 dict[OAuth2Parameter.Password] = _usernamePasswordParameters.Password;
             }
 
-            ISet<string> unionScope = new HashSet<string>()
-            {
-                OAuth2Value.ScopeOpenId,
-                OAuth2Value.ScopeOfflineAccess,
-                OAuth2Value.ScopeProfile
-            };
+            var unionScope = new HashSet<string>(AuthenticationRequestParameters.Scope);
+            unionScope.UnionWith(OAuth2Value.ReservedScopes);
 
-            unionScope.UnionWith(AuthenticationRequestParameters.Scope);
             dict[OAuth2Parameter.Scope] = unionScope.AsSingleString();
             dict[OAuth2Parameter.ClientInfo] = "1";
 


### PR DESCRIPTION
**Problem this proposes to address**
The `OAuth2Value.ReservedScopes` collection is not used by `DeviceCodeRequest` and `UsernamePasswordRequest`, even though those requests utilize the same reserved scopes.

**Changes proposed in this request**
* Bring `DeviceCodeRequest` and `UsernamePasswordRequest` into somewhat better alignment with `TokenClient.GetDefaultScopes()`.
* Allow `OAuth2Value.ReservedScopes` to be respected across all grant types rather than just those that use a `TokenClient`.

**Testing**
N/A. No impacts to resulting scopes.

**Performance impact**
N/A. No performance impact.

**Documentation**
N/A. No documentation changes required.
