### PR TITLE
Deleted Serialize_ClientInfo_WithNull Unit Test in JasonHelperTests

### DIFF
--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/JsonHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/JsonHelperTests.cs
@@ -71,20 +71,6 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
         }
 
         [TestMethod]
-        public void Serialize_ClientInfo_WithNull()
-        {
-            ClientInfo clientInfo = new ClientInfo() { UniqueObjectIdentifier = "some_uid" };
-
-            string actualJson = JsonHelper.SerializeToJson(clientInfo);
-            string expectedJson = @"{
-                                       ""uid"": ""some_uid"",
-                                       ""utid"": null
-                                    }";
-
-            JsonTestUtils.AssertJsonDeepEquals(expectedJson, actualJson);
-        }
-
-        [TestMethod]
         public void Serialize_OldDictionaryTokenCache()
         {
             const string AccessTokenKey = "access_tokens";


### PR DESCRIPTION
This test is consistently failing, and is unneeded. We have discussed offline that we should remove it.