### PR TITLE
Replace buildautomation vault references with ID4sKeyVault and update…

### DIFF
--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -244,7 +244,8 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
-        public const string MsalCCAKeyVaultUri = "https://ID4sKeyVault.vault.azure.net/secrets/AzureADIdentityDivisionTestAgentSecret/";
+        public const string MsalCCAKeyVaultUri = "https://id4skeyvault.vault.azure.net/secrets/AzureADIdentityDivisionTestAgentSecret/";
+
         public const string MsalCCAKeyVaultSecretName = "MSIDLAB4-IDLABS-APP-AzureADMyOrg-CC";
         public const string MsalOBOKeyVaultUri = "https://id4skeyvault.vault.azure.net/secrets/IdentityDivisionDotNetOBOServiceSecret/";
         public const string MsalOBOKeyVaultSecretName = "IdentityDivisionDotNetOBOServiceSecret";

--- a/tests/Microsoft.Identity.Test.Common/TestConstants.cs
+++ b/tests/Microsoft.Identity.Test.Common/TestConstants.cs
@@ -244,9 +244,9 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
-        public const string MsalCCAKeyVaultUri = "https://buildautomation.vault.azure.net/secrets/AzureADIdentityDivisionTestAgentSecret/";
+        public const string MsalCCAKeyVaultUri = "https://ID4sKeyVault.vault.azure.net/secrets/AzureADIdentityDivisionTestAgentSecret/";
         public const string MsalCCAKeyVaultSecretName = "MSIDLAB4-IDLABS-APP-AzureADMyOrg-CC";
-        public const string MsalOBOKeyVaultUri = "https://buildautomation.vault.azure.net/secrets/IdentityDivisionDotNetOBOServiceSecret/";
+        public const string MsalOBOKeyVaultUri = "https://ID4sKeyVault.vault.azure.net/secrets/IdentityDivisionDotNetOBOServiceSecret/";
         public const string MsalOBOKeyVaultSecretName = "IdentityDivisionDotNetOBOServiceSecret";
         public const string MsalArlingtonOBOKeyVaultUri = "https://msidlabs.vault.azure.net:443/secrets/ARLMSIDLAB1-IDLASBS-App-CC-Secret";
         public const string MsalArlingtonOBOKeyVaultSecretName = "ARLMSIDLAB1-IDLASBS-App-CC-Secret";
@@ -594,7 +594,7 @@ namespace Microsoft.Identity.Test.Unit
         public const string ConfidentialClientId = "ConfidentialClientId";
         public const string ClientRedirectUri = "http://localhost:8080";
         public static readonly SortedSet<string> s_supportedScopes = new SortedSet<string>(new[] { "openid", "email", "profile" }, StringComparer.OrdinalIgnoreCase);
-        public const string ADFS2019ClientSecretURL = "https://buildautomation.vault.azure.net/secrets/ADFS2019ClientCredSecret/";
+        public const string ADFS2019ClientSecretURL = "https://ID4sKeyVault.vault.azure.net/secrets/ADFS2019ClientCredSecret/";
         public const string ADFS2019ClientSecretName = "ADFS2019ClientCredSecret";
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/WwwAuthenticateParametersIntegrationTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/WwwAuthenticateParametersIntegrationTests.NetFwk.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         public async Task CreateWwwAuthenticateResponseFromKeyVaultUrlAsync()
         {
             WwwAuthenticateParameters authParams = await WwwAuthenticateParameters.CreateFromAuthenticationResponseAsync(                
-                "https://buildautomation.vault.azure.net/secrets/CertName/CertVersion",
+                "https://ID4sKeyVault.vault.azure.net/secrets/CertName/CertVersion",
                 "Bearer")
                 .ConfigureAwait(false);
 

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
         /// The KeyVault maintained by the MSAL.NET team and have full control over. 
         /// Should be used temporarily - secrets should be stored and managed by MSID Lab.
         /// </summary>
-        public const string MsalTeam = "https://buildautomation.vault.azure.net/";
+        public const string MsalTeam = "https://ID4sKeyVault.vault.azure.net/";
     }
 
     public class KeyVaultSecretsProvider : IDisposable

--- a/tests/Microsoft.Identity.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
+++ b/tests/Microsoft.Identity.Test.LabInfrastructure/KeyVaultSecretsProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Identity.Test.LabInfrastructure
         /// The KeyVault maintained by the MSAL.NET team and have full control over. 
         /// Should be used temporarily - secrets should be stored and managed by MSID Lab.
         /// </summary>
-        public const string MsalTeam = "https://ID4sKeyVault.vault.azure.net/";
+        public const string MsalTeam = "https://id4skeyvault.vault.azure.net/";
     }
 
     public class KeyVaultSecretsProvider : IDisposable

--- a/tests/devapps/NetFxConsoleTestApp/Program.cs
+++ b/tests/devapps/NetFxConsoleTestApp/Program.cs
@@ -62,7 +62,7 @@ namespace NetFx
         private static readonly string s_confidentialClientSecret =
             Environment.GetEnvironmentVariable("LAB_APP_CLIENT_SECRET");
 
-        // https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/c1686c51-b717-4fe0-9af3-24a20a41fb0c/resourceGroups/ADALTesting/providers/Microsoft.KeyVault/vaults/buildautomation/secrets
+        // https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/c1686c51-b717-4fe0-9af3-24a20a41fb0c/resourceGroups/ID4STesting/providers/Microsoft.KeyVault/vaults/ID4sKeyVault/secrets
         private static readonly string s_secretForPoPValidationRequest =
             Environment.GetEnvironmentVariable("POP_VALIDATIONAPI_SECRET");
 


### PR DESCRIPTION
## Summary
This PR updates all references from the legacy buildautomation KeyVault to the new ID4sKeyVault infrastructure.

## Changes Made
- Updated `KeyVaultSecretsProvider.MsalTeam` constant to use ID4sKeyVault
- Updated all KeyVault URI constants in `TestConstants.cs`:
  - `MsalCCAKeyVaultUri`
  - `MsalOBOKeyVaultUri` 
  - `ADFS2019ClientSecretURL`
- Updated hardcoded URL in `WwwAuthenticateParametersIntegrationTests.NetFwk.cs`
- Updated resource group reference from "ADALTesting" to "ID4STesting"
- Updated comment reference in `NetFxConsoleTestApp/Program.cs`

## Files Modified
- `tests/Microsoft.Identity.Test.LabInfrastructure/KeyVaultSecretsProvider.cs`
- `tests/Microsoft.Identity.Test.Common/TestConstants.cs`
- `tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/WwwAuthenticateParametersIntegrationTests.NetFwk.cs`
- `tests/devapps/NetFxConsoleTestApp/Program.cs`

All URLs now point to `https://ID4sKeyVault.vault.azure.net/` instead of `https://buildautomation.vault.azure.net/`.