### PR TITLE
Update logging to use string interpolation

### DIFF
--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Identity.Client
                 // filter by identifier of the user instead
                 accessTokensToDelete.RemoveAll(
                             item => !item.HomeAccountId.Equals(homeAccountId, StringComparison.OrdinalIgnoreCase));
-                requestParams.RequestContext.Logger.Info(() => "Matching entries after filtering by user - " + accessTokensToDelete.Count);
+                requestParams.RequestContext.Logger.Info($"Matching entries after filtering by user - {accessTokensToDelete.Count}");
             }
 
             foreach (var cacheItem in accessTokensToDelete)


### PR DESCRIPTION
Fixes - Update logging to use string interpolation

**Changes proposed in this request**
This pull request makes a minor improvement to the logging in the `DeleteAccessTokensWithIntersectingScopes` method by updating the way the log message is constructed.

* Logging update: Changed the log message construction from string concatenation to string interpolation for better readability and maintainability in `TokenCache.cs`.

**Testing**
unit, integration

**Performance impact**
n/a

**Documentation**
n/a
