### PR TITLE
Add CorrelationId to AssertionRequestOptions for FIC 

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 Claims = p.Claims,
                 CancellationToken = ct,
                 ClientAssertionFmiPath = p.ClientAssertionFmiPath,
+                CorrelationId = p.CorrelationId,
 
                 // Best-effort context. IMPORTANT: use AbsoluteUri, not Uri.Authority (host only).
                 TokenEndpoint = serviceBundle.Config.Authority.AuthorityInfo.CanonicalAuthority.AbsoluteUri

--- a/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -27,12 +28,14 @@ namespace Microsoft.Identity.Client
         /// <param name="appConfig">The application configuration</param>
         /// <param name="tokenEndpoint">The token endpoint used to acquire the token</param>
         /// <param name="tenantId">The tenant ID from the runtime authority</param>
-        internal AssertionRequestOptions(ApplicationConfiguration appConfig, string tokenEndpoint, string tenantId)
+        /// <param name="correlationId">The correlation ID from the authentication request</param>
+        internal AssertionRequestOptions(ApplicationConfiguration appConfig, string tokenEndpoint, string tenantId, Guid correlationId = default)
         {
             ClientID = appConfig.ClientId;
             TokenEndpoint = tokenEndpoint;
             Authority = appConfig.Authority?.AuthorityInfo?.CanonicalAuthority?.ToString();
             TenantId = tenantId;
+            CorrelationId = correlationId;
         }
 
         /// <summary>
@@ -76,5 +79,11 @@ namespace Microsoft.Identity.Client
         /// FMI path to be used for client assertion. Tokens are associated with this path in the cache.
         /// </summary>
         public string ClientAssertionFmiPath { get; set; }
+
+        /// <summary>
+        /// Correlation ID of the authentication request. Use this to propagate the same correlation ID 
+        /// to downstream token requests (e.g., Managed Identity) for coherent end-to-end tracing.
+        /// </summary>
+        public Guid CorrelationId { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CertificateAndClaimsClientCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CertificateAndClaimsClientCredential.cs
@@ -142,7 +142,8 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
             var options = new AssertionRequestOptions(
                 requestParameters.AppConfig,
                 tokenEndpoint,
-                requestParameters.AuthorityManager.Authority.TenantId)
+                requestParameters.AuthorityManager.Authority.TenantId,
+                requestParameters.RequestContext.CorrelationId)
             {
                 Claims = requestParameters.Claims,
                 ClientCapabilities = requestParameters.AppConfig.ClientCapabilities,

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/ClientAssertionDelegateCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/ClientAssertionDelegateCredential.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
                 TokenEndpoint = tokenEndpoint,
                 ClientCapabilities = p.RequestContext.ServiceBundle.Config.ClientCapabilities,
                 Claims = p.Claims,
-                ClientAssertionFmiPath = p.ClientAssertionFmiPath
+                ClientAssertionFmiPath = p.ClientAssertionFmiPath,
+                CorrelationId = p.RequestContext.CorrelationId
             };
 
             ClientSignedAssertion resp = await GetAssertionAsync(opts, ct).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/ClientAssertionStringDelegateCredential.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/ClientAssertionStringDelegateCredential.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
                 TokenEndpoint = tokenEndpoint,
                 ClientCapabilities = p.RequestContext.ServiceBundle.Config.ClientCapabilities,
                 Claims = p.Claims,
-                ClientAssertionFmiPath = p.ClientAssertionFmiPath
+                ClientAssertionFmiPath = p.ClientAssertionFmiPath,
+                CorrelationId = p.RequestContext.CorrelationId
             };
 
             string assertion = await _provider(opts, ct).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -251,7 +251,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 var options = new AssertionRequestOptions(
                     AuthenticationRequestParameters.AppConfig, 
                     tokenEndpoint,
-                    AuthenticationRequestParameters.AuthorityManager.Authority.TenantId);
+                    AuthenticationRequestParameters.AuthorityManager.Authority.TenantId,
+                    AuthenticationRequestParameters.RequestContext.CorrelationId);
                 
                 var executionResult = new ExecutionResult
                 {
@@ -299,7 +300,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 var options = new AssertionRequestOptions(
                     AuthenticationRequestParameters.AppConfig, 
                     tokenEndpoint,
-                    AuthenticationRequestParameters.AuthorityManager.Authority.TenantId);
+                    AuthenticationRequestParameters.AuthorityManager.Authority.TenantId,
+                    AuthenticationRequestParameters.RequestContext.CorrelationId);
                 
                 var executionResult = new ExecutionResult
                 {

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
+Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/Agentic.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/Agentic.cs
@@ -37,19 +37,31 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private static async Task AgentGetsAppTokenForGraph()
         {
+            Guid expectedCorrelationId = Guid.NewGuid();
+            Guid capturedCorrelationId = Guid.Empty;
+
             var cca = ConfidentialClientApplicationBuilder
                         .Create(AgentIdentity)
                         .WithAuthority("https://login.microsoftonline.com/", TenantId)
                         .WithCacheOptions(CacheOptions.EnableSharedCacheOptions)
                         .WithExperimentalFeatures(true)
-                        .WithClientAssertion((AssertionRequestOptions _) => GetAppCredentialAsync(AgentIdentity))
+                        .WithClientAssertion((AssertionRequestOptions options) =>
+                        {
+                            capturedCorrelationId = options.CorrelationId;
+                            return GetAppCredentialAsync(AgentIdentity);
+                        })
                         .Build();
 
             var result = await cca.AcquireTokenForClient([Scope])
+                .WithCorrelationId(expectedCorrelationId)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 
             Trace.WriteLine($"FMI app credential from : {result.AuthenticationResultMetadata.TokenSource}");
+
+            // Verify CorrelationId flowed to the assertion callback (Issue #5924)
+            Assert.AreEqual(expectedCorrelationId, capturedCorrelationId,
+                "CorrelationId from WithCorrelationId() must flow to the assertion callback.");
         }
 
         private static async Task AgentUserIdentityGetsTokenForGraphAsync()

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
@@ -107,11 +107,14 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             // Step 2: build the assertion-based app (NO WithCertificate here)
             bool assertionProviderCalled = false;
             string tokenEndpointSeenByProvider = null;
+            Guid correlationIdSeenByProvider = Guid.Empty;
 
             string requestUriSeen = null;
             string clientAssertionType = null;
             bool sawClientAssertionParam = false;
             bool sawClientAssertionTypeParam = false;
+
+            Guid expectedCorrelationId = Guid.NewGuid();
 
             IConfidentialClientApplication assertionApp = ConfidentialClientApplicationBuilder.Create(MsiAllowListedAppIdforSNI)
                 .WithExperimentalFeatures()
@@ -121,6 +124,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 {
                     assertionProviderCalled = true;
                     tokenEndpointSeenByProvider = options.TokenEndpoint;
+                    correlationIdSeenByProvider = options.CorrelationId;
 
                     return Task.FromResult(new ClientSignedAssertion
                     {
@@ -135,6 +139,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             AuthenticationResult second = await assertionApp
                 .AcquireTokenForClient(new[] { "https://vault.azure.net/.default" })
                 .WithMtlsProofOfPossession()
+                .WithCorrelationId(expectedCorrelationId)
                 .OnBeforeTokenRequest(data =>
                 {
                     requestUriSeen = data.RequestUri?.ToString();
@@ -173,6 +178,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             // Optional: if you rely on regional mTLS endpoints, check the host
             StringAssert.Contains(requestUriSeen ?? "", "mtlsauth.microsoft.com");
+
+            // Verify CorrelationId flowed to the assertion callback (Issue #5924)
+            Assert.AreEqual(expectedCorrelationId, correlationIdSeenByProvider,
+                "CorrelationId from WithCorrelationId() must flow to the assertion callback for FIC two-leg tracing.");
         }
 
         //Downgraded test to verify bearer token acquisition works in SNI + jwt-pop scenario

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/ClientCredentialsMtlsPopTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientAssertionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientAssertionTests.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                         Assert.IsNull(options.ClientCapabilities);
                         Assert.IsNull(options.ClientAssertionFmiPath);
                         Assert.AreEqual(TestConstants.ClientId, options.ClientID);
+                        Assert.AreNotEqual(Guid.Empty, options.CorrelationId, "CorrelationId should be populated");
                         return await Task.FromResult("dummy_assertion").ConfigureAwait(false);
                     })
                     .BuildConcrete();
@@ -1048,6 +1049,71 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
                 Assert.IsGreaterThanOrEqualTo(1, callCount, "Expected the client assertion provider to be called at least once.");
+            }
+        }
+
+        [TestMethod]
+        public async Task CorrelationId_FlowsToSignedAssertionCallback_WithUserProvidedId()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                Guid expectedCorrelationId = Guid.NewGuid();
+                Guid capturedCorrelationId = Guid.Empty;
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithExperimentalFeatures(true)
+                    .WithHttpManager(httpManager)
+                    .WithClientAssertion((AssertionRequestOptions opts, CancellationToken ct) =>
+                    {
+                        capturedCorrelationId = opts.CorrelationId;
+                        return Task.FromResult(new ClientSignedAssertion { Assertion = "jwt" });
+                    })
+                    .BuildConcrete();
+
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithCorrelationId(expectedCorrelationId)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(expectedCorrelationId, capturedCorrelationId,
+                    "CorrelationId from WithCorrelationId() must flow to the assertion callback.");
+            }
+        }
+
+        [TestMethod]
+        public async Task CorrelationId_FlowsToStringAssertionCallback_WithUserProvidedId()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                Guid expectedCorrelationId = Guid.NewGuid();
+                Guid capturedCorrelationId = Guid.Empty;
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithHttpManager(httpManager)
+                    .WithClientAssertion(async (AssertionRequestOptions opts) =>
+                    {
+                        capturedCorrelationId = opts.CorrelationId;
+                        return await Task.FromResult("dummy_assertion").ConfigureAwait(false);
+                    })
+                    .BuildConcrete();
+
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithCorrelationId(expectedCorrelationId)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(expectedCorrelationId, capturedCorrelationId,
+                    "CorrelationId from WithCorrelationId() must flow to the string assertion callback.");
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -1986,6 +1986,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             options.TokenEndpoint = "https://login.microsoft.com/v2.0/token";
             options.CancellationToken = CancellationToken.None;
             options.Claims = TestConstants.Claims;
+            options.CorrelationId = Guid.NewGuid();
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #5924
 
 ## Summary
 
 Adds a `CorrelationId` (`Guid`) property to `AssertionRequestOptions` so that the CCA's correlation ID flows into assertion callbacks. This enables coherent end-to-end tracing across both legs of FIC token exchange flows when the callback implementer forwards the ID to 
downstream MI/CCA requests.
 
 ## Changes
 
 ### Production
 - **`AssertionRequestOptions.cs`** — new `public Guid CorrelationId` property + updated internal constructor
 - **6 construction sites** — propagate `CorrelationId` from `RequestContext` or `CommonParameters`:
   - `ClientAssertionDelegateCredential`
   - `ClientAssertionStringDelegateCredential`
   - `ClientCredentialRequest` (OnMsalServiceFailure + OnCompletion)
   - `MtlsPopParametersInitializer`
   - `CertificateAndClaimsClientCredential`
 - **PublicAPI.Unshipped.txt** — updated for all 6 target frameworks
 
 ### Tests
 - Updated `AssertionInputIsMutable` to cover new property
 - Updated `SignedAssertionDelegateClientCredential_NoClaims` to assert CorrelationId is populated
 - **2 new unit tests** verifying user-provided CorrelationId flows to both delegate types (string + `ClientSignedAssertion`)
 - **2 E2E tests updated** (`Sni_AssertionFlow`, `AgentGetsAppTokenForGraph`) to verify CorrelationId in FIC assertion callbacks
 
 ## Usage
 
 ```csharp
 .WithClientAssertion(async (AssertionRequestOptions options, CancellationToken ct) =>
 {
     // options.CorrelationId now carries the CCA's correlation ID
     var miResult = await miApp
         .AcquireTokenForManagedIdentity("api://AzureADTokenExchange")
         .WithCorrelationId(options.CorrelationId) // propagate for tracing
         .ExecuteAsync(ct);
 
     return new ClientSignedAssertion { Assertion = miResult.AccessToken };
 })