### PR TITLE
Expose refresh token via extension and add CacheOptions.DisableInternalCache

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -190,6 +190,13 @@ namespace Microsoft.Identity.Client
                     MsalErrorMessage.InternalCacheDisabledMutuallyExclusiveMessage);
             }
 
+            if (CacheOptions.IsDisabledFor(options) && Config.IsPublicClient)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidRequest,
+                    MsalErrorMessage.InternalCacheDisabledNotSupportedForPublicClient);
+            }
+
             Config.AccessorOptions = options;
             return this as T;
 #endif

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -183,7 +183,7 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CUSTOM_CACHE 
             throw new PlatformNotSupportedException("WithCacheOptions is supported only on platforms where MSAL stores tokens in memory and not on mobile platforms.");
 #else
-            if (options != null && options.InternalCacheDisabled && options.UseSharedCache)
+            if (options != null && options.IsInternalCacheDisabled && options.UseSharedCache)
             {
                 throw new MsalClientException(
                     MsalError.InvalidRequest,

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CUSTOM_CACHE 
             throw new PlatformNotSupportedException("WithCacheOptions is supported only on platforms where MSAL stores tokens in memory and not on mobile platforms.");
 #else
-            if (options != null && CacheOptions.IsDisabledFor(options) && options.UseSharedCache)
+            if (CacheOptions.IsDisabledFor(options) && options.UseSharedCache)
             {
                 throw new MsalClientException(
                     MsalError.InvalidRequest,

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CUSTOM_CACHE 
             throw new PlatformNotSupportedException("WithCacheOptions is supported only on platforms where MSAL stores tokens in memory and not on mobile platforms.");
 #else
-            if (options != null && options.IsInternalCacheDisabled && options.UseSharedCache)
+            if (options != null && CacheOptions.IsDisabledFor(options) && options.UseSharedCache)
             {
                 throw new MsalClientException(
                     MsalError.InvalidRequest,

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -183,6 +183,13 @@ namespace Microsoft.Identity.Client
 #if !SUPPORTS_CUSTOM_CACHE 
             throw new PlatformNotSupportedException("WithCacheOptions is supported only on platforms where MSAL stores tokens in memory and not on mobile platforms.");
 #else
+            if (options != null && options.InternalCacheDisabled && options.UseSharedCache)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidRequest,
+                    "CacheOptions.InternalCacheDisabled and CacheOptions.UseSharedCache are mutually exclusive. " +
+                    "Set only one of these options.");
+            }
 
             Config.AccessorOptions = options;
             return this as T;

--- a/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AbstractApplicationBuilder.cs
@@ -187,8 +187,7 @@ namespace Microsoft.Identity.Client
             {
                 throw new MsalClientException(
                     MsalError.InvalidRequest,
-                    "CacheOptions.InternalCacheDisabled and CacheOptions.UseSharedCache are mutually exclusive. " +
-                    "Set only one of these options.");
+                    MsalErrorMessage.InternalCacheDisabledMutuallyExclusiveMessage);
             }
 
             Config.AccessorOptions = options;

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -26,15 +26,19 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Options that disable MSAL's internal in-memory token cache entirely.
         /// Use this when your application manages its own token cache lifecycle.
-        /// When set, MSAL will not read from or write to the internal cache accessor,
-        /// and token cache serialization callbacks (<c>OnBeforeAccess</c>, <c>OnAfterAccess</c>, <c>OnBeforeWrite</c>)
-        /// will not be invoked. Built-in cache-based operations such as
-        /// <see cref="IClientApplicationBase.GetAccountsAsync()"/> will return empty results, and
-        /// <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> will throw a <see cref="MsalUiRequiredException"/>
-        /// with error code <see cref="MsalError.InternalCacheDisabled"/>.
+        /// <para>When set:</para>
+        /// <list type="bullet">
+        ///   <item><description>MSAL will not read from or write to the internal cache accessor.</description></item>
+        ///   <item><description>Token cache serialization callbacks (<c>OnBeforeAccess</c>, <c>OnAfterAccess</c>, <c>OnBeforeWrite</c>) will <b>not</b> be invoked.</description></item>
+        ///   <item><description><see cref="IClientApplicationBase.GetAccountsAsync()"/> will always return an empty collection.</description></item>
+        ///   <item><description><see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> will throw a <see cref="MsalUiRequiredException"/> with error code <see cref="MsalError.InternalCacheDisabled"/>.</description></item>
+        /// </list>
+        /// <para>
         /// For confidential client flows, retrieve the refresh token using
         /// <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken(AuthenticationResult)"/>
-        /// and manage token reuse externally.
+        /// and call <see cref="IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable{string}, string)"/>
+        /// to re-acquire a token on subsequent requests, or use another interactive flow.
+        /// </para>
         /// </summary>
         public static CacheOptions DisableInternalCache => new CacheOptions { InternalCacheDisabled = true };
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 namespace Microsoft.Identity.Client
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Client
         /// to re-acquire a token on subsequent requests, or use another interactive flow.
         /// </para>
         /// </summary>
-        public static CacheOptions DisableInternalCache => new CacheOptions { InternalCacheDisabled = true };
+        public static CacheOptions DisableInternalCacheOptions => new CacheOptions { IsInternalCacheDisabled = true };
 
         /// <summary>
         /// Constructor for the options with default values.
@@ -74,7 +74,7 @@ namespace Microsoft.Identity.Client
         /// This is intended for advanced scenarios where the caller manages its own token cache.
         /// Cannot be combined with <see cref="UseSharedCache"/>.
         /// </summary>
-        public bool InternalCacheDisabled { get; set; }
+        public bool IsInternalCacheDisabled { get; set; }
 
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -26,10 +26,15 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Options that disable MSAL's internal in-memory token cache entirely.
         /// Use this when your application manages its own token cache lifecycle.
-        /// When set, MSAL will not read from or write to the internal cache accessor.
+        /// When set, MSAL will not read from or write to the internal cache accessor,
+        /// and token cache serialization callbacks (<c>OnBeforeAccess</c>, <c>OnAfterAccess</c>, <c>OnBeforeWrite</c>)
+        /// will not be invoked. Built-in cache-based operations such as
+        /// <see cref="IClientApplicationBase.GetAccountsAsync()"/> will return empty results, and
         /// <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> will throw a <see cref="MsalUiRequiredException"/>
         /// with error code <see cref="MsalError.InternalCacheDisabled"/>.
-        /// Retrieve the refresh token using <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken"/>.
+        /// For confidential client flows, retrieve the refresh token using
+        /// <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken(AuthenticationResult)"/>
+        /// and manage token reuse externally.
         /// </summary>
         public static CacheOptions DisableInternalCache => new CacheOptions { InternalCacheDisabled = true };
 

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Client
         /// Options that disable MSAL's internal in-memory token cache entirely.
         /// Use this when your application manages its own token cache lifecycle.
         /// When set, MSAL will not read from or write to the internal cache accessor.
-        /// <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> will throw a <see cref="MsalClientException"/>
+        /// <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> will throw a <see cref="MsalUiRequiredException"/>
         /// with error code <see cref="MsalError.InternalCacheDisabled"/>.
         /// Retrieve the refresh token using <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken"/>.
         /// </summary>

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -75,7 +75,18 @@ namespace Microsoft.Identity.Client
         /// This is intended for advanced scenarios where the caller manages its own token cache.
         /// Cannot be combined with <see cref="UseSharedCache"/>.
         /// </summary>
+        /// <remarks>
+        /// When enabled, <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/>
+        /// and <see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess(System.Collections.Generic.IEnumerable{string}, string)"/>
+        /// will throw a <see cref="MsalUiRequiredException"/> with error code <see cref="MsalError.InternalCacheDisabled"/>.
+        /// </remarks>
         public bool IsInternalCacheDisabled { get; set; }
+
+        /// <summary>
+        /// Returns <c>true</c> if the given <see cref="CacheOptions"/> instance has the internal cache disabled.
+        /// Safe to call with a <c>null</c> argument (returns <c>false</c>).
+        /// </summary>
+        internal static bool IsDisabledFor(CacheOptions options) => options?.IsInternalCacheDisabled == true;
 
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Identity.Client
         ///   <item><description>Token cache serialization callbacks (<c>OnBeforeAccess</c>, <c>OnAfterAccess</c>, <c>OnBeforeWrite</c>) will <b>not</b> be invoked.</description></item>
         ///   <item><description><see cref="IClientApplicationBase.GetAccountsAsync()"/> will always return an empty collection.</description></item>
         ///   <item><description><see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> will throw a <see cref="MsalUiRequiredException"/> with error code <see cref="MsalError.InternalCacheDisabled"/>.</description></item>
+        ///   <item><description><see cref="ILongRunningWebApi.AcquireTokenInLongRunningProcess(System.Collections.Generic.IEnumerable{string}, string)"/> will throw a <see cref="MsalUiRequiredException"/> with error code <see cref="MsalError.InternalCacheDisabled"/>, because the long-running OBO flow requires a cached token to refresh.</description></item>
         /// </list>
         /// <para>
         /// For confidential client flows, retrieve the refresh token using

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -24,6 +24,16 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// Options that disable MSAL's internal in-memory token cache entirely.
+        /// Use this when your application manages its own token cache lifecycle.
+        /// When set, MSAL will not read from or write to the internal cache accessor.
+        /// <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> will throw a <see cref="MsalClientException"/>
+        /// with error code <see cref="MsalError.InternalCacheDisabled"/>.
+        /// Retrieve the refresh token using <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken"/>.
+        /// </summary>
+        public static CacheOptions DisableInternalCache => new CacheOptions { InternalCacheDisabled = true };
+
+        /// <summary>
         /// Constructor for the options with default values.
         /// </summary>
         public CacheOptions()
@@ -49,6 +59,13 @@ namespace Microsoft.Identity.Client
         /// ADAL used a static cache by default.
         /// </remarks>
         public bool UseSharedCache { get; set; }
+
+        /// <summary>
+        /// When set to true, MSAL will not read from or write to the internal in-memory token cache.
+        /// This is intended for advanced scenarios where the caller manages its own token cache.
+        /// Cannot be combined with <see cref="UseSharedCache"/>.
+        /// </summary>
+        public bool InternalCacheDisabled { get; set; }
 
     }
 }

--- a/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -361,6 +361,12 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public ClaimsPrincipal ClaimsPrincipal { get; set; }
 
+        /// <summary>
+        /// The refresh token returned in the authentication response, if any.
+        /// Access via <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken"/>.
+        /// </summary>
+        internal string RefreshToken { get; set; }
+
         internal ApiEvent ApiEvent { get; set; }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
@@ -27,6 +27,10 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// When the token request goes to the identity provider because refresh_in was used and the existing token needs to be refreshed
         /// </summary>
-        ProactivelyRefreshed = 4
+        ProactivelyRefreshed = 4,
+        /// <summary>
+        /// When the token request goes to the identity provider because the internal token cache has been disabled via <see cref="CacheOptions.DisableInternalCache"/>.
+        /// </summary>
+        CacheDisabled = 5
     }
 }

--- a/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheRefreshReason.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 namespace Microsoft.Identity.Client
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         ProactivelyRefreshed = 4,
         /// <summary>
-        /// When the token request goes to the identity provider because the internal token cache has been disabled via <see cref="CacheOptions.DisableInternalCache"/>.
+        /// When the token request goes to the identity provider because the internal token cache has been disabled via <see cref="CacheOptions.DisableInternalCacheOptions"/>.
         /// </summary>
         CacheDisabled = 5
     }

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -42,8 +42,17 @@ namespace Microsoft.Identity.Client.Cache
         #region ICacheSessionManager implementation
         public ITokenCacheInternal TokenCacheInternal { get; }
 
+        private bool IsInternalCacheDisabled =>
+            _requestParams.RequestContext.ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true;
+
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {
+            if (IsInternalCacheDisabled)
+            {
+                _requestParams.RequestContext.Logger.Info("[Cache Session Manager] Internal cache disabled. Skipping access token lookup.");
+                return null;
+            }
+
             await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
             return await TokenCacheInternal.FindAccessTokenAsync(_requestParams).ConfigureAwait(false);
         }
@@ -69,6 +78,12 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<MsalRefreshTokenCacheItem> FindFamilyRefreshTokenAsync(string familyId)
         {
+            if (IsInternalCacheDisabled)
+            {
+                _requestParams.RequestContext.Logger.Info("[Cache Session Manager] Internal cache disabled. Skipping family refresh token lookup.");
+                return null;
+            }
+
             await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(familyId))
@@ -81,6 +96,12 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<MsalRefreshTokenCacheItem> FindRefreshTokenAsync()
         {
+            if (IsInternalCacheDisabled)
+            {
+                _requestParams.RequestContext.Logger.Info("[Cache Session Manager] Internal cache disabled. Skipping refresh token lookup.");
+                return null;
+            }
+
             await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
             return await TokenCacheInternal.FindRefreshTokenAsync(_requestParams).ConfigureAwait(false);
         }

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client.Cache
         public ITokenCacheInternal TokenCacheInternal { get; }
 
         private bool IsInternalCacheDisabled =>
-            _requestParams.RequestContext.ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true;
+            CacheOptions.IsDisabledFor(_requestParams.RequestContext.ServiceBundle.Config.AccessorOptions);
 
         private bool ShouldSkipInternalCacheRead(string operationName)
         {

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client.Cache
         public ITokenCacheInternal TokenCacheInternal { get; }
 
         private bool IsInternalCacheDisabled =>
-            _requestParams.RequestContext.ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true;
+            _requestParams.RequestContext.ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true;
 
         private bool ShouldSkipInternalCacheRead(string operationName)
         {

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -68,6 +68,13 @@ namespace Microsoft.Identity.Client.Cache
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {
             await RefreshCacheForReadOperationsIfEnabledAsync("access token lookup").ConfigureAwait(false);
+            // NOTE: Redundant check — IsInternalCacheDisabled is already checked inside RefreshCacheForReadOperationsIfEnabledAsync
+            // via ShouldSkipInternalCacheRead(). To reduce this double-check pattern, consider:
+            // (1) Refactor FindAccessTokenAsync, FindRefreshTokenAsync, and FindFamilyRefreshTokenAsync to match the
+            //     pattern of the other methods (GetAccountsAsync, IsAppFociMemberAsync, etc.) which all use the same guard.
+            // (2) Or simplify all methods to use ShouldSkipInternalCacheRead() for early return + call RefreshCacheForReadOperationsAsync()
+            //     directly, then remove RefreshCacheForReadOperationsIfEnabledAsync entirely.
+            // This would eliminate the redundant second check and make the guard pattern consistent across all cache-read methods.
             if (IsInternalCacheDisabled)
             {
                 return null;

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Cache.Items;

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -67,12 +67,11 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {
-            if (ShouldSkipInternalCacheRead("access token lookup"))
+            await RefreshCacheForReadOperationsIfEnabledAsync("access token lookup").ConfigureAwait(false);
+            if (IsInternalCacheDisabled)
             {
                 return null;
             }
-
-            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
             return await TokenCacheInternal.FindAccessTokenAsync(_requestParams).ConfigureAwait(false);
         }
 
@@ -105,12 +104,11 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<MsalRefreshTokenCacheItem> FindFamilyRefreshTokenAsync(string familyId)
         {
-            if (ShouldSkipInternalCacheRead("family refresh token lookup"))
+            await RefreshCacheForReadOperationsIfEnabledAsync("family refresh token lookup").ConfigureAwait(false);
+            if (IsInternalCacheDisabled)
             {
                 return null;
             }
-
-            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(familyId))
             {
@@ -122,12 +120,11 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<MsalRefreshTokenCacheItem> FindRefreshTokenAsync()
         {
-            if (ShouldSkipInternalCacheRead("refresh token lookup"))
+            await RefreshCacheForReadOperationsIfEnabledAsync("refresh token lookup").ConfigureAwait(false);
+            if (IsInternalCacheDisabled)
             {
                 return null;
             }
-
-            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
             return await TokenCacheInternal.FindRefreshTokenAsync(_requestParams).ConfigureAwait(false);
         }
 

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client.Cache
         public async Task<Tuple<MsalAccessTokenCacheItem, MsalIdTokenCacheItem, Account>> SaveTokenResponseAsync(MsalTokenResponse tokenResponse)
         {
             var result = await TokenCacheInternal.SaveTokenResponseAsync(_requestParams, tokenResponse).ConfigureAwait(false);
-            RequestContext.ApiEvent.CachedAccessTokenCount = TokenCacheInternal.Accessor.EntryCount;
+            RequestContext.ApiEvent.CachedAccessTokenCount = GetInternalCacheEntryCountForTelemetry();
             return result;
         }
 
@@ -234,7 +234,17 @@ namespace Microsoft.Identity.Client.Cache
                 RequestContext.ApiEvent.CacheLevel = CacheLevel.L1Cache;
             }
 
-            RequestContext.ApiEvent.CachedAccessTokenCount = TokenCacheInternal.Accessor.EntryCount;
+            RequestContext.ApiEvent.CachedAccessTokenCount = GetInternalCacheEntryCountForTelemetry();
+        }
+
+        private int GetInternalCacheEntryCountForTelemetry()
+        {
+            if (IsInternalCacheDisabled)
+            {
+                return 0;
+            }
+
+            return TokenCacheInternal.Accessor.EntryCount;
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -45,11 +45,30 @@ namespace Microsoft.Identity.Client.Cache
         private bool IsInternalCacheDisabled =>
             _requestParams.RequestContext.ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true;
 
+        private bool ShouldSkipInternalCacheRead(string operationName)
+        {
+            if (!IsInternalCacheDisabled)
+            {
+                return false;
+            }
+            _requestParams.RequestContext.Logger.Verbose(
+                () => $"[Cache Session Manager] Internal cache disabled. Skipping {operationName}.");
+            return true;
+        }
+
+        private async Task RefreshCacheForReadOperationsIfEnabledAsync(string operationName)
+        {
+            if (ShouldSkipInternalCacheRead(operationName))
+            {
+                return;
+            }
+            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
+        }
+
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {
-            if (IsInternalCacheDisabled)
+            if (ShouldSkipInternalCacheRead("access token lookup"))
             {
-                _requestParams.RequestContext.Logger.Info("[Cache Session Manager] Internal cache disabled. Skipping access token lookup.");
                 return null;
             }
 
@@ -66,21 +85,28 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<Account> GetAccountAssociatedWithAccessTokenAsync(MsalAccessTokenCacheItem msalAccessTokenCacheItem)
         {
-            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
+            await RefreshCacheForReadOperationsIfEnabledAsync("account lookup for access token").ConfigureAwait(false);
+            if (IsInternalCacheDisabled)
+            {
+                return null;
+            }
             return await TokenCacheInternal.GetAccountAssociatedWithAccessTokenAsync(_requestParams, msalAccessTokenCacheItem).ConfigureAwait(false);
         }
 
         public async Task<MsalIdTokenCacheItem> GetIdTokenCacheItemAsync(MsalAccessTokenCacheItem accessTokenCacheItem)
         {
-            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
+            await RefreshCacheForReadOperationsIfEnabledAsync("ID token lookup").ConfigureAwait(false);
+            if (IsInternalCacheDisabled)
+            {
+                return null;
+            }
             return TokenCacheInternal.GetIdTokenCacheItem(accessTokenCacheItem);
         }
 
         public async Task<MsalRefreshTokenCacheItem> FindFamilyRefreshTokenAsync(string familyId)
         {
-            if (IsInternalCacheDisabled)
+            if (ShouldSkipInternalCacheRead("family refresh token lookup"))
             {
-                _requestParams.RequestContext.Logger.Info("[Cache Session Manager] Internal cache disabled. Skipping family refresh token lookup.");
                 return null;
             }
 
@@ -96,9 +122,8 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<MsalRefreshTokenCacheItem> FindRefreshTokenAsync()
         {
-            if (IsInternalCacheDisabled)
+            if (ShouldSkipInternalCacheRead("refresh token lookup"))
             {
-                _requestParams.RequestContext.Logger.Info("[Cache Session Manager] Internal cache disabled. Skipping refresh token lookup.");
                 return null;
             }
 
@@ -108,13 +133,21 @@ namespace Microsoft.Identity.Client.Cache
 
         public async Task<bool?> IsAppFociMemberAsync(string familyId)
         {
-            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
+            await RefreshCacheForReadOperationsIfEnabledAsync("FOCI membership lookup").ConfigureAwait(false);
+            if (IsInternalCacheDisabled)
+            {
+                return null;
+            }
             return await TokenCacheInternal.IsFociMemberAsync(_requestParams, familyId).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<IAccount>> GetAccountsAsync()
         {
-            await RefreshCacheForReadOperationsAsync().ConfigureAwait(false);
+            await RefreshCacheForReadOperationsIfEnabledAsync("accounts lookup").ConfigureAwait(false);
+            if (IsInternalCacheDisabled)
+            {
+                return System.Array.Empty<IAccount>();
+            }
             return await TokenCacheInternal.GetAccountsAsync(_requestParams).ConfigureAwait(false);
         }
 

--- a/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheSessionManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -68,13 +68,6 @@ namespace Microsoft.Identity.Client.Cache
         public async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync()
         {
             await RefreshCacheForReadOperationsIfEnabledAsync("access token lookup").ConfigureAwait(false);
-            // NOTE: Redundant check — IsInternalCacheDisabled is already checked inside RefreshCacheForReadOperationsIfEnabledAsync
-            // via ShouldSkipInternalCacheRead(). To reduce this double-check pattern, consider:
-            // (1) Refactor FindAccessTokenAsync, FindRefreshTokenAsync, and FindFamilyRefreshTokenAsync to match the
-            //     pattern of the other methods (GetAccountsAsync, IsAppFociMemberAsync, etc.) which all use the same guard.
-            // (2) Or simplify all methods to use ShouldSkipInternalCacheRead() for early return + call RefreshCacheForReadOperationsAsync()
-            //     directly, then remove RefreshCacheForReadOperationsIfEnabledAsync entirely.
-            // This would eliminate the redundant second check and make the guard pattern consistent across all cache-read methods.
             if (IsInternalCacheDisabled)
             {
                 return null;

--- a/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Identity.Client.Extensibility
         /// </summary>
         /// <param name="result">The authentication result.</param>
         /// <returns>
-        /// The refresh token string if the result is from a confidential client flow and the token
-        /// response included a refresh token; <c>null</c> otherwise. Refresh tokens are not exposed
+        /// The refresh token string associated with the result for confidential client flows, if available.
+        /// This may be a refresh token returned in the token response or a refresh token used for the
+        /// acquisition and carried on the result; <c>null</c> otherwise. Refresh tokens are not exposed
         /// for public client flows, client credentials, managed identity, or when the token was
         /// served from cache. For the normal (non-long-running) On-Behalf-Of flow, MSAL intentionally
         /// clears the refresh token, so this method will also return <c>null</c>.

--- a/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Client.Extensibility
+{
+    /// <summary>
+    /// Extension methods for <see cref="AuthenticationResult"/>.
+    /// </summary>
+    public static class AuthenticationResultExtensions
+    {
+        /// <summary>
+        /// Returns the refresh token from the authentication result, if available.
+        /// This is intended for advanced scenarios where the caller manages its own token cache,
+        /// for example when using <see cref="CacheOptions.DisableInternalCache"/>.
+        /// </summary>
+        /// <param name="result">The authentication result.</param>
+        /// <returns>
+        /// The refresh token string, or <c>null</c> if the token response did not include a refresh token
+        /// (e.g., client credentials flow, or when the token was served from cache).
+        /// </returns>
+        /// <remarks>
+        /// Refresh tokens are long-lived credentials. Store them securely and never expose them to end users or untrusted code.
+        /// </remarks>
+        public static string GetRefreshToken(this AuthenticationResult result)
+        {
+            return result?.RefreshToken;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <summary>
         /// Returns the refresh token from the authentication result, if available.
         /// This is intended for advanced scenarios where the caller manages its own token cache,
-        /// for example when using <see cref="CacheOptions.DisableInternalCacheOptions"/>.
+        /// for example when using <see cref="Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions"/>.
         /// </summary>
         /// <param name="result">The authentication result.</param>
         /// <returns>

--- a/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
@@ -15,8 +15,11 @@ namespace Microsoft.Identity.Client.Extensibility
         /// </summary>
         /// <param name="result">The authentication result.</param>
         /// <returns>
-        /// The refresh token string, or <c>null</c> if the token response did not include a refresh token
-        /// (e.g., client credentials flow, or when the token was served from cache).
+        /// The refresh token string if the result is from a confidential client flow and the token
+        /// response included a refresh token; <c>null</c> otherwise. Refresh tokens are not exposed
+        /// for public client flows, client credentials, managed identity, or when the token was
+        /// served from cache. For the normal (non-long-running) On-Behalf-Of flow, MSAL intentionally
+        /// clears the refresh token, so this method will also return <c>null</c>.
         /// </returns>
         /// <remarks>
         /// Refresh tokens are long-lived credentials. Store them securely and never expose them to end users or untrusted code.

--- a/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AuthenticationResultExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <summary>
         /// Returns the refresh token from the authentication result, if available.
         /// This is intended for advanced scenarios where the caller manages its own token cache,
-        /// for example when using <see cref="CacheOptions.DisableInternalCache"/>.
+        /// for example when using <see cref="CacheOptions.DisableInternalCacheOptions"/>.
         /// </summary>
         /// <param name="result">The authentication result.</param>
         /// <returns>

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
             AuthenticationResult authResult;
 
-            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 return await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
             AuthenticationResult authResult;
 
-            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
+            if (IsInternalCacheDisabled)
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 return await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -51,6 +51,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
             AuthenticationResult authResult;
 
+            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
+                return await GetAccessTokenAsync(cancellationToken, logger).ConfigureAwait(false);
+            }
+
             // Skip cache if either:
             // 1) ForceRefresh is set, or
             // 2) Claims are specified and there is no AccessTokenHashToRefresh.

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -50,31 +50,28 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             CacheRefreshReason cacheInfoTelemetry = CacheRefreshReason.NotApplicable;
 
+            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
+            }
+
             //Check if initiating a long running process
             if (AuthenticationRequestParameters.ApiId == ApiEvent.ApiIds.InitiateLongRunningObo && !_onBehalfOfParameters.SearchInCacheForLongRunningObo)
             {
                 //Long running OBO doesn't search in cache by default
                 logger.Info("[OBO Request] Initiating long running process. Fetching OBO token from ESTS.");
-
-                if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
-                {
-                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
-                }
-
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true && _onBehalfOfParameters.UserAssertion != null)
+            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true && _onBehalfOfParameters.UserAssertion != null)
             {
-                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
             // AcquireTokenInLongRunningProcess (UserAssertion == null) cannot go to the network
             // because there is no assertion to exchange. Surface the root cause directly.
-            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
             {
-                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 throw new MsalUiRequiredException(
                     MsalError.InternalCacheDisabled,
                     MsalErrorMessage.InternalCacheDisabledMessage,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             CacheRefreshReason cacheInfoTelemetry = CacheRefreshReason.NotApplicable;
 
-            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
+            if (IsInternalCacheDisabled)
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
             }
@@ -63,14 +63,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true && _onBehalfOfParameters.UserAssertion != null)
+            if (IsInternalCacheDisabled && _onBehalfOfParameters.UserAssertion != null)
             {
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
             // AcquireTokenInLongRunningProcess (UserAssertion == null) cannot go to the network
             // because there is no assertion to exchange. Surface the root cause directly.
-            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
+            if (IsInternalCacheDisabled)
             {
                 throw new MsalUiRequiredException(
                     MsalError.InternalCacheDisabled,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -70,6 +70,18 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
+            // AcquireTokenInLongRunningProcess (UserAssertion == null) cannot go to the network
+            // because there is no assertion to exchange. Surface the root cause directly.
+            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
+                throw new MsalUiRequiredException(
+                    MsalError.InternalCacheDisabled,
+                    MsalErrorMessage.InternalCacheDisabledMessage,
+                    null,
+                    UiRequiredExceptionClassification.AcquireTokenSilentFailed);
+            }
+
             if (!_onBehalfOfParameters.ForceRefresh && string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))
             {
                 // look for access token in the cache first.

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -55,6 +55,18 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 //Long running OBO doesn't search in cache by default
                 logger.Info("[OBO Request] Initiating long running process. Fetching OBO token from ESTS.");
+
+                if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+                {
+                    AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
+                }
+
+                return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true && _onBehalfOfParameters.UserAssertion != null)
+            {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -63,15 +63,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            if (IsInternalCacheDisabled && _onBehalfOfParameters.UserAssertion != null)
-            {
-                return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            // AcquireTokenInLongRunningProcess (UserAssertion == null) cannot go to the network
-            // because there is no assertion to exchange. Surface the root cause directly.
             if (IsInternalCacheDisabled)
             {
+                if (_onBehalfOfParameters.UserAssertion != null)
+                {
+                    return await FetchNewAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                // AcquireTokenInLongRunningProcess (UserAssertion == null) cannot go to the network
+                // because there is no assertion to exchange. Surface the root cause directly.
                 throw new MsalUiRequiredException(
                     MsalError.InternalCacheDisabled,
                     MsalErrorMessage.InternalCacheDisabledMessage,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 #if !MOBILE
             atItem?.AddAdditionalCacheParameters(clientInfoFromServer?.AdditionalResponseParameters);
 #endif
-            return await AuthenticationResult.CreateAsync(
+            var authResult = await AuthenticationResult.CreateAsync(
                 atItem,
                 idtItem,
                 AuthenticationRequestParameters.AuthenticationScheme,
@@ -357,6 +357,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 msalTokenResponse.SpaAuthCode,
                 msalTokenResponse.CreateExtensionDataStringMap(),
                 cancellationToken).ConfigureAwait(false);
+
+            authResult.RefreshToken = msalTokenResponse.RefreshToken;
+            return authResult;
         }
 
         protected virtual void ValidateAccountIdentifiers(ClientInfo fromServer)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
         internal ICacheSessionManager CacheManager => AuthenticationRequestParameters.CacheSessionManager;
         internal IServiceBundle ServiceBundle { get; }
 
+        /// <summary>
+        /// Returns <c>true</c> if the internal token cache is disabled via <c>CacheOptions.DisableInternalCacheOptions</c>.
+        /// </summary>
+        protected bool IsInternalCacheDisabled =>
+            ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true;
+
         protected RequestBase(
             IServiceBundle serviceBundle,
             AuthenticationRequestParameters authenticationRequestParameters,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         /// Returns <c>true</c> if the internal token cache is disabled via <c>CacheOptions.DisableInternalCacheOptions</c>.
         /// </summary>
         protected bool IsInternalCacheDisabled =>
-            ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true;
+            CacheOptions.IsDisabledFor(ServiceBundle.Config.AccessorOptions);
 
         protected RequestBase(
             IServiceBundle serviceBundle,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -358,7 +358,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 msalTokenResponse.CreateExtensionDataStringMap(),
                 cancellationToken).ConfigureAwait(false);
 
-            authResult.RefreshToken = msalTokenResponse.RefreshToken;
+            authResult.RefreshToken = AuthenticationRequestParameters.AppConfig.IsConfidentialClient
+                ? msalTokenResponse.RefreshToken
+                : null;
             return authResult;
         }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             
             ThrowIfCurrentBrokerAccount();
 
-            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
+            if (CacheOptions.IsDisabledFor(ServiceBundle.Config.AccessorOptions))
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 throw new MsalUiRequiredException(

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -42,6 +42,13 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             
             ThrowIfCurrentBrokerAccount();
 
+            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            {
+                throw new MsalClientException(
+                    MsalError.InternalCacheDisabled,
+                    MsalErrorMessage.InternalCacheDisabledMessage);
+            }
+
             AuthenticationResult authResult = null;
 
             if (!_silentParameters.ForceRefresh && string.IsNullOrEmpty(AuthenticationRequestParameters.Claims))

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -44,9 +44,11 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
 
             if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
             {
-                throw new MsalClientException(
+                throw new MsalUiRequiredException(
                     MsalError.InternalCacheDisabled,
-                    MsalErrorMessage.InternalCacheDisabledMessage);
+                    MsalErrorMessage.InternalCacheDisabledMessage,
+                    null,
+                    UiRequiredExceptionClassification.AcquireTokenSilentFailed);
             }
 
             AuthenticationResult authResult = null;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
             
             ThrowIfCurrentBrokerAccount();
 
-            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
             {
                 AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 throw new MsalUiRequiredException(

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
 
             if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
             {
+                AuthenticationRequestParameters.RequestContext.ApiEvent.CacheInfo = CacheRefreshReason.CacheDisabled;
                 throw new MsalUiRequiredException(
                     MsalError.InternalCacheDisabled,
                     MsalErrorMessage.InternalCacheDisabledMessage,

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1271,7 +1271,7 @@ namespace Microsoft.Identity.Client
         /// <para>What happened?</para> <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> 
         /// was called but MSAL's internal token cache is disabled via <see cref="CacheOptions.DisableInternalCache"/>.
         /// <para>Mitigation</para> Use <see cref="IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable{string}, string)"/> 
-        /// with the refresh token obtained from <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken"/>, 
+        /// with the refresh token obtained from <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken(AuthenticationResult)"/>, 
         /// or use another interactive flow.
         /// </summary>
         public const string InternalCacheDisabled = "internal_cache_disabled";

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1268,11 +1268,14 @@ namespace Microsoft.Identity.Client
         public const string InvalidCredentialMaterial = "invalid_credential_material";
 
         /// <summary>
-        /// <para>What happened?</para> <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> 
-        /// was called but MSAL's internal token cache is disabled via <see cref="CacheOptions.DisableInternalCacheOptions"/>.
-        /// <para>Mitigation</para> Use <see cref="IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable{string}, string)"/> 
-        /// with the refresh token obtained from <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken(AuthenticationResult)"/>, 
-        /// or use another interactive flow.
+        /// <para>What happened?</para> A cache-dependent API was called, but MSAL's internal token cache is disabled via
+        /// <see cref="CacheOptions.DisableInternalCacheOptions"/>. This can occur with APIs such as
+        /// <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/>
+        /// and <c>AcquireTokenInLongRunningProcess(...)</c>.
+        /// <para>Mitigation</para> Use an authentication flow that does not depend on MSAL's internal cache, such as
+        /// <see cref="IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable{string}, string)"/>
+        /// with the refresh token obtained from <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken(AuthenticationResult)"/>,
+        /// or use another interactive flow, as appropriate for your application.
         /// </summary>
         public const string InternalCacheDisabled = "internal_cache_disabled";
     }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1266,5 +1266,14 @@ namespace Microsoft.Identity.Client
         /// <see cref="ClientSignedAssertion.TokenBindingCertificate"/> when mTLS Proof-of-Possession is required.
         /// </summary>
         public const string InvalidCredentialMaterial = "invalid_credential_material";
+
+        /// <summary>
+        /// <para>What happened?</para> <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> 
+        /// was called but MSAL's internal token cache is disabled via <see cref="CacheOptions.DisableInternalCache"/>.
+        /// <para>Mitigation</para> Use <see cref="IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable{string}, string)"/> 
+        /// with the refresh token obtained from <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken"/>, 
+        /// or use another interactive flow.
+        /// </summary>
+        public const string InternalCacheDisabled = "internal_cache_disabled";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -1269,7 +1269,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// <para>What happened?</para> <see cref="IClientApplicationBase.AcquireTokenSilent(System.Collections.Generic.IEnumerable{string}, IAccount)"/> 
-        /// was called but MSAL's internal token cache is disabled via <see cref="CacheOptions.DisableInternalCache"/>.
+        /// was called but MSAL's internal token cache is disabled via <see cref="CacheOptions.DisableInternalCacheOptions"/>.
         /// <para>Mitigation</para> Use <see cref="IByRefreshToken.AcquireTokenByRefreshToken(System.Collections.Generic.IEnumerable{string}, string)"/> 
         /// with the refresh token obtained from <see cref="Extensibility.AuthenticationResultExtensions.GetRefreshToken(AuthenticationResult)"/>, 
         /// or use another interactive flow.

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Globalization;
@@ -462,12 +462,12 @@ namespace Microsoft.Identity.Client
             "Remove SendCertificateOverMtls or switch to a certificate credential.";
 
         public const string InternalCacheDisabledMessage =
-            "AcquireTokenSilent is not supported when the internal cache is disabled via CacheOptions.DisableInternalCache. " +
+            "AcquireTokenSilent is not supported when the internal cache is disabled via CacheOptions.DisableInternalCacheOptions. " +
             "For confidential client flows, retrieve the refresh token using AuthenticationResultExtensions.GetRefreshToken() and call AcquireTokenByRefreshToken, " +
             "or use another interactive flow.";
 
         public const string InternalCacheDisabledMutuallyExclusiveMessage =
-            "CacheOptions.InternalCacheDisabled and CacheOptions.UseSharedCache are mutually exclusive. " +
+            "CacheOptions.IsInternalCacheDisabled and CacheOptions.UseSharedCache are mutually exclusive. " +
             "Set only one of these options.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -465,5 +465,9 @@ namespace Microsoft.Identity.Client
             "AcquireTokenSilent is not supported when the internal cache is disabled via CacheOptions.DisableInternalCache. " +
             "Retrieve the refresh token using AuthenticationResultExtensions.GetRefreshToken() and call AcquireTokenByRefreshToken, " +
             "or use another interactive flow.";
+
+        public const string InternalCacheDisabledMutuallyExclusiveMessage =
+            "CacheOptions.InternalCacheDisabled and CacheOptions.UseSharedCache are mutually exclusive. " +
+            "Set only one of these options.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -460,5 +460,10 @@ namespace Microsoft.Identity.Client
             "configured via WithCertificate(). Non-certificate credentials (client secrets, static signed " +
             "assertions, and string-returning assertion delegates) are not supported. " +
             "Remove SendCertificateOverMtls or switch to a certificate credential.";
+
+        public const string InternalCacheDisabledMessage =
+            "AcquireTokenSilent is not supported when the internal cache is disabled via CacheOptions.DisableInternalCache. " +
+            "Retrieve the refresh token using AuthenticationResultExtensions.GetRefreshToken() and call AcquireTokenByRefreshToken, " +
+            "or use another interactive flow.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Identity.Client
             "Remove SendCertificateOverMtls or switch to a certificate credential.";
 
         public const string InternalCacheDisabledMessage =
-            "AcquireTokenSilent is not supported when the internal cache is disabled via CacheOptions.DisableInternalCacheOptions. " +
+            "Silent token acquisition is not supported when the internal cache is disabled via CacheOptions.DisableInternalCacheOptions. " +
             "For confidential client flows, retrieve the refresh token using AuthenticationResultExtensions.GetRefreshToken() and call AcquireTokenByRefreshToken, " +
             "or use another interactive flow.";
 

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -469,5 +469,9 @@ namespace Microsoft.Identity.Client
         public const string InternalCacheDisabledMutuallyExclusiveMessage =
             "CacheOptions.IsInternalCacheDisabled and CacheOptions.UseSharedCache are mutually exclusive. " +
             "Set only one of these options.";
+
+        public const string InternalCacheDisabledNotSupportedForPublicClient =
+            "CacheOptions.DisableInternalCacheOptions is not supported for public client applications. " +
+            "This option is intended for confidential client flows where the application manages its own token cache.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Identity.Client
 
         public const string InternalCacheDisabledMessage =
             "AcquireTokenSilent is not supported when the internal cache is disabled via CacheOptions.DisableInternalCache. " +
-            "Retrieve the refresh token using AuthenticationResultExtensions.GetRefreshToken() and call AcquireTokenByRefreshToken, " +
+            "For confidential client flows, retrieve the refresh token using AuthenticationResultExtensions.GetRefreshToken() and call AcquireTokenByRefreshToken, " +
             "or use another interactive flow.";
 
         public const string InternalCacheDisabledMutuallyExclusiveMessage =

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
+const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -2,11 +2,11 @@ Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.g
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
-static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
+const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -2,11 +2,11 @@ Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.g
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
-static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
+const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -2,11 +2,11 @@ Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.g
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
-static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
+const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -2,11 +2,11 @@ Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.g
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
-static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
+const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -2,11 +2,11 @@ Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.g
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
-static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
+Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
+const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,11 +2,11 @@ Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.g
 Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.get -> bool
-Microsoft.Identity.Client.CacheOptions.InternalCacheDisabled.set -> void
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
+Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
-static Microsoft.Identity.Client.CacheOptions.DisableInternalCache.get -> Microsoft.Identity.Client.CacheOptions
+static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
-Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.get -> bool
+Microsoft.Identity.Client.AppConfig.CertificateOptions.SendCertificateOverMtls.init -> void
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.get -> bool
 Microsoft.Identity.Client.CacheOptions.IsInternalCacheDisabled.set -> void
 Microsoft.Identity.Client.CacheRefreshReason.CacheDisabled = 5 -> Microsoft.Identity.Client.CacheRefreshReason
 Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
-const Microsoft.Identity.Client.MsalError.InvalidCredentialMaterial = "invalid_credential_material" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithAttributeTokens<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IEnumerable<string> attributeTokens) -> T
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -142,9 +142,12 @@ namespace Microsoft.Identity.Client
                              tenantId,
                              wamAccountIds);
 
-                // Add the newly obtained id token to the list of profiles
+                // Add the newly obtained id token to the list of profiles.
+                // Skip reading from the internal cache when it is disabled — GetTenantProfilesAsync
+                // reads ID tokens from Accessor, which would violate the no-reads contract.
                 IDictionary<string, TenantProfile> tenantProfiles = null;
-                if (msalIdTokenCacheItem.TenantId != null)
+                if (msalIdTokenCacheItem.TenantId != null &&
+                    ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled != true)
                 {
                     tenantProfiles = await GetTenantProfilesAsync(requestParams, homeAccountId).ConfigureAwait(false);
                     if (tenantProfiles != null)

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Identity.Client
 
             if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
             {
-                logger.Info("[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCache). Skipping all cache writes.");
+                logger.Verbose(() => "[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCache). Skipping all cache writes.");
                 return Tuple.Create(msalAccessTokenCacheItem, msalIdTokenCacheItem, account);
             }
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -165,17 +165,22 @@ namespace Microsoft.Identity.Client
 
             #endregion
 
+            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            {
+                logger.Info("[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCache). Skipping all cache writes.");
+                return Tuple.Create(msalAccessTokenCacheItem, msalIdTokenCacheItem, account);
+            }
+
             logger.Verbose(() => $"[SaveTokenResponseAsync] Entering token cache semaphore. Count {_semaphoreSlim.GetCurrentCountLogMessage()}.");
             await _semaphoreSlim.WaitAsync(requestParams.RequestContext.UserCancellationToken).ConfigureAwait(false);
             logger.Verbose(() => "[SaveTokenResponseAsync] Entered token cache semaphore. ");
             ITokenCacheInternal tokenCacheInternal = this;
-            bool internalCacheDisabled = ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true;
 
             try
             {
                 try
                 {
-                    if (!internalCacheDisabled && tokenCacheInternal.IsAppSubscribedToSerializationEvents())
+                    if (tokenCacheInternal.IsAppSubscribedToSerializationEvents())
                     {
                         var args = new TokenCacheNotificationArgs(
                             tokenCache: this,
@@ -203,10 +208,8 @@ namespace Microsoft.Identity.Client
                         requestParams.RequestContext.ApiEvent.DurationInCacheInMs += measuredResultDuration.Milliseconds;
                     }
 
-                    if (!internalCacheDisabled)
-                    {
-                        // Don't cache access tokens from broker
-                        if (ShouldCacheAccessToken(msalAccessTokenCacheItem, response.TokenSource))
+
+                    if (ShouldCacheAccessToken(msalAccessTokenCacheItem, response.TokenSource))
                         {
                             logger.Info("[SaveTokenResponseAsync] Saving AT in cache and removing overlapping ATs...");
                             DeleteAccessTokensWithIntersectingScopes(
@@ -247,15 +250,10 @@ namespace Microsoft.Identity.Client
                             msalIdTokenCacheItem,
                             tenantId,
                             instanceDiscoveryMetadata);
-                    }
-                    else
-                    {
-                        logger.Info("[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCache). Skipping all cache writes.");
-                    }
                 }
                 finally
                 {
-                    if (!internalCacheDisabled && tokenCacheInternal.IsAppSubscribedToSerializationEvents())
+                    if (tokenCacheInternal.IsAppSubscribedToSerializationEvents())
                     {
                         DateTimeOffset? cacheExpiry = CalculateSuggestedCacheExpiry(Accessor, logger);
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -213,46 +213,46 @@ namespace Microsoft.Identity.Client
 
 
                     if (ShouldCacheAccessToken(msalAccessTokenCacheItem, response.TokenSource))
-                        {
-                            logger.Info("[SaveTokenResponseAsync] Saving AT in cache and removing overlapping ATs...");
-                            DeleteAccessTokensWithIntersectingScopes(
-                                requestParams,
-                                instanceDiscoveryMetadata.Aliases,
-                                tenantId,
-                                msalAccessTokenCacheItem.ScopeSet,
-                                msalAccessTokenCacheItem.HomeAccountId,
-                                msalAccessTokenCacheItem.TokenType);
-
-                            Accessor.SaveAccessToken(msalAccessTokenCacheItem);
-                        }
-
-                        if (idToken != null)
-                        {
-                            logger.Info("[SaveTokenResponseAsync] Saving Id Token and Account in cache ...");
-                            Accessor.SaveIdToken(msalIdTokenCacheItem);
-                            MergeWamAccountIds(msalAccountCacheItem);
-                            Accessor.SaveAccount(msalAccountCacheItem);
-                        }
-
-                        // if server returns the refresh token back, save it in the cache.
-                        if (msalRefreshTokenCacheItem != null)
-                        {
-                            logger.Info("[SaveTokenResponseAsync] Saving RT in cache...");
-                            Accessor.SaveRefreshToken(msalRefreshTokenCacheItem);
-                        }
-
-                        UpdateAppMetadata(
-                            requestParams.AppConfig.ClientId,
-                            instanceDiscoveryMetadata.PreferredCache,
-                            response.FamilyId);
-
-                        SaveToLegacyAdalCache(
+                    {
+                        logger.Info("[SaveTokenResponseAsync] Saving AT in cache and removing overlapping ATs...");
+                        DeleteAccessTokensWithIntersectingScopes(
                             requestParams,
-                            response,
-                            msalRefreshTokenCacheItem,
-                            msalIdTokenCacheItem,
+                            instanceDiscoveryMetadata.Aliases,
                             tenantId,
-                            instanceDiscoveryMetadata);
+                            msalAccessTokenCacheItem.ScopeSet,
+                            msalAccessTokenCacheItem.HomeAccountId,
+                            msalAccessTokenCacheItem.TokenType);
+
+                        Accessor.SaveAccessToken(msalAccessTokenCacheItem);
+                    }
+
+                    if (idToken != null)
+                    {
+                        logger.Info("[SaveTokenResponseAsync] Saving Id Token and Account in cache ...");
+                        Accessor.SaveIdToken(msalIdTokenCacheItem);
+                        MergeWamAccountIds(msalAccountCacheItem);
+                        Accessor.SaveAccount(msalAccountCacheItem);
+                    }
+
+                    // if server returns the refresh token back, save it in the cache.
+                    if (msalRefreshTokenCacheItem != null)
+                    {
+                        logger.Info("[SaveTokenResponseAsync] Saving RT in cache...");
+                        Accessor.SaveRefreshToken(msalRefreshTokenCacheItem);
+                    }
+
+                    UpdateAppMetadata(
+                        requestParams.AppConfig.ClientId,
+                        instanceDiscoveryMetadata.PreferredCache,
+                        response.FamilyId);
+
+                    SaveToLegacyAdalCache(
+                        requestParams,
+                        response,
+                        msalRefreshTokenCacheItem,
+                        msalIdTokenCacheItem,
+                        tenantId,
+                        instanceDiscoveryMetadata);
                 }
                 finally
                 {

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -143,17 +143,25 @@ namespace Microsoft.Identity.Client
                              wamAccountIds);
 
                 // Add the newly obtained id token to the list of profiles.
-                // Skip reading from the internal cache when it is disabled — GetTenantProfilesAsync
-                // reads ID tokens from Accessor, which would violate the no-reads contract.
                 IDictionary<string, TenantProfile> tenantProfiles = null;
-                if (msalIdTokenCacheItem.TenantId != null &&
-                    ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled != true)
+                if (msalIdTokenCacheItem.TenantId != null)
                 {
-                    tenantProfiles = await GetTenantProfilesAsync(requestParams, homeAccountId).ConfigureAwait(false);
-                    if (tenantProfiles != null)
+                    if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
                     {
-                        TenantProfile tenantProfile = new TenantProfile(msalIdTokenCacheItem);
-                        tenantProfiles[msalIdTokenCacheItem.TenantId] = tenantProfile;
+                        // When the internal cache is disabled, skip GetTenantProfilesAsync (which reads
+                        // from Accessor) and instead seed a fresh dict with just the current profile.
+                        tenantProfiles = new Dictionary<string, TenantProfile>
+                        {
+                            [msalIdTokenCacheItem.TenantId] = new TenantProfile(msalIdTokenCacheItem)
+                        };
+                    }
+                    else
+                    {
+                        tenantProfiles = await GetTenantProfilesAsync(requestParams, homeAccountId).ConfigureAwait(false);
+                        if (tenantProfiles != null)
+                        {
+                            tenantProfiles[msalIdTokenCacheItem.TenantId] = new TenantProfile(msalIdTokenCacheItem);
+                        }
                     }
                 }
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -169,12 +169,13 @@ namespace Microsoft.Identity.Client
             await _semaphoreSlim.WaitAsync(requestParams.RequestContext.UserCancellationToken).ConfigureAwait(false);
             logger.Verbose(() => "[SaveTokenResponseAsync] Entered token cache semaphore. ");
             ITokenCacheInternal tokenCacheInternal = this;
+            bool internalCacheDisabled = ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true;
 
             try
             {
                 try
                 {
-                    if (tokenCacheInternal.IsAppSubscribedToSerializationEvents())
+                    if (!internalCacheDisabled && tokenCacheInternal.IsAppSubscribedToSerializationEvents())
                     {
                         var args = new TokenCacheNotificationArgs(
                             tokenCache: this,
@@ -202,52 +203,59 @@ namespace Microsoft.Identity.Client
                         requestParams.RequestContext.ApiEvent.DurationInCacheInMs += measuredResultDuration.Milliseconds;
                     }
 
-                    // Don't cache access tokens from broker
-                    if (ShouldCacheAccessToken(msalAccessTokenCacheItem, response.TokenSource))
+                    if (!internalCacheDisabled)
                     {
-                        logger.Info("[SaveTokenResponseAsync] Saving AT in cache and removing overlapping ATs...");
-                        DeleteAccessTokensWithIntersectingScopes(
+                        // Don't cache access tokens from broker
+                        if (ShouldCacheAccessToken(msalAccessTokenCacheItem, response.TokenSource))
+                        {
+                            logger.Info("[SaveTokenResponseAsync] Saving AT in cache and removing overlapping ATs...");
+                            DeleteAccessTokensWithIntersectingScopes(
+                                requestParams,
+                                instanceDiscoveryMetadata.Aliases,
+                                tenantId,
+                                msalAccessTokenCacheItem.ScopeSet,
+                                msalAccessTokenCacheItem.HomeAccountId,
+                                msalAccessTokenCacheItem.TokenType);
+
+                            Accessor.SaveAccessToken(msalAccessTokenCacheItem);
+                        }
+
+                        if (idToken != null)
+                        {
+                            logger.Info("[SaveTokenResponseAsync] Saving Id Token and Account in cache ...");
+                            Accessor.SaveIdToken(msalIdTokenCacheItem);
+                            MergeWamAccountIds(msalAccountCacheItem);
+                            Accessor.SaveAccount(msalAccountCacheItem);
+                        }
+
+                        // if server returns the refresh token back, save it in the cache.
+                        if (msalRefreshTokenCacheItem != null)
+                        {
+                            logger.Info("[SaveTokenResponseAsync] Saving RT in cache...");
+                            Accessor.SaveRefreshToken(msalRefreshTokenCacheItem);
+                        }
+
+                        UpdateAppMetadata(
+                            requestParams.AppConfig.ClientId,
+                            instanceDiscoveryMetadata.PreferredCache,
+                            response.FamilyId);
+
+                        SaveToLegacyAdalCache(
                             requestParams,
-                            instanceDiscoveryMetadata.Aliases,
+                            response,
+                            msalRefreshTokenCacheItem,
+                            msalIdTokenCacheItem,
                             tenantId,
-                            msalAccessTokenCacheItem.ScopeSet,
-                            msalAccessTokenCacheItem.HomeAccountId,
-                            msalAccessTokenCacheItem.TokenType);
-
-                        Accessor.SaveAccessToken(msalAccessTokenCacheItem);
+                            instanceDiscoveryMetadata);
                     }
-
-                    if (idToken != null)
+                    else
                     {
-                        logger.Info("[SaveTokenResponseAsync] Saving Id Token and Account in cache ...");
-                        Accessor.SaveIdToken(msalIdTokenCacheItem);
-                        MergeWamAccountIds(msalAccountCacheItem);
-                        Accessor.SaveAccount(msalAccountCacheItem);
+                        logger.Info("[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCache). Skipping all cache writes.");
                     }
-
-                    // if server returns the refresh token back, save it in the cache.
-                    if (msalRefreshTokenCacheItem != null)
-                    {
-                        logger.Info("[SaveTokenResponseAsync] Saving RT in cache...");
-                        Accessor.SaveRefreshToken(msalRefreshTokenCacheItem);
-                    }
-
-                    UpdateAppMetadata(
-                        requestParams.AppConfig.ClientId,
-                        instanceDiscoveryMetadata.PreferredCache,
-                        response.FamilyId);
-
-                    SaveToLegacyAdalCache(
-                        requestParams,
-                        response,
-                        msalRefreshTokenCacheItem,
-                        msalIdTokenCacheItem,
-                        tenantId,
-                        instanceDiscoveryMetadata);
                 }
                 finally
                 {
-                    if (tokenCacheInternal.IsAppSubscribedToSerializationEvents())
+                    if (!internalCacheDisabled && tokenCacheInternal.IsAppSubscribedToSerializationEvents())
                     {
                         DateTimeOffset? cacheExpiry = CalculateSuggestedCacheExpiry(Accessor, logger);
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Identity.Client
                 IDictionary<string, TenantProfile> tenantProfiles = null;
                 if (msalIdTokenCacheItem.TenantId != null)
                 {
-                    if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
+                    if (CacheOptions.IsDisabledFor(ServiceBundle.Config.AccessorOptions))
                     {
                         // When the internal cache is disabled, skip GetTenantProfilesAsync (which reads
                         // from Accessor) and instead seed a fresh dict with just the current profile.
@@ -176,7 +176,7 @@ namespace Microsoft.Identity.Client
 
             #endregion
 
-            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
+            if (CacheOptions.IsDisabledFor(ServiceBundle.Config.AccessorOptions))
             {
                 logger.Verbose(() => "[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCacheOptions). Skipping all cache writes.");
                 return Tuple.Create(msalAccessTokenCacheItem, msalIdTokenCacheItem, account);

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Client
                 // reads ID tokens from Accessor, which would violate the no-reads contract.
                 IDictionary<string, TenantProfile> tenantProfiles = null;
                 if (msalIdTokenCacheItem.TenantId != null &&
-                    ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled != true)
+                    ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled != true)
                 {
                     tenantProfiles = await GetTenantProfilesAsync(requestParams, homeAccountId).ConfigureAwait(false);
                     if (tenantProfiles != null)
@@ -168,9 +168,9 @@ namespace Microsoft.Identity.Client
 
             #endregion
 
-            if (ServiceBundle.Config.AccessorOptions?.InternalCacheDisabled == true)
+            if (ServiceBundle.Config.AccessorOptions?.IsInternalCacheDisabled == true)
             {
-                logger.Verbose(() => "[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCache). Skipping all cache writes.");
+                logger.Verbose(() => "[SaveTokenResponseAsync] Internal cache is disabled (CacheOptions.DisableInternalCacheOptions). Skipping all cache writes.");
                 return Tuple.Create(msalAccessTokenCacheItem, msalIdTokenCacheItem, account);
             }
 
@@ -211,7 +211,7 @@ namespace Microsoft.Identity.Client
                         requestParams.RequestContext.ApiEvent.DurationInCacheInMs += measuredResultDuration.Milliseconds;
                     }
 
-
+                    // Don't cache access tokens from broker
                     if (ShouldCacheAccessToken(msalAccessTokenCacheItem, response.TokenSource))
                     {
                         logger.Info("[SaveTokenResponseAsync] Saving AT in cache and removing overlapping ATs...");

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             var ccaAppConfig = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppWebApi).ConfigureAwait(false);
 
             // Step 1: get a user access token via ROPC on a PCA (scoped to the web API)
-            var pca = PublicClientApplicationBuilder
+            var pcaForRopc = PublicClientApplicationBuilder
                 .Create(pcaAppConfig.AppId)
                 .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                 .Build();
 
 #pragma warning disable CS0618
-            var userResult = await pca
+            var userResult = await pcaForRopc
                 .AcquireTokenByUsernamePassword(new[] { ccaAppConfig.DefaultScopes }, user.Upn, user.GetOrFetchPassword())
                 .ExecuteAsync()
                 .ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -14,6 +14,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Unit;
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
 {
@@ -29,31 +30,62 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private IPublicClientApplication pca = null;
 
+        private string _confidentialClientSecret;
+        private readonly KeyVaultSecretsProvider _keyVault = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            ApplicationBase.ResetStateForTest();
+            if (string.IsNullOrEmpty(_confidentialClientSecret))
+            {
+                _confidentialClientSecret = _keyVault.GetSecretByName(TestConstants.MsalOBOKeyVaultSecretName).Value;
+            }
+        }
+
         [TestMethod]
         public async Task DisableInternalCache_GetRefreshToken_ReturnsToken_Async()
         {
+            // Arrange: get lab user + app configs
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
-            var app = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppPCAClient).ConfigureAwait(false);
+            var pcaAppConfig = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppS2S).ConfigureAwait(false);
+            var ccaAppConfig = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppWebApi).ConfigureAwait(false);
 
-            var pcaWithDisabledCache = PublicClientApplicationBuilder
-                .Create(app.AppId)
-                .WithAuthority("https://login.microsoftonline.com/organizations")
-                .WithCacheOptions(CacheOptions.DisableInternalCache)
-                .WithTestLogging()
+            // Step 1: get a user access token via ROPC on a PCA (scoped to the web API)
+            var pca = PublicClientApplicationBuilder
+                .Create(pcaAppConfig.AppId)
+                .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
                 .Build();
 
 #pragma warning disable CS0618
-            AuthenticationResult result = await pcaWithDisabledCache
-                .AcquireTokenByUsernamePassword(s_scopes, user.Upn, user.GetOrFetchPassword())
+            var userResult = await pca
+                .AcquireTokenByUsernamePassword(new[] { ccaAppConfig.DefaultScopes }, user.Upn, user.GetOrFetchPassword())
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 #pragma warning restore CS0618
 
+            // Step 2: exchange the user token via OBO on a CCA with internal cache disabled
+            var ccaWithDisabledCache = ConfidentialClientApplicationBuilder
+                .Create(ccaAppConfig.AppId)
+                .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                .WithClientSecret(_confidentialClientSecret)
+                .WithCacheOptions(CacheOptions.DisableInternalCache)
+                .WithTestLogging()
+                .Build();
+
+            var result = await ccaWithDisabledCache
+                .AcquireTokenOnBehalfOf(s_scopes, new UserAssertion(userResult.AccessToken))
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Assert: RT is exposed and cache is empty
             string rt = result.GetRefreshToken();
-            Assert.IsNotNull(rt, "GetRefreshToken() should return a non-null refresh token from the network response.");
+            Assert.IsNotNull(rt, "GetRefreshToken() should return a non-null refresh token from a confidential client OBO response.");
             Assert.IsFalse(string.IsNullOrEmpty(rt), "Refresh token should not be empty.");
 
-            var accounts = await pcaWithDisabledCache.GetAccountsAsync().ConfigureAwait(false);
+#pragma warning disable CS0618
+            var accounts = await ccaWithDisabledCache.GetAccountsAsync().ConfigureAwait(false);
+#pragma warning restore CS0618
             Assert.IsFalse(accounts.Any(), "No accounts should be stored in cache when InternalCacheDisabled is set.");
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
-        public async Task DisableInternalCache_GetRefreshToken_ReturnsToken_Async()
+        public async Task DisableInternalCache_NormalOboFlow_DoesNotExposeRefreshToken_Async()
         {
             // Arrange: get lab user + app configs
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 
-            // Assert: RT is exposed and cache is empty
+            // Assert: normal OBO does not expose a refresh token (MSAL intentionally clears it
+            // in OnBehalfOfRequest.FetchNewAccessTokenAsync for non-long-running OBO) and cache is empty.
             string rt = result.GetRefreshToken();
-            Assert.IsNotNull(rt, "GetRefreshToken() should return a non-null refresh token from a confidential client OBO response.");
-            Assert.IsFalse(string.IsNullOrEmpty(rt), "Refresh token should not be empty.");
+            Assert.IsNull(rt, "GetRefreshToken() should return null for the normal confidential client OBO flow.");
 
 #pragma warning disable CS0618
             var accounts = await ccaWithDisabledCache.GetAccountsAsync().ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Test.Integration.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,6 +28,34 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         public TestContext TestContext { get; set; }
 
         private IPublicClientApplication pca = null;
+
+        [TestMethod]
+        public async Task DisableInternalCache_GetRefreshToken_ReturnsToken_Async()
+        {
+            var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
+            var app = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppPCAClient).ConfigureAwait(false);
+
+            var pcaWithDisabledCache = PublicClientApplicationBuilder
+                .Create(app.AppId)
+                .WithAuthority("https://login.microsoftonline.com/organizations")
+                .WithCacheOptions(CacheOptions.DisableInternalCache)
+                .WithTestLogging()
+                .Build();
+
+#pragma warning disable CS0618
+            AuthenticationResult result = await pcaWithDisabledCache
+                .AcquireTokenByUsernamePassword(s_scopes, user.Upn, user.GetOrFetchPassword())
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+#pragma warning restore CS0618
+
+            string rt = result.GetRefreshToken();
+            Assert.IsNotNull(rt, "GetRefreshToken() should return a non-null refresh token from the network response.");
+            Assert.IsFalse(string.IsNullOrEmpty(rt), "Refresh token should not be empty.");
+
+            var accounts = await pcaWithDisabledCache.GetAccountsAsync().ConfigureAwait(false);
+            Assert.IsFalse(accounts.Any(), "No accounts should be stored in cache when InternalCacheDisabled is set.");
+        }
 
         [TestMethod]
         public async Task SilentAuth_ForceRefresh_Async()

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Test.Integration.Infrastructure;
 using Microsoft.Identity.Test.LabInfrastructure;
@@ -14,7 +13,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Test.Common.Core.Helpers;
-using Microsoft.Identity.Test.Unit;
+
 
 namespace Microsoft.Identity.Test.Integration.HeadlessTests
 {
@@ -30,17 +29,10 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
         private IPublicClientApplication pca = null;
 
-        private string _confidentialClientSecret;
-        private readonly KeyVaultSecretsProvider _keyVault = new KeyVaultSecretsProvider(KeyVaultInstance.MsalTeam);
-
         [TestInitialize]
         public void TestInitialize()
         {
             ApplicationBase.ResetStateForTest();
-            if (string.IsNullOrEmpty(_confidentialClientSecret))
-            {
-                _confidentialClientSecret = _keyVault.GetSecretByName(TestConstants.MsalOBOKeyVaultSecretName).Value;
-            }
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/SilentAuthTests.cs
@@ -44,52 +44,6 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
-        public async Task DisableInternalCache_NormalOboFlow_DoesNotExposeRefreshToken_Async()
-        {
-            // Arrange: get lab user + app configs
-            var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);
-            var pcaAppConfig = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppS2S).ConfigureAwait(false);
-            var ccaAppConfig = await LabResponseHelper.GetAppConfigAsync(KeyVaultSecrets.AppWebApi).ConfigureAwait(false);
-
-            // Step 1: get a user access token via ROPC on a PCA (scoped to the web API)
-            var pcaForRopc = PublicClientApplicationBuilder
-                .Create(pcaAppConfig.AppId)
-                .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
-                .Build();
-
-#pragma warning disable CS0618
-            var userResult = await pcaForRopc
-                .AcquireTokenByUsernamePassword(new[] { ccaAppConfig.DefaultScopes }, user.Upn, user.GetOrFetchPassword())
-                .ExecuteAsync()
-                .ConfigureAwait(false);
-#pragma warning restore CS0618
-
-            // Step 2: exchange the user token via OBO on a CCA with internal cache disabled
-            var ccaWithDisabledCache = ConfidentialClientApplicationBuilder
-                .Create(ccaAppConfig.AppId)
-                .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
-                .WithClientSecret(_confidentialClientSecret)
-                .WithCacheOptions(CacheOptions.DisableInternalCache)
-                .WithTestLogging()
-                .Build();
-
-            var result = await ccaWithDisabledCache
-                .AcquireTokenOnBehalfOf(s_scopes, new UserAssertion(userResult.AccessToken))
-                .ExecuteAsync()
-                .ConfigureAwait(false);
-
-            // Assert: normal OBO does not expose a refresh token (MSAL intentionally clears it
-            // in OnBehalfOfRequest.FetchNewAccessTokenAsync for non-long-running OBO) and cache is empty.
-            string rt = result.GetRefreshToken();
-            Assert.IsNull(rt, "GetRefreshToken() should return null for the normal confidential client OBO flow.");
-
-#pragma warning disable CS0618
-            var accounts = await ccaWithDisabledCache.GetAccountsAsync().ConfigureAwait(false);
-#pragma warning restore CS0618
-            Assert.IsFalse(accounts.Any(), "No accounts should be stored in cache when InternalCacheDisabled is set.");
-        }
-
-        [TestMethod]
         public async Task SilentAuth_ForceRefresh_Async()
         {
             var user = await LabResponseHelper.GetUserConfigAsync(KeyVaultSecrets.UserPublicCloud).ConfigureAwait(false);

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -230,6 +230,32 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
+        /// <summary>GetRefreshToken() returns null for public client applications — RT exposure is confidential client only.</summary>
+        [TestMethod]
+        public async Task GetRefreshToken_PublicClient_ReturnsNull_Async()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
+
+                var pca = PublicClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                pca.ServiceBundle.ConfigureMockWebUI();
+
+                AuthenticationResult result = await pca
+                    .AcquireTokenInteractive(TestConstants.s_scope)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.IsNull(result.GetRefreshToken(), "GetRefreshToken() must return null for public client applications.");
+            }
+        }
+
         /// <summary>When DisableInternalCache is set, AcquireTokenForClient always hits the network and nothing is stored.</summary>
         [TestMethod]
         public async Task DisableInternalCache_AcquireTokenForClient_NeverCaches_Async()

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -437,6 +437,45 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         }
 
         /// <summary>
+        /// When DisableInternalCacheOptions is set, Account.TenantProfiles should still contain
+        /// the current tenant's profile derived from the freshly received ID token (no cache reads needed).
+        /// </summary>
+        [TestMethod]
+        public async Task DisableInternalCacheOptions_OboResult_HasTenantProfile_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant)
+                    .WithHttpManager(httpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
+                    .BuildConcrete();
+
+                var userAssertion = new UserAssertion(TestConstants.DefaultAccessToken);
+
+                httpManager.AddMockHandler(new MockHttpMessageHandler
+                {
+                    ExpectedUrl = TestConstants.AuthorityCommonTenant + "oauth2/v2.0/token",
+                    ExpectedMethod = HttpMethod.Post,
+                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                });
+
+                var result = await cca.AcquireTokenOnBehalfOf(TestConstants.s_scope, userAssertion)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                var profiles = result.Account.GetTenantProfiles()?.ToList();
+                Assert.IsNotNull(profiles, "TenantProfiles should not be null when DisableInternalCacheOptions is set.");
+                Assert.HasCount(1, profiles, "Should have exactly one TenantProfile from the freshly received ID token.");
+                Assert.AreEqual(TestConstants.Utid, profiles[0].TenantId,
+                    "TenantProfile.TenantId should match the ID token's tenant.");
+            }
+        }
+
+        /// <summary>
         /// Long-running OBO with DisableInternalCacheOptions: InitiateLongRunningProcessInWebApi always hits
         /// the network and stores nothing. AcquireTokenInLongRunningProcess cannot go to the network
         /// (no user assertion to exchange) and throws MsalUiRequiredException(IsInternalCacheDisabled)

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensibility;
-using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Test.Common.Mocks;

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -543,7 +543,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .ConfigureAwait(false);
 
                 Assert.AreEqual(MsalError.InternalCacheDisabled, ex.ErrorCode,
-                    "AcquireTokenInLongRunningProcess should throw IsInternalCacheDisabled when the cache is disabled.");
+                    "AcquireTokenInLongRunningProcess should throw MsalError.InternalCacheDisabled when the cache is disabled.");
                 Assert.AreEqual(UiRequiredExceptionClassification.AcquireTokenSilentFailed, ex.Classification,
                     "Classification should signal that silent auth failed.");
             }

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -438,8 +438,9 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         /// <summary>
         /// Long-running OBO with DisableInternalCache: InitiateLongRunningProcessInWebApi always hits
-        /// the network and stores nothing. AcquireTokenInLongRunningProcess cannot function without the
-        /// internal cache and throws MsalUiRequiredException(InternalCacheDisabled).
+        /// the network and stores nothing. AcquireTokenInLongRunningProcess cannot go to the network
+        /// (no user assertion to exchange) and throws MsalUiRequiredException(InternalCacheDisabled)
+        /// to surface the root cause directly.
         /// </summary>
         [TestMethod]
         public async Task DisableInternalCache_LongRunningObo_InitiateAlwaysHitsNetwork_AcquireThrows_Async()
@@ -480,15 +481,16 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 Assert.IsEmpty(cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens(),
                     "No refresh tokens should have been stored in the internal cache.");
 
-                // AcquireTokenInLongRunningProcess relies entirely on the internal cache for key-based
-                // lookups. Because DisableInternalCache prevented Initiate from writing to the cache,
-                // there is no token under this key and the call fails with a cache-miss error.
-                var ex = await AssertException.TaskThrowsAsync<MsalClientException>(
+                // AcquireTokenInLongRunningProcess cannot go to the network (no user assertion to
+                // exchange). When the cache is disabled it surfaces the root cause directly.
+                var ex = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(
                     () => cca.AcquireTokenInLongRunningProcess(TestConstants.s_scope, oboCacheKey).ExecuteAsync())
                     .ConfigureAwait(false);
 
-                Assert.AreEqual(MsalError.OboCacheKeyNotInCacheError, ex.ErrorCode,
-                    "AcquireTokenInLongRunningProcess should report that the OBO cache key is absent when the cache is disabled.");
+                Assert.AreEqual(MsalError.InternalCacheDisabled, ex.ErrorCode,
+                    "AcquireTokenInLongRunningProcess should throw InternalCacheDisabled when the cache is disabled.");
+                Assert.AreEqual(UiRequiredExceptionClassification.AcquireTokenSilentFailed, ex.Classification,
+                    "Classification should signal that silent auth failed.");
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensibility;
@@ -367,6 +368,145 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             Assert.AreEqual(MsalError.InvalidRequest, ex.ErrorCode,
                 "Setting both InternalCacheDisabled and UseSharedCache should throw an InvalidRequest error.");
+        }
+
+        /// <summary>
+        /// Short-running OBO with DisableInternalCache: every call always goes to the network
+        /// and nothing is written to the internal cache.
+        /// </summary>
+        [TestMethod]
+        public async Task DisableInternalCache_ShortRunningObo_AlwaysHitsNetwork_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant)
+                    .WithHttpManager(httpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                var userAssertion = new UserAssertion(TestConstants.DefaultAccessToken);
+
+                // First OBO call — must hit the network.
+                httpManager.AddMockHandler(new MockHttpMessageHandler
+                {
+                    ExpectedUrl = TestConstants.AuthorityCommonTenant + "oauth2/v2.0/token",
+                    ExpectedMethod = HttpMethod.Post,
+                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                });
+
+                var result1 = await cca.AcquireTokenOnBehalfOf(TestConstants.s_scope, userAssertion)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
+                    "First OBO call should hit the network.");
+                Assert.IsNull(result1.GetRefreshToken(),
+                    "Normal OBO does not expose a refresh token (MSAL intentionally clears it).");
+
+                // Second OBO call with the same assertion — must hit the network again because the cache is disabled.
+                httpManager.AddMockHandler(new MockHttpMessageHandler
+                {
+                    ExpectedUrl = TestConstants.AuthorityCommonTenant + "oauth2/v2.0/token",
+                    ExpectedMethod = HttpMethod.Post,
+                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                });
+
+                var result2 = await cca.AcquireTokenOnBehalfOf(TestConstants.s_scope, userAssertion)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource,
+                    "Second OBO call should also hit the network because the internal cache is disabled.");
+
+                Assert.IsEmpty(cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens(),
+                    "No access tokens should have been stored in the internal cache.");
+                Assert.IsEmpty(cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens(),
+                    "No refresh tokens should have been stored in the internal cache.");
+            }
+        }
+
+        /// <summary>
+        /// Long-running OBO with DisableInternalCache: InitiateLongRunningProcessInWebApi always hits
+        /// the network and stores nothing. AcquireTokenInLongRunningProcess cannot function without the
+        /// internal cache and throws MsalUiRequiredException(InternalCacheDisabled).
+        /// </summary>
+        [TestMethod]
+        public async Task DisableInternalCache_LongRunningObo_InitiateAlwaysHitsNetwork_AcquireThrows_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant)
+                    .WithHttpManager(httpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                string oboCacheKey = "obo-cache-key";
+
+                // Initiate — must hit the network.
+                httpManager.AddMockHandler(new MockHttpMessageHandler
+                {
+                    ExpectedUrl = TestConstants.AuthorityCommonTenant + "oauth2/v2.0/token",
+                    ExpectedMethod = HttpMethod.Post,
+                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                });
+
+                var result = await cca
+                    .InitiateLongRunningProcessInWebApi(TestConstants.s_scope, TestConstants.DefaultAccessToken, ref oboCacheKey)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource,
+                    "Initiate should always hit the network when the internal cache is disabled.");
+
+                Assert.IsEmpty(cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens(),
+                    "No access tokens should have been stored in the internal cache.");
+                Assert.IsEmpty(cca.UserTokenCacheInternal.Accessor.GetAllRefreshTokens(),
+                    "No refresh tokens should have been stored in the internal cache.");
+
+                // AcquireTokenInLongRunningProcess relies entirely on the internal cache for key-based
+                // lookups. Because DisableInternalCache prevented Initiate from writing to the cache,
+                // there is no token under this key and the call fails with a cache-miss error.
+                var ex = await AssertException.TaskThrowsAsync<MsalClientException>(
+                    () => cca.AcquireTokenInLongRunningProcess(TestConstants.s_scope, oboCacheKey).ExecuteAsync())
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.OboCacheKeyNotInCacheError, ex.ErrorCode,
+                    "AcquireTokenInLongRunningProcess should report that the OBO cache key is absent when the cache is disabled.");
+            }
+        }
+
+        /// <summary>
+        /// AcquireTokenSilent on a CCA (confidential client) throws the same MsalUiRequiredException
+        /// as on a PCA when DisableInternalCache is set.
+        /// </summary>
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenSilent_CcaVariant_ThrowsWithCorrectError_Async()
+        {
+            var cca = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithCacheOptions(CacheOptions.DisableInternalCache)
+                .Build();
+
+            var account = new Account("aid.tid", "user@contoso.com", "login.microsoftonline.com");
+
+            var ex = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(
+                () => cca.AcquireTokenSilent(TestConstants.s_scope, account).ExecuteAsync())
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(MsalError.InternalCacheDisabled, ex.ErrorCode,
+                "The error code should identify that the internal cache is disabled.");
+            StringAssert.Contains(ex.Message, "AcquireTokenByRefreshToken",
+                "The error message should guide the caller towards AcquireTokenByRefreshToken.");
+            Assert.AreEqual(UiRequiredExceptionClassification.AcquireTokenSilentFailed, ex.Classification,
+                "Classification should signal that silent auth failed.");
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -294,6 +294,10 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 Assert.AreEqual(CacheRefreshReason.CacheDisabled, result2.AuthenticationResultMetadata.CacheRefreshReason,
                     "CacheRefreshReason should be CacheDisabled when the internal cache is disabled.");
 
+                // Client credentials does not include a refresh token in the token response.
+                Assert.IsNull(result1.GetRefreshToken(),
+                    "GetRefreshToken() must return null for AcquireTokenForClient — the server does not issue refresh tokens for client credentials.");
+
                 Assert.IsEmpty(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens(),
                     "No access tokens should have been stored in the internal cache.");
             }

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -346,27 +346,20 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
-        /// <summary>AcquireTokenSilent throws MsalUiRequiredException (the established "silent failed" contract) when the internal cache is disabled.</summary>
+        /// <summary>DisableInternalCacheOptions throws at configuration time for public client applications — the feature is confidential client only.</summary>
         [TestMethod]
-        public async Task DisableInternalCacheOptions_AcquireTokenSilent_ThrowsWithCorrectError_Async()
+        public void DisableInternalCacheOptions_PublicClient_ThrowsOnWithCacheOptions()
         {
-            var app = PublicClientApplicationBuilder
-                .Create(TestConstants.ClientId)
-                .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
-                .Build();
+            var ex = AssertException.Throws<MsalClientException>(
+                () => PublicClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
+                    .Build());
 
-            var account = new Account("aid.tid", "user@contoso.com", "login.microsoftonline.com");
-
-            var ex = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(
-                () => app.AcquireTokenSilent(TestConstants.s_scope, account).ExecuteAsync())
-                .ConfigureAwait(false);
-
-            Assert.AreEqual(MsalError.InternalCacheDisabled, ex.ErrorCode,
-                "The error code should identify that the internal cache is disabled.");
-            StringAssert.Contains(ex.Message, "AcquireTokenByRefreshToken",
-                "The error message should guide the caller towards AcquireTokenByRefreshToken.");
-            Assert.AreEqual(UiRequiredExceptionClassification.AcquireTokenSilentFailed, ex.Classification,
-                "Classification should signal that silent auth failed.");
+            Assert.AreEqual(MsalError.InvalidRequest, ex.ErrorCode,
+                "The error code should be InvalidRequest.");
+            StringAssert.Contains(ex.Message, "public client",
+                "The error message should explain that this option is not supported for public clients.");
         }
 
         /// <summary>Mutual exclusivity: IsInternalCacheDisabled and UseSharedCache cannot both be set.</summary>

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -193,15 +193,15 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         /// <summary>Static helper and the bool property have correct values.</summary>
         [TestMethod]
-        public void DisableInternalCache_StaticProperty_HasCorrectValues()
+        public void DisableInternalCacheOptions_StaticProperty_HasCorrectValues()
         {
-            var disabled = CacheOptions.DisableInternalCache;
+            var disabled = CacheOptions.DisableInternalCacheOptions;
             Assert.IsNotNull(disabled);
-            Assert.IsTrue(disabled.InternalCacheDisabled, "DisableInternalCache.InternalCacheDisabled should be true");
-            Assert.IsFalse(disabled.UseSharedCache, "DisableInternalCache.UseSharedCache should be false");
+            Assert.IsTrue(disabled.IsInternalCacheDisabled, "DisableInternalCacheOptions.IsInternalCacheDisabled should be true");
+            Assert.IsFalse(disabled.UseSharedCache, "DisableInternalCacheOptions.UseSharedCache should be false");
 
             var defaults = new CacheOptions();
-            Assert.IsFalse(defaults.InternalCacheDisabled, "Default CacheOptions should have InternalCacheDisabled == false");
+            Assert.IsFalse(defaults.IsInternalCacheDisabled, "Default CacheOptions should have IsInternalCacheDisabled == false");
         }
 
         /// <summary>GetRefreshToken() extension returns the refresh token from a real token flow.</summary>
@@ -257,9 +257,9 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
-        /// <summary>When DisableInternalCache is set, AcquireTokenForClient always hits the network and nothing is stored.</summary>
+        /// <summary>When DisableInternalCacheOptions is set, AcquireTokenForClient always hits the network and nothing is stored.</summary>
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenForClient_NeverCaches_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenForClient_NeverCaches_Async()
         {
             using (var httpManager = new MockHttpManager())
             {
@@ -269,7 +269,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .Create(TestConstants.ClientId)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(httpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 // Two separate network calls expected because the cache is disabled.
@@ -299,9 +299,9 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
-        /// <summary>DisableInternalCache also skips the user token cache.</summary>
+        /// <summary>DisableInternalCacheOptions also skips the user token cache.</summary>
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenByAuthCode_DoesNotCacheTokens_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenByAuthCode_DoesNotCacheTokens_Async()
         {
             using (var harness = CreateTestHarness())
             {
@@ -313,7 +313,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithRedirectUri(TestConstants.RedirectUri)
                     .WithHttpManager(harness.HttpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 await app
@@ -332,11 +332,11 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         /// <summary>AcquireTokenSilent throws MsalUiRequiredException (the established "silent failed" contract) when the internal cache is disabled.</summary>
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenSilent_ThrowsWithCorrectError_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenSilent_ThrowsWithCorrectError_Async()
         {
             var app = PublicClientApplicationBuilder
                 .Create(TestConstants.ClientId)
-                .WithCacheOptions(CacheOptions.DisableInternalCache)
+                .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                 .Build();
 
             var account = new Account("aid.tid", "user@contoso.com", "login.microsoftonline.com");
@@ -353,13 +353,13 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 "Classification should signal that silent auth failed.");
         }
 
-        /// <summary>Mutual exclusivity: InternalCacheDisabled and UseSharedCache cannot both be set.</summary>
+        /// <summary>Mutual exclusivity: IsInternalCacheDisabled and UseSharedCache cannot both be set.</summary>
         [TestMethod]
-        public void DisableInternalCache_AndUseSharedCache_ThrowsOnBuild()
+        public void DisableInternalCacheOptions_AndUseSharedCache_ThrowsOnBuild()
         {
             var conflictingOptions = new CacheOptions
             {
-                InternalCacheDisabled = true,
+                IsInternalCacheDisabled = true,
                 UseSharedCache = true
             };
 
@@ -371,15 +371,15 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .Build());
 
             Assert.AreEqual(MsalError.InvalidRequest, ex.ErrorCode,
-                "Setting both InternalCacheDisabled and UseSharedCache should throw an InvalidRequest error.");
+                "Setting both IsInternalCacheDisabled and UseSharedCache should throw an InvalidRequest error.");
         }
 
         /// <summary>
-        /// Short-running OBO with DisableInternalCache: every call always goes to the network
+        /// Short-running OBO with DisableInternalCacheOptions: every call always goes to the network
         /// and nothing is written to the internal cache.
         /// </summary>
         [TestMethod]
-        public async Task DisableInternalCache_ShortRunningObo_AlwaysHitsNetwork_Async()
+        public async Task DisableInternalCacheOptions_ShortRunningObo_AlwaysHitsNetwork_Async()
         {
             using (var httpManager = new MockHttpManager())
             {
@@ -390,7 +390,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithAuthority(TestConstants.AuthorityCommonTenant)
                     .WithHttpManager(httpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 var userAssertion = new UserAssertion(TestConstants.DefaultAccessToken);
@@ -437,13 +437,13 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         }
 
         /// <summary>
-        /// Long-running OBO with DisableInternalCache: InitiateLongRunningProcessInWebApi always hits
+        /// Long-running OBO with DisableInternalCacheOptions: InitiateLongRunningProcessInWebApi always hits
         /// the network and stores nothing. AcquireTokenInLongRunningProcess cannot go to the network
-        /// (no user assertion to exchange) and throws MsalUiRequiredException(InternalCacheDisabled)
+        /// (no user assertion to exchange) and throws MsalUiRequiredException(IsInternalCacheDisabled)
         /// to surface the root cause directly.
         /// </summary>
         [TestMethod]
-        public async Task DisableInternalCache_LongRunningObo_InitiateAlwaysHitsNetwork_AcquireThrows_Async()
+        public async Task DisableInternalCacheOptions_LongRunningObo_InitiateAlwaysHitsNetwork_AcquireThrows_Async()
         {
             using (var httpManager = new MockHttpManager())
             {
@@ -454,7 +454,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithAuthority(TestConstants.AuthorityCommonTenant)
                     .WithHttpManager(httpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 string oboCacheKey = "obo-cache-key";
@@ -488,7 +488,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                     .ConfigureAwait(false);
 
                 Assert.AreEqual(MsalError.InternalCacheDisabled, ex.ErrorCode,
-                    "AcquireTokenInLongRunningProcess should throw InternalCacheDisabled when the cache is disabled.");
+                    "AcquireTokenInLongRunningProcess should throw IsInternalCacheDisabled when the cache is disabled.");
                 Assert.AreEqual(UiRequiredExceptionClassification.AcquireTokenSilentFailed, ex.Classification,
                     "Classification should signal that silent auth failed.");
             }
@@ -496,15 +496,15 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         /// <summary>
         /// AcquireTokenSilent on a CCA (confidential client) throws the same MsalUiRequiredException
-        /// as on a PCA when DisableInternalCache is set.
+        /// as on a PCA when DisableInternalCacheOptions is set.
         /// </summary>
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenSilent_CcaVariant_ThrowsWithCorrectError_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenSilent_CcaVariant_ThrowsWithCorrectError_Async()
         {
             var cca = ConfidentialClientApplicationBuilder
                 .Create(TestConstants.ClientId)
                 .WithClientSecret(TestConstants.ClientSecret)
-                .WithCacheOptions(CacheOptions.DisableInternalCache)
+                .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                 .Build();
 
             var account = new Account("aid.tid", "user@contoso.com", "login.microsoftonline.com");

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -204,6 +204,18 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.IsFalse(defaults.IsInternalCacheDisabled, "Default CacheOptions should have IsInternalCacheDisabled == false");
         }
 
+        /// <summary>CacheOptions.IsDisabledFor is null-safe and returns the correct value for all inputs.</summary>
+        [TestMethod]
+        public void CacheOptions_IsDisabledFor_NullSafeAndCorrect()
+        {
+            Assert.IsFalse(CacheOptions.IsDisabledFor(null),
+                "IsDisabledFor(null) should return false — null options means cache is not disabled.");
+            Assert.IsFalse(CacheOptions.IsDisabledFor(new CacheOptions()),
+                "IsDisabledFor(default CacheOptions) should return false.");
+            Assert.IsTrue(CacheOptions.IsDisabledFor(CacheOptions.DisableInternalCacheOptions),
+                "IsDisabledFor(DisableInternalCacheOptions) should return true.");
+        }
+
         /// <summary>GetRefreshToken() extension returns the refresh token from a real token flow.</summary>
         [TestMethod]
         public async Task GetRefreshToken_AcquireTokenByAuthCode_ReturnsToken_Async()
@@ -482,8 +494,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         /// <summary>
         /// Long-running OBO with DisableInternalCacheOptions: InitiateLongRunningProcessInWebApi always hits
         /// the network and stores nothing. AcquireTokenInLongRunningProcess cannot go to the network
-        /// (no user assertion to exchange) and throws MsalUiRequiredException(IsInternalCacheDisabled)
-        /// to surface the root cause directly.
+        /// (no user assertion to exchange) and throws MsalUiRequiredException with error code
+        /// MsalError.InternalCacheDisabled to surface the root cause directly.
         /// </summary>
         [TestMethod]
         public async Task DisableInternalCacheOptions_LongRunningObo_InitiateAlwaysHitsNetwork_AcquireThrows_Async()

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
-        /// <summary>AcquireTokenSilent throws a descriptive MsalClientException when the internal cache is disabled.</summary>
+        /// <summary>AcquireTokenSilent throws MsalUiRequiredException (the established "silent failed" contract) when the internal cache is disabled.</summary>
         [TestMethod]
         public async Task DisableInternalCache_AcquireTokenSilent_ThrowsWithCorrectError_Async()
         {
@@ -336,7 +336,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             var account = new Account("aid.tid", "user@contoso.com", "login.microsoftonline.com");
 
-            var ex = await AssertException.TaskThrowsAsync<MsalClientException>(
+            var ex = await AssertException.TaskThrowsAsync<MsalUiRequiredException>(
                 () => app.AcquireTokenSilent(TestConstants.s_scope, account).ExecuteAsync())
                 .ConfigureAwait(false);
 
@@ -344,6 +344,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 "The error code should identify that the internal cache is disabled.");
             StringAssert.Contains(ex.Message, "AcquireTokenByRefreshToken",
                 "The error message should guide the caller towards AcquireTokenByRefreshToken.");
+            Assert.AreEqual(UiRequiredExceptionClassification.AcquireTokenSilentFailed, ex.Classification,
+                "Classification should signal that silent auth failed.");
         }
 
         /// <summary>Mutual exclusivity: InternalCacheDisabled and UseSharedCache cannot both be set.</summary>

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -192,9 +192,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             return result;
         }
 
-        // ─── New tests for issue #5942 ────────────────────────────────────────────
-
-        /// <summary>AC3 + AC4: Static helper and the bool property have correct values.</summary>
+        /// <summary>Static helper and the bool property have correct values.</summary>
         [TestMethod]
         public void DisableInternalCache_StaticProperty_HasCorrectValues()
         {
@@ -207,7 +205,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.IsFalse(defaults.InternalCacheDisabled, "Default CacheOptions should have InternalCacheDisabled == false");
         }
 
-        /// <summary>AC2: The refresh token must NOT appear as a public property on AuthenticationResult.</summary>
+        /// <summary>The refresh token must NOT appear as a public property on AuthenticationResult.</summary>
         [TestMethod]
         public void RefreshToken_IsNotPublicProperty()
         {
@@ -217,7 +215,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.IsNull(prop, "RefreshToken must not be exposed as a public property on AuthenticationResult.");
         }
 
-        /// <summary>AC1: GetRefreshToken() extension returns the refresh token from a real token flow.</summary>
+        /// <summary>GetRefreshToken() extension returns the refresh token from a real token flow.</summary>
         [TestMethod]
         public async Task GetRefreshToken_AcquireTokenByAuthCode_ReturnsToken_Async()
         {
@@ -244,7 +242,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
-        /// <summary>AC5: When DisableInternalCache is set, AcquireTokenForClient always hits the network and nothing is stored.</summary>
+        /// <summary>When DisableInternalCache is set, AcquireTokenForClient always hits the network and nothing is stored.</summary>
         [TestMethod]
         public async Task DisableInternalCache_AcquireTokenForClient_NeverCaches_Async()
         {
@@ -282,7 +280,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
-        /// <summary>AC5 (user-flow variant): DisableInternalCache also skips the user token cache.</summary>
+        /// <summary>DisableInternalCache also skips the user token cache.</summary>
         [TestMethod]
         public async Task DisableInternalCache_AcquireTokenByAuthCode_DoesNotCacheTokens_Async()
         {
@@ -313,7 +311,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             }
         }
 
-        /// <summary>AC6: AcquireTokenSilent throws a descriptive MsalClientException when the internal cache is disabled.</summary>
+        /// <summary>AcquireTokenSilent throws a descriptive MsalClientException when the internal cache is disabled.</summary>
         [TestMethod]
         public async Task DisableInternalCache_AcquireTokenSilent_ThrowsWithCorrectError_Async()
         {

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
+using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.Identity.Test.Common.Mocks;
@@ -187,6 +190,169 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 result.AuthenticationResultMetadata.CachedAccessTokenCount);
 
             return result;
+        }
+
+        // ─── New tests for issue #5942 ────────────────────────────────────────────
+
+        /// <summary>AC3 + AC4: Static helper and the bool property have correct values.</summary>
+        [TestMethod]
+        public void DisableInternalCache_StaticProperty_HasCorrectValues()
+        {
+            var disabled = CacheOptions.DisableInternalCache;
+            Assert.IsNotNull(disabled);
+            Assert.IsTrue(disabled.InternalCacheDisabled, "DisableInternalCache.InternalCacheDisabled should be true");
+            Assert.IsFalse(disabled.UseSharedCache, "DisableInternalCache.UseSharedCache should be false");
+
+            var defaults = new CacheOptions();
+            Assert.IsFalse(defaults.InternalCacheDisabled, "Default CacheOptions should have InternalCacheDisabled == false");
+        }
+
+        /// <summary>AC2: The refresh token must NOT appear as a public property on AuthenticationResult.</summary>
+        [TestMethod]
+        public void RefreshToken_IsNotPublicProperty()
+        {
+            var prop = typeof(AuthenticationResult)
+                .GetProperty("RefreshToken", BindingFlags.Public | BindingFlags.Instance);
+
+            Assert.IsNull(prop, "RefreshToken must not be exposed as a public property on AuthenticationResult.");
+        }
+
+        /// <summary>AC1: GetRefreshToken() extension returns the refresh token from a real token flow.</summary>
+        [TestMethod]
+        public async Task GetRefreshToken_AcquireTokenByAuthCode_ReturnsToken_Async()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithRedirectUri(TestConstants.RedirectUri)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                AuthenticationResult result = await app
+                    .AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                string rt = result.GetRefreshToken();
+                Assert.IsNotNull(rt, "GetRefreshToken() should return a non-null refresh token.");
+                Assert.AreEqual(TestConstants.RTSecret, rt, "GetRefreshToken() should return the refresh token from the token response.");
+            }
+        }
+
+        /// <summary>AC5: When DisableInternalCache is set, AcquireTokenForClient always hits the network and nothing is stored.</summary>
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenForClient_NeverCaches_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                // Two separate network calls expected because the cache is disabled.
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                var result1 = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithTenantId(TestConstants.Utid)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                var result2 = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithTenantId(TestConstants.Utid)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
+                    "First call should come from the network, not the cache.");
+                Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource,
+                    "Second call should also come from the network because the internal cache is disabled.");
+
+                Assert.IsEmpty(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens(),
+                    "No access tokens should have been stored in the internal cache.");
+            }
+        }
+
+        /// <summary>AC5 (user-flow variant): DisableInternalCache also skips the user token cache.</summary>
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenByAuthCode_DoesNotCacheTokens_Async()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(TestConstants.AuthorityCommonTenant);
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithRedirectUri(TestConstants.RedirectUri)
+                    .WithHttpManager(harness.HttpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                await app
+                    .AcquireTokenByAuthorizationCode(TestConstants.s_scope, TestConstants.DefaultAuthorizationCode)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.IsEmpty(app.UserTokenCacheInternal.Accessor.GetAllAccessTokens(),
+                    "No access tokens should be stored when the internal cache is disabled.");
+                Assert.IsEmpty(app.UserTokenCacheInternal.Accessor.GetAllRefreshTokens(),
+                    "No refresh tokens should be stored when the internal cache is disabled.");
+                Assert.IsEmpty(app.UserTokenCacheInternal.Accessor.GetAllIdTokens(),
+                    "No ID tokens should be stored when the internal cache is disabled.");
+            }
+        }
+
+        /// <summary>AC6: AcquireTokenSilent throws a descriptive MsalClientException when the internal cache is disabled.</summary>
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenSilent_ThrowsWithCorrectError_Async()
+        {
+            var app = PublicClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithCacheOptions(CacheOptions.DisableInternalCache)
+                .Build();
+
+            var account = new Account("aid.tid", "user@contoso.com", "login.microsoftonline.com");
+
+            var ex = await AssertException.TaskThrowsAsync<MsalClientException>(
+                () => app.AcquireTokenSilent(TestConstants.s_scope, account).ExecuteAsync())
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(MsalError.InternalCacheDisabled, ex.ErrorCode,
+                "The error code should identify that the internal cache is disabled.");
+            StringAssert.Contains(ex.Message, "AcquireTokenByRefreshToken",
+                "The error message should guide the caller towards AcquireTokenByRefreshToken.");
+        }
+
+        /// <summary>Mutual exclusivity: InternalCacheDisabled and UseSharedCache cannot both be set.</summary>
+        [TestMethod]
+        public void DisableInternalCache_AndUseSharedCache_ThrowsOnBuild()
+        {
+            var conflictingOptions = new CacheOptions
+            {
+                InternalCacheDisabled = true,
+                UseSharedCache = true
+            };
+
+            var ex = AssertException.Throws<MsalClientException>(
+                () => ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithCacheOptions(conflictingOptions)
+                    .Build());
+
+            Assert.AreEqual(MsalError.InvalidRequest, ex.ErrorCode,
+                "Setting both InternalCacheDisabled and UseSharedCache should throw an InvalidRequest error.");
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensibility;
@@ -203,16 +202,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
             var defaults = new CacheOptions();
             Assert.IsFalse(defaults.InternalCacheDisabled, "Default CacheOptions should have InternalCacheDisabled == false");
-        }
-
-        /// <summary>The refresh token must NOT appear as a public property on AuthenticationResult.</summary>
-        [TestMethod]
-        public void RefreshToken_IsNotPublicProperty()
-        {
-            var prop = typeof(AuthenticationResult)
-                .GetProperty("RefreshToken", BindingFlags.Public | BindingFlags.Instance);
-
-            Assert.IsNull(prop, "RefreshToken must not be exposed as a public property on AuthenticationResult.");
         }
 
         /// <summary>GetRefreshToken() extension returns the refresh token from a real token flow.</summary>

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InternalCacheOptionsTests.cs
@@ -287,8 +287,12 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
                     "First call should come from the network, not the cache.");
+                Assert.AreEqual(CacheRefreshReason.CacheDisabled, result1.AuthenticationResultMetadata.CacheRefreshReason,
+                    "CacheRefreshReason should be CacheDisabled when the internal cache is disabled.");
                 Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource,
                     "Second call should also come from the network because the internal cache is disabled.");
+                Assert.AreEqual(CacheRefreshReason.CacheDisabled, result2.AuthenticationResultMetadata.CacheRefreshReason,
+                    "CacheRefreshReason should be CacheDisabled when the internal cache is disabled.");
 
                 Assert.IsEmpty(app.AppTokenCacheInternal.Accessor.GetAllAccessTokens(),
                     "No access tokens should have been stored in the internal cache.");
@@ -404,6 +408,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
                     "First OBO call should hit the network.");
+                Assert.AreEqual(CacheRefreshReason.CacheDisabled, result1.AuthenticationResultMetadata.CacheRefreshReason,
+                    "CacheRefreshReason should be CacheDisabled for OBO when the internal cache is disabled.");
                 Assert.IsNull(result1.GetRefreshToken(),
                     "Normal OBO does not expose a refresh token (MSAL intentionally clears it).");
 
@@ -420,6 +426,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource,
                     "Second OBO call should also hit the network because the internal cache is disabled.");
+                Assert.AreEqual(CacheRefreshReason.CacheDisabled, result2.AuthenticationResultMetadata.CacheRefreshReason,
+                    "CacheRefreshReason should be CacheDisabled for OBO when the internal cache is disabled.");
 
                 Assert.IsEmpty(cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens(),
                     "No access tokens should have been stored in the internal cache.");
@@ -464,6 +472,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource,
                     "Initiate should always hit the network when the internal cache is disabled.");
+                Assert.AreEqual(CacheRefreshReason.CacheDisabled, result.AuthenticationResultMetadata.CacheRefreshReason,
+                    "CacheRefreshReason should be CacheDisabled for long-running OBO when the internal cache is disabled.");
 
                 Assert.IsEmpty(cca.UserTokenCacheInternal.Accessor.GetAllAccessTokens(),
                     "No access tokens should have been stored in the internal cache.");

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -531,7 +531,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         }
 
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenForClient_EmitsCacheDisabledTelemetry_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenForClient_EmitsCacheDisabledTelemetry_Async()
         {
             using (_harness = CreateTestHarness())
             {
@@ -542,7 +542,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithAuthority(TestConstants.AuthorityCommonTenant)
                     .WithHttpManager(_harness.HttpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 await cca.AcquireTokenForClient(TestConstants.s_scope)
@@ -553,7 +553,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         }
 
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenOnBehalfOf_EmitsCacheDisabledTelemetry_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenOnBehalfOf_EmitsCacheDisabledTelemetry_Async()
         {
             using (_harness = CreateTestHarness())
             {
@@ -564,7 +564,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithAuthority(TestConstants.AuthorityCommonTenant)
                     .WithHttpManager(_harness.HttpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 await cca.AcquireTokenOnBehalfOf(TestConstants.s_scope, new UserAssertion(TestConstants.DefaultAccessToken))
@@ -575,7 +575,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         }
 
         [TestMethod]
-        public async Task DisableInternalCache_InitiateLongRunningObo_EmitsCacheDisabledTelemetry_Async()
+        public async Task DisableInternalCacheOptions_InitiateLongRunningObo_EmitsCacheDisabledTelemetry_Async()
         {
             using (_harness = CreateTestHarness())
             {
@@ -586,7 +586,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithAuthority(TestConstants.AuthorityCommonTenant)
                     .WithHttpManager(_harness.HttpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 var cacheKey = string.Empty;

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
@@ -530,6 +530,73 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
             }
         }
 
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenForClient_EmitsCacheDisabledTelemetry_Async()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                var requestHandler = _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant)
+                    .WithHttpManager(_harness.HttpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                await cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                AssertCurrentTelemetry(requestHandler.ActualRequestMessage, ApiIds.AcquireTokenForClient, CacheRefreshReason.CacheDisabled);
+            }
+        }
+
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenOnBehalfOf_EmitsCacheDisabledTelemetry_Async()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                var requestHandler = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();
+
+                var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant)
+                    .WithHttpManager(_harness.HttpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                await cca.AcquireTokenOnBehalfOf(TestConstants.s_scope, new UserAssertion(TestConstants.DefaultAccessToken))
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                AssertCurrentTelemetry(requestHandler.ActualRequestMessage, ApiIds.AcquireTokenOnBehalfOf, CacheRefreshReason.CacheDisabled);
+            }
+        }
+
+        [TestMethod]
+        public async Task DisableInternalCache_InitiateLongRunningObo_EmitsCacheDisabledTelemetry_Async()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                var requestHandler = _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();
+
+                var cca = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant)
+                    .WithHttpManager(_harness.HttpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                var cacheKey = string.Empty;
+                await cca.InitiateLongRunningProcessInWebApi(TestConstants.s_scope, TestConstants.DefaultAccessToken, ref cacheKey)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                AssertCurrentTelemetry(requestHandler.ActualRequestMessage, ApiIds.InitiateLongRunningObo, CacheRefreshReason.CacheDisabled);
+            }
+        }
+
         private PublicClientApplication CreatePublicClientApp(bool isLegacyCacheEnabled = true)
         {
             return PublicClientApplicationBuilder.Create(TestConstants.ClientId)

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -404,15 +404,95 @@ namespace Microsoft.Identity.Test.Unit
             Assert.IsNotNull(exClient.ErrorCode);
         }
 
-        private void CreateApplication()
+        private void CreateApplication(CacheOptions useCacheOptions = null)
         {
-            _cca = ConfidentialClientApplicationBuilder
+            var builder = ConfidentialClientApplicationBuilder
                         .Create(TestConstants.ClientId)
                         .WithExperimentalFeatures()
                         .WithAuthority(TestConstants.AuthorityUtidTenant)
                         .WithClientSecret(TestConstants.ClientSecret)
-                        .WithHttpManager(_harness.HttpManager)
-                        .BuildConcrete();
+                        .WithHttpManager(_harness.HttpManager);
+
+            if (useCacheOptions != null)
+            {
+                builder = builder.WithCacheOptions(useCacheOptions);
+            }
+
+            _cca = builder.BuildConcrete();
+        }
+
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenForClient_OTelEmitsCacheDisabledReason_Async()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                CreateApplication(useCacheOptions: CacheOptions.DisableInternalCache);
+
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                AuthenticationResult result = await _cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(CacheRefreshReason.CacheDisabled, result.AuthenticationResultMetadata.CacheRefreshReason);
+
+                s_meterProvider.ForceFlush();
+
+                var msalSuccess = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalSuccess");
+                Assert.IsNotNull(msalSuccess, "MsalSuccess metric should be emitted.");
+
+                foreach (var metricPoint in msalSuccess.GetMetricPoints())
+                {
+                    AssertTagValue(metricPoint.Tags, TelemetryConstants.CacheRefreshReason, CacheRefreshReason.CacheDisabled);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task DisableInternalCache_AcquireTokenOnBehalfOf_OTelEmitsCacheDisabledReason_Async()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost();
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority(TestConstants.AuthorityCommonTenant)
+                    .WithHttpManager(_harness.HttpManager)
+                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .BuildConcrete();
+
+                AuthenticationResult result = await cca.AcquireTokenOnBehalfOf(
+                    TestConstants.s_scope, new UserAssertion(TestConstants.DefaultAccessToken))
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(CacheRefreshReason.CacheDisabled, result.AuthenticationResultMetadata.CacheRefreshReason);
+
+                s_meterProvider.ForceFlush();
+
+                var msalSuccess = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalSuccess");
+                Assert.IsNotNull(msalSuccess, "MsalSuccess metric should be emitted.");
+
+                foreach (var metricPoint in msalSuccess.GetMetricPoints())
+                {
+                    AssertTagValue(metricPoint.Tags, TelemetryConstants.CacheRefreshReason, CacheRefreshReason.CacheDisabled);
+                }
+            }
+        }
+
+        private void AssertTagValue(ReadOnlyTagCollection tags, string tagKey, object expectedValue)
+        {
+            IDictionary<string, object> tagDictionary = new Dictionary<string, object>();
+            foreach (var tag in tags)
+            {
+                tagDictionary[tag.Key] = tag.Value;
+            }
+            Assert.IsTrue(tagDictionary.ContainsKey(tagKey), $"Tag '{tagKey}' is missing from metric point.");
+            Assert.AreEqual(expectedValue, tagDictionary[tagKey], $"Tag '{tagKey}' has unexpected value.");
         }
 
         private void VerifyMetrics(int expectedMetricCount, List<Metric> exportedMetrics, 

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Identity.Test.Unit
             Assert.IsNotNull(exClient.ErrorCode);
         }
 
-        private void CreateApplication(CacheOptions useCacheOptions = null)
+        private void CreateApplication(CacheOptions cacheOptions = null)
         {
             var builder = ConfidentialClientApplicationBuilder
                         .Create(TestConstants.ClientId)
@@ -413,9 +413,9 @@ namespace Microsoft.Identity.Test.Unit
                         .WithClientSecret(TestConstants.ClientSecret)
                         .WithHttpManager(_harness.HttpManager);
 
-            if (useCacheOptions != null)
+            if (cacheOptions != null)
             {
-                builder = builder.WithCacheOptions(useCacheOptions);
+                builder = builder.WithCacheOptions(cacheOptions);
             }
 
             _cca = builder.BuildConcrete();
@@ -426,7 +426,7 @@ namespace Microsoft.Identity.Test.Unit
         {
             using (_harness = CreateTestHarness())
             {
-                CreateApplication(useCacheOptions: CacheOptions.DisableInternalCacheOptions);
+                CreateApplication(cacheOptions: CacheOptions.DisableInternalCacheOptions);
 
                 _harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -422,11 +422,11 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenForClient_OTelEmitsCacheDisabledReason_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenForClient_OTelEmitsCacheDisabledReason_Async()
         {
             using (_harness = CreateTestHarness())
             {
-                CreateApplication(useCacheOptions: CacheOptions.DisableInternalCache);
+                CreateApplication(useCacheOptions: CacheOptions.DisableInternalCacheOptions);
 
                 _harness.HttpManager.AddInstanceDiscoveryMockHandler();
                 _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
@@ -450,7 +450,7 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
-        public async Task DisableInternalCache_AcquireTokenOnBehalfOf_OTelEmitsCacheDisabledReason_Async()
+        public async Task DisableInternalCacheOptions_AcquireTokenOnBehalfOf_OTelEmitsCacheDisabledReason_Async()
         {
             using (_harness = CreateTestHarness())
             {
@@ -462,7 +462,7 @@ namespace Microsoft.Identity.Test.Unit
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithAuthority(TestConstants.AuthorityCommonTenant)
                     .WithHttpManager(_harness.HttpManager)
-                    .WithCacheOptions(CacheOptions.DisableInternalCache)
+                    .WithCacheOptions(CacheOptions.DisableInternalCacheOptions)
                     .BuildConcrete();
 
                 AuthenticationResult result = await cca.AcquireTokenOnBehalfOf(


### PR DESCRIPTION
## Summary

Implements [#5942](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5942)

### Deliverable 1: Expose refresh token via extension method
- Added internal `string RefreshToken { get; set; }` to `AuthenticationResult`
- Populated it in `RequestBase.CacheTokenResponseAndCreateAuthenticationResultAsync`
- Created public `AuthenticationResultExtensions.GetRefreshToken()` extension method in `src/client/Microsoft.Identity.Client/Extensibility/`

### Deliverable 2: `CacheOptions.DisableInternalCacheOptions`
- Added `IsInternalCacheDisabled` bool property to `CacheOptions`
- Added `DisableInternalCacheOptions` static factory property to `CacheOptions`
- Guarded all token cache writes (`SaveTokenResponseAsync`) behind `!IsInternalCacheDisabled`
- Skipped cache reads in `CacheSessionManager.Find*Async` when disabled
- `GetInternalCacheEntryCountForTelemetry()` returns 0 instead of reading `Accessor.EntryCount` when disabled
- Populates `Account.TenantProfiles` from the freshly received ID token (no accessor reads) when disabled
- Added early-throw in `CacheSilentStrategy.ExecuteAsync` with `MsalError.InternalCacheDisabled`
- Added mutual exclusivity validation in `AbstractApplicationBuilder.WithCacheOptions`
- Consolidated `CacheRefreshReason.CacheDisabled` telemetry assignment in `OnBehalfOfRequest.cs`
- `AcquireTokenInLongRunningProcess` throws `MsalUiRequiredException(InternalCacheDisabled)` when cache is disabled (surfaces root cause instead of confusing `OboCacheKeyNotInCacheError`)

### Other changes
- `MsalError.InternalCacheDisabled = "internal_cache_disabled"` error code
- `MsalErrorMessage.InternalCacheDisabledMessage` with guidance toward `AcquireTokenByRefreshToken`
- All 6 `PublicAPI.Unshipped.txt` files updated with new API surface
- Added `internal static CacheOptions.IsDisabledFor(CacheOptions)` helper — centralizes the null-safe `IsInternalCacheDisabled` check used in `RequestBase`, `CacheSessionManager`, `CacheSilentStrategy`, and `TokenCache`
- Added `protected RequestBase.IsInternalCacheDisabled` property so request subclasses (`OnBehalfOfRequest`, `ClientCredentialRequest`) use a single expression instead of repeating the verbose pattern
- Collapsed the two sequential `IsInternalCacheDisabled` branches in `OnBehalfOfRequest` into one block
- Updated `CacheOptions.IsInternalCacheDisabled` and `DisableInternalCacheOptions` XML docs to document all throwing behaviors

### Tests
- **`InternalCacheOptionsTests.cs`**: 14 tests covering all acceptance criteria, including `GetRefreshToken()` null assertion for client credentials (server never issues RTs for `client_credentials` grant)
- **`HttpTelemetryTests.cs`**: 3 new tests verifying `CacheRefreshReason.CacheDisabled` in `x-client-current-telemetry` header (ATFC, OBO, InitiateLongRunningObo)
- **`OTelInstrumentationTests.cs`**: 2 new tests verifying `CacheRefreshReason.CacheDisabled` in OTel `MsalSuccess` metric tags (ATFC, OBO)