### PR TITLE
Update msi_with_credential_design.md and remove CUID 

### DIFF
--- a/docs/msi_v2/msi_with_credential_design.md
+++ b/docs/msi_v2/msi_with_credential_design.md
@@ -120,7 +120,7 @@ This section outlines the necessary steps to acquire an access token using the M
 
 ### 1. Retrieve Platform Metadata
 
-`GET /metadata/identity/getPlatformMetadata?api-version=2025-05-01&cid={CUID}&uaid={client_id}`
+`GET /metadata/identity/getPlatformMetadata?api-version=2025-05-01&uaid={client_id}`
 
 Response supplies the UAID/client_id, tenant_id, CUID, and (for attestable VMs) the regional MAA endpoint
 


### PR DESCRIPTION
Fixes design doc for MSI v2

**Changes proposed in this request**
This pull request updates the documentation for acquiring an access token using the MSI v2 credential design. The main change is a simplification of the API call to retrieve platform metadata.

Documentation update:

* In `docs/msi_v2/msi_with_credential_design.md`, the example API call for retrieving platform metadata was updated to remove the `cid={CUID}` parameter, clarifying the required request format.

**Testing**
n/a

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
