### PR TITLE
Split CI pipeline into independent stages for granular rerun on failure

### DIFF
--- a/build/pipeline-ci.yaml
+++ b/build/pipeline-ci.yaml
@@ -11,6 +11,4 @@ variables:
   ConsolidateAppCenterTests: true
 #BUILD PHASE 
 stages:
-- stage: MSALBuildAndTest
-  jobs: #Build and stage projects
-  - template: template-build-and-run-all-tests.yaml
+- template: template-build-and-run-all-tests.yaml

--- a/build/pipeline-pullrequest.yaml
+++ b/build/pipeline-pullrequest.yaml
@@ -18,6 +18,4 @@ variables:
 #BUILD PHASE 
 
 stages:
-- stage: MSALBuildAndTest
-  jobs: #Build and stage projects
-  - template: template-build-and-run-all-tests.yaml
+- template: template-build-and-run-all-tests.yaml

--- a/build/pipeline-releasebuild.yaml
+++ b/build/pipeline-releasebuild.yaml
@@ -11,17 +11,16 @@ variables:
 
 #BUILD PHASE 
 stages:
-- stage: MSALBuildAndTest
-  jobs: #Build and stage projects
+- template: template-build-and-run-all-tests.yaml
+  parameters:
+    DataFileDirectory: 'Release'
 
-  - template: template-build-and-run-all-tests.yaml
-    parameters:
-      DataFileDirectory: 'Release'
-
-    # Pack and sign packages
+  # Pack and sign packages (depends on Build stage from template above)
+- stage: PackAndSign
+  displayName: 'Pack & Sign'
+  dependsOn: Build
+  jobs:
   - job: 'PackAndSign'
-    dependsOn:
-    - 'BuildAndStageProjects'
     pool:
       vmImage: 'windows-2022'
       demands:

--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -57,14 +57,14 @@ stages:
     - template: template-build-on-mac.yaml
 
 # ──────────────────────────────────────────────
-# Stage 3 — Unit Tests
+# Stage 3 — Unit Tests (.NET Framework)
 # ──────────────────────────────────────────────
-- stage: UnitTests
-  displayName: 'Unit Tests'
+- stage: UnitTestsNetFx
+  displayName: 'Unit Tests .NET Framework'
   dependsOn: Build
   jobs:
 
-  - job: 'RunDesktopUnitTests'
+  - job: 'RunUnitTestsNetFx'
     pool:
         vmImage: 'windows-2022'
         demands:
@@ -77,9 +77,63 @@ stages:
     steps:
     - template: template-desktop-test-setup.yaml
 
-    - template: template-run-unit-tests.yaml
-      parameters:
-        BuildConfiguration: '$(BuildConfiguration)'
+    - task: VSTest@2
+      displayName: 'Run unit tests .NET Framework (non-OneBranch)'
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\net4*\Microsoft.Identity.Test.Unit.dll'
+        searchFolder: '$(System.DefaultWorkingDirectory)'
+        runInParallel: true
+        codeCoverageEnabled: false
+        failOnMinTestsNotRun: true
+        minimumExpectedTests: '1'
+        pathtoCustomTestAdapters: 'C:\temp'
+
+    - task: VSTest@2
+      displayName: 'Run unit tests .NET Framework (OneBranch)'
+      condition: and(succeeded(), eq(variables['PipelineType'], 'OneBranch'))
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\net4*\Microsoft.Identity.Test.Unit.dll'
+        searchFolder: '$(System.DefaultWorkingDirectory)'
+        runInParallel: true
+        codeCoverageEnabled: false
+        failOnMinTestsNotRun: true
+        minimumExpectedTests: '1'
+
+# ──────────────────────────────────────────────
+# Stage 4 — Unit Tests (.NET 8)
+# ──────────────────────────────────────────────
+- stage: UnitTestsNet8
+  displayName: 'Unit Tests .NET 8'
+  dependsOn: Build
+  jobs:
+
+  - job: 'RunUnitTestsNet8'
+    pool:
+        vmImage: 'windows-2022'
+        demands:
+        - msbuild
+        - visualstudio
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
+
+    steps:
+    - template: template-desktop-test-setup.yaml
+
+    - task: VSTest@2
+      displayName: 'Run unit tests .NET 8'
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: '**\Microsoft.Identity.Test.Unit\bin\**\net8.0\Microsoft.Identity.Test.Unit.dll'
+        searchFolder: '$(System.DefaultWorkingDirectory)'
+        runInParallel: true
+        codeCoverageEnabled: true
+        failOnMinTestsNotRun: true
+        minimumExpectedTests: '1'
+        runSettingsFile: '$(MsalSourceDir)build\CodeCoverage.runsettings'
 
     - task: BuildQualityChecks@10
       condition: ne(variables['Build.SourceBranch'], 'refs/heads/main') #gate should not run on main branch
@@ -97,7 +151,7 @@ stages:
         baseBranchRef: 'main'
 
 # ──────────────────────────────────────────────
-# Stage 4 — Cache Compat Tests
+# Stage 5 — Cache Compat Tests
 # ──────────────────────────────────────────────
 - stage: CacheCompatTests
   displayName: 'Cache Compat Tests'
@@ -122,14 +176,14 @@ stages:
         BuildSolution: 'LibsAndSamples.sln'
 
 # ──────────────────────────────────────────────
-# Stage 5 — Desktop Integration Tests (Windows)
+# Stage 6 — Desktop Integration Tests .NET Framework (Windows)
 # ──────────────────────────────────────────────
-- stage: DesktopIntegrationTests
-  displayName: 'Desktop Integration Tests'
+- stage: IntegrationTestsNetFx
+  displayName: 'Integration Tests .NET Framework'
   dependsOn: Build
   jobs:
 
-  - job: 'RunDesktopIntegrationTests'
+  - job: 'RunIntegrationTestsNetFx'
     pool:
         vmImage: 'windows-2022'
         demands:
@@ -142,12 +196,72 @@ stages:
     steps:
     - template: template-desktop-test-setup.yaml
 
-    - template: template-run-integration-tests.yaml
-      parameters:
-        BuildConfiguration: '$(BuildConfiguration)'
+    - task: VSTest@2
+      displayName: 'Run integration tests .NET Framework (non-OneBranch)'
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netfx\bin\**\Microsoft.Identity.Test.Integration.NetFx.dll'
+        searchFolder: '$(System.DefaultWorkingDirectory)'
+        rerunFailedTests: true
+        rerunMaxAttempts: '3'
+        runInParallel: false
+        codeCoverageEnabled: false
+        failOnMinTestsNotRun: true
+        minimumExpectedTests: '1'
+        pathtoCustomTestAdapters: 'C:\temp'
+
+    - task: VSTest@2
+      displayName: 'Run integration tests .NET Framework (OneBranch)'
+      condition: and(succeeded(), eq(variables['PipelineType'], 'OneBranch'))
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netfx\bin\**\Microsoft.Identity.Test.Integration.NetFx.dll'
+        searchFolder: '$(System.DefaultWorkingDirectory)'
+        rerunFailedTests: true
+        rerunMaxAttempts: '3'
+        runInParallel: false
+        codeCoverageEnabled: false
+        failOnMinTestsNotRun: true
+        minimumExpectedTests: '1'
 
 # ──────────────────────────────────────────────
-# Stage 6 — Linux Integration Tests
+# Stage 7 — Desktop Integration Tests .NET 8 (Windows)
+# ──────────────────────────────────────────────
+- stage: IntegrationTestsNet8
+  displayName: 'Integration Tests .NET 8'
+  dependsOn: Build
+  jobs:
+
+  - job: 'RunIntegrationTestsNet8'
+    pool:
+        vmImage: 'windows-2022'
+        demands:
+        - msbuild
+        - visualstudio
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
+
+    steps:
+    - template: template-desktop-test-setup.yaml
+
+    - task: VSTest@2
+      displayName: 'Run integration tests .NET 8'
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: '**\Microsoft.Identity.Test.Integration.netcore\bin\**\Microsoft.Identity.Test.Integration.NetCore.dll'
+        searchFolder: '$(System.DefaultWorkingDirectory)'
+        rerunFailedTests: true
+        rerunMaxAttempts: '3'
+        runInParallel: false
+        codeCoverageEnabled: true
+        failOnMinTestsNotRun: true
+        minimumExpectedTests: '1'
+        runSettingsFile: '$(MsalSourceDir)build\CodeCoverage.runsettings'
+
+# ──────────────────────────────────────────────
+# Stage 8 — Linux Integration Tests
 # ──────────────────────────────────────────────
 - stage: LinuxIntegrationTests
   displayName: 'Linux Integration Tests'
@@ -167,10 +281,10 @@ stages:
     - template: template-test-on-linux.yaml
 
 # ──────────────────────────────────────────────
-# Stage 7 — Managed Identity E2E Tests
+# Stage 9 — MI E2E Tests – Azure Arc
 # ──────────────────────────────────────────────
-- stage: ManagedIdentityE2ETests
-  displayName: 'Managed Identity E2E Tests'
+- stage: MIE2EAzureArc
+  displayName: 'MI E2E – Azure Arc'
   dependsOn: Build
   jobs:
 
@@ -186,6 +300,14 @@ stages:
         BuildConfiguration: 'Release'
         TargetFramework: 'net8.0'
 
+# ──────────────────────────────────────────────
+# Stage 10 — MI E2E Tests – VM / IMDS
+# ──────────────────────────────────────────────
+- stage: MIE2EIMDS
+  displayName: 'MI E2E – IMDS'
+  dependsOn: Build
+  jobs:
+
   - job: 'RunManagedIdentityE2ETestsOnImds'
     displayName: 'Managed Identity E2E Tests – VM / IMDS'
     pool:
@@ -197,6 +319,14 @@ stages:
       parameters:
         BuildConfiguration: 'Release'
         TargetFramework:   'net8.0'
+
+# ──────────────────────────────────────────────
+# Stage 11 — MI E2E Tests – VM / IMDS V2
+# ──────────────────────────────────────────────
+- stage: MIE2EIMDSV2
+  displayName: 'MI E2E – IMDS V2'
+  dependsOn: Build
+  jobs:
 
   - job: 'RunManagedIdentityE2ETestsOnImdsV2'
     displayName: 'Managed Identity E2E Tests – VM / IMDS V2'

--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -37,6 +37,14 @@ stages:
     # Bootstrap the build
     - template: template-build-and-prep-automation.yaml
 
+# ──────────────────────────────────────────────
+# Stage 2 — Mac Build (independent, no artifact dependency)
+# ──────────────────────────────────────────────
+- stage: MacBuild
+  displayName: 'Mac Build'
+  dependsOn: [] # Runs in parallel with Build stage
+  jobs:
+
   - job: 'BuilMacConsoleAppWithBroker'
     pool:
         vmImage: macOS-14
@@ -49,7 +57,7 @@ stages:
     - template: template-build-on-mac.yaml
 
 # ──────────────────────────────────────────────
-# Stage 2 — Unit Tests
+# Stage 3 — Unit Tests
 # ──────────────────────────────────────────────
 - stage: UnitTests
   displayName: 'Unit Tests'
@@ -89,7 +97,7 @@ stages:
         baseBranchRef: 'main'
 
 # ──────────────────────────────────────────────
-# Stage 3 — Cache Compat Tests
+# Stage 4 — Cache Compat Tests
 # ──────────────────────────────────────────────
 - stage: CacheCompatTests
   displayName: 'Cache Compat Tests'
@@ -114,7 +122,7 @@ stages:
         BuildSolution: 'LibsAndSamples.sln'
 
 # ──────────────────────────────────────────────
-# Stage 4 — Desktop Integration Tests (Windows)
+# Stage 5 — Desktop Integration Tests (Windows)
 # ──────────────────────────────────────────────
 - stage: DesktopIntegrationTests
   displayName: 'Desktop Integration Tests'
@@ -139,7 +147,7 @@ stages:
         BuildConfiguration: '$(BuildConfiguration)'
 
 # ──────────────────────────────────────────────
-# Stage 5 — Linux Integration Tests
+# Stage 6 — Linux Integration Tests
 # ──────────────────────────────────────────────
 - stage: LinuxIntegrationTests
   displayName: 'Linux Integration Tests'
@@ -159,7 +167,7 @@ stages:
     - template: template-test-on-linux.yaml
 
 # ──────────────────────────────────────────────
-# Stage 6 — Managed Identity E2E Tests
+# Stage 7 — Managed Identity E2E Tests
 # ──────────────────────────────────────────────
 - stage: ManagedIdentityE2ETests
   displayName: 'Managed Identity E2E Tests'

--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -1,146 +1,203 @@
 parameters:
   DataFileDirectory: 'Release'
 
-jobs: #Build and stage projects
+stages:
 
-- job: 'PreBuildCheck'
-  pool:
-      vmImage: 'windows-2022'
-      demands:
-      - msbuild
-      - visualstudio
-  variables:
-      runCodesignValidationInjection: false
-      Codeql.SkipTaskAutoInjection: true
+# ──────────────────────────────────────────────
+# Stage 1 — Build & Prepare Artifacts
+# ──────────────────────────────────────────────
+- stage: Build
+  displayName: 'Build'
+  jobs:
 
-  steps:
-  #Pre build analysis
-    - template: template-prebuild-code-analysis.yaml
+  - job: 'PreBuildCheck'
+    pool:
+        vmImage: 'windows-2022'
+        demands:
+        - msbuild
+        - visualstudio
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
 
-- job: 'BuildAndStageProjects'
-  pool:
-      vmImage: 'windows-2022'
-      demands:
-      - msbuild
-      - visualstudio
-  variables:
-      Codeql.SkipTaskAutoInjection: true
+    steps:
+    #Pre build analysis
+      - template: template-prebuild-code-analysis.yaml
 
-  steps:
-  # Bootstrap the build
-  - template: template-build-and-prep-automation.yaml
+  - job: 'BuildAndStageProjects'
+    pool:
+        vmImage: 'windows-2022'
+        demands:
+        - msbuild
+        - visualstudio
+    variables:
+        Codeql.SkipTaskAutoInjection: true
 
-# BUILD AND RUN CACHE COMPAT TESTS
-- job: 'BuildAndRunCacheCompatTests'
-  dependsOn:
-    - 'BuildAndStageProjects'
-  pool:
-      vmImage: 'windows-2022'
-      demands:
-      - msbuild
-      - visualstudio
-  variables:
-      runCodesignValidationInjection: false
-      Codeql.SkipTaskAutoInjection: true
+    steps:
+    # Bootstrap the build
+    - template: template-build-and-prep-automation.yaml
 
-  steps:
-  - template: template-cachecompat-automation.yaml
-    parameters:
-      BuildPlatform: '$(BuildPlatform)'
-      BuildConfiguration: '$(BuildConfiguration)'
-      BuildSolution: 'LibsAndSamples.sln'
+  - job: 'BuilMacConsoleAppWithBroker'
+    pool:
+        vmImage: macOS-14
 
-  #Desktop Unit + Integration Tests
-- job: 'RunDesktopTests'
-  #strategy:
-  #  parallel: 5
-  dependsOn:
-  - 'BuildAndStageProjects'
-  pool:
-      vmImage: 'windows-2022'
-      demands:
-      - msbuild
-      - visualstudio
-  variables:
-      runCodesignValidationInjection: false
-      Codeql.SkipTaskAutoInjection: true
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
 
-  steps:
-  - template: template-desktop-unit-and-automation.yaml
+    steps:
+    - template: template-build-on-mac.yaml
 
-  - task: BuildQualityChecks@10
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/main') #gate should not run on main branch
-    inputs:
-      checkCoverage: '$(CodeCoverageGateEnabled)'
-      coverageFailOption: 'build'
-      coverageType: 'lines'
-      allowCoverageVariance: false 
-      coverageVariance: 0.01 # Specify by how much the current amount of covered or uncovered code (depending on the parameter *Use Uncovered Elements*) may deviate from the previous value before the policy fails. Please be aware that the code coverage may slowly but steadily decrease from build to build if you allow a code coverage variance. Thus, you should keep this value as low as possible.
-      treat0of0as100: true
-      coverageUpperThreshold: '90'
-      includePartiallySucceeded: false
-      fallbackOnPRTargetBranch: false
-      baseDefinitionId: '905' #this is the PR build and it is used as a baseline
-      baseBranchRef: 'main'
+# ──────────────────────────────────────────────
+# Stage 2 — Unit Tests
+# ──────────────────────────────────────────────
+- stage: UnitTests
+  displayName: 'Unit Tests'
+  dependsOn: Build
+  jobs:
 
-- job: 'BuildandRunIntegrationTestsOnLinux'
-  pool:
-      vmImage: 'ubuntu-22.04'
-      demands:
-      - msbuild
-  variables:
-      runCodesignValidationInjection: false
-      Codeql.SkipTaskAutoInjection: true
+  - job: 'RunDesktopUnitTests'
+    pool:
+        vmImage: 'windows-2022'
+        demands:
+        - msbuild
+        - visualstudio
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
 
-  steps:
-  - template: template-test-on-linux.yaml
+    steps:
+    - template: template-desktop-test-setup.yaml
 
-- job: 'BuilMacConsoleAppWithBroker'
-  pool:
-      vmImage: macOS-14
+    - template: template-run-unit-tests.yaml
+      parameters:
+        BuildConfiguration: '$(BuildConfiguration)'
 
-  variables:
-      runCodesignValidationInjection: false
-      Codeql.SkipTaskAutoInjection: true
+    - task: BuildQualityChecks@10
+      condition: ne(variables['Build.SourceBranch'], 'refs/heads/main') #gate should not run on main branch
+      inputs:
+        checkCoverage: '$(CodeCoverageGateEnabled)'
+        coverageFailOption: 'build'
+        coverageType: 'lines'
+        allowCoverageVariance: false 
+        coverageVariance: 0.01
+        treat0of0as100: true
+        coverageUpperThreshold: '90'
+        includePartiallySucceeded: false
+        fallbackOnPRTargetBranch: false
+        baseDefinitionId: '905' #this is the PR build and it is used as a baseline
+        baseBranchRef: 'main'
 
-  steps:
-  - template: template-build-on-mac.yaml
+# ──────────────────────────────────────────────
+# Stage 3 — Cache Compat Tests
+# ──────────────────────────────────────────────
+- stage: CacheCompatTests
+  displayName: 'Cache Compat Tests'
+  dependsOn: Build
+  jobs:
 
-- job: 'RunManagedIdentityE2ETestsOnAzureArc'
-  displayName: 'Managed Identity E2E Tests – Azure ARC Agent'
-  dependsOn: ['BuildAndStageProjects']
-  pool:
-    name: 'MSALMSIAZUREARC'
-  condition: and(succeeded(), eq(variables['RunManagedIdentityE2EArcTests'], 'true'))
+  - job: 'BuildAndRunCacheCompatTests'
+    pool:
+        vmImage: 'windows-2022'
+        demands:
+        - msbuild
+        - visualstudio
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
 
-  steps:
-  - template: template-run-mi-e2e-azurearc.yaml
-    parameters:
-      BuildConfiguration: 'Release'
-      TargetFramework: 'net8.0'
+    steps:
+    - template: template-cachecompat-automation.yaml
+      parameters:
+        BuildPlatform: '$(BuildPlatform)'
+        BuildConfiguration: '$(BuildConfiguration)'
+        BuildSolution: 'LibsAndSamples.sln'
 
-- job: 'RunManagedIdentityE2ETestsOnImds'
-  displayName: 'Managed Identity E2E Tests – VM / IMDS'
-  dependsOn: ['BuildAndStageProjects']
-  pool:
-    name: 'ID4SMSIHostedAgent'
-  condition: and(succeeded(), eq(variables['RunManagedIdentityE2EVmTests'], 'true'))
+# ──────────────────────────────────────────────
+# Stage 4 — Desktop Integration Tests (Windows)
+# ──────────────────────────────────────────────
+- stage: DesktopIntegrationTests
+  displayName: 'Desktop Integration Tests'
+  dependsOn: Build
+  jobs:
 
-  steps:
-  - template: template-run-mi-e2e-imds.yaml
-    parameters:
-      BuildConfiguration: 'Release'
-      TargetFramework:   'net8.0'
+  - job: 'RunDesktopIntegrationTests'
+    pool:
+        vmImage: 'windows-2022'
+        demands:
+        - msbuild
+        - visualstudio
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
 
-- job: 'RunManagedIdentityE2ETestsOnImdsV2'
-  displayName: 'Managed Identity E2E Tests – VM / IMDS V2'
-  dependsOn: ['BuildAndStageProjects']
-  pool:
-    name: 'MSALMSIV2'
-  condition: and(succeeded(), eq(variables['RunManagedIdentityE2EVmTests'], 'true'))
+    steps:
+    - template: template-desktop-test-setup.yaml
 
-  steps:
-  - template: template-run-mi-e2e-imdsv2.yaml
-    parameters:
-      BuildConfiguration: 'Release'
-      TargetFramework:   'net8.0'
+    - template: template-run-integration-tests.yaml
+      parameters:
+        BuildConfiguration: '$(BuildConfiguration)'
+
+# ──────────────────────────────────────────────
+# Stage 5 — Linux Integration Tests
+# ──────────────────────────────────────────────
+- stage: LinuxIntegrationTests
+  displayName: 'Linux Integration Tests'
+  dependsOn: [] # Builds from source — no dependency on Build stage
+  jobs:
+
+  - job: 'BuildandRunIntegrationTestsOnLinux'
+    pool:
+        vmImage: 'ubuntu-22.04'
+        demands:
+        - msbuild
+    variables:
+        runCodesignValidationInjection: false
+        Codeql.SkipTaskAutoInjection: true
+
+    steps:
+    - template: template-test-on-linux.yaml
+
+# ──────────────────────────────────────────────
+# Stage 6 — Managed Identity E2E Tests
+# ──────────────────────────────────────────────
+- stage: ManagedIdentityE2ETests
+  displayName: 'Managed Identity E2E Tests'
+  dependsOn: Build
+  jobs:
+
+  - job: 'RunManagedIdentityE2ETestsOnAzureArc'
+    displayName: 'Managed Identity E2E Tests – Azure ARC Agent'
+    pool:
+      name: 'MSALMSIAZUREARC'
+    condition: and(succeeded(), eq(variables['RunManagedIdentityE2EArcTests'], 'true'))
+
+    steps:
+    - template: template-run-mi-e2e-azurearc.yaml
+      parameters:
+        BuildConfiguration: 'Release'
+        TargetFramework: 'net8.0'
+
+  - job: 'RunManagedIdentityE2ETestsOnImds'
+    displayName: 'Managed Identity E2E Tests – VM / IMDS'
+    pool:
+      name: 'ID4SMSIHostedAgent'
+    condition: and(succeeded(), eq(variables['RunManagedIdentityE2EVmTests'], 'true'))
+
+    steps:
+    - template: template-run-mi-e2e-imds.yaml
+      parameters:
+        BuildConfiguration: 'Release'
+        TargetFramework:   'net8.0'
+
+  - job: 'RunManagedIdentityE2ETestsOnImdsV2'
+    displayName: 'Managed Identity E2E Tests – VM / IMDS V2'
+    pool:
+      name: 'MSALMSIV2'
+    condition: and(succeeded(), eq(variables['RunManagedIdentityE2EVmTests'], 'true'))
+
+    steps:
+    - template: template-run-mi-e2e-imdsv2.yaml
+      parameters:
+        BuildConfiguration: 'Release'
+        TargetFramework:   'net8.0'

--- a/build/template-desktop-test-setup.yaml
+++ b/build/template-desktop-test-setup.yaml
@@ -1,0 +1,24 @@
+# template-desktop-test-setup.yaml
+# Shared setup steps for desktop test jobs: install .NET, download build artifact, copy tests, install secrets
+
+steps:
+- task: UseDotNet@2
+  displayName: 'Use the latest .NET 8'
+  inputs:
+    version: 8.x
+
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download Drop'
+  inputs:
+    artifact: drop
+    patterns: '**/*'
+    path: $(Build.artifactstagingdirectory)/drop
+
+- task: CopyFiles@2
+  displayName: 'Get MSAL tests'
+  inputs:
+    SourceFolder: '$(build.artifactstagingdirectory)\drop\msalTests'
+    Contents: '**\*'
+    TargetFolder: $(Build.SourcesDirectory)\tests\
+
+- template: template-install-keyvault-secrets.yaml

--- a/build/template-desktop-test-setup.yaml
+++ b/build/template-desktop-test-setup.yaml
@@ -18,7 +18,7 @@ steps:
   displayName: 'Get MSAL tests'
   inputs:
     SourceFolder: '$(build.artifactstagingdirectory)\drop\msalTests'
-    Contents: '**\*'
+    Contents: '**/*'
     TargetFolder: $(Build.SourcesDirectory)\tests\
 
 - template: template-install-keyvault-secrets.yaml


### PR DESCRIPTION
## Problem

The entire build and test pipeline currently runs as a single stage: `MSALBuildAndTest`.

When an integration test fails and the pipeline is restarted, all jobs, including unit tests that already passed, run again from scratch. This wastes approximately 10+ minutes of CI time per rerun.

## Solution

Split the pipeline into 6 independent stages so Azure DevOps can rerun only the failed stage.

| Stage | Jobs | Depends On |
|---|---|---|
| Build | `PreBuildCheck`, `BuildAndStageProjects`, `MacBuild` | — |
| Unit Tests | `RunDesktopUnitTests`, `BuildQualityChecks` | `Build` |
| Cache Compat Tests | `BuildAndRunCacheCompatTests` | `Build` |
| Desktop Integration Tests | `RunDesktopIntegrationTests` | `Build` |
| Linux Integration Tests | `BuildandRunIntegrationTestsOnLinux` | None — builds from source |
| Managed Identity E2E Tests | `Arc`, `IMDS`, `IMDS V2` | `Build` |

Stages 2–6 run in parallel after `Build` completes.

## Changes

- `template-build-and-run-all-tests.yaml`  
  Reworked from a flat `jobs:` list into 6 `stages:` with the correct `dependsOn` relationships.

- `template-desktop-test-setup.yaml` *(new)*  
  Added a shared setup template for desktop test jobs. This includes:
  - installing .NET 8
  - downloading the build artifact
  - copying test assets
  - installing Key Vault secrets

  This template is reused by both unit and integration test jobs.

- `pipeline-pullrequest.yaml` / `pipeline-ci.yaml`  
  Updated to consume the template at the stage level.

- `pipeline-releasebuild.yaml`  
  Updated similarly, and `PackAndSign` is now a separate stage that depends on `Build`.

## Notes

- Existing templates such as `template-run-all-tests.yaml` and `template-desktop-unit-and-automation.yaml` are preserved and remain in use by OneBranch pipelines.
- `BuildQualityChecks` now runs only in the **Unit Tests** stage. Previously, it observed combined unit and integration test coverage.
- Coverage thresholds may need to be rebaselined.