### PR TITLE
Update result to pass the tenant id in case of client credentials.

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -218,7 +218,9 @@ namespace Microsoft.Identity.Client
             }
 
             UniqueId = msalIdTokenCacheItem?.IdToken?.GetUniqueId();
-            TenantId = msalIdTokenCacheItem?.IdToken?.TenantId;
+            // For client credentials flow, ID token is not available, so fall back to access token's tenant
+            // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5743
+            TenantId = msalIdTokenCacheItem?.IdToken?.TenantId ?? msalAccessTokenCacheItem?.TenantId;
             IdToken = msalIdTokenCacheItem?.Secret;
             SpaAuthCode = spaAuthCode;
             _authenticationScheme = authenticationScheme;


### PR DESCRIPTION
Fixes #5743 

**Changes proposed in this request**
Update to populate the tenant id when not available in id token

**Testing**
Added integration test

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
