### PR TITLE
Remove passing x-client-os as query param in authorization uri

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Interactive/AuthCodeRequestComponent.cs
@@ -214,10 +214,10 @@ namespace Microsoft.Identity.Client.Internal
                     _requestParams.RequestContext.CorrelationId.ToString();
             }
 
-            foreach (KeyValuePair<string, string> kvp in MsalIdHelper.GetMsalIdParameters(_requestParams.RequestContext.Logger))
-            {
-                authorizationRequestParameters[kvp.Key] = kvp.Value;
-            }
+            MsalIdHelper.GetMsalIdParameters(_requestParams.RequestContext.Logger)
+                .Where(kvp => kvp.Key != MsalIdParameter.OS)
+                .ToList()
+                .ForEach(kvp => authorizationRequestParameters[kvp.Key] = kvp.Value);
 
             if (_interactiveParameters.Prompt == Prompt.NotSpecified)
             {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -991,6 +991,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .ConfigureAwait(false);
 
                 AssertCcsHint(uri, "oid:oid@tid");
+                Dictionary<string, string> qp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', true, null);
+                ValidateCommonQueryParams(qp);
             }
         }
 
@@ -1025,6 +1027,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .ConfigureAwait(false);
 
                 AssertCcsHint(uri, $"upn:{TestConstants.DisplayableId}");
+                Dictionary<string, string> qp = CoreHelpers.ParseKeyValueList(uri.Query.Substring(1), '&', true, null);
+                ValidateCommonQueryParams(qp);
             }
         }
 
@@ -1347,7 +1351,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.AreEqual(Prompt.SelectAccount.PromptValue, qp["prompt"]);
             Assert.AreEqual(TestCommon.CreateDefaultServiceBundle().PlatformProxy.GetProductName(), qp["x-client-sku"]);
             Assert.IsFalse(string.IsNullOrEmpty(qp["x-client-ver"]));
-            Assert.IsFalse(string.IsNullOrEmpty(qp["x-client-os"]));
+            Assert.IsFalse(qp.ContainsKey("x-client-os"));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #5451 

**Changes proposed in this request**
Exclude passing the x-client-os param from GetAuthorizationUri 

**Testing**
Update unit tests to validate that the query param is not passed

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
