### PR TITLE
Remove ADFS usage where not needed

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/OnBehalfOfTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/OnBehalfOfTests.cs
@@ -226,20 +226,17 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
-#if IGNORE_FEDERATED
-        [Ignore]
-#endif
         public async Task WithMultipleUsers_TestAsync()
         {
             var aadUser1 = (await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false)).User;
             var aadUser2 = (await LabUserHelper.GetDefaultUser2Async().ConfigureAwait(false)).User;
-            var adfsUser = (await LabUserHelper.GetAdfsUserAsync(FederationProvider.ADFSv2019).ConfigureAwait(false)).User;
+            var aadUser3 = (await LabUserHelper.GetDefaultUser3Async().ConfigureAwait(false)).User;
 
-            await RunOnBehalfOfTestAsync(adfsUser, false).ConfigureAwait(false);
+            await RunOnBehalfOfTestAsync(aadUser3, false).ConfigureAwait(false);
             await RunOnBehalfOfTestAsync(aadUser1, false).ConfigureAwait(false);
             await RunOnBehalfOfTestAsync(aadUser1, true).ConfigureAwait(false);
             await RunOnBehalfOfTestAsync(aadUser2, false).ConfigureAwait(false);
-            await RunOnBehalfOfTestAsync(adfsUser, true).ConfigureAwait(false);
+            await RunOnBehalfOfTestAsync(aadUser3, true).ConfigureAwait(false);
             await RunOnBehalfOfTestAsync(aadUser2, true).ConfigureAwait(false);
             await RunOnBehalfOfTestAsync(aadUser2, false, true).ConfigureAwait(false);
         }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/UsernamePasswordIntegrationTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/UsernamePasswordIntegrationTests.NetFwk.cs
@@ -81,14 +81,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [RunOn(TargetFrameworks.NetCore)]
-        [TestCategory(TestCategories.Arlington)]
-#if IGNORE_FEDERATED
-        [Ignore]
-#endif
-        public async Task ARLINGTON_ROPC_ADFS_Async()
+        public async Task Public_ROPC_Cloud_Async()
         {
-            var labResponse = await LabUserHelper.GetArlingtonADFSUserAsync().ConfigureAwait(false);
-            await RunHappyPathTestAsync(labResponse).ConfigureAwait(false);
+            var aadUser = await LabUserHelper.GetDefaultUserAsync().ConfigureAwait(false);
+            await RunHappyPathTestAsync(aadUser).ConfigureAwait(false);
         }
 
         [RunOn(TargetFrameworks.NetCore)]

--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/DeviceCodeFlowIntegrationTest.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/DeviceCodeFlowIntegrationTest.cs
@@ -64,19 +64,6 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
 
         [TestMethod]
         [Timeout(2 * 60 * 1000)] // 2 min timeout
-        [TestCategory(TestCategories.ADFS)]
-#if IGNORE_FEDERATED
-        [Ignore]
-#endif
-        public async Task DeviceCodeFlowAdfsTestAsync()
-        {
-            LabResponse labResponse = await LabUserHelper.GetAdfsUserAsync(FederationProvider.ADFSv2019, true).ConfigureAwait(false);
-
-            await AcquireTokenWithDeviceCodeFlowAsync(labResponse, "adfs user").ConfigureAwait(false);
-        }
-
-        [TestMethod]
-        [Timeout(2 * 60 * 1000)] // 2 min timeout
         [TestCategory(TestCategories.Arlington)]
 #if IGNORE_FEDERATED
         [Ignore]

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/LabUserHelper.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/LabUserHelper.cs
@@ -75,6 +75,15 @@ namespace Microsoft.Identity.Test.LabInfrastructure
             return GetLabUserDataAsync(UserQuery.PublicAadUser2Query);
         }
 
+        /// <summary>
+        /// Returns the AAD cloud user idlab@msidlab4.onmicrosoft.com
+        /// </summary>
+        /// <returns></returns>
+        public static Task<LabResponse> GetDefaultUser3Async()
+        {
+            return GetLabUserDataAsync(UserQuery.PublicAadUser3Query);
+        }
+
         public static Task<LabResponse> GetMsaUserAsync()
         {
             return GetLabUserDataAsync(UserQuery.MsaUserQuery);

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/UserQueryParameters.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/UserQueryParameters.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Identity.Test.LabInfrastructure
             Upn = "idlab@msidlab4.onmicrosoft.com"
         };
 
+        public static UserQuery PublicAadUser3Query => new UserQuery()
+        {
+            Upn = "idlabxcg@msidlab4.onmicrosoft.com"
+        };
+
         public static UserQuery MsaUserQuery => new UserQuery
         {
             UserType = LabInfrastructure.UserType.MSA


### PR DESCRIPTION
Fixes #test coverage

**Changes proposed in this request**
This pull request updates several integration and lab infrastructure tests to remove dependencies on ADFS (Active Directory Federation Services) users and instead use additional Azure Active Directory (AAD) cloud users. The changes improve consistency and reliability by focusing tests on supported AAD scenarios and cleaning up obsolete ADFS-specific test cases.

**Test scenario updates:**

* Replaced usage of ADFS users with a new AAD cloud user (`idlabxcg@msidlab4.onmicrosoft.com`) in the `WithMultipleUsers_TestAsync` test in `OnBehalfOfTests.cs`, ensuring all test cases now use AAD users.
* Removed the obsolete ADFS device code flow test (`DeviceCodeFlowAdfsTestAsync`) from `DeviceCodeFlowIntegrationTest.cs`, eliminating unsupported and redundant test coverage.
* Updated the ROPC test in `UsernamePasswordIntegrationTests.NetFwk.cs` to use a public AAD user instead of an Arlington ADFS user, aligning with current test requirements.

**Lab infrastructure enhancements:**

* Added a helper method `GetDefaultUser3Async` in `LabUserHelper.cs` to retrieve the new AAD user for use in tests.
* Added a new query `PublicAadUser3Query` in `UserQueryParameters.cs` to support fetching the third AAD user (`idlabxcg@msidlab4.onmicrosoft.com`).

**Testing**
tests

**Performance impact**
none

**Documentation**
- [x] All relevant documentation is updated.
