### PR TITLE
Revert "Managed Identity: make IMDS probing explicit and restore DefaultToImds fallback (no-probe by default)"

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -44,10 +44,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             AcquireTokenForManagedIdentityParameters parameters,
             CancellationToken cancellationToken)
         {
-            AbstractManagedIdentity msi =
-                await GetOrSelectManagedIdentitySourceAsync(requestContext, parameters.IsMtlsPopRequested, cancellationToken)
-                    .ConfigureAwait(false);
-
+            AbstractManagedIdentity msi = await GetOrSelectManagedIdentitySourceAsync(requestContext, parameters.IsMtlsPopRequested, cancellationToken).ConfigureAwait(false);
             return await msi.AuthenticateAsync(parameters, cancellationToken).ConfigureAwait(false);
         }
 
@@ -67,15 +64,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 // If the source is not already set, determine it
                 if (s_sourceName == ManagedIdentitySource.None)
                 {
-                    // Default behavior: do NOT probe IMDS during selection.
-                    // If no env-based source is found, this will return DefaultToImds.
-                    sourceResult = await GetManagedIdentitySourceAsync(
-                        requestContext,
-                        isMtlsPopRequested,
-                        probe: false,
-                        cancellationToken)
-                        .ConfigureAwait(false);
-
+                    // First invocation: detect and cache
+                    sourceResult = await GetManagedIdentitySourceAsync(requestContext, isMtlsPopRequested, cancellationToken).ConfigureAwait(false);
                     source = sourceResult.Source;
                 }
                 else
@@ -89,7 +79,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 if (source == ManagedIdentitySource.ImdsV2 && !isMtlsPopRequested)
                 {
                     requestContext.Logger.Info("[Managed Identity] ImdsV2 detected, but mTLS PoP was not requested. Falling back to ImdsV1 for this request only. Please use the \"WithMtlsProofOfPossession\" API to request a token via ImdsV2.");
-
+                    
                     // Mark that we used IMDSv1 in this process while IMDSv2 is cached (preview behavior).
                     s_imdsV1UsedForPreview = true;
 
@@ -107,9 +97,9 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                         MsalErrorMessage.CannotSwitchBetweenImdsVersionsForPreview);
                 }
 
-                // If we are in DefaultToImds (no-probe sentinel) and PoP was requested,
-                // fail fast rather than implicitly probing/attempting IMDSv2.
-                if (source == ManagedIdentitySource.DefaultToImds && isMtlsPopRequested)
+                // If the source is determined to be ImdsV1 and mTLS PoP was requested,
+                // throw an exception since ImdsV1 does not support mTLS PoP
+                if (source == ManagedIdentitySource.Imds && isMtlsPopRequested)
                 {
                     throw new MsalClientException(
                         MsalError.MtlsPopTokenNotSupportedinImdsV1,
@@ -123,11 +113,6 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     ManagedIdentitySource.MachineLearning => MachineLearningManagedIdentitySource.Create(requestContext),
                     ManagedIdentitySource.CloudShell => CloudShellManagedIdentitySource.Create(requestContext),
                     ManagedIdentitySource.AzureArc => AzureArcManagedIdentitySource.Create(requestContext),
-                    // DefaultToImds means: no env-based source detected; don't probe; fall back to IMDS as the default source.
-                    // For mTLS PoP requests we must use the IMDSv2 flow. For non-PoP, use IMDSv1 flow.
-                    ManagedIdentitySource.DefaultToImds => isMtlsPopRequested
-                        ? ImdsV2ManagedIdentitySource.Create(requestContext)
-                        : ImdsManagedIdentitySource.Create(requestContext),
                     ManagedIdentitySource.ImdsV2 => ImdsV2ManagedIdentitySource.Create(requestContext),
                     ManagedIdentitySource.Imds => ImdsManagedIdentitySource.Create(requestContext),
                     _ => throw CreateManagedIdentityUnavailableException(sourceResult)
@@ -140,7 +125,6 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         internal async Task<ManagedIdentitySourceResult> GetManagedIdentitySourceAsync(
             RequestContext requestContext,
             bool isMtlsPopRequested,
-            bool probe,
             CancellationToken cancellationToken)
         {
             // First check env vars to avoid the probe if possible
@@ -151,33 +135,19 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 return new ManagedIdentitySourceResult(source);
             }
 
-            // Default behavior: do NOT probe IMDS here.
-            // If no env-based source is found, return DefaultToImds and do not throw.
-            if (!probe)
-            {
-                requestContext.Logger.Info("[Managed Identity] No environment-based source detected. Returning DefaultToImds without probing.");
-                s_sourceName = ManagedIdentitySource.DefaultToImds;
-                return new ManagedIdentitySourceResult(s_sourceName);
-            }
-
-            // Probe mode: probe IMDS and return None if unreachable (no fatal throw from detection)
             string imdsV2FailureReason = null;
             string imdsV1FailureReason = null;
 
             // skip the ImdsV2 probe if MtlsPop was NOT requested
             if (isMtlsPopRequested)
             {
-                var (imdsV2Success, imdsV2Failure) =
-                    await ImdsManagedIdentitySource.ProbeImdsEndpointAsync(requestContext, ImdsVersion.V2, cancellationToken)
-                        .ConfigureAwait(false);
-
+                var (imdsV2Success, imdsV2Failure) = await ImdsManagedIdentitySource.ProbeImdsEndpointAsync(requestContext, ImdsVersion.V2, cancellationToken).ConfigureAwait(false);
                 if (imdsV2Success)
                 {
                     requestContext.Logger.Info("[Managed Identity] ImdsV2 detected.");
                     s_sourceName = ManagedIdentitySource.ImdsV2;
                     return new ManagedIdentitySourceResult(s_sourceName);
                 }
-
                 imdsV2FailureReason = imdsV2Failure;
             }
             else
@@ -185,22 +155,18 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 requestContext.Logger.Info("[Managed Identity] Mtls Pop was not requested; skipping ImdsV2 probe.");
             }
 
-            var (imdsV1Success, imdsV1Failure) =
-                await ImdsManagedIdentitySource.ProbeImdsEndpointAsync(requestContext, ImdsVersion.V1, cancellationToken)
-                    .ConfigureAwait(false);
-
+            var (imdsV1Success, imdsV1Failure) = await ImdsManagedIdentitySource.ProbeImdsEndpointAsync(requestContext, ImdsVersion.V1, cancellationToken).ConfigureAwait(false);
             if (imdsV1Success)
             {
                 requestContext.Logger.Info("[Managed Identity] ImdsV1 detected.");
                 s_sourceName = ManagedIdentitySource.Imds;
                 return new ManagedIdentitySourceResult(s_sourceName);
             }
-
             imdsV1FailureReason = imdsV1Failure;
 
             requestContext.Logger.Info($"[Managed Identity] {MsalErrorMessage.ManagedIdentityAllSourcesUnavailable}");
             s_sourceName = ManagedIdentitySource.None;
-
+            
             return new ManagedIdentitySourceResult(s_sourceName)
             {
                 ImdsV1FailureReason = imdsV1FailureReason,
@@ -259,8 +225,10 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 logger?.Info("[Managed Identity] Azure Arc detected.");
                 return ManagedIdentitySource.AzureArc;
             }
-
-            return ManagedIdentitySource.None;
+            else
+            {
+                return ManagedIdentitySource.None;
+            }
         }
 
         // Method to return true if a file exists and is not empty to validate the Azure arc environment.
@@ -284,8 +252,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             {
                 logger?.Verbose(() => "[Managed Identity] Azure Arc managed identity is available through file detection.");
                 return true;
-            }
-
+            } 
+            
             logger?.Verbose(() => "[Managed Identity] Azure Arc managed identity is not available.");
             return false;
         }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         /// Indicates that the source is defaulted to IMDS since no environment variables are set.
         /// This is used to detect the managed identity source.
         /// </summary>
+        [Obsolete("In use only to support the now obsolete GetManagedIdentitySource API. Will be removed in a future version. Use GetManagedIdentitySourceAsync instead.")]
         DefaultToImds,
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySourceResult.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySourceResult.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
     /// Result of managed identity source detection, including the detected source and any failure information from IMDS probes.
     /// </summary>
     /// <remarks>
-    /// This class is returned by <see cref="ManagedIdentityApplication.GetManagedIdentitySourceAsync(bool, System.Threading.CancellationToken)"/> to provide
+    /// This class is returned by <see cref="ManagedIdentityApplication.GetManagedIdentitySourceAsync"/> to provide
     /// detailed information about managed identity source detection, including failure reasons when IMDS probes fail.
     /// This information is useful for credential chains like DefaultAzureCredential to determine whether to skip
     /// managed identity authentication entirely.

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -55,40 +55,19 @@ namespace Microsoft.Identity.Client
                 resource);
         }
 
-        /// <summary>
-        /// Detects and returns the managed identity source available on the environment.
-        /// probe=false: no IMDS probe; returns DefaultToImds if no env-based MI source detected.
-        /// probe=true: probes IMDS; returns None if IMDS is unreachable.
-        /// </summary>
-        public async Task<ManagedIdentitySourceResult> GetManagedIdentitySourceAsync(
-            bool probe,
-            CancellationToken cancellationToken)
+        /// <inheritdoc/>
+        public async Task<ManagedIdentitySourceResult> GetManagedIdentitySourceAsync(CancellationToken cancellationToken)
         {
-            var cached = ManagedIdentityClient.s_sourceName;
-
-            if (!probe && cached != ManagedIdentitySource.None)
+            if (ManagedIdentityClient.s_sourceName != ManagedIdentitySource.None)
             {
-                return new ManagedIdentitySourceResult(cached);
+                return new ManagedIdentitySourceResult(ManagedIdentityClient.s_sourceName);
             }
 
-            if (probe && cached != ManagedIdentitySource.None)
-            {
-                if (cached != ManagedIdentitySource.DefaultToImds)
-                {
-                    // Cache contains a concrete source; no need to probe again.
-                    return new ManagedIdentitySourceResult(cached);
-                }
-
-                // If cached is DefaultToImds, probing can refine to Imds/ImdsV2/None.
-            }
-
-            // Create a temporary RequestContext for the logger and the optional IMDS probe request.
+            // Create a temporary RequestContext for the logger and the IMDS probe request.
             var requestContext = new RequestContext(this.ServiceBundle, Guid.NewGuid(), null, cancellationToken);
 
-            // Use isMtlsPopRequested: true so probe mode can detect IMDSv2 capability when available.
-            return await ManagedIdentityClient
-                .GetManagedIdentitySourceAsync(requestContext, isMtlsPopRequested: true, probe: probe, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+            // GetManagedIdentitySourceAsync might return ImdsV2 = true, but it still requires .WithMtlsProofOfPossesion on the Managed Identity Application object to hit the ImdsV2 flow
+            return await ManagedIdentityClient.GetManagedIdentitySourceAsync(requestContext, isMtlsPopRequested: true, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -101,9 +80,11 @@ namespace Microsoft.Identity.Client
             var source = ManagedIdentityClient.GetManagedIdentitySourceNoImds();
             
             return source == ManagedIdentitySource.None
+#pragma warning disable CS0618
                 // ManagedIdentitySource.DefaultToImds is marked obsolete, but is intentionally used here as a sentinel value to support legacy detection logic.
                 // This value signals that none of the environment-based managed identity sources were detected.
                 ? ManagedIdentitySource.DefaultToImds
+#pragma warning restore CS0618
                 : source;
 
         }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
@@ -1117,5 +1117,6 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2Fail
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ManagedIdentitySourceResult(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.Source.get -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder.WithSendX5C(bool withSendX5C) -> Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder
 

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
-Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(bool probe, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.ManagedIdentityPopExtensions
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
@@ -1117,5 +1117,6 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2Fail
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ManagedIdentitySourceResult(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.Source.get -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder.WithSendX5C(bool withSendX5C) -> Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder
 

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
-Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(bool probe, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.ManagedIdentityPopExtensions
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
@@ -1083,4 +1083,6 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2Fail
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ManagedIdentitySourceResult(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.Source.get -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder.WithSendX5C(bool withSendX5C) -> Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
-Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(bool probe, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.ManagedIdentityPopExtensions
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
@@ -1085,4 +1085,6 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2Fail
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ManagedIdentitySourceResult(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.Source.get -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder.WithSendX5C(bool withSendX5C) -> Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
-Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(bool probe, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.ManagedIdentityPopExtensions
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
@@ -1079,4 +1079,6 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2Fail
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ManagedIdentitySourceResult(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.Source.get -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder.WithSendX5C(bool withSendX5C) -> Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
-Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(bool probe, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.ManagedIdentityPopExtensions
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -1079,4 +1079,6 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2Fail
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ManagedIdentitySourceResult(Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.Source.get -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
+Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder.WithSendX5C(bool withSendX5C) -> Microsoft.Identity.Client.AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
-Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySourceAsync(bool probe, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult>
 Microsoft.Identity.Client.ManagedIdentityPopExtensions
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/AppServiceTests.cs
@@ -65,9 +65,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var miBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
                     .WithHttpManager(httpManager);
 
+                
+                
+
                 ManagedIdentityApplication mi = miBuilder.Build() as ManagedIdentityApplication;
 
-                var miSourceResult = await mi.GetManagedIdentitySourceAsync(probe: false, cancellationToken: ManagedIdentityTests.ImdsProbesCancellationToken).ConfigureAwait(false);
+                var miSourceResult = await mi.GetManagedIdentitySourceAsync(ManagedIdentityTests.ImdsProbesCancellationToken).ConfigureAwait(false);
                 Assert.AreEqual(expectedManagedIdentitySource, miSourceResult.Source);
             }
         }


### PR DESCRIPTION
Reverts AzureAD/microsoft-authentication-library-for-dotnet#5656