### PR TITLE
Take home account from request, if not available elsewhere.

### DIFF
--- a/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
+++ b/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client
         public static string GetHomeAccountId(AuthenticationRequestParameters requestParams, MsalTokenResponse response, IdToken idToken)
         {
             ClientInfo clientInfo = response.ClientInfo != null ? ClientInfo.CreateFromJson(response.ClientInfo) : null;
-            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject ?? requestParams.Account.HomeAccountId.Identifier; // ADFS does not have client info, so we use subject
+            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject ?? requestParams.Account?.HomeAccountId?.Identifier; // ADFS does not have client info, so we use subject
 
             if (homeAccountId == null)
             {

--- a/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
+++ b/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client
         public static string GetHomeAccountId(AuthenticationRequestParameters requestParams, MsalTokenResponse response, IdToken idToken)
         {
             ClientInfo clientInfo = response.ClientInfo != null ? ClientInfo.CreateFromJson(response.ClientInfo) : null;
-            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject; // ADFS does not have client info, so we use subject
+            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject ?? requestParams.Account.HomeAccountId.Identifier; // ADFS does not have client info, so we use subject
 
             if (homeAccountId == null)
             {

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -1087,6 +1087,38 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         [TestMethod]
         [TestCategory(TestCategories.TokenCacheTests)]
+        public async Task SaveAccessAndRefreshTokenWithNoClientInfoAsync()
+        {
+            var serviceBundle = TestCommon.CreateDefaultServiceBundle();
+            ITokenCacheInternal cache = new TokenCache(serviceBundle, false);
+            MsalTokenResponse response = TestConstants.CreateMsalTokenResponse();
+
+            var requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
+            requestParams.AuthorityManager = new AuthorityManager(
+                requestParams.RequestContext,
+                Authority.CreateAuthorityWithTenant(
+                    requestParams.AuthorityInfo,
+                    TestConstants.Utid));
+            AddHostToInstanceCache(serviceBundle, TestConstants.ProductionPrefNetworkEnvironment);
+
+            await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(false);
+
+            requestParams.Account = new Account(_homeAccountId, null, null);
+            response.IdToken = null;
+            response.ClientInfo = null;
+            response.AccessToken = "access-token-2";
+            response.RefreshToken = "refresh-token-2";
+
+            await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(false);
+
+            Assert.AreEqual(1, cache.Accessor.GetAllRefreshTokens().Count());
+            Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
+            Assert.AreEqual("refresh-token-2", (cache.Accessor.GetAllRefreshTokens()).First().Secret);
+            Assert.AreEqual("access-token-2", (cache.Accessor.GetAllAccessTokens()).First().Secret);
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategories.TokenCacheTests)]
         public void CacheAdfsTokenTest()
         {
             using (var harness = CreateTestHarness())


### PR DESCRIPTION
Fixes #5618


**Changes proposed in this request**
When refreshing a token, PingIdentity does not return the home account.  This change takes the home account from the request if existing places do not supply it.

**Testing**
Added a test for the `TokenCache` for the PingIdentity scenario I face.

**Performance impact**
None done, minor impact of and extra `??` when there is no ID/client_info returned.

**Documentation**
This is a PR to fix an issue with the experimental feature of using an OIDC that is not Azure, namely PingIdentity.  When getting a refresh token, the client_info is not returned, and nor is a new identity token.  I believe that according to the spec these are optional so seems a valid scenario.  In this case to get the right cache key the home account is taken from the request.  If that is not present we will be back to a NRE again, but at least for PingIdentity we seem to be able to refresh tokens.

First PR here, so hopefully this is at least food for thought, if it is not the right approach.

Thanks for looking.
