### PR TITLE
Expose expires on in attestation token #5739

### DIFF
--- a/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/AttestationResult.cs
+++ b/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/AttestationResult.cs
@@ -7,21 +7,24 @@ namespace Microsoft.Identity.Client.KeyAttestation.Attestation
     /// AttestationResult is the result of an attestation operation.
     /// </summary>
     /// <param name="Status">High-level outcome category.</param>
-    /// <param name="Jwt">JWT on success; null otherwise (caller may pass null).</param>
+    /// <param name="Token">Structured attestation token with expiry on success; null otherwise (caller may pass null).</param>
+    /// <param name="Jwt">JWT on success; null otherwise (caller may pass null). Retained for backward compatibility.</param>
     /// <param name="NativeErrorCode">Raw native return code (0 on success).</param>
     /// <param name="ErrorMessage">Optional descriptive text for non-success cases.</param>
     /// <remarks>
     /// This is a positional record. The compiler synthesizes init-only auto-properties:
     ///   public AttestationStatus Status { get; init; }
-    ///   public string Jwt           { get; init; }
-    ///   public int NativeErrorCode  { get; init; }
-    ///   public string ErrorMessage  { get; init; }
+    ///   public AttestationToken Token  { get; init; }
+    ///   public string Jwt              { get; init; }
+    ///   public int NativeErrorCode     { get; init; }
+    ///   public string ErrorMessage     { get; init; }
     /// Because they are init-only, values are fixed after construction; to "modify" use a 'with'
     /// expression, e.g.: var updated = result with { Jwt = newJwt };
     /// The netstandard2.0 target relies on the IsExternalInit shim (see IsExternalInit.cs) to enable 'init'.
     /// </remarks>
     internal sealed record AttestationResult(
         AttestationStatus Status,
+        AttestationToken Token,
         string Jwt,
         int NativeErrorCode,
         string ErrorMessage);

--- a/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/AttestationToken.cs
+++ b/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/AttestationToken.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Identity.Client.KeyAttestation.Attestation
+{
+    /// <summary>
+    /// Represents a successfully attested token with structured metadata.
+    /// </summary>
+    /// <param name="Token">The raw JWT string.</param>
+    /// <param name="ExpiresOn">The expiration time of the token (UTC).</param>
+    /// <remarks>
+    /// Internal use only. This record enables the library to access token expiry 
+    /// without requiring callers to manually decode the JWT.
+    /// </remarks>
+    internal sealed record AttestationToken(
+        string Token,
+        DateTimeOffset ExpiresOn);
+}

--- a/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/JwtClaimExtractor.cs
+++ b/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/JwtClaimExtractor.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Client.KeyAttestation.Attestation
+{
+    /// <summary>
+    /// JWT claim extractor leveraging MSAL's existing helper utilities.
+    /// </summary>
+    internal static class JwtClaimExtractor
+    {
+        /// <summary>
+        /// Extracts the 'exp' (expiration) claim from a JWT payload.
+        /// </summary>
+        /// <param name="jwt">The JWT string (format: header.payload.signature).</param>
+        /// <param name="expiresOn">The parsed expiration time in UTC, or DateTimeOffset.MinValue on failure.</param>
+        /// <returns>True if the exp claim was successfully extracted; false otherwise.</returns>
+        internal static bool TryExtractExpirationClaim(string jwt, out DateTimeOffset expiresOn)
+        {
+            expiresOn = DateTimeOffset.MinValue;
+
+            try
+            {
+                // Split JWT into parts
+                var parts = jwt.Split('.');
+                if (parts.Length < 2)
+                    return false;
+
+                // Use MSAL's Base64UrlHelpers to decode the payload (handles padding automatically)
+                string payloadJson = Base64UrlHelpers.Decode(parts[1]);
+
+                if (string.IsNullOrEmpty(payloadJson))
+                    return false;
+
+                // Use MSAL's JsonHelper to parse JSON (handles both System.Text.Json and Newtonsoft)
+                var claims = JsonHelper.DeserializeFromJson<Dictionary<string, object>>(payloadJson);
+
+                if (claims == null || !claims.TryGetValue("exp", out object expObj))
+                    return false;
+
+                // Parse the exp claim (Unix timestamp in seconds)
+                if (expObj is long expLong)
+                {
+                    expiresOn = DateTimeOffset.FromUnixTimeSeconds(expLong);
+                    return true;
+                }
+
+                // Handle case where exp comes as string (defensive)
+                if (expObj is string expStr && long.TryParse(expStr, out long parsedExp))
+                {
+                    expiresOn = DateTimeOffset.FromUnixTimeSeconds(parsedExp);
+                    return true;
+                }
+            }
+            catch
+            {
+                // Silently fail: malformed JWT or parsing error
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client.KeyAttestation/PopKeyAttestor.cs
+++ b/src/client/Microsoft.Identity.Client.KeyAttestation/PopKeyAttestor.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Client.KeyAttestation
                 catch (Exception ex)
                 {
                     // Map any managed exception to AttestationStatus.Exception for consistency.
-                    return new AttestationResult(AttestationStatus.Exception, string.Empty, -1, ex.Message);
+                    return new AttestationResult(AttestationStatus.Exception, null, string.Empty, -1, ex.Message);
                 }
             }, cancellationToken);
         }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/TestAttestationProviders.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/TestAttestationProviders.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             return (attestationEndpoint, keyHandle, clientId, cancellationToken) =>
             {
                 var fakeJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.fake.attestation.sig";
-                return Task.FromResult(new AttestationResult(AttestationStatus.Success, fakeJwt, 0, string.Empty));
+                var token = new AttestationToken(fakeJwt, DateTimeOffset.UtcNow.AddHours(1));
+                return Task.FromResult(new AttestationResult(AttestationStatus.Success, token, fakeJwt, 0, string.Empty));
             };
         }
 


### PR DESCRIPTION
Fixes #5739

**Changes proposed in this request**
This pull request enhances the attestation result returned by the attestation client to include structured token expiry information, making it easier for caching based on the expiration of attestation JWTs without manual decoding. The main changes introduce a new `AttestationToken` type, extract expiry from JWTs, and update code and tests to use the new structure.

**Attestation result structure and expiry extraction:**

* Introduced a new `AttestationToken` record that encapsulates the raw JWT and its expiration (`ExpiresOn`), allowing structured access to expiry metadata.
* Updated the `AttestationResult` record to include the new `Token` property, and updated all usages and documentation to reflect this addition. The original `Jwt` string is retained for backward compatibility. [[1]](diffhunk://#diff-263c25ddb1616216dedc6b7abb13ff200ca292aa0b3fa9da90c6d72f59b6fa29L10-R17) [[2]](diffhunk://#diff-263c25ddb1616216dedc6b7abb13ff200ca292aa0b3fa9da90c6d72f59b6fa29R27)
* Implemented a new `JwtClaimExtractor` utility class to extract the `exp` (expiration) claim from JWT payloads using existing MSAL utilities.

**Attestation client and error handling updates:**

* Modified `AttestationClient.Attest` to extract the expiry from the JWT, populate the new `AttestationToken`, and update all error paths to use the new result structure. [[1]](diffhunk://#diff-b22f9f2e99c07481e8129764debea9224143585eb3ca9f0e4affefb16561d19eL12-R12) [[2]](diffhunk://#diff-b22f9f2e99c07481e8129764debea9224143585eb3ca9f0e4affefb16561d19eL40-R47) [[3]](diffhunk://#diff-b22f9f2e99c07481e8129764debea9224143585eb3ca9f0e4affefb16561d19eL61-R92)
* Updated error handling in `PopKeyAttestor` and unit tests to construct `AttestationResult` with the new `Token` property, ensuring consistency across the codebase. [[1]](diffhunk://#diff-6a089356bf47f7583d0c83b8e1d43ac615e597ddc9a9fb958d4338aa2cfbf965L73-R73) [[2]](diffhunk://#diff-decfebf37424759dcedfad85327ea93c96122b8c22a342cdfc13cc4039157530L26-R27)

**Testing**
Updated existing tests. 

**Performance impact**
none

**Documentation**
- [ ] All relevant documentation is updated.
