### PR TITLE
ImdsV2: Created Factory to replace Imds GetValidatedEndpoint

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Identity.Client
 
         internal IRetryPolicyFactory RetryPolicyFactory { get; set; }
         internal ICsrFactory CsrFactory { get; set; }
+        internal IValidatedProbeEndpointFactory ValidatedProbeEndpointFactory { get; set; }
 
         #region ClientCredentials
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/BaseAbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/BaseAbstractApplicationBuilder.cs
@@ -46,6 +46,12 @@ namespace Microsoft.Identity.Client
             {
                 Config.CsrFactory = new DefaultCsrFactory();
             }
+
+            // Ensure the default validated probe endpoint factory is set if the test factory was not provided
+            if (Config.ValidatedProbeEndpointFactory == null)
+            {
+                Config.ValidatedProbeEndpointFactory = new DefaultValidatedProbeEndpointFactory();
+            }
         }
 
         internal ApplicationConfiguration Config { get; }
@@ -261,6 +267,17 @@ namespace Microsoft.Identity.Client
         internal T WithCsrFactory(ICsrFactory factory)
         {
             Config.CsrFactory = factory;
+            return (T)this;
+        }
+
+        /// <summary>
+        /// Internal only: Allows tests to inject a custom validated probe endpoint factory.
+        /// </summary>
+        /// <param name="factory">The validated probe endpoint factory to use.</param>
+        /// <returns>The builder for chaining.</returns>
+        internal T WithValidatedProbeEndpointFactory(IValidatedProbeEndpointFactory factory)
+        {
+            Config.ValidatedProbeEndpointFactory = factory;
             return (T)this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
@@ -178,27 +178,31 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         public static Uri GetValidatedEndpoint(
             ILoggerAdapter logger,
             string subPath,
-            string queryParams = null
+            string queryParams = null,
+            string existingImdsBaseEndpoint = null
             )
         {
-            UriBuilder builder;
-
-            if (!string.IsNullOrEmpty(EnvironmentVariables.PodIdentityEndpoint))
+            string baseEndpoint = null;
+            if (!string.IsNullOrEmpty(existingImdsBaseEndpoint))
+            {
+                logger.Verbose(() => "[Managed Identity] Using IMDS endpoint from an instance of IValidatedProbeEndpointFactory : " + existingImdsBaseEndpoint);
+                baseEndpoint = existingImdsBaseEndpoint;
+            }
+            else if (!string.IsNullOrEmpty(EnvironmentVariables.PodIdentityEndpoint))
             {
                 logger.Verbose(() => "[Managed Identity] Environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST for IMDS returned endpoint: " + EnvironmentVariables.PodIdentityEndpoint);
-                builder = new UriBuilder(EnvironmentVariables.PodIdentityEndpoint)
-                {
-                    Path = subPath
-                };
+                baseEndpoint = EnvironmentVariables.PodIdentityEndpoint;
             }
             else
             {
                 logger.Verbose(() => "[Managed Identity] Unable to find AZURE_POD_IDENTITY_AUTHORITY_HOST environment variable for IMDS, using the default endpoint.");
-                builder = new UriBuilder(DefaultImdsBaseEndpoint)
-                {
-                    Path = subPath
-                };
+                baseEndpoint = DefaultImdsBaseEndpoint;
             }
+
+            UriBuilder builder = new UriBuilder(baseEndpoint)
+            {
+                Path = subPath
+            };
 
             if (!string.IsNullOrEmpty(queryParams))
             {

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/DefaultValidatedProbeEndpointFactory.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/DefaultValidatedProbeEndpointFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Core;
+
+namespace Microsoft.Identity.Client.ManagedIdentity.V2
+{
+    internal class DefaultValidatedProbeEndpointFactory : IValidatedProbeEndpointFactory
+    {
+        public Uri GetValidatedEndpoint(ILoggerAdapter logger, string subPath, string queryParams)
+        {
+            return ImdsManagedIdentitySource.GetValidatedEndpoint(logger, subPath, queryParams);
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/IValidatedProbeEndpointFactory.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/IValidatedProbeEndpointFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Core;
+
+namespace Microsoft.Identity.Client.ManagedIdentity.V2
+{
+    internal interface IValidatedProbeEndpointFactory
+    {
+        Uri GetValidatedEndpoint(ILoggerAdapter logger, string subPath, string queryParams);
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
@@ -45,12 +45,14 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             IRetryPolicyFactory retryPolicyFactory = requestContext.ServiceBundle.Config.RetryPolicyFactory;
             IRetryPolicy retryPolicy = retryPolicyFactory.GetRetryPolicy(RequestType.CsrMetadataProbe);
 
+            IValidatedProbeEndpointFactory validatedProbeEndpointFactory = requestContext.ServiceBundle.Config.ValidatedProbeEndpointFactory;
+
             HttpResponse response = null;
 
             try
             {
                 response = await requestContext.ServiceBundle.HttpManager.SendRequestAsync(
-                    ImdsManagedIdentitySource.GetValidatedEndpoint(requestContext.Logger, CsrMetadataPath, queryParams),
+                    validatedProbeEndpointFactory.GetValidatedEndpoint(requestContext.Logger, CsrMetadataPath, queryParams),
                     headers,
                     body: null,
                     method: HttpMethod.Get,

--- a/tests/Microsoft.Identity.Test.Unit/Helpers/TestValidatedProbeEndpointFactory.cs
+++ b/tests/Microsoft.Identity.Test.Unit/Helpers/TestValidatedProbeEndpointFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Client.ManagedIdentity.V2;
+
+namespace Microsoft.Identity.Test.Unit.Helpers
+{
+    internal class TestValidatedProbeEndpointFactory : IValidatedProbeEndpointFactory
+    {
+        public Uri GetValidatedEndpoint(ILoggerAdapter logger, string subPath, string queryParams)
+        {
+            return ImdsManagedIdentitySource.GetValidatedEndpoint(logger, subPath, queryParams, Microsoft.Identity.Test.Unit.ManagedIdentityTests.ManagedIdentityTests.ImdsEndpoint);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
     [TestClass]
     public class ImdsV2Tests : TestBase
     {
+        private readonly TestCsrFactory _testCsrFactory = new TestCsrFactory(); 
         private readonly TestRetryPolicyFactory _testRetryPolicyFactory = new TestRetryPolicyFactory();
-        private readonly TestCsrFactory _testCsrFactory = new TestCsrFactory();
         private readonly IdentityLoggerAdapter _identityLoggerAdapter = new IdentityLoggerAdapter(
             new TestIdentityLogger(),
             Guid.Empty,


### PR DESCRIPTION
The `UnsupportedManagedIdentitySource_ThrowsExceptionDuringTokenAcquisition` in `ManagedIdentityTests.cs` was breaking for the Imds source.

The test sets the Imds endpoint to "unsupported://endpoint". This breaks the probe request before the acquireToken request has a chance to be (correctly) broken by this bad endpoint.

I've added a Factory so we can inject a custom endpoint into the probe request, for testing purposes.