### PR TITLE
Add MsalRemainingTokenLifetime histogram for token expiry 

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -131,6 +131,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         durationInUs,
                         authenticationResult.AuthenticationResultMetadata,
                         AuthenticationRequestParameters.RequestContext.Logger);
+
+            ServiceBundle.PlatformProxy.OtelInstrumentation.LogRemainingTokenLifetime(
+                        ServiceBundle.PlatformProxy.GetProductName(),
+                        apiEvent.ApiId,
+                        authenticationResult.AuthenticationResultMetadata.TokenSource,
+                        GetCacheLevel(authenticationResult),
+                        authenticationResult.AuthenticationResultMetadata.CacheRefreshReason,
+                        authenticationResult.AuthenticationResultMetadata.TelemetryTokenType,
+                        authenticationResult.ExpiresOn);
         }
 
         private void LogFailureTelemetryToOtel(string errorCodeToLog, ApiEvent apiEvent, CacheRefreshReason cacheRefreshReason)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -129,24 +129,18 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private void LogSuccessTelemetryToOtel(AuthenticationResult authenticationResult, ApiEvent apiEvent, long durationInUs)
         {
+            CacheLevel cacheLevel = GetCacheLevel(authenticationResult);
+
             // Log metrics
             ServiceBundle.PlatformProxy.OtelInstrumentation.LogSuccessMetrics(
                         ServiceBundle.PlatformProxy.GetProductName(),
                         apiEvent.ApiId,
                         apiEvent.CallerSdkApiId,
                         apiEvent.CallerSdkVersion,
-                        GetCacheLevel(authenticationResult),
+                        cacheLevel,
                         durationInUs,
                         authenticationResult.AuthenticationResultMetadata,
-                        AuthenticationRequestParameters.RequestContext.Logger);
-
-            ServiceBundle.PlatformProxy.OtelInstrumentation.LogRemainingTokenLifetime(
-                        ServiceBundle.PlatformProxy.GetProductName(),
-                        apiEvent.ApiId,
-                        authenticationResult.AuthenticationResultMetadata.TokenSource,
-                        GetCacheLevel(authenticationResult),
-                        authenticationResult.AuthenticationResultMetadata.CacheRefreshReason,
-                        authenticationResult.AuthenticationResultMetadata.TelemetryTokenType,
+                        AuthenticationRequestParameters.RequestContext.Logger,
                         authenticationResult.ExpiresOn);
         }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -139,6 +139,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         durationInUs,
                         authenticationResult.AuthenticationResultMetadata,
                         AuthenticationRequestParameters.RequestContext.Logger);
+
+            ServiceBundle.PlatformProxy.OtelInstrumentation.LogRemainingTokenLifetime(
+                        ServiceBundle.PlatformProxy.GetProductName(),
+                        apiEvent.ApiId,
+                        authenticationResult.AuthenticationResultMetadata.TokenSource,
+                        GetCacheLevel(authenticationResult),
+                        authenticationResult.AuthenticationResultMetadata.CacheRefreshReason,
+                        authenticationResult.AuthenticationResultMetadata.TelemetryTokenType,
+                        authenticationResult.ExpiresOn);
         }
 
         private void LogFailureTelemetryToOtel(string errorCodeToLog, ApiEvent apiEvent, CacheRefreshReason cacheRefreshReason, string rawStsErrorCode = null)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -105,6 +105,15 @@ namespace Microsoft.Identity.Client.Internal
                         Cache.CacheLevel.None,
                         logger,
                         apiEvent.TokenType);
+
+                    serviceBundle.PlatformProxy.OtelInstrumentation.LogRemainingTokenLifetime(
+                        serviceBundle.PlatformProxy.GetProductName(),
+                        apiEvent.ApiId,
+                        TokenSource.IdentityProvider,
+                        Cache.CacheLevel.None,
+                        CacheRefreshReason.ProactivelyRefreshed,
+                        apiEvent.TokenType,
+                        authResult.ExpiresOn);
                 }
                 catch (MsalServiceException ex)
                 {

--- a/src/client/Microsoft.Identity.Client/Internal/TelemetryTokenTypeConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/TelemetryTokenTypeConstants.cs
@@ -21,5 +21,19 @@ namespace Microsoft.Identity.Client.Internal
         public const int Extension = 5;
 
         public const int MtlsPop = 6;
+
+        /// <summary>
+        /// Maps a telemetry token type integer to its human-readable string representation.
+        /// </summary>
+        internal static string ToDisplayString(int tokenType) => tokenType switch
+        {
+            Bearer => nameof(Bearer),
+            Pop => nameof(Pop),
+            SshCert => nameof(SshCert),
+            AtPop => "ExternalBoundToken",
+            Extension => nameof(Extension),
+            MtlsPop => nameof(MtlsPop),
+            _ => $"Unknown({tokenType})"
+        };
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/TelemetryTokenTypeConstants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/TelemetryTokenTypeConstants.cs
@@ -21,19 +21,5 @@ namespace Microsoft.Identity.Client.Internal
         public const int Extension = 5;
 
         public const int MtlsPop = 6;
-
-        /// <summary>
-        /// Maps a telemetry token type integer to its human-readable string representation.
-        /// </summary>
-        internal static string ToDisplayString(int tokenType) => tokenType switch
-        {
-            Bearer => nameof(Bearer),
-            Pop => nameof(Pop),
-            SshCert => nameof(SshCert),
-            AtPop => "ExternalBoundToken",
-            Extension => nameof(Extension),
-            MtlsPop => nameof(MtlsPop),
-            _ => $"Unknown({tokenType})"
-        };
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         private const string DurationInL2CacheHistogramName = "MsalDurationInL2Cache.1A";
         private const string DurationInHttpHistogramName = "MsalDurationInHttp.1A";
         private const string DurationInExtensionInMsHistogram = "MsalDurationInExtensionInMs.1B";
+        private const string RemainingTokenLifetimeHistogramName = "MsalRemainingTokenLifetime.1A";
 
         /// <summary>
         /// Meter to hold the MSAL metrics.
@@ -87,6 +88,14 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             DurationInExtensionInMsHistogram,
             unit: "us",
             description: "Performance of token acquisition calls extension latency."));
+
+        /// <summary>
+        /// Histogram to record the remaining lifetime of acquired tokens in seconds.
+        /// </summary>
+        internal static readonly Lazy<Histogram<long>> s_remainingTokenLifetime = new(() => Meter.CreateHistogram<long>(
+            RemainingTokenLifetimeHistogramName,
+            unit: "s",
+            description: "Remaining lifetime of acquired tokens at the time of acquisition."));
 
         public OtelInstrumentation()
         {
@@ -216,6 +225,29 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                         new(TelemetryConstants.CallerSdkId, callerSdkId ?? string.Empty + "," + callerSdkVersion ?? string.Empty),
                         new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
                         new(TelemetryConstants.TokenType, tokenType));
+            }
+        }
+
+        public void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn)
+        {
+            if (s_remainingTokenLifetime.Value.Enabled)
+            {
+                long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
+
+                s_remainingTokenLifetime.Value.Record(remainingSeconds,
+                    new(TelemetryConstants.MsalVersionPlatform, $"{MsalIdHelper.GetMsalVersion()},{platform}"),
+                    new(TelemetryConstants.ApiId, apiId),
+                    new(TelemetryConstants.TokenSource, tokenSource),
+                    new(TelemetryConstants.CacheLevel, cacheLevel),
+                    new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
+                    new(TelemetryConstants.TokenType, TelemetryTokenTypeConstants.ToDisplayString(tokenType)));
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         private const string DurationInL2CacheHistogramName = "MsalDurationInL2Cache.1A";
         private const string DurationInHttpHistogramName = "MsalDurationInHttp.1A";
         private const string DurationInExtensionInMsHistogram = "MsalDurationInExtensionInMs.1B";
+        private const string RemainingTokenLifetimeHistogramName = "MsalRemainingTokenLifetime.1A";
 
         /// <summary>
         /// Meter to hold the MSAL metrics.
@@ -88,6 +89,14 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             DurationInExtensionInMsHistogram,
             unit: "us",
             description: "Performance of token acquisition calls extension latency."));
+
+        /// <summary>
+        /// Histogram to record the remaining lifetime of acquired tokens in seconds.
+        /// </summary>
+        internal static readonly Lazy<Histogram<long>> s_remainingTokenLifetime = new(() => Meter.CreateHistogram<long>(
+            RemainingTokenLifetimeHistogramName,
+            unit: "s",
+            description: "Remaining lifetime of acquired tokens at the time of acquisition."));
 
         public OtelInstrumentation()
         {
@@ -226,6 +235,29 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 tags.Add(TelemetryConstants.RawStsErrorCode, rawStsErrorCode);
 
             s_failureCounter.Value.Add(1, in tags);
+        }
+
+        public void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn)
+        {
+            if (s_remainingTokenLifetime.Value.Enabled)
+            {
+                long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
+
+                s_remainingTokenLifetime.Value.Record(remainingSeconds,
+                    new(TelemetryConstants.MsalVersionPlatform, $"{MsalIdHelper.GetMsalVersion()},{platform}"),
+                    new(TelemetryConstants.ApiId, apiId),
+                    new(TelemetryConstants.TokenSource, tokenSource),
+                    new(TelemetryConstants.CacheLevel, cacheLevel),
+                    new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
+                    new(TelemetryConstants.TokenType, TelemetryTokenTypeConstants.ToDisplayString(tokenType)));
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             CacheLevel cacheLevel,
             long totalDurationInUs,
             AuthenticationResultMetadata authResultMetadata,
-            ILoggerAdapter logger)
+            ILoggerAdapter logger,
+            DateTimeOffset expiresOn)
         {
             IncrementSuccessCounter(
                 platform,
@@ -181,6 +182,19 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 new(TelemetryConstants.CacheLevel, authResultMetadata.CacheLevel),
                 new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
             }
+
+            if (s_remainingTokenLifetime.Value.Enabled)
+            {
+                long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
+
+                s_remainingTokenLifetime.Value.Record(remainingSeconds,
+                    new(TelemetryConstants.MsalVersionPlatform, $"{MsalIdHelper.GetMsalVersion()},{platform}"),
+                    new(TelemetryConstants.ApiId, apiId),
+                    new(TelemetryConstants.TokenSource, authResultMetadata.TokenSource),
+                    new(TelemetryConstants.CacheLevel, cacheLevel),
+                    new(TelemetryConstants.CacheRefreshReason, authResultMetadata.CacheRefreshReason),
+                    new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
+            }
         }
 
         public void IncrementSuccessCounter(string platform,
@@ -237,27 +251,5 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             s_failureCounter.Value.Add(1, in tags);
         }
 
-        public void LogRemainingTokenLifetime(
-            string platform,
-            ApiEvent.ApiIds apiId,
-            TokenSource tokenSource,
-            CacheLevel cacheLevel,
-            CacheRefreshReason cacheRefreshReason,
-            int tokenType,
-            DateTimeOffset expiresOn)
-        {
-            if (s_remainingTokenLifetime.Value.Enabled)
-            {
-                long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
-
-                s_remainingTokenLifetime.Value.Record(remainingSeconds,
-                    new(TelemetryConstants.MsalVersionPlatform, $"{MsalIdHelper.GetMsalVersion()},{platform}"),
-                    new(TelemetryConstants.ApiId, apiId),
-                    new(TelemetryConstants.TokenSource, tokenSource),
-                    new(TelemetryConstants.CacheLevel, cacheLevel),
-                    new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
-                    new(TelemetryConstants.TokenType, TelemetryTokenTypeConstants.ToDisplayString(tokenType)));
-            }
-        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -183,18 +183,14 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
             }
 
-            if (s_remainingTokenLifetime.Value.Enabled)
-            {
-                long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
-
-                s_remainingTokenLifetime.Value.Record(remainingSeconds,
-                    new(TelemetryConstants.MsalVersionPlatform, $"{MsalIdHelper.GetMsalVersion()},{platform}"),
-                    new(TelemetryConstants.ApiId, apiId),
-                    new(TelemetryConstants.TokenSource, authResultMetadata.TokenSource),
-                    new(TelemetryConstants.CacheLevel, cacheLevel),
-                    new(TelemetryConstants.CacheRefreshReason, authResultMetadata.CacheRefreshReason),
-                    new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
-            }
+            LogRemainingTokenLifetime(
+                platform,
+                apiId,
+                authResultMetadata.TokenSource,
+                cacheLevel,
+                authResultMetadata.CacheRefreshReason,
+                authResultMetadata.TelemetryTokenType,
+                expiresOn);
         }
 
         public void IncrementSuccessCounter(string platform,
@@ -249,6 +245,29 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 tags.Add(TelemetryConstants.RawStsErrorCode, rawStsErrorCode);
 
             s_failureCounter.Value.Add(1, in tags);
+        }
+
+        public void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn)
+        {
+            if (s_remainingTokenLifetime.Value.Enabled)
+            {
+                long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
+
+                s_remainingTokenLifetime.Value.Record(remainingSeconds,
+                    new(TelemetryConstants.MsalVersionPlatform, $"{MsalIdHelper.GetMsalVersion()},{platform}"),
+                    new(TelemetryConstants.ApiId, apiId),
+                    new(TelemetryConstants.TokenSource, tokenSource),
+                    new(TelemetryConstants.CacheLevel, cacheLevel),
+                    new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
+                    new(TelemetryConstants.TokenType, tokenType));
+            }
         }
 
     }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
@@ -38,5 +38,14 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             string callerSdkVersion,
             CacheRefreshReason cacheRefreshReason,
             int tokenType);
+
+        internal void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn);
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
@@ -40,5 +40,14 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
             string rawStsErrorCode = null);
+
+        internal void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn);
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
@@ -39,5 +39,14 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
             string rawStsErrorCode = null);
+
+        internal void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn);
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheLevel cacheLevel,
             long totalDurationInUs,
             AuthenticationResultMetadata authResultMetadata,
-            ILoggerAdapter logger);
+            ILoggerAdapter logger,
+            DateTimeOffset expiresOn);
 
         internal void IncrementSuccessCounter(string platform,
             ApiEvent.ApiIds apiId,
@@ -39,14 +40,5 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
             string rawStsErrorCode = null);
-
-        internal void LogRemainingTokenLifetime(
-            string platform,
-            ApiEvent.ApiIds apiId,
-            TokenSource tokenSource,
-            CacheLevel cacheLevel,
-            CacheRefreshReason cacheRefreshReason,
-            int tokenType,
-            DateTimeOffset expiresOn);
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
@@ -50,5 +50,17 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
         {
             // No op
         }
+
+        public void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn)
+        {
+            // No op
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
@@ -51,5 +51,17 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
         {
             // No op
         }
+
+        public void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn)
+        {
+            // No op
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheLevel cacheLevel,
             long totalDurationInUs,
             AuthenticationResultMetadata authResultMetadata,
-            ILoggerAdapter logger)
+            ILoggerAdapter logger,
+            DateTimeOffset expiresOn)
         {
             // No op
         }
@@ -52,16 +53,5 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             // No op
         }
 
-        public void LogRemainingTokenLifetime(
-            string platform,
-            ApiEvent.ApiIds apiId,
-            TokenSource tokenSource,
-            CacheLevel cacheLevel,
-            CacheRefreshReason cacheRefreshReason,
-            int tokenType,
-            DateTimeOffset expiresOn)
-        {
-            // No op
-        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
@@ -53,5 +53,17 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             // No op
         }
 
+        public void LogRemainingTokenLifetime(
+            string platform,
+            ApiEvent.ApiIds apiId,
+            TokenSource tokenSource,
+            CacheLevel cacheLevel,
+            CacheRefreshReason cacheRefreshReason,
+            int tokenType,
+            DateTimeOffset expiresOn)
+        {
+            // No op
+        }
+
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/TelemetryConstants.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Identity.Client.TelemetryCore
         public const string IsProactiveRefresh = "IsProactiveRefresh";
         public const string CallerSdkId = "CallerSdkId";
         public const string CallerSdkVersion = "CallerSdkVersion";
+        public const string MsalVersionPlatform = "MsalVersionPlatform";
 
 #endregion
     }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ProactiveRefreshTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ProactiveRefreshTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private long ValidateSuccessMetrics(MeterProvider meterProvider, List<Metric> exportedMetrics)
         {
-            Assert.HasCount(5, exportedMetrics);
+            Assert.HasCount(6, exportedMetrics);
 
             foreach (var metric in exportedMetrics)
             {

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Identity.Test.Unit
                 await AcquireTokenMsalClientExceptionAsync().ConfigureAwait(false);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(6, _exportedMetrics, 2, 2);
+                VerifyMetrics(7, _exportedMetrics, 2, 2);
             }
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Test.Unit
                 await AcquireTokenMsalClientExceptionAsync().ConfigureAwait(false);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(6, _exportedMetrics, 2, 2);
+                VerifyMetrics(7, _exportedMetrics, 2, 2);
             }
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(5, _exportedMetrics, 4, 0);
+                VerifyMetrics(6, _exportedMetrics, 4, 0);
             }
         }
 
@@ -222,7 +222,7 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(5, _exportedMetrics, 4, 0);
+                VerifyMetrics(6, _exportedMetrics, 4, 0);
             }
         }
 
@@ -279,7 +279,7 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(5, _exportedMetrics, 4, 0);
+                VerifyMetrics(6, _exportedMetrics, 4, 0);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Microsoft.Identity.Test.Unit
                 Thread.Sleep(1000);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(4, _exportedMetrics, 3, 1);
+                VerifyMetrics(5, _exportedMetrics, 3, 1);
             }
         }
 
@@ -570,6 +570,24 @@ namespace Microsoft.Identity.Test.Unit
                         expectedTags.Add(TelemetryConstants.ApiId);
                         expectedTags.Add(TelemetryConstants.TokenSource);
                         expectedTags.Add(TelemetryConstants.CacheLevel);
+                        expectedTags.Add(TelemetryConstants.TokenType);
+
+                        foreach (var metricPoint in exportedItem.GetMetricPoints())
+                        {
+                            AssertTags(metricPoint.Tags, expectedTags);
+                        }
+
+                        break;
+
+                    case "MsalRemainingTokenLifetime.1A":
+                        Trace.WriteLine("Verify the metrics captured for MsalRemainingTokenLifetime.1A histogram.");
+                        Assert.AreEqual(MetricType.Histogram, exportedItem.MetricType);
+
+                        expectedTags.Add(TelemetryConstants.MsalVersionPlatform);
+                        expectedTags.Add(TelemetryConstants.ApiId);
+                        expectedTags.Add(TelemetryConstants.TokenSource);
+                        expectedTags.Add(TelemetryConstants.CacheLevel);
+                        expectedTags.Add(TelemetryConstants.CacheRefreshReason);
                         expectedTags.Add(TelemetryConstants.TokenType);
 
                         foreach (var metricPoint in exportedItem.GetMetricPoints())

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -743,6 +743,8 @@ namespace Microsoft.Identity.Test.Unit
                         foreach (var metricPoint in exportedItem.GetMetricPoints())
                         {
                             AssertTags(metricPoint.Tags, expectedTags);
+                            Assert.IsGreaterThan((long)0, metricPoint.GetHistogramCount(), "Histogram should have at least one recorded value.");
+                            Assert.IsGreaterThanOrEqualTo(0.0, metricPoint.GetHistogramSum(), "Remaining token lifetime should be non-negative.");
                         }
 
                         break;

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Identity.Test.Unit
                 await AcquireTokenMsalClientExceptionAsync().ConfigureAwait(false);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(6, _exportedMetrics, 2, 2);
+                VerifyMetrics(7, _exportedMetrics, 2, 2);
             }
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.Identity.Test.Unit
                 await AcquireTokenMsalClientExceptionAsync().ConfigureAwait(false);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(6, _exportedMetrics, 2, 2);
+                VerifyMetrics(7, _exportedMetrics, 2, 2);
             }
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(5, _exportedMetrics, 4, 0);
+                VerifyMetrics(6, _exportedMetrics, 4, 0);
             }
         }
 
@@ -222,7 +222,7 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(5, _exportedMetrics, 4, 0);
+                VerifyMetrics(6, _exportedMetrics, 4, 0);
             }
         }
 
@@ -279,7 +279,7 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.AreEqual(CacheRefreshReason.NotApplicable, result.AuthenticationResultMetadata.CacheRefreshReason);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(5, _exportedMetrics, 4, 0);
+                VerifyMetrics(6, _exportedMetrics, 4, 0);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Microsoft.Identity.Test.Unit
                 Thread.Sleep(1000);
 
                 s_meterProvider.ForceFlush();
-                VerifyMetrics(4, _exportedMetrics, 3, 1);
+                VerifyMetrics(5, _exportedMetrics, 3, 1);
             }
         }
 
@@ -720,6 +720,24 @@ namespace Microsoft.Identity.Test.Unit
                         expectedTags.Add(TelemetryConstants.ApiId);
                         expectedTags.Add(TelemetryConstants.TokenSource);
                         expectedTags.Add(TelemetryConstants.CacheLevel);
+                        expectedTags.Add(TelemetryConstants.TokenType);
+
+                        foreach (var metricPoint in exportedItem.GetMetricPoints())
+                        {
+                            AssertTags(metricPoint.Tags, expectedTags);
+                        }
+
+                        break;
+
+                    case "MsalRemainingTokenLifetime.1A":
+                        Trace.WriteLine("Verify the metrics captured for MsalRemainingTokenLifetime.1A histogram.");
+                        Assert.AreEqual(MetricType.Histogram, exportedItem.MetricType);
+
+                        expectedTags.Add(TelemetryConstants.MsalVersionPlatform);
+                        expectedTags.Add(TelemetryConstants.ApiId);
+                        expectedTags.Add(TelemetryConstants.TokenSource);
+                        expectedTags.Add(TelemetryConstants.CacheLevel);
+                        expectedTags.Add(TelemetryConstants.CacheRefreshReason);
                         expectedTags.Add(TelemetryConstants.TokenType);
 
                         foreach (var metricPoint in exportedItem.GetMetricPoints())


### PR DESCRIPTION
Add new OTel histogram (MsalRemainingTokenLifetime.1A) that records the remaining lifetime of tokens in seconds at the time of acquisition.

Tags (6/8): MsalVersionPlatform (combined), ApiId, TokenSource, CacheLevel, CacheRefreshReason, TokenType.

Also adds TelemetryTokenTypeConstants.ToDisplayString() helper for int-to- string token type mapping used by the new histogram.

Resolves: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5889
PBI: 3554274

Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
