### PR TITLE
Fix interactive authentication tests to use confidential client app

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         [RunOn(TargetFrameworks.NetCore)]
         public async Task InteractiveConsentPromptAsync()
         {
-            LabResponse labResponse = await LabUserHelper.MergeKVLabDataAsync("MSAL-User-Default-JSON", "ID4SLAB1", "MSAL-APP-AzureADMultipleOrgsPC-JSON").ConfigureAwait(false);
+            LabResponse labResponse = await LabUserHelper.GetDefaultUserWithMultiTenantAppAsync().ConfigureAwait(false);
 
             await RunPromptTestForUserAsync(labResponse, Prompt.Consent, true).ConfigureAwait(false);
             await RunPromptTestForUserAsync(labResponse, Prompt.Consent, false).ConfigureAwait(false);
@@ -153,7 +153,7 @@ namespace Microsoft.Identity.Test.Integration.SeleniumTests
         [RunOn(TargetFrameworks.NetCore)]
         public async Task ValidateCcsHeadersForInteractiveAuthCodeFlowAsync()
         {
-            LabResponse labResponse = await LabUserHelper.MergeKVLabDataAsync("MSAL-User-Default-JSON", "ID4SLAB1", "MSAL-APP-AzureADMultipleOrgsPC-JSON").ConfigureAwait(false);
+            LabResponse labResponse = await LabUserHelper.GetDefaultUserWithMultiTenantAppAsync().ConfigureAwait(false);
 
             var pca = PublicClientApplicationBuilder
                .Create(labResponse.App.AppId)


### PR DESCRIPTION
## Problem
The InteractiveConsentPromptAsync and ValidateCcsHeadersForInteractiveAuthCodeFlowAsync tests were failing with AADSTS7000218 errors: The request body must contain the following parameter: client_assertion or client_secret.

## Root Cause
These tests were using the public client app (MSAL-APP-AzureADMultipleOrgsPC-JSON / ae585197-25c5-423b-be00-49175b144fd7) but trying to perform web-based interactive authentication with localhost redirect URIs. Azure AD requires client authentication for web flows with multi-tenant apps.

## Solution
Changed both tests to use the existing GetDefaultUserWithMultiTenantAppAsync() helper method which provides the confidential client app (54a2d933-8bf8-483b-a8f8-0a31924f3c1f) with proper client secret and certificates.

## Changes
- InteractiveConsentPromptAsync: Now uses GetDefaultUserWithMultiTenantAppAsync()
- ValidateCcsHeadersForInteractiveAuthCodeFlowAsync: Now uses GetDefaultUserWithMultiTenantAppAsync()

## Testing
Local testing confirms authentication configuration is now correct - uses confidential client app ID and no more AADSTS7000218 authentication errors. These 2 tests should now pass in CI pipeline.