### PR TITLE
Fix MSB3277 “WindowsBase” conflicts in dev apps by enabling WPF build refs

### DIFF
--- a/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
+++ b/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
@@ -8,6 +8,7 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseWinForms>true</UseWinForms>
+    <UseWPF>true</UseWPF>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
   </PropertyGroup>
 

--- a/tests/devapps/WAM/NetCoreWinFormsWam/NetCoreWinFormsWAM.csproj
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/NetCoreWinFormsWAM.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net8.0-windows10.0.17763.0</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes - a warning in the build 

```
##[warning]C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): Warning MSB3277: Found conflicts between different versions of "WindowsBase" that could not be resolved.
There was a conflict between "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35".
    "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was chosen because it was primary and "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was not.
    References which depend on "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" [C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\WindowsBase.dll].
        C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\WindowsBase.dll
          Project file item includes which caused reference "C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\WindowsBase.dll".
            C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref/net8.0/WindowsBase.dll
    References which depend on or have been unified to "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" [].
        C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll
          Project file item includes which caused reference "C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll".
            C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\buildTransitive\..\\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277: Found conflicts between different versions of "WindowsBase" that could not be resolved. [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277: There was a conflict between "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35". [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:     "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was chosen because it was primary and "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was not. [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:     References which depend on "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" [C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\WindowsBase.dll]. [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:         C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\WindowsBase.dll [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:           Project file item includes which caused reference "C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\WindowsBase.dll". [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:             C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref/net8.0/WindowsBase.dll [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:     References which depend on or have been unified to "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" []. [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:         C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:           Project file item includes which caused reference "C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll". [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277:             C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\buildTransitive\..\\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll [D:\a\1\s\tests\devapps\WAM\NetCoreWinFormsWam\NetCoreWinFormsWAM.csproj::TargetFramework=net8.0-windows10.0.17763.0]
CoreResGen:
  "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\resgen.exe" /useSourcePath /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\Accessibility.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\Microsoft.CSharp.dll /r:D:\a\1\s\src\client\Microsoft.Identity.Client.Broker\bin\Release\netstandard2.0\Microsoft.Identity.Client.Broker.dll /r:D:\a\1\s\src\client\Microsoft.Identity.Client.Desktop\bin\Release\netcoreapp3.1\Microsoft.Identity.Client.Desktop.dll /r:D:\a\1\s\src\client\Microsoft.Identity.Client\obj\Release\net8.0\ref\Microsoft.Identity.Client.dll /r:D:\a\1\s\src\client\Microsoft.Identity.Client.Extensions.Msal\obj\Release\net8.0\ref\Microsoft.Identity.Client.Extensions.Msal.dll /r:C:\Users\VssAdministrator\.nuget\packages\microsoft.identity.client.nativeinterop\0.19.4\lib\netstandard2.0\Microsoft.Identity.Client.NativeInterop.dll /r:C:\Users\VssAdministrator\.nuget\packages\microsoft.identitymodel.abstractions\8.14.0\lib\net8.0\Microsoft.IdentityModel.Abstractions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\Microsoft.VisualBasic.Core.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\Microsoft.VisualBasic.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\Microsoft.VisualBasic.Forms.dll /r:C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\lib_manual\netcoreapp3.0\Microsoft.Web.WebView2.Core.dll /r:C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\lib_manual\netcoreapp3.0\Microsoft.Web.WebView2.WinForms.dll /r:C:\Users\VssAdministrator\.nuget\packages\microsoft.web.webview2\1.0.2903.40\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\Microsoft.Win32.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\Microsoft.Win32.Registry.AccessControl.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\Microsoft.Win32.Registry.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\Microsoft.Win32.SystemEvents.dll /r:C:\Users\VssAdministrator\.nuget\packages\microsoft.windows.sdk.net.ref\10.0.17763.56\lib\net8.0\Microsoft.Windows.SDK.NET.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\mscorlib.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\netstandard.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.AppContext.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Buffers.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.CodeDom.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Collections.Concurrent.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Collections.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Collections.Immutable.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Collections.NonGeneric.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Collections.Specialized.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ComponentModel.Annotations.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ComponentModel.DataAnnotations.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ComponentModel.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ComponentModel.EventBasedAsync.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ComponentModel.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ComponentModel.TypeConverter.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Configuration.ConfigurationManager.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Configuration.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Console.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Core.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Data.Common.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Data.DataSetExtensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Data.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Design.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.Contracts.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.Debug.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.DiagnosticSource.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.EventLog.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.FileVersionInfo.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.PerformanceCounter.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.Process.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.StackTrace.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.TextWriterTraceListener.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.Tools.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.TraceSource.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Diagnostics.Tracing.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.DirectoryServices.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Drawing.Common.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Drawing.Design.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Drawing.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Drawing.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Dynamic.Runtime.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Formats.Asn1.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Formats.Tar.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Globalization.Calendars.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Globalization.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Globalization.Extensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.Compression.Brotli.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.Compression.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.Compression.FileSystem.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.Compression.ZipFile.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.FileSystem.AccessControl.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.FileSystem.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.FileSystem.DriveInfo.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.FileSystem.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.FileSystem.Watcher.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.IsolatedStorage.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.MemoryMappedFiles.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.IO.Packaging.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.Pipes.AccessControl.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.Pipes.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.IO.UnmanagedMemoryStream.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Linq.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Linq.Expressions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Linq.Parallel.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Linq.Queryable.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Memory.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Http.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Http.Json.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.HttpListener.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Mail.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.NameResolution.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.NetworkInformation.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Ping.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Quic.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Requests.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Security.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.ServicePoint.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.Sockets.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.WebClient.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.WebHeaderCollection.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.WebProxy.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.WebSockets.Client.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Net.WebSockets.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Numerics.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Numerics.Vectors.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ObjectModel.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.DispatchProxy.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.Emit.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.Emit.ILGeneration.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.Emit.Lightweight.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.Extensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.Metadata.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Reflection.TypeExtensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Resources.Extensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Resources.Reader.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Resources.ResourceManager.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Resources.Writer.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.CompilerServices.Unsafe.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.CompilerServices.VisualC.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Extensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Handles.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.InteropServices.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.InteropServices.JavaScript.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.InteropServices.RuntimeInformation.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Intrinsics.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Loader.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Numerics.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Serialization.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Serialization.Formatters.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Serialization.Json.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Serialization.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Runtime.Serialization.Xml.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.AccessControl.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Claims.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.Algorithms.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.Cng.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.Csp.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.Encoding.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.OpenSsl.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.Pkcs.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.ProtectedData.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.X509Certificates.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Security.Cryptography.Xml.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Security.Permissions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Principal.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.Principal.Windows.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Security.SecureString.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ServiceModel.Web.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ServiceProcess.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Text.Encoding.CodePages.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Text.Encoding.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Text.Encoding.Extensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Text.Encodings.Web.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Text.Json.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Text.RegularExpressions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Threading.AccessControl.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Channels.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Overlapped.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Tasks.Dataflow.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Tasks.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Tasks.Extensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Tasks.Parallel.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Thread.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.ThreadPool.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Threading.Timer.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Transactions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Transactions.Local.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.ValueTuple.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Web.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Web.HttpUtility.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Windows.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Windows.Extensions.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Windows.Forms.Design.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Windows.Forms.Design.Editors.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Windows.Forms.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.19\ref\net8.0\System.Windows.Forms.Primitives.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.Linq.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.ReaderWriter.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.Serialization.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.XDocument.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.XmlDocument.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.XmlSerializer.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.XPath.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\System.Xml.XPath.XDocument.dll /r:C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.19\ref\net8.0\WindowsBase.dll /r:C:\Users\VssAdministrator\.nuget\packages\microsoft.windows.sdk.net.ref\10.0.17763.56\lib\net8.0\WinRT.Runtime.dll /compile Form1.resx,obj\Release\net8.0-windows10.0.17763.0\NetDesktopWinForms.Form1.resources
  Processing resource file "Form1.resx" into "obj\Release\net8.0-windows10.0.17763.0\NetDesktopWinForms.Form1.resources".
CoreGenerateAssemblyInfo:
  Could not infer the type of parameter "#1" because the attribute type is unknown. The value will be treated as a string.
  Could not infer the type of parameter "#1" because the attribute type is unknown. The value will be treated as a string.

```

**Changes proposed in this request**

After recent Desktop/UI changes (and newer WebView2), several SDK‑style dev/test projects (e.g., NetCoreWinFormsWAM, the net8.0-windows target of NetFxConsoleApp) began emitting MSB3277 warnings due to a reference‑graph conflict between WindowsBase 4.0.0.0 (facade from Microsoft.NETCore.App.Ref) and WindowsBase 5.0.0.0 (required by Microsoft.Web.WebView2.Wpf.dll).

This PR resolves the conflict by enabling WPF build references in the affected SDK‑style projects so WindowsBase unifies to the desktop pack version.

> Note: This does not “turn the app into a WPF UI.” It only opts the project into WPF framework references so the assembly graph is consistent. Apps remain WinForms/console unless XAML is actually added.

**Background / Root cause**

- Our Desktop package pulls in WebView2; its WPF assembly (Microsoft.Web.WebView2.Wpf.dll) is introduced transitively via buildTransitive.
- WinForms/console SDK‑style projects don’t reference WPF by default, so MSBuild/ResolveAssemblyReference picks WindowsBase 4.0.0.0 from Microsoft.NETCore.App.Ref.
-The WPF WebView2 assembly requires WindowsBase 5.0.0.0 (from the Windows Desktop/WPF pack).
- With both versions present, RAR logs MSB3277 and “chooses” 4.0 as primary, leading to persistent warnings during solution builds.

**What this change does**

For SDK‑style projects that started warning (WinForms/console samples that consume our Desktop bits), we add <UseWPF>true</UseWPF> (per‑TFM when multi‑targeting).

This instructs the SDK to include the WPF framework references (WindowsBase/PresentationCore/PresentationFramework), aligning the graph to WindowsBase 5.0.0.0 and eliminating MSB3277.

**Testing**
build and dev apps 

**Performance impact**
n/a

**Documentation**
- [x] All relevant documentation is updated.
