### PR TITLE
Feature: mTLS Bearer support via CertificateOptions.SendCertificateOverMtls

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         /// <summary>
         /// NON-PoP request:
-        /// We may still need mTLS transport if the credential can return a TokenBindingCertificate.
+        /// We may still need mTLS transport in two situations:
+        /// Case 1 – The app-level SendCertificateOverMtls option is set and the credential is a certificate.
+        /// Case 2 – The credential is a signed-assertion provider that returns a TokenBindingCertificate.
         /// </summary>
         private static async Task TryInitImplicitBearerOverMtlsAsync(
             AcquireTokenCommonParameters tokenParameters,
@@ -48,7 +50,23 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 return;
             }
 
-            // Only cert-capable credentials implement this capability interface.
+            // Case 1 – App opted into mTLS Bearer via SendCertificateOverMtls on a certificate credential.
+            if (serviceBundle.Config.CertificateOptions?.SendCertificateOverMtls == true &&
+                serviceBundle.Config.ClientCredential is CertificateClientCredential certCred)
+            {
+                if (certCred.Certificate == null)
+                {
+                    throw new MsalClientException(
+                        MsalError.MtlsCertificateNotProvided,
+                        MsalErrorMessage.MtlsCertificateNotProvidedMessage);
+                }
+
+                tokenParameters.MtlsCertificate = certCred.Certificate;
+                ThrowIfRegionMissingForImplicitMtls(serviceBundle);
+                return;
+            }
+
+            // Case 2 – Only cert-capable credentials implement this capability interface.
             if (serviceBundle.Config.ClientCredential is IClientSignedAssertionProvider signedProvider)
             {
                 var opts = CreateAssertionRequestOptions(tokenParameters, serviceBundle, ct);

--- a/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ApplicationConfiguration.cs
@@ -125,6 +125,7 @@ namespace Microsoft.Identity.Client
         public bool IsConfidentialClient { get; }
         public bool IsPublicClient => !IsConfidentialClient && !IsManagedIdentity;
         public string CertificateIdToAssociateWithToken { get; set; }
+        public CertificateOptions CertificateOptions { get; internal set; }
 
         public Func<AppTokenProviderParameters, Task<AppTokenProviderResult>> AppTokenProvider;
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/CertificateOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CertificateOptions.cs
@@ -24,5 +24,26 @@ namespace Microsoft.Identity.Client.AppConfig
         /// by default it is set to <see langword="false"/> /></remarks>
         /// </summary>
         public bool AssociateTokensWithCertificate { get; init; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the certificate should be sent over the mTLS connection
+        /// for token acquisition (without requiring PoP token type).
+        /// When <see langword="true"/>, the certificate is sent in the TLS handshake (client certificate authentication)
+        /// and the resulting token is a standard Bearer token.
+        /// When <see langword="false"/> (default), the certificate is sent as a JWT assertion in the request body.
+        /// </summary>
+        /// <remarks>
+        /// <para>This property sets the default transport for requests that do not explicitly call
+        /// <see cref="AcquireTokenForClientParameterBuilder.WithMtlsProofOfPossession"/>.</para>
+        /// <para>Request-level <see cref="AcquireTokenForClientParameterBuilder.WithMtlsProofOfPossession"/>
+        /// always implies mTLS transport, regardless of this setting.</para>
+        /// <para>This option is only supported with certificate credentials configured via
+        /// <see cref="ConfidentialClientApplicationBuilder.WithCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2, CertificateOptions)"/>.
+        /// Using it with client secrets or assertion-based credentials will throw at build time.</para>
+        /// <para>For AAD authorities, <see cref="ConfidentialClientApplicationBuilder.WithAzureRegion(string)"/>
+        /// must also be configured; otherwise an <see cref="MsalClientException"/> with error code
+        /// <see cref="MsalError.MtlsBearerWithoutRegion"/> is thrown at token acquisition time.</para>
+        /// </remarks>
+        public bool SendCertificateOverMtls { get; init; } = false;
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ConfidentialClientApplicationBuilder.cs
@@ -163,7 +163,8 @@ namespace Microsoft.Identity.Client
 
             Config.ClientCredential = new CertificateClientCredential(certificate);
             Config.SendX5C = certificateOptions?.SendX5C ?? false;
-            
+            Config.CertificateOptions = certificateOptions;
+
             return this;
         }
 
@@ -470,6 +471,14 @@ namespace Microsoft.Identity.Client
             }
 
             ValidateAndUpdateRegion();
+
+            if (Config.CertificateOptions?.SendCertificateOverMtls == true &&
+                Config.ClientCredential is not CertificateClientCredential)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidCredentialMaterial,
+                    MsalErrorMessage.SendCertificateOverMtlsRequiresCertificate);
+            }
         }
 
         private void ValidateAndUpdateRegion()

--- a/src/client/Microsoft.Identity.Client/Extensibility/ConfidentialClientApplicationBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/ConfidentialClientApplicationBuilderExtensions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Identity.Client.Extensibility
                 certificateProvider: certificateProvider);
 
             builder.Config.SendX5C = certificateOptions?.SendX5C ?? false;
+            builder.Config.CertificateOptions = certificateOptions;
 
             return builder;
         }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1255,5 +1255,13 @@ namespace Microsoft.Identity.Client
         /// Represents the error code returned when an IMDS operation fails.
         /// </summary>
         public const string ImdsServiceError = "imds_service_error";
+
+        /// <summary>
+        /// <para>What happened?</para> The configured credential type is not compatible with the
+        /// requested authentication mode. For example, <c>SendCertificateOverMtls</c> requires a
+        /// certificate-based credential.
+        /// <para>Mitigation:</para> Use a certificate credential via <c>WithCertificate()</c>.
+        /// </summary>
+        public const string InvalidCredentialMaterial = "invalid_credential_material";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -455,5 +455,9 @@ namespace Microsoft.Identity.Client
         public const string CannotSwitchBetweenImdsVersionsForPreview = "ImdsV2 is currently experimental - A Bearer token has already been received; Please restart the application to receive a mTLS PoP token.";
         public const string MtlsPopTokenNotSupportedinImdsV1 = "A mTLS PoP token cannot be requested because the application\'s source was determined to be ImdsV1.";
         public const string ManagedIdentityAllSourcesUnavailable = "All Managed Identity sources are unavailable.";
+        public const string SendCertificateOverMtlsRequiresCertificate =
+            "CertificateOptions.SendCertificateOverMtls is only valid when the application is configured with " +
+            "a certificate credential via WithCertificate(). " +
+            "Remove SendCertificateOverMtls or switch to a certificate-based credential.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
@@ -267,5 +267,91 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // Optional: if you rely on regional mTLS endpoints, check the host
             StringAssert.Contains(requestUriSeen ?? "", "mtlsauth.microsoft.com");
         }
+
+        [RunOn(SkipConditions.Linux)] // mTLS is not supported on Linux
+        public async Task Sni_Over_Mtls_Gets_Bearer_Token_Successfully_TestAsync()
+        {
+            // Arrange: Use LabResponseHelper to get app configuration
+            var appConfig = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppS2S).ConfigureAwait(false);
+
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+
+            string[] appScopes = new[] { "https://vault.azure.net/.default" };
+
+            var certificateOptions = new Client.AppConfig.CertificateOptions
+            {
+                SendX5C = true,
+                SendCertificateOverMtls = true
+            };
+
+            // Build Confidential Client Application with mTLS Bearer transport
+            IConfidentialClientApplication confidentialApp = ConfidentialClientApplicationBuilder.Create(MsiAllowListedAppIdforSNI)
+                .WithAuthority("https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c")
+                .WithAzureRegion("westus3") //test slice region
+                .WithCertificate(cert, certificateOptions)
+                .WithTestLogging()
+                .Build();
+
+            // Act: Acquire token - should be Bearer via mTLS transport
+            AuthenticationResult authResult = await confidentialApp
+                .AcquireTokenForClient(appScopes)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Assert: Check that a Bearer token was acquired
+            Assert.IsNotNull(authResult, "The authentication result should not be null.");
+            Assert.AreEqual("Bearer", authResult.TokenType, "Token type should be Bearer for mTLS Bearer flow");
+            Assert.IsNotNull(authResult.AccessToken, "Access token should not be null");
+
+            // Simulate cache retrieval
+            authResult = await confidentialApp
+               .AcquireTokenForClient(appScopes)
+               .ExecuteAsync()
+               .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, authResult.AuthenticationResultMetadata.TokenSource, "Token should be retrieved from cache");
+        }
+
+        [RunOn(SkipConditions.Linux)]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task Sni_Gets_Pop_Token_WithCertificateOptions_TestAsync(bool sendCertificateOverMtls)
+        {
+            // Arrange
+            var appConfig = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppS2S).ConfigureAwait(false);
+
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+
+            string[] appScopes = new[] { "https://vault.azure.net/.default" };
+
+            var certificateOptions = new Client.AppConfig.CertificateOptions
+            {
+                SendX5C = true,
+                SendCertificateOverMtls = sendCertificateOverMtls
+            };
+
+            // Build with CertificateOptions overload
+            IConfidentialClientApplication confidentialApp = ConfidentialClientApplicationBuilder.Create(MsiAllowListedAppIdforSNI)
+                .WithAuthority("https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c")
+                .WithAzureRegion("westus3")
+                .WithCertificate(cert, certificateOptions)
+                .WithTestLogging()
+                .Build();
+
+            // Act: WithMtlsProofOfPossession should always produce PoP, regardless of SendCertificateOverMtls
+            AuthenticationResult authResult = await confidentialApp
+                .AcquireTokenForClient(appScopes)
+                .WithMtlsProofOfPossession()
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Assert
+            Assert.IsNotNull(authResult, "The authentication result should not be null.");
+            Assert.AreEqual(Constants.MtlsPoPTokenType, authResult.TokenType, "Token type should be MTLS PoP");
+            Assert.IsNotNull(authResult.AccessToken, "Access token should not be null");
+            Assert.IsNotNull(authResult.BindingCertificate, "BindingCertificate should be set in SNI flow.");
+            Assert.AreEqual(cert.Thumbprint, authResult.BindingCertificate.Thumbprint,
+                "BindingCertificate must match the certificate supplied via WithCertificate().");
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppConfigTests/ConfidentialClientApplicationBuilderTests.cs
@@ -467,6 +467,67 @@ namespace Microsoft.Identity.Test.Unit.AppConfigTests
         }
 
         [TestMethod]
+        public void TestConstructor_CertificateOptions_SendCertificateOverMtls_DefaultsFalse()
+        {
+            var options = new CertificateOptions();
+            Assert.IsFalse(options.SendCertificateOverMtls,
+                "SendCertificateOverMtls should default to false.");
+        }
+
+        [TestMethod]
+        [DeploymentItem(@"Resources\testCert.crtfile")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Internal.Analyzers", "IA5352:DoNotMisuseCryptographicApi", Justification = "Test only")]
+        public void TestConstructor_WithCertificate_CertificateOptions_SendCertificateOverMtls_True()
+        {
+            var cert = new X509Certificate2(
+                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestPlaceholderCredential);
+            var certificateOptions = new CertificateOptions { SendCertificateOverMtls = true };
+
+            var app = ConfidentialClientApplicationBuilder
+                      .Create(TestConstants.ClientId)
+                      .WithCertificate(cert, certificateOptions)
+                      .Build();
+
+            Assert.IsTrue((app.AppConfig as ApplicationConfiguration).CertificateOptions?.SendCertificateOverMtls,
+                "SendCertificateOverMtls should be stored in ApplicationConfiguration when set to true.");
+        }
+
+        [TestMethod]
+        [DeploymentItem(@"Resources\testCert.crtfile")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Internal.Analyzers", "IA5352:DoNotMisuseCryptographicApi", Justification = "Test only")]
+        public void TestConstructor_WithCertificate_CertificateOptions_SendCertificateOverMtls_False()
+        {
+            var cert = new X509Certificate2(
+                ResourceHelper.GetTestResourceRelativePath("testCert.crtfile"), TestConstants.TestPlaceholderCredential);
+            var certificateOptions = new CertificateOptions { SendCertificateOverMtls = false };
+
+            var app = ConfidentialClientApplicationBuilder
+                      .Create(TestConstants.ClientId)
+                      .WithCertificate(cert, certificateOptions)
+                      .Build();
+
+            Assert.IsFalse(app.AppConfig is ApplicationConfiguration config && (config.CertificateOptions?.SendCertificateOverMtls ?? false),
+                "SendCertificateOverMtls should be false when not enabled.");
+        }
+
+        [TestMethod]
+        public void TestBuild_SendCertificateOverMtls_WithNonCertificateCredential_ThrowsAtBuildTime()
+        {
+            var builder = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret);
+
+            // Simulate misconfiguration by setting CertificateOptions directly
+            builder.Config.CertificateOptions = new CertificateOptions { SendCertificateOverMtls = true };
+
+            var ex = Assert.Throws<MsalClientException>(() => builder.Build());
+
+            Assert.AreEqual(MsalError.InvalidCredentialMaterial, ex.ErrorCode);
+            StringAssert.Contains(ex.Message, "SendCertificateOverMtls",
+                "Error message should reference the misconfigured property.");
+        }
+
+        [TestMethod]
         [DeploymentItem(@"Resources\CustomInstanceMetadata.json")]
         public void TestConstructor_WithValidInstanceDicoveryMetadata()
         {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
@@ -951,5 +951,110 @@ namespace Microsoft.Identity.Test.Unit
                 Assert.IsNull(bearerResult.BindingCertificate, "BindingCertificate must be null for Bearer tokens.");
             }
         }
+
+        #region SendCertificateOverMtls tests
+
+        [TestMethod]
+        public async Task SendCertificateOverMtls_NoRegion_ThrowsMtlsBearerWithoutRegionAsync()
+        {
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", null);
+
+                var options = new Client.AppConfig.CertificateOptions
+                {
+                    SendCertificateOverMtls = true
+                };
+
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithCertificate(s_testCertificate, options)
+                    .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                    .Build();
+
+                MsalClientException ex = await AssertException.TaskThrowsAsync<MsalClientException>(
+                    () => app.AcquireTokenForClient(TestConstants.s_scope).ExecuteAsync())
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.MtlsBearerWithoutRegion, ex.ErrorCode,
+                    "SendCertificateOverMtls=true without a region should throw MtlsBearerWithoutRegion.");
+            }
+        }
+
+        [TestMethod]
+        public async Task SendCertificateOverMtls_WithRegion_AcquiresBearerTokenAsync()
+        {
+            const string region = EastUsRegion;
+
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                using (var httpManager = new MockHttpManager())
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(tokenType: "Bearer");
+
+                    var options = new Client.AppConfig.CertificateOptions
+                    {
+                        SendCertificateOverMtls = true
+                    };
+
+                    var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                        .WithCertificate(s_testCertificate, options)
+                        .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                        .WithHttpManager(httpManager)
+                        .BuildConcrete();
+
+                    AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    Assert.AreEqual("Bearer", result.TokenType,
+                        "SendCertificateOverMtls without WithMtlsProofOfPossession should produce a Bearer token.");
+                    Assert.AreEqual(region, result.AuthenticationResultMetadata.RegionDetails.RegionUsed,
+                        "Token should be acquired from the regional endpoint.");
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task SendCertificateOverMtls_WithPopRequest_StillProducesPopTokenAsync()
+        {
+            const string region = EastUsRegion;
+
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                using (var httpManager = new MockHttpManager())
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(tokenType: "mtls_pop");
+
+                    var options = new Client.AppConfig.CertificateOptions
+                    {
+                        SendCertificateOverMtls = true
+                    };
+
+                    var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                        .WithCertificate(s_testCertificate, options)
+                        .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                        .WithHttpManager(httpManager)
+                        .BuildConcrete();
+
+                    AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithMtlsProofOfPossession()
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    Assert.AreEqual(Constants.MtlsPoPAuthHeaderPrefix, result.TokenType,
+                        "WithMtlsProofOfPossession() must produce an mTLS PoP token even when SendCertificateOverMtls=true.");
+                    Assert.IsNotNull(result.BindingCertificate,
+                        "BindingCertificate should be present for mTLS PoP.");
+                }
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Summary

Adds `CertificateOptions.SendCertificateOverMtls` to allow certificates to be sent over the mTLS handshake for standard **Bearer** token acquisition, without requiring PoP token type.

## Behavior matrix

| `SendCertificateOverMtls` | `.WithMtlsProofOfPossession()` | Transport              | Token type          |
|---|---|---|---|
| `false` (default) | No  | Request body assertion | Bearer — existing |
| `true` | No  | mTLS handshake         | Bearer — new |
| `false` | Yes | mTLS handshake         | mTLS PoP — existing |
| `true` | Yes | mTLS handshake         | mTLS PoP — existing |

Request-level `.WithMtlsProofOfPossession()` always wins. `SendCertificateOverMtls` is only the default transport for requests that do not request PoP.

## Usage

```csharp
var app = ConfidentialClientApplicationBuilder
    .Create(clientId)
    .WithAzureRegion("eastus")
    .WithCertificate(cert, new CertificateOptions { SendCertificateOverMtls = true })
    .Build();

var result = await app.AcquireTokenForClient(scopes).ExecuteAsync();
// result.TokenType == "Bearer", cert sent over mTLS handshake
```

## Changes

### Public API

- `CertificateOptions.SendCertificateOverMtls { get; init; } = false`
- `MsalError.InvalidCredentialMaterial`
- All 6 `PublicAPI.Unshipped.txt` files updated

### Config flow

- `ApplicationConfiguration.CertificateOptions` now stores the full options object, per review feedback, instead of copying individual properties.
- `ConfidentialClientApplicationBuilder.WithCertificate(X509Certificate2, CertificateOptions)` and `ConfidentialClientApplicationBuilderExtensions.WithCertificate(Func<…>, CertificateOptions)` both forward the options.

### Build-time validation

- `ConfidentialClientApplicationBuilder.Validate()` throws `InvalidCredentialMaterial` if `SendCertificateOverMtls = true` is set alongside a non-certificate credential.

### Core logic

- `MtlsPopParametersInitializer.TryInitImplicitBearerOverMtlsAsync` adds a new **Case 1**:
  - when `SendCertificateOverMtls = true` and the credential is `CertificateClientCredential`, it sets `MtlsCertificate` and enforces the AAD region check.
- The existing `IClientSignedAssertionProvider` path becomes **Case 2** and is otherwise unchanged.

## Tests

### New unit tests

7 new unit tests, all passing:

| Test | Validates |
|---|---|
| `TestConstructor_CertificateOptions_SendCertificateOverMtls_DefaultsFalse` | Default is `false` |
| `TestConstructor_…_True` / `TestConstructor_…_False` | Property round-trips through `ApplicationConfiguration.CertificateOptions` |
| `TestBuild_SendCertificateOverMtls_WithNonCertificateCredential_ThrowsAtBuildTime` | Build-time guard fires on non-certificate credential |
| `SendCertificateOverMtls_NoRegion_ThrowsMtlsBearerWithoutRegionAsync` | Missing AAD region throws at token acquisition |
| `SendCertificateOverMtls_WithRegion_AcquiresBearerTokenAsync` | Bearer acquired via mTLS transport path |
| `SendCertificateOverMtls_WithPopRequest_StillProducesPopTokenAsync` | Request-level PoP overrides app-level transport |

### New integration tests

2 new integration tests:

| Test | Validates |
|---|---|
| `Sni_Over_Mtls_Gets_Bearer_Token_Successfully_TestAsync` | mTLS Bearer happy path with region |
| `Sni_Gets_Pop_Token_WithCertificateOptions_TestAsync` | PoP still works with `CertificateOptions` overload (`DataRow(false)` / `DataRow(true)`) |
