### PR TITLE
Remove confusing error text as it only applies to one of many possible causes

### DIFF
--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -90,10 +90,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
                         $" Error Code: {errorCode} \n" +
                         $" Error Message: {authResult.Error.Status} \n" +
                         $" WAM Error Message: {authResult.Error.Context} \n" +
-                        $" Internal Error Code: {internalErrorCode} \n" +
-                        $" Possible causes: \n" +
-                        $"- Invalid redirect uri - ensure you have configured the following url in the application registration in Azure Portal: " +
-                        $"{GetExpectedRedirectUri(authenticationRequestParameters.AppConfig.ClientId)} \n";
+                        $" Internal Error Code: {internalErrorCode} \n";
                     logger.Error($"[RuntimeBroker] WAM_provider_error_{errorCode} {errorMessage}");
                     serviceException = new MsalServiceException($"WAM_provider_error_{errorCode}", errorMessage);
                     serviceException.IsRetryable = false;

--- a/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
+++ b/src/client/Microsoft.Identity.Client.Broker/WamAdapters.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.RuntimeBroker
                         $" Error Code: {errorCode} \n" +
                         $" Error Message: {authResult.Error.Status} \n" +
                         $" WAM Error Message: {authResult.Error.Context} \n" +
-                        $" Internal Error Code: {internalErrorCode} \n";
+                        $" Internal Error Code: {internalErrorCode} \n" + 
+                        $" See troubleshooting: https://aka.ms/msal-net-wam \n";
                     logger.Error($"[RuntimeBroker] WAM_provider_error_{errorCode} {errorMessage}");
                     serviceException = new MsalServiceException($"WAM_provider_error_{errorCode}", errorMessage);
                     serviceException.IsRetryable = false;


### PR DESCRIPTION
**Changes proposed in this request**
The text that is removed only applies to one of many possible causes of ApiContractViolation or IncorrectConfigiration.
This causes confusion with developers. 
The recommendation would be to enable PII during development to see the WAM error message which will contain the correct reason for the error. 
A long-term change may be considered, and that will require proper classification of all cases where ApiContractViolation or IncorrectConfigiration may occur.

**Testing**
No new tests are needed

**Performance impact**
No perf impact

**Documentation**
- [ ] All relevant documentation is updated.
