### PR TITLE
Align OIDC issuer validation with other MSAL's 

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Oidc/OidcRetrieverWithCache.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Oidc/OidcRetrieverWithCache.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
@@ -77,54 +76,59 @@ namespace Microsoft.Identity.Client.Instance.Oidc
 
         /// <summary>
         /// Validates that the issuer in the OIDC metadata matches the authority.
+        /// Aligned with Python MSAL's has_valid_issuer() logic.
         /// </summary>
         /// <param name="authority">The authority URL.</param>
         /// <param name="issuer">The issuer from the OIDC metadata - the single source of truth.</param>
         /// <exception cref="MsalServiceException">Thrown when issuer validation fails.</exception>
-        private static void ValidateIssuer(Uri authority, string issuer)
+        internal static void ValidateIssuer(Uri authority, string issuer)
         {
-            // Normalize both URLs to handle trailing slash differences
-            string normalizedAuthority = authority.AbsoluteUri.TrimEnd('/');
-            string normalizedIssuer = issuer?.TrimEnd('/');
-
-            // OIDC validation: if the issuer's scheme and host match the authority's, consider it valid
-            if (!string.IsNullOrEmpty(issuer) && Uri.TryCreate(issuer, UriKind.Absolute, out Uri issuerUri))
+            if (string.IsNullOrEmpty(issuer) || !Uri.TryCreate(issuer, UriKind.Absolute, out Uri issuerUri))
             {
-                if (string.Equals(authority.Scheme, issuerUri.Scheme, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(authority.Host, issuerUri.Host, StringComparison.OrdinalIgnoreCase))
+                throw new MsalServiceException(
+                    MsalError.AuthorityValidationFailed,
+                    string.Format(MsalErrorMessage.IssuerValidationFailed, authority, issuer));
+            }
+
+            string issuerHost = issuerUri.Host;
+
+            // Check 1: Scheme + Host match (existing check)
+            if (string.Equals(authority.Scheme, issuerUri.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(authority.Host, issuerHost, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            // Check 2: Well-known authority host allowlist (O(1) lookup)
+            if (Constants.WellKnownAuthorityHosts.Contains(issuerHost))
+            {
+                return;
+            }
+
+            // Check 3: Regional variant (e.g., westus2.login.microsoft.com)
+            int dotIndex = issuerHost.IndexOf('.');
+            if (dotIndex > 0)
+            {
+                string potentialBase = issuerHost.Substring(dotIndex + 1);
+
+                // 3a: Base host is a well-known authority host
+                if (Constants.WellKnownAuthorityHosts.Contains(potentialBase))
+                {
+                    return;
+                }
+
+                // 3b: Base host matches the authority host (e.g., issuer=us.custom.com, authority=custom.com)
+                if (string.Equals(potentialBase, authority.Host, StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }
             }
 
-            // CIAM-specific validation: In a CIAM scenario the issuer is expected to have "{tenant}.ciamlogin.com"
-            // as the host, even when using a custom domain.
-            string tenant = null;
-            try
+            // Check 4: B2C host suffix (e.g., mytenant.b2clogin.com, mytenant.ciamlogin.com)
+            // Uses dot prefix to prevent spoofing (fakeb2clogin.com won't match)
+            foreach (string suffix in Constants.WellKnownB2CHostSuffixes)
             {
-                tenant = AuthorityInfo.GetFirstPathSegment(authority);
-            }
-            catch (InvalidOperationException)
-            {
-                // If no path segments exist, try to extract from hostname (first part)
-                var hostParts = authority.Host.Split('.');
-                tenant = hostParts.Length > 0 ? hostParts[0] : null;
-            }
-
-            // If tenant extraction failed or returned empty, validation fails
-            if (!string.IsNullOrEmpty(tenant))
-            {
-                // Create a collection of valid CIAM issuer patterns for the tenant
-                string[] validCiamPatterns =
-                {
-                    $"https://{tenant}{Constants.CiamAuthorityHostSuffix}",
-                    $"https://{tenant}{Constants.CiamAuthorityHostSuffix}/{tenant}",
-                    $"https://{tenant}{Constants.CiamAuthorityHostSuffix}/{tenant}/v2.0"
-                };
-
-                // Normalize and check if the issuer matches any of the valid patterns
-                if (validCiamPatterns.Any(pattern =>
-                    string.Equals(normalizedIssuer, pattern.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)))
+                if (issuerHost.EndsWith("." + suffix, StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Constants.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Identity.Client.Internal
 {
@@ -52,6 +53,41 @@ namespace Microsoft.Identity.Client.Internal
         public const string ManagedIdentityDefaultClientId = "system_assigned_managed_identity";
         public const string ManagedIdentityDefaultTenant = "managed_identity";
         public const string CiamAuthorityHostSuffix = ".ciamlogin.com";
+
+        /// <summary>
+        /// Well-known Microsoft authority hosts trusted for issuer validation.
+        /// Aligned with Python MSAL's WELL_KNOWN_AUTHORITY_HOSTS.
+        /// </summary>
+        public static readonly HashSet<string> WellKnownAuthorityHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "login.microsoftonline.com",
+            "login.microsoft.com",
+            "login.windows.net",
+            "sts.windows.net",
+            "login.chinacloudapi.cn",
+            "login.partner.microsoftonline.cn",
+            "login.microsoftonline.de",
+            "login-us.microsoftonline.com",
+            "login.microsoftonline.us",
+            "login.usgovcloudapi.net",
+            "login.sovcloud-identity.fr",
+            "login.sovcloud-identity.de",
+            "login.sovcloud-identity.sg",
+        };
+
+        /// <summary>
+        /// Well-known B2C host suffixes (without leading dot) for issuer validation.
+        /// Aligned with Python MSAL's WELL_KNOWN_B2C_HOSTS.
+        /// </summary>
+        public static readonly string[] WellKnownB2CHostSuffixes = new[]
+        {
+            "b2clogin.com",
+            "b2clogin.cn",
+            "b2clogin.us",
+            "b2clogin.de",
+            "ciamlogin.com",
+        };
+
         public const string CertSerialNumber = "cert_sn";
         public const string FmiNodeClientId = "urn:microsoft:identity:fmi";
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/OidcIssuerValidationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/OidcIssuerValidationTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Instance.Oidc;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
+{
+    [TestClass]
+    public class OidcIssuerValidationTests
+    {
+        #region Passing cases
+
+        [TestMethod]
+        [DataRow("https://login.microsoftonline.com/tenant/v2.0", "https://login.microsoftonline.com/tenant/v2.0", DisplayName = "ExactSchemeAndHostMatch")]
+        [DataRow("https://login.microsoftonline.com/tenant1", "https://login.microsoftonline.com/tenant2/v2.0", DisplayName = "SameHostDifferentPath")]
+        [DataRow("https://login.microsoftonline.com/tenant/", "https://login.microsoftonline.com/tenant", DisplayName = "TrailingSlashNormalization")]
+        public void ValidateIssuer_SchemeAndHostMatch_Passes(string authority, string issuer)
+        {
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        [TestMethod]
+        [DataRow("https://clientlogin.test.parentpay.com/ebdf0e4c/v2.0", "https://login.microsoftonline.com/ebdf0e4c/v2.0", DisplayName = "WellKnownIssuer_CustomDomainAuthority")]
+        [DataRow("https://custom.example.com/tenant", "https://login.windows.net/tenant", DisplayName = "WellKnownIssuer_LoginWindowsNet")]
+        [DataRow("https://custom.example.com/tenant", "https://sts.windows.net/tenant", DisplayName = "WellKnownIssuer_StsWindowsNet")]
+        [DataRow("https://custom.example.com/tenant", "https://login.microsoftonline.us/tenant", DisplayName = "WellKnownIssuer_USGov")]
+        [DataRow("https://custom.example.com/tenant", "https://login.chinacloudapi.cn/tenant", DisplayName = "WellKnownIssuer_China")]
+        public void ValidateIssuer_WellKnownHost_Passes(string authority, string issuer)
+        {
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        [TestMethod]
+        [DataRow("https://custom.example.com/tenant", "https://westus2.login.microsoft.com/tenant", DisplayName = "RegionalVariant_WellKnownBase")]
+        [DataRow("https://myidp.example.com/tenant", "https://eastus.myidp.example.com/tenant", DisplayName = "RegionalVariant_AuthorityHost")]
+        public void ValidateIssuer_RegionalVariant_Passes(string authority, string issuer)
+        {
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        [TestMethod]
+        [DataRow("https://custom.example.com/tenant", "https://mytenant.b2clogin.com/tenant", DisplayName = "B2C_ValidSubdomain")]
+        [DataRow("https://custom.example.com/tenant", "https://mytenant.ciamlogin.com/tenant", DisplayName = "B2C_CiamLogin")]
+        public void ValidateIssuer_B2CHostSuffix_Passes(string authority, string issuer)
+        {
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        [TestMethod]
+        [DataRow("https://customdomain.com/mytenantid", "https://mytenantid.ciamlogin.com/mytenantid/v2.0", DisplayName = "CIAM_TenantPattern")]
+        [DataRow("https://customdomain.com/mytenantid", "https://mytenantid.ciamlogin.com/mytenantid", DisplayName = "CIAM_TenantPatternNoVersion")]
+        [DataRow("https://customdomain.com/mytenantid", "https://mytenantid.ciamlogin.com", DisplayName = "CIAM_TenantPatternHostOnly")]
+        public void ValidateIssuer_CIAMTenantPattern_Passes(string authority, string issuer)
+        {
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        #endregion
+
+        #region Failing cases
+
+        [TestMethod]
+        public void ValidateIssuer_UnknownIssuer_Throws()
+        {
+            var ex = AssertException.Throws<MsalServiceException>(() =>
+                OidcRetrieverWithCache.ValidateIssuer(
+                    new Uri("https://custom.example.com/tenant"),
+                    "https://evil.example.net/tenant"));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void ValidateIssuer_SpoofedB2C_NoDotPrefix_Throws()
+        {
+            var ex = AssertException.Throws<MsalServiceException>(() =>
+                OidcRetrieverWithCache.ValidateIssuer(
+                    new Uri("https://custom.example.com/tenant"),
+                    "https://fakeb2clogin.com/tenant"));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void ValidateIssuer_NullIssuer_Throws()
+        {
+            var ex = AssertException.Throws<MsalServiceException>(() =>
+                OidcRetrieverWithCache.ValidateIssuer(
+                    new Uri("https://custom.example.com/tenant"),
+                    null));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void ValidateIssuer_EmptyIssuer_Throws()
+        {
+            var ex = AssertException.Throws<MsalServiceException>(() =>
+                OidcRetrieverWithCache.ValidateIssuer(
+                    new Uri("https://custom.example.com/tenant"),
+                    ""));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void ValidateIssuer_HttpScheme_WellKnownHost_Passes()
+        {
+            // http scheme with a well-known host is accepted because the host is trusted
+            // (matches Python MSAL behavior where well-known host check doesn't verify scheme)
+            OidcRetrieverWithCache.ValidateIssuer(
+                new Uri("https://login.microsoftonline.com/tenant"),
+                "http://login.microsoftonline.com/tenant");
+        }
+
+        [TestMethod]
+        public void ValidateIssuer_HttpScheme_UnknownHost_Throws()
+        {
+            // http scheme with an unknown host should fail (scheme mismatch + not well-known)
+            var ex = AssertException.Throws<MsalServiceException>(() =>
+                OidcRetrieverWithCache.ValidateIssuer(
+                    new Uri("https://custom.example.com/tenant"),
+                    "http://custom.example.com/tenant"));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #5927

## Description:

### Problem
Custom domain authorities (e.g., clientlogin.test.parentpay.com) fail OIDC issuer validation when the discovery endpoint returns a well-known Microsoft issuer (e.g., login.microsoftonline.com). The existing code only checked scheme+host match and CIAM patterns, missing several legitimate scenarios.

### Solution
Added three validation checks from other MSAL's issuer validation:

Well-known authority host allowlist, Accept issuers from trusted Microsoft hosts (e.g., `login.microsoftonline.com`, `sts.windows.net`, `login.chinacloudapi.cn`, `sovereign clouds`)
Regional variants, Accept issuers like `westus2.login.microsoft.com` where the base host is trusted or matches the authority
B2C host suffixes, Accept issuers from `*.b2clogin.com,` `*.ciamlogin.com`, etc. with dot-prefix to prevent spoofing
Removed the redundant CIAM tenant pattern check since it's fully covered by the B2C suffix check.

### Example: Previously failing, now passing
```c#
Authority:  https://clientlogin.test.parentpay.com/ebdf0e4c/v2.0
Issuer:     https://login.microsoftonline.com/ebdf0e4c/v2.0
Result:     ✅ Accepted (issuer host is in well-known allowlist)
```
### Changes
`Constants.cs` : Added WellKnownAuthorityHosts (13 hosts) and WellKnownB2CHostSuffixes (5 suffixes)
`OidcRetrieverWithCache.cs` : Updated ValidateIssuer with new checks, changed to internal static for testability
`OidcIssuerValidationTests.cs` (new) : 21 unit tests covering all validation paths

**Documentation**
- [x] All relevant documentation is updated.
