### PR TITLE
Unbsolete Managed Identity API

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySource.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         /// Indicates that the source is defaulted to IMDS since no environment variables are set.
         /// This is used to detect the managed identity source.
         /// </summary>
-        [Obsolete("In use only to support the now obsolete GetManagedIdentitySource API. Will be removed in a future version. Use GetManagedIdentitySourceAsync instead.")]
         DefaultToImds,
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -74,17 +74,12 @@ namespace Microsoft.Identity.Client
         /// Detects and returns the managed identity source available on the environment.
         /// </summary>
         /// <returns>Managed identity source detected on the environment if any.</returns>
-        [Obsolete("Use GetManagedIdentitySourceAsync() instead. \"ManagedIdentityApplication mi = miBuilder.Build() as ManagedIdentityApplication;\"")]
         public static ManagedIdentitySource GetManagedIdentitySource()
         {
             var source = ManagedIdentityClient.GetManagedIdentitySourceNoImds();
             
             return source == ManagedIdentitySource.None
-#pragma warning disable CS0618
-                // ManagedIdentitySource.DefaultToImds is marked obsolete, but is intentionally used here as a sentinel value to support legacy detection logic.
-                // This value signals that none of the environment-based managed identity sources were detected.
                 ? ManagedIdentitySource.DefaultToImds
-#pragma warning restore CS0618
                 : source;
 
         }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -1549,5 +1549,33 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             Assert.AreEqual("value3", miBuilder.Config.ExtraQueryParameters["param3"]);
             Assert.AreEqual("value4", miBuilder.Config.ExtraQueryParameters["param4"]);
         }
+
+        [DataTestMethod]
+        // IMDS sources should default to DefaultToImds
+        [DataRow(ManagedIdentitySource.Imds, null, ManagedIdentitySource.DefaultToImds)]
+        [DataRow(ManagedIdentitySource.ImdsV2, null, ManagedIdentitySource.DefaultToImds)]
+        // Non-IMDS sources should return their respective source
+        [DataRow(ManagedIdentitySource.AppService, AppServiceEndpoint, ManagedIdentitySource.AppService)]
+        [DataRow(ManagedIdentitySource.AzureArc, AzureArcEndpoint, ManagedIdentitySource.AzureArc)]
+        [DataRow(ManagedIdentitySource.CloudShell, CloudShellEndpoint, ManagedIdentitySource.CloudShell)]
+        [DataRow(ManagedIdentitySource.ServiceFabric, ServiceFabricEndpoint, ManagedIdentitySource.ServiceFabric)]
+        [DataRow(ManagedIdentitySource.MachineLearning, MachineLearningEndpoint, ManagedIdentitySource.MachineLearning)]
+        public void GetManagedIdentitySource_StaticApi_ReturnsExpectedSource(
+            ManagedIdentitySource envConfiguredSource,
+            string endpoint,
+            ManagedIdentitySource expected)
+        {
+            using (new EnvVariableContext())
+            {
+                // Arrange: configure environment variables for the desired source
+                SetEnvironmentVariables(envConfiguredSource, endpoint);
+
+                // Act
+                ManagedIdentitySource actual = ManagedIdentityApplication.GetManagedIdentitySource();
+
+                // Assert
+                Assert.AreEqual(expected, actual);
+            }
+        }
     }
 }


### PR DESCRIPTION
**Needs approval from Chris - Ongoing discussions around this** 

This pull request focuses on cleaning up obsolete warnings and improving test coverage for managed identity source detection logic. The main changes include removing `[Obsolete]` attributes and related comments from legacy APIs, and adding new unit tests to verify the behavior of managed identity source detection.

**Obsolete attribute and legacy API cleanup:**

* Removed the `[Obsolete]` attribute from the `DefaultToImds` member of the `ManagedIdentitySource` enum in `ManagedIdentitySource.cs`.
* Removed the `[Obsolete]` attribute and related pragma warning comments from the `GetManagedIdentitySource()` method in `ManagedIdentityApplication.cs`, simplifying the legacy detection logic.

**Test improvements:**

* Added a new data-driven unit test `GetManagedIdentitySource_StaticApi_ReturnsExpectedSource` in `ManagedIdentityTests.cs` to verify that IMDS sources default to `DefaultToImds` and other sources return their respective type.