### PR TITLE
Remove Build dependency from MI E2E test stages

### DIFF
--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -285,7 +285,7 @@ stages:
 # ──────────────────────────────────────────────
 - stage: MIE2EAzureArc
   displayName: 'MI E2E – Azure Arc'
-  dependsOn: Build
+  dependsOn: [] # Builds from source — no dependency on Build stage
   jobs:
 
   - job: 'RunManagedIdentityE2ETestsOnAzureArc'
@@ -305,7 +305,7 @@ stages:
 # ──────────────────────────────────────────────
 - stage: MIE2EIMDS
   displayName: 'MI E2E – IMDS'
-  dependsOn: Build
+  dependsOn: [] # Builds from source — no dependency on Build stage
   jobs:
 
   - job: 'RunManagedIdentityE2ETestsOnImds'
@@ -325,7 +325,7 @@ stages:
 # ──────────────────────────────────────────────
 - stage: MIE2EIMDSV2
   displayName: 'MI E2E – IMDS V2'
-  dependsOn: Build
+  dependsOn: [] # Builds from source — no dependency on Build stage
   jobs:
 
   - job: 'RunManagedIdentityE2ETestsOnImdsV2'


### PR DESCRIPTION
Updated dependencies for MI E2E test stages to remove reliance on Build stage. These stages do not rely on Build. The test project itself gets built with MSAL 
