### PR TITLE
Fix tenant mismatch in GetFmiCredentialFromRma FMI integration test

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/FmiIntegrationTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/FmiIntegrationTests.cs
@@ -239,15 +239,14 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         private static async Task<string> GetFmiCredentialFromRma(AssertionRequestOptions options)
         {
             //Fmi app/scenario parameters
-            var clientId = "4df2cbbb-8612-49c1-87c8-f334d6d065ad";
             var scope = "api://AzureFMITokenExchange/.default";
 
             X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
 
             //Create application
             var confidentialApp = ConfidentialClientApplicationBuilder
-                        .Create(clientId)
-                        .WithAuthority("https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca", true)
+                        .Create(RmaClientId)
+                        .WithAuthority("https://login.microsoftonline.com/", TenantId)
                         .WithCertificate(cert, sendX5C: true) //sendX5c enables SN+I auth which is required for FMI flows
                         .WithAzureRegion(AzureRegion)
                         .BuildConcrete();


### PR DESCRIPTION
Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
The `GetFmiCredentialFromRma` helper method had a hardcoded old tenant ID (`f645ad92-e38d-4d1a-b510-d1b09a74a8ca`) that was missed when the `TenantId` constant was updated to `10c419d4-4a50-45b2-aa4e-919fb84df24f` in PR #5605. This causes `AADSTS70057` because the FMI credential's issuer tenant does not match the consuming app's tenant.

Replaced the hardcoded tenant with the shared `TenantId` constant to match the rest of the file.

**Testing**
This fixes the existing `Flow3_FmiCredential_From_AnotherFmiCredential`, `Flow5_FmiToken_From_FmiCred`, and `Flow4_SubRma_FIC_From_FmiCredential` integration tests which all call `GetFmiCredentialFromRma`.

**Performance impact**
None.

**Documentation**
- [x] All relevant documentation is updated.