### PR TITLE
Fix eager evaluation in ConcurrentDictionary.GetOrAdd calls and add r…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,28 @@ Carefully review all markdown documents in the ../.clinerules folder. Those are 
 
 ---
 
+# Code Review Rules
+
+## ConcurrentDictionary.GetOrAdd — always use the factory delegate overload
+
+`ConcurrentDictionary.GetOrAdd(key, value)` **eagerly evaluates** the second argument before checking the dictionary. If the value is a constructor call or method invocation (e.g., `new HttpClient(...)`, `CreateFoo()`), a new object is created and discarded on every cache hit.
+
+**Bad** — object created on every call, discarded on cache hit:
+```csharp
+pool.GetOrAdd(key, new ExpensiveObject());
+pool.GetOrAdd(key, CreateExpensiveObject());
+```
+
+**Good** — factory lambda only runs on cache miss:
+```csharp
+pool.GetOrAdd(key, _ => new ExpensiveObject());
+pool.GetOrAdd(key, _ => CreateExpensiveObject());
+```
+
+When reviewing code, flag any `GetOrAdd` call where the second argument is **not** a delegate/lambda/method group. The only exception is when the key is guaranteed to be unique per call (i.e., caching is not the intent).
+
+---
+
 # GitHub Copilot Agent Skills (Repository Skills)
 
 This repository defines **Copilot Agent Skills** under `.github/skills/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ pool.GetOrAdd(key, _ => new ExpensiveObject());
 pool.GetOrAdd(key, _ => CreateExpensiveObject());
 ```
 
-When reviewing code, flag any `GetOrAdd` call where the second argument is **not** a delegate/lambda/method group. All other usages if GetOrAdd(key, value) should be justified.
+When reviewing code, flag any `GetOrAdd` call where the second argument is **not** a delegate/lambda/method group. All other usages of GetOrAdd(key, value) should be justified.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ pool.GetOrAdd(key, _ => new ExpensiveObject());
 pool.GetOrAdd(key, _ => CreateExpensiveObject());
 ```
 
-When reviewing code, flag any `GetOrAdd` call where the second argument is **not** a delegate/lambda/method group. The only exception is when the key is guaranteed to be unique per call (i.e., caching is not the intent).
+When reviewing code, flag any `GetOrAdd` call where the second argument is **not** a delegate/lambda/method group. All other usages if GetOrAdd(key, value) should be justified.
 
 ---
 

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedUserTokenCacheAccessor.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             string partitionKey = CacheKeyFactory.GetKeyFromCachedItem(item);
 
             RefreshTokenCacheDictionary
-                .GetOrAdd(partitionKey, new ConcurrentDictionary<string, MsalRefreshTokenCacheItem>())[itemKey] = item;
+                .GetOrAdd(partitionKey, _ => new ConcurrentDictionary<string, MsalRefreshTokenCacheItem>())[itemKey] = item;
         }
 
         public void SaveIdToken(MsalIdTokenCacheItem item)
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             string partitionKey = CacheKeyFactory.GetKeyFromCachedItem(item);
 
             IdTokenCacheDictionary
-                .GetOrAdd(partitionKey, new ConcurrentDictionary<string, MsalIdTokenCacheItem>())[itemKey] = item;
+                .GetOrAdd(partitionKey, _ => new ConcurrentDictionary<string, MsalIdTokenCacheItem>())[itemKey] = item;
         }
 
         public void SaveAccount(MsalAccountCacheItem item)
@@ -117,7 +117,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             string partitionKey = CacheKeyFactory.GetKeyFromCachedItem(item);
 
             AccountCacheDictionary
-                .GetOrAdd(partitionKey, new ConcurrentDictionary<string, MsalAccountCacheItem>())[itemKey] = item;
+                .GetOrAdd(partitionKey, _ => new ConcurrentDictionary<string, MsalAccountCacheItem>())[itemKey] = item;
         }
 
         public void SaveAppMetadata(MsalAppMetadataCacheItem item)


### PR DESCRIPTION
…eview rule

GetOrAdd(key, value) eagerly evaluates the second argument before checking the dictionary. When the value is a constructor call, a new object is created and immediately discarded on every cache hit.

Fixed in InMemoryPartitionedUserTokenCacheAccessor: unnecessary ConcurrentDictionary allocated on every SaveRefreshToken, SaveIdToken, and SaveAccount call.

Also added a code review rule to copilot-instructions.md to prevent this pattern from being reintroduced.

Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
