### PR TITLE
Add discoverable SKILL.md for auth-code-flow, client-credentials, and obo-flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,18 +45,24 @@ Copilot will automatically reference and describe:
 - `@msal-mtls-pop-guidance` - Foundational concepts
 - `@msal-mtls-pop-vanilla` - Direct token acquisition
 - `@msal-mtls-pop-fic-two-leg` - Token exchange patterns
+- `@msal-auth-code-flow` - Authorization Code Flow
+- `@msal-client-credentials` - Client Credentials Flow
+- `@msal-obo-flow` - On-Behalf-Of Flow
 
 ---
 
 ## 📚 Available Skills Overview
 
-This repository contains **three GitHub Agent Skills** for mTLS Proof-of-Possession (PoP) authentication:
+This repository contains **six GitHub Agent Skills** for MSAL.NET authentication:
 
 | Skill | Purpose | Best For |
 |-------|---------|----------|
 | **@msal-mtls-pop-guidance** | Foundational concepts, terminology, decision frameworks | Learning the fundamentals, comparing approaches |
 | **@msal-mtls-pop-vanilla** | Direct single-step token acquisition with complete code | Quick implementation with MSI or Confidential Client |
 | **@msal-mtls-pop-fic-two-leg** | Two-step token exchange patterns | Complex scenarios requiring token exchange |
+| **@msal-auth-code-flow** | Authorization Code Flow for web apps | User sign-in with server-side backend |
+| **@msal-client-credentials** | Client Credentials Flow for daemons | Service-to-service, no user context |
+| **@msal-obo-flow** | On-Behalf-Of Flow for multi-tier APIs | Propagating user identity through API chain |
 
 ---
 

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -13,15 +13,15 @@ GitHub Copilot Agent Skills are specialized knowledge modules that help Copilot 
 
 ## Available Skills
 
-### 1. Confidential Client Authentication (`msal-confidential-auth/`)
+### 1. Confidential Client Authentication
 
-A comprehensive skill set for confidential client authentication patterns in MSAL.NET, covering three core flows with granularized, reusable credential setup patterns.
+Three individual skills for confidential client authentication patterns in MSAL.NET, with reusable credential setup patterns in `msal-shared/`.
 
 #### Authentication Flows
 
-- **[Authorization Code Flow](msal-confidential-auth/auth-code-flow/SKILL.md)** - Web applications with user sign-in
-- **[On-Behalf-Of (OBO) Flow](msal-confidential-auth/obo-flow/SKILL.md)** - Multi-tier services acting on behalf of users  
-- **[Client Credentials Flow](msal-confidential-auth/client-credentials/SKILL.md)** - Service-to-service daemon applications
+- **[Authorization Code Flow](msal-auth-code-flow/SKILL.md)** - Web applications with user sign-in
+- **[On-Behalf-Of (OBO) Flow](msal-obo-flow/SKILL.md)** - Multi-tier services acting on behalf of users  
+- **[Client Credentials Flow](msal-client-credentials/SKILL.md)** - Service-to-service daemon applications
 
 #### Shared Resources (DRY Principle)
 
@@ -141,9 +141,9 @@ Specialized skills for mTLS PoP authentication with Managed Identity and Confide
 
 | Scenario | Skill to Use |
 |----------|--------------|
-| Web app with user sign-in | [Authorization Code Flow](msal-confidential-auth/auth-code-flow/SKILL.md) |
-| API acting on behalf of user | [On-Behalf-Of Flow](msal-confidential-auth/obo-flow/SKILL.md) |
-| Daemon/background service | [Client Credentials Flow](msal-confidential-auth/client-credentials/SKILL.md) |
+| Web app with user sign-in | [Authorization Code Flow](msal-auth-code-flow/SKILL.md) |
+| API acting on behalf of user | [On-Behalf-Of Flow](msal-obo-flow/SKILL.md) |
+| Daemon/background service | [Client Credentials Flow](msal-client-credentials/SKILL.md) |
 | Direct mTLS PoP token (MSI/SNI) | [Vanilla mTLS PoP](msal-mtls-pop-vanilla/SKILL.md) |
 | FIC token exchange with mTLS PoP | [FIC Two-Leg mTLS PoP](msal-mtls-pop-fic-two-leg/SKILL.md) |
 
@@ -235,11 +235,12 @@ skill-name/
 │   ├── code-examples/            # Copy-paste code snippets
 │   ├── credential-setup/         # Setup guides by credential type
 │   └── patterns/                 # Common patterns, troubleshooting
-├── skill-set-name/
-│   ├── flow1/
-│   │   └── SKILL.md              # Flow-specific documentation
-│   └── flow2/
-│       └── SKILL.md
+├── msal-auth-code-flow/
+│   └── SKILL.md                  # Auth Code Flow skill
+├── msal-client-credentials/
+│   └── SKILL.md                  # Client Credentials Flow skill
+├── msal-obo-flow/
+│   └── SKILL.md                  # OBO Flow skill
 └── individual-skill-name/
     ├── SKILL.md                  # Main documentation with YAML frontmatter
     └── HelperClass.cs            # Optional production helper class

--- a/.github/skills/msal-auth-code-flow/SKILL.md
+++ b/.github/skills/msal-auth-code-flow/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: msal-auth-code-flow
 description: Authorization Code Flow for web applications using MSAL.NET confidential client to sign in users and access APIs on their behalf
+tags:
+  - msal
+  - auth-code
+  - authorization-code
+  - web-app
+  - confidential-client
+  - user-sign-in
+  - redirect
+  - consent
 ---
 
 # Authorization Code Flow Skill

--- a/.github/skills/msal-auth-code-flow/SKILL.md
+++ b/.github/skills/msal-auth-code-flow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: msal-auth-code-flow
+description: Authorization Code Flow for web applications using MSAL.NET confidential client to sign in users and access APIs on their behalf
+---
+
 # Authorization Code Flow Skill
 
 ## Overview
@@ -20,15 +25,15 @@ Authorization Code Flow is used by web applications to authenticate users and ob
 
 ### Generate Code Snippet
 Agent can show code snippets for each credential type:
-- Standard Certificate: [with-certificate.cs](../../msal-shared/code-examples/with-certificate.cs)
-- Certificate with SNI: [with-certificate-sni.cs](../../msal-shared/code-examples/with-certificate-sni.cs)
-- Federated Identity Credentials: [with-federated-identity-credentials.cs](../../msal-shared/code-examples/with-federated-identity-credentials.cs)
+- Standard Certificate: [with-certificate.cs](../msal-shared/code-examples/with-certificate.cs)
+- Certificate with SNI: [with-certificate-sni.cs](../msal-shared/code-examples/with-certificate-sni.cs)
+- Federated Identity Credentials: [with-federated-identity-credentials.cs](../msal-shared/code-examples/with-federated-identity-credentials.cs)
 
 ### Setup Guidance
 Reference appropriate credential setup:
-- [Certificate Setup](../../msal-shared/credential-setup/certificate-setup.md)
-- [Certificate with SNI](../../msal-shared/credential-setup/certificate-sni-setup.md)
-- [Federated Identity Credentials](../../msal-shared/credential-setup/federated-identity-credentials.md)
+- [Certificate Setup](../msal-shared/credential-setup/certificate-setup.md)
+- [Certificate with SNI](../msal-shared/credential-setup/certificate-sni-setup.md)
+- [Federated Identity Credentials](../msal-shared/credential-setup/federated-identity-credentials.md)
 
 ### Example: Web Application with Certificate
 ```csharp
@@ -54,11 +59,11 @@ public async Task HandleCallback(string code, string state)
 ```
 
 ### Error Resolution
-Refer to [Troubleshooting Guide](../../msal-shared/patterns/troubleshooting.md)
+Refer to [Troubleshooting Guide](../msal-shared/patterns/troubleshooting.md)
 
 ### Best Practices
-- Use [Token Caching Strategies](../../msal-shared/patterns/token-caching-strategies.md) for optimal token acquisition
-- Implement [Error Handling Patterns](../../msal-shared/patterns/error-handling-patterns.md)
+- Use [Token Caching Strategies](../msal-shared/patterns/token-caching-strategies.md) for optimal token acquisition
+- Implement [Error Handling Patterns](../msal-shared/patterns/error-handling-patterns.md)
 - Store refresh tokens securely
 - Use PKCE for native clients
 - For advanced caching options including distributed caches for multi-instance deployments, see [Token cache serialization documentation](https://learn.microsoft.com/en-us/entra/msal/dotnet/how-to/token-cache-serialization?tabs=msal)

--- a/.github/skills/msal-client-credentials/SKILL.md
+++ b/.github/skills/msal-client-credentials/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: msal-client-credentials
+description: Client Credentials Flow for service-to-service (daemon) authentication in MSAL.NET without user involvement
+---
+
 # Client Credentials Flow Skill
 
 ## Overview
@@ -20,15 +25,15 @@ Client Credentials Flow is used for service-to-service authentication without us
 
 ### Generate Code Snippet
 Agent can show code for each credential type:
-- Standard Certificate: [with-certificate.cs](../../msal-shared/code-examples/with-certificate.cs)
-- Certificate with SNI: [with-certificate-sni.cs](../../msal-shared/code-examples/with-certificate-sni.cs)
-- Federated Identity Credentials: [with-federated-identity-credentials.cs](../../msal-shared/code-examples/with-federated-identity-credentials.cs)
+- Standard Certificate: [with-certificate.cs](../msal-shared/code-examples/with-certificate.cs)
+- Certificate with SNI: [with-certificate-sni.cs](../msal-shared/code-examples/with-certificate-sni.cs)
+- Federated Identity Credentials: [with-federated-identity-credentials.cs](../msal-shared/code-examples/with-federated-identity-credentials.cs)
 
 ### Setup Guidance
 Reference appropriate credential setup:
-- [Certificate Setup](../../msal-shared/credential-setup/certificate-setup.md)
-- [Certificate with SNI](../../msal-shared/credential-setup/certificate-sni-setup.md)
-- [Federated Identity Credentials](../../msal-shared/credential-setup/federated-identity-credentials.md)
+- [Certificate Setup](../msal-shared/credential-setup/certificate-setup.md)
+- [Certificate with SNI](../msal-shared/credential-setup/certificate-sni-setup.md)
+- [Federated Identity Credentials](../msal-shared/credential-setup/federated-identity-credentials.md)
 
 ### Example: Service with Certificate
 ```csharp
@@ -60,11 +65,11 @@ public class TokenAcquisitionService
 ```
 
 ### Error Resolution
-Refer to [Troubleshooting Guide](../../msal-shared/patterns/troubleshooting.md)
+Refer to [Troubleshooting Guide](../msal-shared/patterns/troubleshooting.md)
 
 ### Best Practices
-- Use [Token Caching Strategies](../../msal-shared/patterns/token-caching-strategies.md) - enable static token caching with `.WithCacheOptions(CacheOptions.EnableSharedCacheOptions)` for optimal performance
-- Implement [Error Handling Patterns](../../msal-shared/patterns/error-handling-patterns.md) 
+- Use [Token Caching Strategies](../msal-shared/patterns/token-caching-strategies.md) - enable static token caching with `.WithCacheOptions(CacheOptions.EnableSharedCacheOptions)` for optimal performance
+- Implement [Error Handling Patterns](../msal-shared/patterns/error-handling-patterns.md) 
 - Monitor token acquisition using `AuthenticationResultMetadata` for cache hit ratios
 - Rotate certificates periodically (if using certificate-based auth)
 - Use Federated Identity Credentials with Managed Identity for keyless authentication

--- a/.github/skills/msal-client-credentials/SKILL.md
+++ b/.github/skills/msal-client-credentials/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: msal-client-credentials
 description: Client Credentials Flow for service-to-service (daemon) authentication in MSAL.NET without user involvement
+tags:
+  - msal
+  - client-credentials
+  - daemon
+  - service-to-service
+  - confidential-client
+  - background-service
+  - machine-to-machine
 ---
 
 # Client Credentials Flow Skill

--- a/.github/skills/msal-obo-flow/SKILL.md
+++ b/.github/skills/msal-obo-flow/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: msal-obo-flow
 description: On-Behalf-Of (OBO) Flow for web APIs to call downstream APIs while preserving user identity in MSAL.NET
+tags:
+  - msal
+  - obo
+  - on-behalf-of
+  - token-exchange
+  - confidential-client
+  - multi-tier
+  - downstream-api
+  - user-assertion
 ---
 
 # On-Behalf-Of (OBO) Flow Skill

--- a/.github/skills/msal-obo-flow/SKILL.md
+++ b/.github/skills/msal-obo-flow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: msal-obo-flow
+description: On-Behalf-Of (OBO) Flow for web APIs to call downstream APIs while preserving user identity in MSAL.NET
+---
+
 # On-Behalf-Of (OBO) Flow Skill
 
 ## Overview
@@ -23,15 +28,15 @@ ID tokens are for authentication; access tokens are for authorization and API ac
 
 ### Generate Code Snippet
 Agent can show code for each credential type:
-- Standard Certificate: [with-certificate.cs](../../msal-shared/code-examples/with-certificate.cs)
-- Certificate with SNI: [with-certificate-sni.cs](../../msal-shared/code-examples/with-certificate-sni.cs)
-- Federated Identity Credentials: [with-federated-identity-credentials.cs](../../msal-shared/code-examples/with-federated-identity-credentials.cs)
+- Standard Certificate: [with-certificate.cs](../msal-shared/code-examples/with-certificate.cs)
+- Certificate with SNI: [with-certificate-sni.cs](../msal-shared/code-examples/with-certificate-sni.cs)
+- Federated Identity Credentials: [with-federated-identity-credentials.cs](../msal-shared/code-examples/with-federated-identity-credentials.cs)
 
 ### Setup Guidance
 Reference appropriate credential setup:
-- [Certificate Setup](../../msal-shared/credential-setup/certificate-setup.md)
-- [Certificate with SNI](../../msal-shared/credential-setup/certificate-sni-setup.md)
-- [Federated Identity Credentials](../../msal-shared/credential-setup/federated-identity-credentials.md)
+- [Certificate Setup](../msal-shared/credential-setup/certificate-setup.md)
+- [Certificate with SNI](../msal-shared/credential-setup/certificate-sni-setup.md)
+- [Federated Identity Credentials](../msal-shared/credential-setup/federated-identity-credentials.md)
 
 ### Example: Web API with Certificate
 ```csharp
@@ -64,15 +69,15 @@ public async Task<IActionResult> GetData()
 ```
 
 ### Error Resolution
-Refer to [Troubleshooting Guide](../../msal-shared/patterns/troubleshooting.md)
+Refer to [Troubleshooting Guide](../msal-shared/patterns/troubleshooting.md)
 
 **Common OBO errors:**
 - `MsalUiRequiredException`: MFA or conditional access required—requires client re-authentication
 - Invalid token: Verify access token (not ID token) is passed
 
 ### Best Practices
-- Use [Token Caching Strategies](../../msal-shared/patterns/token-caching-strategies.md) for optimal session-based token caching
-- Implement [Error Handling Patterns](../../msal-shared/patterns/error-handling-patterns.md)
+- Use [Token Caching Strategies](../msal-shared/patterns/token-caching-strategies.md) for optimal session-based token caching
+- Implement [Error Handling Patterns](../msal-shared/patterns/error-handling-patterns.md)
 - Always validate incoming token before using in OBO
 - Extract `tid` claim from user token for guest user scenarios—use tenant-specific authority, not /common
 - For multi-instance deployments and advanced caching, see [Token cache serialization documentation](https://learn.microsoft.com/en-us/entra/msal/dotnet/how-to/token-cache-serialization?tabs=msal)


### PR DESCRIPTION
## Summary

Promote three nested sub-skills from \msal-confidential-auth/\ to top-level skill folders so Copilot can discover them.

Copilot discovers skills by looking for \SKILL.md\ directly inside \.github/skills/<skill-folder>/\. The existing sub-skills were nested one level too deep and were invisible to discovery.

## Changes

- **Move** \msal-confidential-auth/auth-code-flow\ → \msal-auth-code-flow\
- **Move** \msal-confidential-auth/client-credentials\ → \msal-client-credentials\
- **Move** \msal-confidential-auth/obo-flow\ → \msal-obo-flow\
- **Add** YAML frontmatter (\
ame\, \description\) to each SKILL.md
- **Fix** relative paths to \msal-shared/\ resources (\../../\ → \../\)