### PR TITLE
[Feature] MSI V2 : add mTLS PoP support with cache‑correct auth scheme

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForManagedIdentityParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForManagedIdentityParameters.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
@@ -21,6 +22,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public string RevokedTokenHash { get; set; }
 
         public bool IsMtlsPopRequested { get; set; }
+
+        public X509Certificate2 MtlsCertificate { get; set; }
 
         public void LogParameters(ILoggerAdapter logger)
         {

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -115,6 +115,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public bool IsMtlsPopRequested => _commonParameters.IsMtlsPopRequested;
 
+        // Request-scoped override for the authentication operation.
+        // When set, MSAL will use this operation; otherwise it falls back to the common parameters.
+        internal IAuthenticationOperation AuthenticationOperationOverride { get; set; }
+
         /// <summary>
         /// Indicates if the user configured claims via .WithClaims. Not affected by Client Capabilities
         /// </summary>
@@ -127,7 +131,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
         }
 
-        public IAuthenticationOperation AuthenticationScheme => _commonParameters.AuthenticationOperation;
+        // Effective operation for this request.
+        // Prefer the override when present; otherwise use the operation coming from common parameters.
+        public IAuthenticationOperation AuthenticationScheme =>
+            AuthenticationOperationOverride ?? _commonParameters.AuthenticationOperation;
 
         public IEnumerable<string> PersistedCacheParameters => _commonParameters.AdditionalCacheParameters;
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -61,6 +61,13 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
             ManagedIdentityRequest request = await CreateRequestAsync(resource).ConfigureAwait(false);
 
+            // If PoP was requested and a cert exists, stash it on the per-request parameters.
+            // The request layer will later set AuthenticationOperationOverride based on this.
+            if (_isMtlsPopRequested && request?.MtlsCertificate != null)
+            {
+                parameters.MtlsCertificate = request.MtlsCertificate;
+            }
+
             // Automatically add claims / capabilities if this MI source supports them
             if (_sourceType.SupportsClaimsAndCapabilities())
             {

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Threading.Tasks;
-using System.Threading;
-using Microsoft.Identity.Client.Internal;
-using Microsoft.Identity.Client.ApiConfig.Parameters;
-using Microsoft.Identity.Client.PlatformsCommon.Shared;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.ManagedIdentity.V2;
+using Microsoft.Identity.Client.PlatformsCommon.Shared;
 
 namespace Microsoft.Identity.Client.ManagedIdentity
 {
@@ -21,6 +22,21 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         private const string WindowsHimdsFilePath = "%Programfiles%\\AzureConnectedMachineAgent\\himds.exe";
         private const string LinuxHimdsFilePath = "/opt/azcmagent/bin/himds";
         internal static ManagedIdentitySource s_sourceName = ManagedIdentitySource.None;
+        private X509Certificate2 _mtlsBindingCertificate;
+        internal X509Certificate2 MtlsBindingCertificate
+        {
+            get => _mtlsBindingCertificate;
+            set
+            {
+                var old = Interlocked.Exchange(ref _mtlsBindingCertificate, value);
+                if (old != null && !ReferenceEquals(old, value))
+                {
+                    try
+                    { old.Dispose(); }
+                    catch { }
+                }
+            }
+        }
 
         internal static void ResetSourceForTest()
         {

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             {
                 if (probeMode)
                 {
-                    requestContext.Logger.Info(() => $"[Managed Identity] IMDSv2 CSR endpoint failure. Exception occurred while sending request to CSR metadata endpoint: ${ex}");
+                    requestContext.Logger.Info(() => $"[Managed Identity] IMDSv2 CSR endpoint failure. Exception occurred while sending request to CSR metadata endpoint: {ex}");
                     return null;
                 }
                 else

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -266,19 +266,18 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
+                 Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
 
-                // TODO: broken until Gladwin's PR is merged in
-                /*result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
                     .WithMtlsProofOfPossession()
                     .ExecuteAsync().ConfigureAwait(false);
 
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
-                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);*/
+                Assert.IsNotNull(result.BindingCertificate);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
             }
         }
 
@@ -305,19 +304,18 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
+                Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
 
-                // TODO: broken until Gladwin's PR is merged in
-                /*result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
                     .WithMtlsProofOfPossession()
                     .ExecuteAsync().ConfigureAwait(false);
 
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
-                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);*/
+                Assert.IsNotNull(result.BindingCertificate);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
                 #endregion Identity 1
 
                 #region Identity 2
@@ -332,22 +330,19 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result2);
                 Assert.IsNotNull(result2.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
+                Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource);
 
-                // TODO: broken until Gladwin's PR is merged in
-                /*result2 = await managedIdentityApp2.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                result2 = await managedIdentityApp2.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
                     .WithMtlsProofOfPossession()
                     .ExecuteAsync().ConfigureAwait(false);
 
                 Assert.IsNotNull(result2);
                 Assert.IsNotNull(result2.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
-                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource);*/
+                Assert.IsNotNull(result.BindingCertificate);
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource);
                 #endregion Identity 2
-
-                // TODO: Assert.AreEqual(CertificateCache.Count, 2);
             }
         }
 
@@ -373,11 +368,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
+                Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
 
-                // TODO: Add functionality to check cert expiration in the cache
-                /**
                 AddMocksToGetEntraToken(httpManager, userAssignedIdentityId, userAssignedId, mTLSPop: true);
 
                 result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
@@ -387,13 +380,150 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(result.TokenType, MTLSPoP);
-                // Assert.IsNotNull(result.BindingCertificate); // TODO: implement mTLS Pop BindingCertificate
+                Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
-
-                Assert.AreEqual(CertificateCache.Count, 1); // expired cert was removed from the cache
-                */
             }
         }
+
+        [TestMethod]
+        public async Task MtlsPop_SkipsBearerCache_OnFirstPopRequest()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = await CreateManagedIdentityAsync(httpManager).ConfigureAwait(false);
+
+                // Seed Bearer: network then cache
+                AddMocksToGetEntraToken(httpManager, mTLSPop: false);
+                var bearer = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .ExecuteAsync().ConfigureAwait(false);
+                Assert.AreEqual(Bearer, bearer.TokenType);
+                Assert.AreEqual(TokenSource.IdentityProvider, bearer.AuthenticationResultMetadata.TokenSource);
+
+                var bearerCached = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .ExecuteAsync().ConfigureAwait(false);
+                Assert.AreEqual(TokenSource.Cache, bearerCached.AuthenticationResultMetadata.TokenSource);
+
+                // Now request PoP – must bypass Bearer cache and hit network
+                AddMocksToGetEntraToken(httpManager, mTLSPop: true);
+                var pop = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(MTLSPoP, pop.TokenType);
+                Assert.IsNotNull(pop.BindingCertificate);
+                Assert.AreEqual(TokenSource.IdentityProvider, pop.AuthenticationResultMetadata.TokenSource);
+
+                // Subsequent PoP should be cached
+                var popCached = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(MTLSPoP, popCached.TokenType);
+                Assert.IsNotNull(popCached.BindingCertificate);
+                Assert.AreEqual(TokenSource.Cache, popCached.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public async Task Bearer_AfterPop_GoesToNetwork_WhenNoBearerCached()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = await CreateManagedIdentityAsync(httpManager).ConfigureAwait(false);
+
+                // First get PoP
+                AddMocksToGetEntraToken(httpManager, mTLSPop: true);
+                var pop = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .ExecuteAsync().ConfigureAwait(false);
+                Assert.AreEqual(MTLSPoP, pop.TokenType);
+                Assert.IsNotNull(pop.BindingCertificate);
+                Assert.AreEqual(TokenSource.IdentityProvider, pop.AuthenticationResultMetadata.TokenSource);
+
+                // Next PoP call should hit cache
+                var popCached = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession().ExecuteAsync().ConfigureAwait(false);
+                Assert.AreEqual(MTLSPoP, popCached.TokenType);
+                Assert.AreEqual(TokenSource.Cache, popCached.AuthenticationResultMetadata.TokenSource);
+
+                // Now request Bearer – there is no Bearer cache yet, so hit network
+                AddMocksToGetEntraToken(httpManager, mTLSPop: false);
+                var bearer = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .ExecuteAsync().ConfigureAwait(false);
+                Assert.AreEqual(Bearer, bearer.TokenType);
+                Assert.AreEqual(TokenSource.IdentityProvider, bearer.AuthenticationResultMetadata.TokenSource);
+
+                // Next Bearer call should hit cache
+                var bearerCached = await app.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .ExecuteAsync().ConfigureAwait(false);
+                Assert.AreEqual(Bearer, bearerCached.TokenType);
+                Assert.AreEqual(TokenSource.Cache, bearerCached.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(UserAssignedIdentityId.None, null)]                             // SAMI
+        [DataRow(UserAssignedIdentityId.ClientId, TestConstants.ClientId)]       // UAMI
+        [DataRow(UserAssignedIdentityId.ResourceId, TestConstants.MiResourceId)] // UAMI
+        [DataRow(UserAssignedIdentityId.ObjectId, TestConstants.ObjectId)]       // UAMI
+        public async Task MtlsPop_WithClaims_BypassesCache(UserAssignedIdentityId userAssignedIdentityId, 
+            string userAssignedId)
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange: Build MI app and seed a cached PoP token first
+                var managedIdentityApp = await CreateManagedIdentityAsync(httpManager, userAssignedIdentityId, userAssignedId).ConfigureAwait(false);
+
+                // First call (PoP): network then cache
+                AddMocksToGetEntraToken(httpManager, userAssignedIdentityId, userAssignedId, mTLSPop: true);
+                var first = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(first);
+                Assert.AreEqual(MTLSPoP, first.TokenType);
+                Assert.IsNotNull(first.BindingCertificate);
+                Assert.AreEqual(TokenSource.IdentityProvider, first.AuthenticationResultMetadata.TokenSource);
+
+                // Second call (PoP without claims): should be a cache hit
+                var cached = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(cached);
+                Assert.AreEqual(MTLSPoP, cached.TokenType);
+                Assert.IsNotNull(cached.BindingCertificate);
+                Assert.AreEqual(TokenSource.Cache, cached.AuthenticationResultMetadata.TokenSource);
+
+                // Act: Third call (PoP + Claims): must bypass cache and go to network
+                // Prepare network mocks for this call
+                AddMocksToGetEntraToken(httpManager, userAssignedIdentityId, userAssignedId, mTLSPop: true);
+
+                // Use a claims payload; TestConstants.Claims is typically present in the test suite.
+                // If not, replace with a minimal valid claims JSON for your pipeline.
+                var withClaims = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .WithClaims(TestConstants.Claims)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                // Assert: result is PoP and came from the IDP (not cache)
+                Assert.IsNotNull(withClaims);
+                Assert.AreEqual(MTLSPoP, withClaims.TokenType);
+                Assert.IsNotNull(withClaims.BindingCertificate);
+                Assert.AreEqual(TokenSource.IdentityProvider, withClaims.AuthenticationResultMetadata.TokenSource);
+
+                // Optional: Fourth call (PoP without claims): should be cached again
+                var cachedAgain = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(cachedAgain);
+                Assert.AreEqual(MTLSPoP, cachedAgain.TokenType);
+                Assert.IsNotNull(cachedAgain.BindingCertificate);
+                Assert.AreEqual(TokenSource.Cache, cachedAgain.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
         #endregion mTLS Pop Token Tests
         #endregion Acceptance Tests
 


### PR DESCRIPTION
**Summary**

This pull request implements support for mTLS PoP (Mutual TLS Proof-of-Possession) tokens in the Managed Identity authentication flow. The main improvements include proper handling and persistence of binding certificates, ensuring cache lookups use the correct authentication scheme, and updating tests to validate mTLS PoP scenarios. These changes make sure that tokens are acquired and cached securely when mTLS PoP is requested, and that expired certificates are handled correctly.

**Managed Identity mTLS PoP support and certificate handling:**

* Added `MtlsCertificate` property to `AcquireTokenForManagedIdentityParameters` and ensured it is passed through the authentication flow for mTLS PoP requests. [[1]](diffhunk://#diff-8a2dae698d340180c3ad81c8c6d92b32dce6ba143a830f70ee279f46eea034b9R26-R27) [[2]](diffhunk://#diff-26925862fc2f25040b857e0a110d355651a21e695340d3683565fba12fa30001R64-R70)
* Implemented logic in `ManagedIdentityAuthRequest` to apply the `MtlsPopAuthenticationOperation` when a binding certificate is available, persist the certificate for future cache lookups, and bypass cache when no valid certificate is present. [[1]](diffhunk://#diff-a1260a45bdc4ac7ab60d4a348996be6b69c5a48fa6f484fa41daa390c7e69ca8R44-R59) [[2]](diffhunk://#diff-a1260a45bdc4ac7ab60d4a348996be6b69c5a48fa6f484fa41daa390c7e69ca8L90-R118) [[3]](diffhunk://#diff-a1260a45bdc4ac7ab60d4a348996be6b69c5a48fa6f484fa41daa390c7e69ca8R192-R213) [[4]](diffhunk://#diff-a1260a45bdc4ac7ab60d4a348996be6b69c5a48fa6f484fa41daa390c7e69ca8R254-R270)

**Authentication scheme and request parameter enhancements:**

* Added `AuthenticationOperationOverride` to `AuthenticationRequestParameters`, allowing per-request authentication scheme overrides, and updated the effective authentication scheme selection logic. [[1]](diffhunk://#diff-ed9c2f02cbc643a34c89b0eb94b2b2a73c40bbf6569cf752c2f329ebfa523be7R118-R121) [[2]](diffhunk://#diff-ed9c2f02cbc643a34c89b0eb94b2b2a73c40bbf6569cf752c2f329ebfa523be7L130-R137)

**ManagedIdentityClient certificate persistence:**

* Introduced `MtlsBindingCertificate` property in `ManagedIdentityClient` to persist and manage the lifecycle of the binding certificate, including safe disposal of old certificates.

**Unit test improvements for mTLS PoP:**

* Updated unit tests to assert presence of `BindingCertificate` in mTLS PoP scenarios and verify correct caching and token source behavior. [[1]](diffhunk://#diff-5fd48f0c03e6b55dc8c9e6782bfa5bb68367d5502151dab256a16520095f3e10L269-R280) [[2]](diffhunk://#diff-5fd48f0c03e6b55dc8c9e6782bfa5bb68367d5502151dab256a16520095f3e10L308-R318) [[3]](diffhunk://#diff-5fd48f0c03e6b55dc8c9e6782bfa5bb68367d5502151dab256a16520095f3e10L335-L350) [[4]](diffhunk://#diff-5fd48f0c03e6b55dc8c9e6782bfa5bb68367d5502151dab256a16520095f3e10L376-L380)

**Minor logging and formatting fixes:**

* Corrected string interpolation in logging for CSR metadata and probe failure exceptions. [[1]](diffhunk://#diff-808d041a244e38d189b1537c14258b322045d65e51ddf066a97d5c8a5f1bd1f2L69-R69) [[2]](diffhunk://#diff-808d041a244e38d189b1537c14258b322045d65e51ddf066a97d5c8a5f1bd1f2L112-R112)