### PR TITLE
Updated DesktopOsHelper.IsMac to work properly on net10 + macOS 26

### DIFF
--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DesktopOsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/DesktopOsHelper.cs
@@ -52,11 +52,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 #elif NETFRAMEWORK
             return Environment.OSVersion.Platform == PlatformID.MacOSX;
 #elif NET8_0_OR_GREATER
-            string OSDescription = RuntimeInformation.OSDescription;
-
-            // .NET 10 and later changes the OS string in `OSDescription`
-            return OSDescription.Contains("Darwin", StringComparison.OrdinalIgnoreCase) ||
-                   OSDescription.Contains("macOS", StringComparison.OrdinalIgnoreCase);
+            return OperatingSystem.IsMacOS();
 #else
             return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 #endif


### PR DESCRIPTION
**Changes proposed in this request**
Before .NET 10, `RuntimeInformation.OSDescription` [called `uname`](https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/native/libs/System.Native/pal_runtimeinformation.c#L44) on *nix systems to populate itself. Now it uses a [nicer way](https://github.com/dotnet/runtime/blob/cc5f4c0ed72aad319bf032d03f9a99213845aeaf/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Unix.cs#L12) using the .NET runtime target information, that means that field no longer contains `Darwin`, so `IsMac` always returned false. This simply lets that method check for `macOs` as well.

**Testing**
I couldn't find any unit tests for this class.

**Performance impact**
None
