### PR TITLE
WinFormsTestApp: purge stale lock/obj to drop Microsoft.WindowsDesktop.App.Ref 3.1.0 (fix CG Critical from #5482)

### DIFF
--- a/tests/devapps/WinFormsTestApp/WinFormsTestApp.csproj
+++ b/tests/devapps/WinFormsTestApp/WinFormsTestApp.csproj
@@ -10,6 +10,8 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <!-- Avoid sticky lockfiles for this test app -->
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
   </PropertyGroup>
 
   <!-- Platform-specific configurations -->


### PR DESCRIPTION
Fixes- CG alert

**Changes proposed in this request**
Component Governance flags a Critical alert for Microsoft.WindowsDesktop.App.Ref 3.1.0 during the WinForms test app build. There is no explicit reference in the repo; the alert results from restore artifacts/lockfile behavior. This PR prevents creation of a per-project lockfile for the test app so new builds resolve against current framework refs and do not surface the legacy package.

**Component detection** - https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1535830&view=logs&j=5af50cc2-dfd2-559f-4713-be7402902cc5&t=154cf91c-b1f3-57ab-1919-56f7d79b7fe3&l=2456 

**Rationale**

- The test app targets net8.0-windows* and uses framework refs (WinForms/WPF).
- CG was reading an older dependency resolution from lockfile/restore artifacts and attributing it to this project.
- Disabling the per-project lockfile for this test app ensures future restores don’t reintroduce the legacy Microsoft.WindowsDesktop.App.Ref 3.1.0 into the scanned graph.

**Testing**
devapp 

**Performance impact**
none

**Documentation**
n/a
