### PR TITLE
Fix MSB3277 “WindowsBase” conflicts in dev apps by enabling WPF build ref

### DIFF
--- a/tests/devapps/Net5TestApp/Net5TestApp.csproj
+++ b/tests/devapps/Net5TestApp/Net5TestApp.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
+++ b/tests/devapps/NetFxConsoleTestApp/NetFxConsoleApp.csproj
@@ -8,6 +8,7 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseWinForms>true</UseWinForms>
+    <UseWPF>true</UseWPF>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
   </PropertyGroup>
 

--- a/tests/devapps/WAM/NetCoreWinFormsWam/NetCoreWinFormsWAM.csproj
+++ b/tests/devapps/WAM/NetCoreWinFormsWam/NetCoreWinFormsWAM.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net8.0-windows10.0.17763.0</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
     <Configurations>Debug;Release;Debug + MobileApps</Configurations>
   </PropertyGroup>
 

--- a/tests/devapps/WinFormsTestApp/WinFormsTestApp.csproj
+++ b/tests/devapps/WinFormsTestApp/WinFormsTestApp.csproj
@@ -5,6 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>WinFormsTestApp</RootNamespace>
     <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Fixes - Build warning 

```
  22>C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277: Found conflicts between different versions of "WindowsBase" that could not be resolved. [D:\a\1\s\tests\devapps\WinFormsTestApp\WinFormsTestApp.csproj]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2433,5): warning MSB3277: There was a conflict between "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35". 
```

**Changes proposed in this request**
After recent Desktop/UI changes (and newer WebView2), several SDK‑style dev/test projects (e.g., NetCoreWinFormsWAM, the net8.0-windows target of NetFxConsoleApp) began emitting MSB3277 warnings due to a reference‑graph conflict between WindowsBase 4.0.0.0 (facade from Microsoft.NETCore.App.Ref) and WindowsBase 5.0.0.0 (required by Microsoft.Web.WebView2.Wpf.dll).

This PR resolves the conflict by enabling WPF build references in the affected SDK‑style projects so WindowsBase unifies to the desktop pack version.

> Note: This does not “turn the app into a WPF UI.” It only opts the project into WPF framework references so the assembly graph is consistent. Apps remain WinForms/console unless XAML is actually added.

**Testing**
n/a

**Performance impact**
n/a

**Documentation**
- [x] All relevant documentation is updated.
