### PR TITLE
Avdunn/issuer validation adjustment

### DIFF
--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
@@ -338,8 +338,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         {
             using (var httpManager = new MockHttpManager())
             {
-                string authority = "https://demo.duendesoftware.com/tenant1/2.0/";
-                string issuerWithDifferentPath = "https://demo.duendesoftware.com/oidc/2.0/";
+                string authority = "https://demo.duendesoftware.com/someTenant/2.0/";
+                string issuerWithDifferentPath = "https://demo.duendesoftware.com/organizations/2.0/";
 
                 IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                     .Create(TestConstants.ClientId)

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
@@ -334,6 +334,50 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         }
 
         [TestMethod]
+        public async Task OidcIssuerValidation_AcceptsDifferentPath_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                string authority = "https://demo.duendesoftware.com/tenant1/2.0/";
+                string issuerWithDifferentPath = "https://demo.duendesoftware.com/oidc/2.0/";
+
+                IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithHttpManager(httpManager)
+                    .WithOidcAuthority(authority)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .Build();
+
+                // Create OIDC document with matching host but different path
+                string oidcDocumentWithDifferentPath = TestConstants.GenericOidcResponse.Replace(
+                        $"\"issuer\":\"{TestConstants.GenericAuthority}\"",
+                        $"\"issuer\":\"{issuerWithDifferentPath}\"");
+
+                // Mock OIDC endpoint response
+                httpManager.AddMockHandler(new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedUrl = $"{authority}{Constants.WellKnownOpenIdConfigurationPath}",
+                    ResponseMessage = MockHelpers.CreateSuccessResponseMessage(oidcDocumentWithDifferentPath)
+                });
+
+                // Mock token endpoint response
+                httpManager.AddMockHandler(
+                    CreateTokenResponseHttpHandler(
+                        "https://demo.duendesoftware.com/connect/token",
+                        scopesInRequest: "api",
+                        scopesInResponse: "api", 
+                        grant: "client_credentials"));
+
+                // Should not throw an exception with our updated validation
+                var result = await app.AcquireTokenForClient(new[] { "api" }).ExecuteAsync().ConfigureAwait(false);
+                
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.AccessToken);
+            }
+        }
+
+        [TestMethod]
         public async Task OidcIssuerValidation_ThrowsForNonMatchingIssuer_Async()
         {
             using (var httpManager = new MockHttpManager())

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
@@ -338,8 +338,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         {
             using (var httpManager = new MockHttpManager())
             {
-                string authority = "https://demo.duendesoftware.com/someTenant/2.0/";
-                string issuerWithDifferentPath = "https://demo.duendesoftware.com/organizations/2.0/";
+                string authority = "https://demo.duendesoftware.com/organizations/2.0/";
+                string issuerWithDifferentPath = "https://demo.duendesoftware.com/someTenant/2.0/";
 
                 IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
                     .Create(TestConstants.ClientId)


### PR DESCRIPTION
This issue in the identity web repo exposed a problem in the issuer validation steps: https://github.com/AzureAD/microsoft-identity-web/issues/3450

Originally the validation step would pass if the authority "started with" the issuer, i.e. it matched the scheme, host, and start of the path. However, there are cases where the path could be different but it still represents a valid authority/issuer pair, such as when the authority uses "organizations" but the issuer uses the actual tenant. 

While it might be better to use the `authority` API instead of `oidcAuthority` in that scenario, we don't strictly need to check the path for the OIDC issuer validation and as https://github.com/AzureAD/microsoft-identity-web/issues/3450 shows this can be a breaking change.

This PR adjust the issuer validation to only check the HTTP scheme and host, and adds a test confirming that behavior. The existing tests should still pass.