### PR TITLE
Fix fallback where OpenTelemetry instrumentation is not available

### DIFF
--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/AbstractPlatformProxy.cs
@@ -61,7 +61,11 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             try
             {
                 return new OtelInstrumentation();
-            } catch (FileNotFoundException ex) 
+            }
+            catch (Exception ex) 
+            when (ex is FileNotFoundException
+                     or TypeLoadException
+                     or TypeInitializationException)
             {
                 // Can happen in in-process Azure Functions: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4456
                 Logger.Warning("Failed instantiating OpenTelemetry instrumentation. Exception: " + ex.Message);
@@ -247,3 +251,4 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         public IManagedIdentityKeyProvider ManagedIdentityKeyProvider => _miKeyProvider.Value;
     }
 }
+


### PR DESCRIPTION
When initializing OTel, additionally catch `TypeLoadException` and `TypeInitializationException` which wrap existing catch of `FileNotFoundException` when only older version of `System.Diagnostics.DiagnosticSource` is loaded, such as on some Azure Functions versions.

Follow up to https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/4487

edit: I can see this was actually [already considered](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/4486/changes#r1443839669) but it was decided to only include if the other exceptions were observed. I'm observing `TypeLoadException`.