### PR TITLE
Remove TOKEN_ATTESTATION_ENDPOINT check from tests

### DIFF
--- a/tests/Microsoft.Identity.Test.E2e/ManagedIdentityImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.E2e/ManagedIdentityImdsV2Tests.cs
@@ -68,13 +68,6 @@ namespace Microsoft.Identity.Test.E2E
                 Assert.Inconclusive("Credential Guard attestation is only available on Windows.");
             }
 
-            // Check if TOKEN_ATTESTATION_ENDPOINT is configured (required for attestation)
-            var attestationEndpoint = Environment.GetEnvironmentVariable("TOKEN_ATTESTATION_ENDPOINT");
-            if (string.IsNullOrWhiteSpace(attestationEndpoint))
-            {
-                Assert.Inconclusive("TOKEN_ATTESTATION_ENDPOINT is not configured. Attestation tests require this environment variable.");
-            }
-
             var mi = BuildMi(id, idType);
 
             try


### PR DESCRIPTION
Removed check for TOKEN_ATTESTATION_ENDPOINT environment variable in attestation tests.

Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
