### PR TITLE
Support Android edge to edge

### DIFF
--- a/src/client/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/AuthenticationAgentActivity.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Android/EmbeddedWebview/AuthenticationAgentActivity.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
     internal class AuthenticationAgentActivity : Activity
     {
         private const string AboutBlankUri = "about:blank";
+        private const int ApiLevelVanillaIceCream = 35; // Android API 35 (Vanilla Ice Cream)
         private CoreWebViewClient _client;
 
         protected override void OnCreate(Bundle bundle)
@@ -70,7 +71,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
                 Window.SetDecorFitsSystemWindows(false);
                 
                 // For API 35+, ensure proper edge-to-edge behavior
-                if ((int)Build.VERSION.SdkInt >= 35) // API 35 (VanillaIceCream not available in current binding)
+                if ((int)Build.VERSION.SdkInt >= ApiLevelVanillaIceCream)
                 {
                     // Additional API 35 specific configurations using SetStatusBarColor/SetNavigationBarColor methods
                     Window.SetStatusBarColor(global::Android.Graphics.Color.Transparent);
@@ -86,6 +87,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
             if (Build.VERSION.SdkInt >= BuildVersionCodes.R) // API 30+
             {
                 ViewCompat.SetOnApplyWindowInsetsListener(parentLayout, new OnApplyWindowInsetsListener(webView));
+                ViewCompat.RequestApplyInsets(parentLayout);
             }
 #endif
         }
@@ -248,7 +250,7 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
                 var systemBarsInsets = insets.GetInsets(WindowInsetsCompat.Type.SystemBars());
                 var imeInsets = insets.GetInsets(WindowInsetsCompat.Type.Ime());
                 
-                // Apply padding to avoid system UI overlap
+                // Apply margins to avoid system UI overlap
                 var layoutParams = _webView.LayoutParameters as RelativeLayout.LayoutParams;
                 if (layoutParams != null)
                 {
@@ -260,8 +262,8 @@ namespace Microsoft.Identity.Client.Platforms.Android.EmbeddedWebview
                     );
                     _webView.LayoutParameters = layoutParams;
                 }
-                
-                return WindowInsetsCompat.Consumed;
+
+                return insets;
             }
         }
 #endif


### PR DESCRIPTION
Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

ICM: https://portal.microsofticm.com/imp/v5/incidents/details/687314906/summary

When running on API 35 devices the UI looks weird due to edge to edge scenarios.

Before:
<img width="422" height="903" alt="image" src="https://github.com/user-attachments/assets/a694a528-6ef4-4dc3-b64d-a4fc6f5f0d9f" />

After:
<img width="429" height="925" alt="image" src="https://github.com/user-attachments/assets/cc915766-9983-4166-85c9-64d456c88d73" />

I tested API 34 and 35 works fine.


**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
