### PR TITLE
fix: make System.ValueTuple conditional on net462 only (#5894)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -154,7 +154,17 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Abstractions" />
+  </ItemGroup>
+
+  <!-- System.ValueTuple is in-box starting with .NET Framework 4.7; only net462 needs the package. -->
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop462)'">
     <PackageReference Include="System.ValueTuple" />
+  </ItemGroup>
+
+  <!-- Suppress transitive System.ValueTuple from System.Formats.Asn1 on net472+, where it is in-box
+       and the NuGet package causes harmful binding redirects (see #5894). -->
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop472)'">
+    <PackageReference Include="System.ValueTuple" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="For public api analyzer support">

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -164,7 +164,7 @@
   <!-- Suppress transitive System.ValueTuple from System.Formats.Asn1 on net472+, where it is in-box
        and the NuGet package causes harmful binding redirects (see #5894). -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop472)'">
-    <PackageReference Include="System.ValueTuple" PrivateAssets="all" ExcludeAssets="all" />
+    <PackageReference Include="System.ValueTuple" PrivateAssets="All" ExcludeAssets="All" />
   </ItemGroup>
 
   <ItemGroup Label="For public api analyzer support">

--- a/src/client/Microsoft.Identity.Lab.Api/Microsoft.Identity.Lab.Api.csproj
+++ b/src/client/Microsoft.Identity.Lab.Api/Microsoft.Identity.Lab.Api.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="System.Threading.Tasks" />
     <PackageReference Include="System.Threading.Tasks.Parallel" />
     <PackageReference Include="System.Threading.Thread" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Identity.Test.Common/Microsoft.Identity.Test.Common.csproj
+++ b/tests/Microsoft.Identity.Test.Common/Microsoft.Identity.Test.Common.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="System.Threading.Tasks" />
     <PackageReference Include="System.Threading.Tasks.Parallel" />
     <PackageReference Include="System.Threading.Thread" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
System.ValueTuple was an unconditional PackageReference, causing it to appear in the NuGet dependency group for all TFMs including net472. On .NET Framework 4.7+ ValueTuple is in-box, so the NuGet package generates harmful binding redirects in Web.Config that cause runtime failures.

Changes:
- Microsoft.Identity.Client.csproj: restrict direct ValueTuple ref to net462 (the only TFM that needs it) and suppress the transitive dep from System.Formats.Asn1 on net472 via PrivateAssets/ExcludeAssets.
- Remove unnecessary ValueTuple refs from Microsoft.Identity.Lab.Api and Microsoft.Identity.Test.Common (both netstandard2.0-only).

Fixes #5894

# 📦 PR #5906 — NuSpec Verification Report

## `System.ValueTuple` Conditional Fix

> **PR:** [fix: make System.ValueTuple conditional on net462 only (#5894)](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5906)
> **Date:** April 30, 2026
> **Package:** `Microsoft.Identity.Client 4.61.0`

---

## 🔍 NuSpec Dependency Diff

Generated `.nupkg` from both `main` and PR branch, extracted `.nuspec`, and compared dependency groups.

### `System.ValueTuple` presence per TFM

| Target Framework | main (before) | PR #5906 (after) | Status |
|:-----------------|:--------------|:-----------------|:-------|
| `.NETFramework4.6.2` | `System.ValueTuple 4.5.0` | `System.ValueTuple 4.5.0` | 🟢 Kept — not in-box on 4.6.2 |
| `.NETFramework4.7.2` | `System.ValueTuple 4.5.0` ⚠️ | **Removed** | 🟢 Fixed — in-box on 4.7+ |
| `net8.0` | `System.ValueTuple 4.5.0` ⚠️ | **Removed** | 🟢 Fixed — in-box on .NET Core+ |
| `.NETStandard2.0` | absent | absent | 🟡 No change |

### Full dependency groups (after fix)

```xml
<!-- net462 — ValueTuple KEPT (needed) -->
<group targetFramework=".NETFramework4.6.2">
  <dependency id="Microsoft.IdentityModel.Abstractions" version="8.14.0" />
  <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" />
  <dependency id="System.Formats.Asn1" version="8.0.1" />
  <dependency id="System.ValueTuple" version="4.5.0" />     ✅
</group>

<!-- net472 — ValueTuple REMOVED (in-box) -->
<group targetFramework=".NETFramework4.7.2">
  <dependency id="Microsoft.IdentityModel.Abstractions" version="8.14.0" />
  <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" />
  <dependency id="System.Formats.Asn1" version="8.0.1" />
  <!-- No System.ValueTuple — in-box on .NET Framework 4.7+ -->  ✅
</group>

<!-- net8.0 — ValueTuple REMOVED (in-box) -->
<group targetFramework="net8.0">
  <dependency id="Microsoft.IdentityModel.Abstractions" version="8.14.0" />
  <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" />
  <!-- No System.ValueTuple — in-box on .NET Core+ -->  ✅
</group>
```

---

<img width="351" height="377" alt="image" src="https://github.com/user-attachments/assets/0543eebb-fa6f-4f14-9885-823850de2467" />

