### PR TITLE
Refactor conditions for skipping tests

### DIFF
--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/AttributeOrderingBugDemoTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/AttributeOrderingBugDemoTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if NET_CORE
+
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Integration.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Integration.Broker
+{
+    /// <summary>
+    /// Temporary demonstration tests for the attribute ordering bug between
+    /// [IgnoreOnOneBranch] and platform attributes like [DoNotRunOnLinux].
+    ///
+    /// Root cause: MSTest uses only the *first* TestMethodAttribute-derived attribute
+    /// on a method as its executor. When [DoNotRunOnLinux] is listed before
+    /// [IgnoreOnOneBranch], the platform check runs but the OneBranch skip never fires.
+    ///
+    /// HOW TO REPRODUCE:
+    ///   Build with: dotnet build -p:PipelineType=OneBranch
+    ///   Run with:   dotnet test --no-build
+    ///
+    /// EXPECTED RESULTS (OneBranch build, Windows agent):
+    ///   CorrectOrder_IgnoreOnOneBranchFirst  => NotExecuted (skipped correctly)
+    ///   WrongOrder_DoNotRunOnLinuxFirst      => Failed      (bug: skip was shadowed)
+    ///
+    /// EXPECTED RESULTS (normal build, no ONEBRANCH_BUILD):
+    ///   Both tests fail - this is intentional; they exist only to demonstrate the bug.
+    /// </summary>
+    [TestClass]
+    public class AttributeOrderingBugDemoTests
+    {
+        /// <summary>
+        /// Correct ordering: [IgnoreOnOneBranch] first.
+        /// On an OneBranch build this test should be skipped (NotExecuted) and
+        /// never reach the Assert.Fail below.
+        /// </summary>
+        [IgnoreOnOneBranch]
+        [DoNotRunOnLinux]
+        public void CorrectOrder_IgnoreOnOneBranchFirst_ShouldBeSkippedOnOneBranch()
+        {
+            Assert.Fail(
+                "BUG: [IgnoreOnOneBranch] should have prevented this test from running on an OneBranch build. " +
+                "If this failure appears when ONEBRANCH_BUILD is defined, the skip logic is broken.");
+        }
+
+        /// <summary>
+        /// Wrong ordering: [DoNotRunOnLinux] first shadows [IgnoreOnOneBranch].
+        /// On an OneBranch build on Windows, [DoNotRunOnLinux] sees a non-Linux platform,
+        /// passes through to base.ExecuteAsync, and [IgnoreOnOneBranch] is never consulted.
+        /// The test body runs and hits Assert.Fail, demonstrating the bug.
+        /// </summary>
+        [DoNotRunOnLinux]
+        [IgnoreOnOneBranch]
+        public void WrongOrder_DoNotRunOnLinuxFirst_RunsOnOneBranchWhenItShouldnt()
+        {
+            Assert.Fail(
+                "BUG DEMONSTRATED: This test reached its body on an OneBranch build because [DoNotRunOnLinux] " +
+                "was listed first and shadowed [IgnoreOnOneBranch]. " +
+                "Fix: move [IgnoreOnOneBranch] to be the first attribute.");
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // FIX DEMONSTRATION: new-style [RunOn] with SkipConditions flags
+        // All conditions are evaluated inside a single ExecuteAsync — ordering is impossible to
+        // get wrong because there is only one attribute.
+        // -----------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// New style: single [RunOn] attribute with combined SkipConditions flags.
+        /// On an OneBranch build (Windows agent) the OneBranchBuild condition fires and the
+        /// test is skipped before its body is reached, regardless of how many conditions are listed.
+        /// </summary>
+        [RunOn(SkipConditions.OneBranchBuild | SkipConditions.Linux)]
+        public void NewStyle_CombinedConditions_SkippedOnOneBranchBuild()
+        {
+            Assert.Fail(
+                "BUG: SkipConditions.OneBranchBuild should have skipped this test. " +
+                "If this failure appears when ONEBRANCH_BUILD is defined, EvaluateSkipConditions is broken.");
+        }
+
+        /// <summary>
+        /// New style: demonstrates that the order of flags inside SkipConditions is irrelevant.
+        /// This is logically identical to NewStyle_CombinedConditions_SkippedOnOneBranchBuild
+        /// (Linux and OneBranchBuild are swapped) but produces the same skip behavior —
+        /// proving the old fragile ordering convention is no longer needed.
+        /// </summary>
+        [RunOn(SkipConditions.Linux | SkipConditions.OneBranchBuild)]
+        public void NewStyle_FlagOrderIsIrrelevant_AlsoSkippedOnOneBranchBuild()
+        {
+            Assert.Fail(
+                "BUG: SkipConditions.OneBranchBuild should have skipped this test. " +
+                "Flag order in SkipConditions is irrelevant — all conditions are evaluated together.");
+        }
+    }
+}
+#endif

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/RuntimeBrokerTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/RuntimeBrokerTests.cs
@@ -57,8 +57,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
         }
         
         // This test should fail locally but succeed in a CI build.
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild)]
         public async Task WamSilentAuthUserInteractionRequiredAsync()
         {
             string[] scopes = new[]
@@ -91,10 +90,8 @@ namespace Microsoft.Identity.Test.Integration.Broker
             }
         }
 
-        [DoNotRunOnLinux] // POP is not supported on Linux
-        [IgnoreOnOneBranch]
         [Ignore("Tracking here: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5305")]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild | SkipConditions.Linux)]
         public async Task ExtractNonceWithAuthParserAndValidateShrAsync()
         {
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
@@ -141,9 +138,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                 result);
         }
     
-        [DoNotRunOnLinux] // Linux broker return different error code
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild | SkipConditions.Linux)]
         public async Task WamInvalidROPC_ThrowsException_TestAsync()
         {
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
@@ -176,8 +171,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             
         }
 
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild)]
         public async Task WamSilentAuthLoginHintNoAccontInCacheAsync()
         {
             string[] scopes = new[]
@@ -205,8 +199,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             }
         }
 
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild)]
         public async Task WamUsernamePasswordRequestAsync()
         {
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
@@ -261,9 +254,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                 .ConfigureAwait(false);
         }
 
-        [DoNotRunOnLinux] // SSH Certs are not supported on Linux
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild | SkipConditions.Linux)]
         public async Task WamWithSSHCertificateAuthenticationSchemeAsync()
         {
             IntPtr intPtr = TestUtils.GetWindowHandle();
@@ -304,8 +295,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             Assert.AreEqual("SshCert", result.TokenType);
         }
 
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild)]
         public async Task WamUsernamePasswordWithForceRefreshAsync()
         {
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
@@ -357,8 +347,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             Assert.AreNotEqual(ropcToken, result.AccessToken);
         }
 
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild)]
         public async Task WamUsernamePasswordRequestAsync_WithPiiAsync()
         {
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
@@ -413,9 +402,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
                 await pca.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false)).ConfigureAwait(false);
         }
 
-        [DoNotRunOnLinux] // List Windows Work and School accounts is not supported on Linux
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild | SkipConditions.Linux)]
         public async Task WamListWindowsWorkAndSchoolAccountsAsync()
         {
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
@@ -454,8 +441,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             Assert.AreEqual(user.Upn, account.Username);
         }
 
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild)]
         [DataRow(null)]
         public async Task WamAddDefaultScopesWhenNoScopesArePassedAsync(string scopes)
         {
@@ -485,9 +471,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             }
         }
 
-        [DoNotRunOnLinux] // POP is not supported on Linux     
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild | SkipConditions.Linux)]
         public async Task WamUsernamePasswordPopTokenEnforcedWithCaOnValidResourceAsync()
         {
             //Arrange
@@ -521,9 +505,7 @@ namespace Microsoft.Identity.Test.Integration.Broker
             Assert.AreEqual(user.Upn, result.Account.Username);
         }
 
-        [DoNotRunOnLinux] // POP are not supported on Linux  
-        [IgnoreOnOneBranch]
-        [TestMethod]
+        [RunOn(SkipConditions.OneBranchBuild | SkipConditions.Linux)]
         public async Task WamUsernamePasswordPopTokenEnforcedWithCaOnInValidResourceAsync()
         {
             //Arrange

--- a/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/TargetFramework.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/TargetFramework.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,11 +15,22 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
     public class RunOnAttribute : TestMethodAttribute
     {
         private readonly TargetFrameworks _tfms;
+        private readonly SkipConditions _skip;
 
-        public RunOnAttribute(TargetFrameworks tfms, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = 0)
+        public RunOnAttribute(TargetFrameworks tfms, SkipConditions skipOn = SkipConditions.None, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = 0)
             : base(filePath, lineNumber)
         {
             _tfms = tfms;
+            _skip = skipOn;
+        }
+
+        /// <summary>
+        /// Use this overload when no framework targeting is needed — the test runs on all frameworks
+        /// but should be skipped under the specified conditions.
+        /// </summary>
+        public RunOnAttribute(SkipConditions skipOn, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = 0)
+            : this(TargetFrameworks.NetFx | TargetFrameworks.NetCore, skipOn, filePath, lineNumber)
+        {
         }
 
         public override async Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
@@ -26,19 +38,54 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
             if (RunOnHelper.IsNetFwk() && (_tfms & TargetFrameworks.NetFx) != TargetFrameworks.NetFx ||
                 RunOnHelper.IsNetCore() && (_tfms & TargetFrameworks.NetCore) != TargetFrameworks.NetCore)
             {
-                return new[]
-                {
-                    new TestResult
-                    {
-                        Outcome = UnitTestOutcome.Inconclusive,
-                        TestFailureException = new AssertInconclusiveException(
-                            $"Skipped on target framework {_tfms}")
-                    }
-                };
+                return Inconclusive($"Skipped on target framework {_tfms}");
             }
+
+            string skipReason = EvaluateSkipConditions(_skip);
+            if (skipReason != null)
+                return Inconclusive(skipReason);
 
             return await base.ExecuteAsync(testMethod).ConfigureAwait(false);
         }
+
+        private static string EvaluateSkipConditions(SkipConditions conditions)
+        {
+            if (conditions == SkipConditions.None)
+                return null;
+
+#if ONEBRANCH_BUILD
+            if ((conditions & SkipConditions.OneBranchBuild) != 0)
+                return "Skipped on OneBranch pipeline";
+#endif
+
+            if ((conditions & SkipConditions.Linux) != 0 && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return "Skipped on Linux";
+
+            if ((conditions & SkipConditions.Windows) != 0 && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return "Skipped on Windows";
+
+            if ((conditions & SkipConditions.macOS) != 0 && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return "Skipped on macOS";
+
+            if ((conditions & SkipConditions.NotAzureDevOps) != 0 && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD")))
+                return "Skipped outside Azure DevOps";
+
+#if IGNORE_FEDERATED
+            if ((conditions & SkipConditions.FederatedDisabled) != 0)
+                return "Skipped: federated tests disabled";
+#endif
+
+            return null;
+        }
+
+        private static TestResult[] Inconclusive(string message) => new[]
+        {
+            new TestResult
+            {
+                Outcome = UnitTestOutcome.Inconclusive,
+                TestFailureException = new AssertInconclusiveException(message)
+            }
+        };
     }
 
     /// <summary>
@@ -48,7 +95,30 @@ namespace Microsoft.Identity.Test.Common.Core.Helpers
     public enum TargetFrameworks
     {
         NetFx = 1,
-        NetCore = 2        
+        NetCore = 2
+    }
+
+    /// <summary>
+    /// Conditions that, when matched, cause a <see cref="RunOnAttribute"/> to skip the test as inconclusive.
+    /// Multiple conditions can be combined with the bitwise OR operator; if any condition is met the test is skipped.
+    /// </summary>
+    [Flags]
+    public enum SkipConditions
+    {
+        /// <summary>No skip conditions.</summary>
+        None              = 0,
+        /// <summary>Skip when built with the ONEBRANCH_BUILD compile-time symbol (PipelineType=OneBranch).</summary>
+        OneBranchBuild    = 1,
+        /// <summary>Skip when running on Linux.</summary>
+        Linux             = 2,
+        /// <summary>Skip when running on Windows.</summary>
+        Windows           = 4,
+        /// <summary>Skip when running on macOS.</summary>
+        macOS             = 8,
+        /// <summary>Skip when not running inside an Azure DevOps pipeline (TF_BUILD env var absent).</summary>
+        NotAzureDevOps    = 16,
+        /// <summary>Skip when built with the IGNORE_FEDERATED compile-time symbol.</summary>
+        FederatedDisabled = 32
     }
 
     public static class RunOnHelper


### PR DESCRIPTION
Currently, the library has a variety of ways to conditionally skipping tests:
1. Attributes that require a developer to specify a value, such as `[RunOn]` in [`InteractiveFlowTests.NetFwk.cs`](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/main/tests/Microsoft.Identity.Test.Integration.netcore/SeleniumTests/InteractiveFlowTests.NetFwk.cs)
2. Attributes that look for certain environment characteristics, such as `[IgnoreOnOneBranch]` and `[DoNotRunOnLinux]` in [`RuntimeBrokerTests.cs`](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/main/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/RuntimeBrokerTests.cs)
3. If statements that look for certain parameters and environment variables, such as `#if !IGNORE_FEDERATED` in [`ClientCredentialsTests.NetFwk.cs`](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/main/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsTests.NetFwk.cs)

And as this PR's `AttributeOrderingBugDemoTests` shows the conditions mentioned in 1) and 2) cannot be combined: `[RunOn]`, `[IgnoreOnOneBranch]` and `[DoNotRunOnLinux]` are all defined by classes that implement `TestMethodAttribute`, and it appears that only the first one defined above a test matters and the rest are ignored.

That isn't a major problem at the moment because currently there are few tests that try to combine them and our pipelines happen to run in a way that makes the issue latent, but having set of behaviors that are very similar but mutually exclusive is quite fragile and hard to maintain.

This PR offers an alternative: `[RunOn]` is used far more often than the other conditions, so it just adds a new enum and a set of condition checks to it so a single easy-to-expand annotation can be used for all of our test skipping needs.

Currently this is a draft PR, as it only refactors one existing test class and adds `AttributeOrderingBugDemoTests` which does not need to be merged in and is only there to demonstrate the condition stacking issue and the solution. Because of this, several tests are expected to fail in our non-OneBranch PR pipeline and one test is expected to fail in our OneBrach PR pipeline,

After initial reviews, other relevant tests will have the same small changes applied and vestigial code like `[IgnoreOnOneBranch]` and `[DoNotRunOnLinux]` will be removed.