### PR TITLE
Upgrade Build Quality Checks task to v10 to remove Node 16 EOL warning

### DIFF
--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -68,7 +68,7 @@ jobs: #Build and stage projects
   steps:
   - template: template-desktop-unit-and-automation.yaml
 
-  - task: BuildQualityChecks@9
+  - task: BuildQualityChecks@10
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/main') #gate should not run on main branch
     inputs:
       checkCoverage: '$(CodeCoverageGateEnabled)'


### PR DESCRIPTION
Fixes - Build 

```
Downloading task: BuildQualityChecks (9.2.2)
##[warning]Task 'Build Quality Checks' version 9 (BuildQualityChecks@9) is dependent on a Node version (16) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance
```

**Changes proposed in this request**
This pull request makes a minor update to the build pipeline configuration, specifically upgrading the `BuildQualityChecks` task to a newer version in the `build/template-build-and-run-all-tests.yaml` file.

* Upgraded the `BuildQualityChecks` task from version 9 to version 10 to ensure the build uses the latest features and fixes.

**Testing**
builds

**Performance impact**
n/a

**Documentation**
- [x] All relevant documentation is updated.
