### PR TITLE
Add static GetComputeMetadataAsync API for IMDS compute metadata retrieval

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ComputeMetadataResponse.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ComputeMetadataResponse.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if SUPPORTS_SYSTEM_TEXT_JSON
+using Microsoft.Identity.Client.Platforms.net;
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Microsoft.Identity.Json;
+#endif
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    /// <summary>
+    /// Represents compute metadata retrieved from the Azure Instance Metadata Service (IMDS).
+    /// </summary>
+    [JsonObject]
+    [Preserve(AllMembers = true)]
+    public class ComputeMetadataResponse
+    {
+        /// <summary>Azure cloud environment (e.g., AzurePublicCloud).</summary>
+        [JsonProperty("azEnvironment")]
+        public string AzEnvironment { get; set; }
+
+        /// <summary>Azure region of the VM.</summary>
+        [JsonProperty("location")]
+        public string Location { get; set; }
+
+        /// <summary>Name of the VM resource.</summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>Operating system type (e.g., Windows, Linux).</summary>
+        [JsonProperty("osType")]
+        public string OsType { get; set; }
+
+        /// <summary>Resource group containing the VM.</summary>
+        [JsonProperty("resourceGroupName")]
+        public string ResourceGroupName { get; set; }
+
+        /// <summary>Full ARM resource ID of the VM.</summary>
+        [JsonProperty("resourceId")]
+        public string ResourceId { get; set; }
+
+        /// <summary>Azure subscription ID.</summary>
+        [JsonProperty("subscriptionId")]
+        public string SubscriptionId { get; set; }
+
+        /// <summary>Unique identifier of the VM.</summary>
+        [JsonProperty("vmId")]
+        public string VmId { get; set; }
+
+        /// <summary>VM SKU size (e.g., Standard_D4s_v5).</summary>
+        [JsonProperty("vmSize")]
+        public string VmSize { get; set; }
+
+        /// <summary>Security profile indicating platform security posture.</summary>
+        [JsonProperty("securityProfile")]
+        public ComputeSecurityProfile SecurityProfile { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the security profile of an Azure VM from IMDS compute metadata.
+    /// </summary>
+    [JsonObject]
+    [Preserve(AllMembers = true)]
+    public class ComputeSecurityProfile
+    {
+        /// <summary>Whether Secure Boot is enabled on the VM.</summary>
+        [JsonProperty("secureBootEnabled")]
+        public string SecureBootEnabled { get; set; }
+
+        /// <summary>Whether a virtual TPM is enabled on the VM.</summary>
+        [JsonProperty("virtualTpmEnabled")]
+        public string VirtualTpmEnabled { get; set; }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ComputeMetadataResponse.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ComputeMetadataResponse.cs
@@ -1,12 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if SUPPORTS_SYSTEM_TEXT_JSON
 using Microsoft.Identity.Client.Platforms.net;
 using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
-#else
-using Microsoft.Identity.Json;
-#endif
 
 namespace Microsoft.Identity.Client.ManagedIdentity
 {
@@ -53,7 +49,10 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         [JsonProperty("vmSize")]
         public string VmSize { get; set; }
 
-        /// <summary>Security profile indicating platform security posture.</summary>
+        /// <summary>
+        /// Security profile indicating platform security posture. May be null when IMDS
+        /// does not return security profile information for the current VM.
+        /// </summary>
         [JsonProperty("securityProfile")]
         public ComputeSecurityProfile SecurityProfile { get; set; }
     }
@@ -65,11 +64,11 @@ namespace Microsoft.Identity.Client.ManagedIdentity
     [Preserve(AllMembers = true)]
     public class ComputeSecurityProfile
     {
-        /// <summary>Whether Secure Boot is enabled on the VM.</summary>
+        /// <summary>Whether Secure Boot is enabled on the VM, when returned by IMDS.</summary>
         [JsonProperty("secureBootEnabled")]
         public string SecureBootEnabled { get; set; }
 
-        /// <summary>Whether a virtual TPM is enabled on the VM.</summary>
+        /// <summary>Whether a virtual TPM is enabled on the VM, when returned by IMDS.</summary>
         [JsonProperty("virtualTpmEnabled")]
         public string VirtualTpmEnabled { get; set; }
     }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsComputeMetadataManager.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsComputeMetadataManager.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Http.Retry;
+using Microsoft.Identity.Client.Internal.Logger;
+using Microsoft.Identity.Client.PlatformsCommon.Factories;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    internal static class ImdsComputeMetadataManager
+    {
+        private static readonly Lazy<IHttpManager> s_httpManager = new Lazy<IHttpManager>(
+            () => HttpManagerFactory.GetHttpManager(
+                PlatformProxyFactory.CreatePlatformProxy(null).CreateDefaultHttpClientFactory()));
+
+        internal static async Task<ComputeMetadataResponse> GetComputeMetadataAsync(
+            CancellationToken cancellationToken)
+        {
+            return await GetComputeMetadataAsync(s_httpManager.Value, cancellationToken).ConfigureAwait(false);
+        }
+
+        internal static async Task<ComputeMetadataResponse> GetComputeMetadataAsync(
+            IHttpManager httpManager,
+            CancellationToken cancellationToken)
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { "Metadata", "true" }
+            };
+
+            string queryParams = $"{ImdsManagedIdentitySource.ApiVersionQueryParam}={ImdsManagedIdentitySource.ImdsComputeApiVersion}";
+            Uri endpoint = ImdsManagedIdentitySource.GetValidatedEndpoint(
+                new NullLogger(),
+                ImdsManagedIdentitySource.ImdsComputePath,
+                queryParams);
+
+            HttpResponse response;
+            try
+            {
+                response = await httpManager.SendRequestAsync(
+                    endpoint,
+                    headers,
+                    body: null,
+                    method: HttpMethod.Get,
+                    logger: new NullLogger(),
+                    doNotThrow: true,
+                    mtlsCertificate: null,
+                    validateServerCertificate: null,
+                    cancellationToken: cancellationToken,
+                    retryPolicy: new ImdsRetryPolicy())
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            if (response == null || response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return JsonHelper.TryToDeserializeFromJson<ComputeMetadataResponse>(response.Body);
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsComputeMetadataManager.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsComputeMetadataManager.cs
@@ -36,27 +36,39 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 { "Metadata", "true" }
             };
 
-            string queryParams = $"{ImdsManagedIdentitySource.ApiVersionQueryParam}={ImdsManagedIdentitySource.ImdsComputeApiVersion}";
-            Uri endpoint = ImdsManagedIdentitySource.GetValidatedEndpoint(
-                new NullLogger(),
-                ImdsManagedIdentitySource.ImdsComputePath,
-                queryParams);
+            var logger = new NullLogger();
 
-            HttpResponse response;
             try
             {
-                response = await httpManager.SendRequestAsync(
+                string queryParams =
+                    $"{ImdsManagedIdentitySource.ApiVersionQueryParam}={ImdsManagedIdentitySource.ImdsComputeApiVersion}";
+
+                // Reuse existing IMDS endpoint resolution so compute metadata follows the same
+                // endpoint override behavior as managed identity token requests.
+                Uri endpoint = ImdsManagedIdentitySource.GetValidatedEndpoint(
+                    logger,
+                    ImdsManagedIdentitySource.ImdsComputePath,
+                    queryParams);
+
+                HttpResponse response = await httpManager.SendRequestAsync(
                     endpoint,
                     headers,
                     body: null,
                     method: HttpMethod.Get,
-                    logger: new NullLogger(),
+                    logger: logger,
                     doNotThrow: true,
                     mtlsCertificate: null,
                     validateServerCertificate: null,
                     cancellationToken: cancellationToken,
                     retryPolicy: new ImdsRetryPolicy())
                     .ConfigureAwait(false);
+
+                if (response == null || response.StatusCode != HttpStatusCode.OK)
+                {
+                    return null;
+                }
+
+                return JsonHelper.TryToDeserializeFromJson<ComputeMetadataResponse>(response.Body);
             }
             catch (OperationCanceledException)
             {
@@ -66,13 +78,6 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             {
                 return null;
             }
-
-            if (response == null || response.StatusCode != HttpStatusCode.OK)
-            {
-                return null;
-            }
-
-            return JsonHelper.TryToDeserializeFromJson<ComputeMetadataResponse>(response.Body);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsManagedIdentitySource.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         public const string DefaultImdsBaseEndpoint= "http://169.254.169.254";
         public const string ImdsApiVersion = "2018-02-01";
         public const string ImdsTokenPath = "/metadata/identity/oauth2/token";
+        public const string ImdsComputePath = "/metadata/instance/compute";
+        public const string ImdsComputeApiVersion = "2021-02-01";
 
         private const string DefaultMessage = "[Managed Identity] Service request failed.";
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -85,10 +85,14 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Retrieves compute metadata from the Azure Instance Metadata Service (IMDS).
-        /// Returns VM properties including security profile, OS type, and location.
+        /// Returns VM properties such as OS type, location, VM size, and security profile when available.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Compute metadata from IMDS, or null if IMDS is unreachable, returns a non-200 response, or the response cannot be deserialized.</returns>
+        /// <returns>
+        /// Compute metadata from IMDS, or null if IMDS is unreachable, returns a non-200 response,
+        /// or the response cannot be deserialized. The returned object's SecurityProfile property
+        /// may be null when IMDS does not provide security profile information for the current VM.
+        /// </returns>
         public static Task<ComputeMetadataResponse> GetComputeMetadataAsync(
             CancellationToken cancellationToken = default)
         {

--- a/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentityApplication.cs
@@ -82,5 +82,17 @@ namespace Microsoft.Identity.Client
                 : source;
 
         }
+
+        /// <summary>
+        /// Retrieves compute metadata from the Azure Instance Metadata Service (IMDS).
+        /// Returns VM properties including security profile, OS type, and location.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Compute metadata from IMDS, or null if IMDS is unreachable, returns a non-200 response, or the response cannot be deserialized.</returns>
+        public static Task<ComputeMetadataResponse> GetComputeMetadataAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return ImdsComputeMetadataManager.GetComputeMetadataAsync(cancellationToken);
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Platforms/net/MsalJsonSerializerContext.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net/MsalJsonSerializerContext.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Identity.Client.Platforms.net
     [JsonSerializable(typeof(CuidInfo))]
     [JsonSerializable(typeof(CertificateRequestBody))]
     [JsonSerializable(typeof(CertificateRequestResponse))]
+    [JsonSerializable(typeof(ComputeMetadataResponse))]
+    [JsonSerializable(typeof(ComputeSecurityProfile))]
     [JsonSerializable(typeof(Dictionary<string, object>))]
     [JsonSourceGenerationOptions]
     internal partial class MsalJsonSerializerContext : JsonSerializerContext

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -12,3 +12,32 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ComputeMetadataResponse() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.get -> Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.ComputeSecurityProfile() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.set -> void
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetComputeMetadataAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -12,3 +12,32 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ComputeMetadataResponse() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.get -> Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.ComputeSecurityProfile() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.set -> void
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetComputeMetadataAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -12,3 +12,32 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ComputeMetadataResponse() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.get -> Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.ComputeSecurityProfile() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.set -> void
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetComputeMetadataAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -12,3 +12,32 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ComputeMetadataResponse() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.get -> Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.ComputeSecurityProfile() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.set -> void
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetComputeMetadataAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -12,3 +12,32 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ComputeMetadataResponse() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.get -> Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.ComputeSecurityProfile() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.set -> void
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetComputeMetadataAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -12,3 +12,32 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.AzEnvironment.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ComputeMetadataResponse() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Location.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.Name.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.OsType.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceGroupName.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.ResourceId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.get -> Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SecurityProfile.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.SubscriptionId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmId.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse.VmSize.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.ComputeSecurityProfile() -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.SecureBootEnabled.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.get -> string
+Microsoft.Identity.Client.ManagedIdentity.ComputeSecurityProfile.VirtualTpmEnabled.set -> void
+static Microsoft.Identity.Client.ManagedIdentityApplication.GetComputeMetadataAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Identity.Client.ManagedIdentity.ComputeMetadataResponse>

--- a/tests/Microsoft.Identity.Test.E2e/ManagedIdentityImdsTests.cs
+++ b/tests/Microsoft.Identity.Test.E2e/ManagedIdentityImdsTests.cs
@@ -63,5 +63,25 @@ namespace Microsoft.Identity.Test.E2E
             Assert.AreEqual(TokenSource.Cache, second.AuthenticationResultMetadata.TokenSource);
             Assert.AreEqual(result.AccessToken, second.AccessToken);
         }
+
+        [RunOnAzureDevOps]
+        [TestCategory("MI_E2E_Imds")]
+        [TestMethod]
+        public async Task GetComputeMetadata_OnImds_Succeeds()
+        {
+            var result = await ManagedIdentityApplication
+                .GetComputeMetadataAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(result, "ComputeMetadataResponse should not be null on an Azure VM.");
+            Assert.IsFalse(string.IsNullOrEmpty(result.OsType), "OsType should be populated.");
+            Assert.IsFalse(string.IsNullOrEmpty(result.VmId), "VmId should be populated.");
+            Assert.IsFalse(string.IsNullOrEmpty(result.Location), "Location should be populated.");
+            Assert.IsFalse(string.IsNullOrEmpty(result.VmSize), "VmSize should be populated.");
+            Assert.IsFalse(string.IsNullOrEmpty(result.AzEnvironment), "AzEnvironment should be populated.");
+            Assert.IsNotNull(result.SecurityProfile, "SecurityProfile should not be null.");
+            Assert.IsNotNull(result.SecurityProfile.SecureBootEnabled, "SecureBootEnabled should be populated.");
+            Assert.IsNotNull(result.SecurityProfile.VirtualTpmEnabled, "VirtualTpmEnabled should be populated.");
+        }
     }
 }

--- a/tests/Microsoft.Identity.Test.E2e/ManagedIdentityImdsTests.cs
+++ b/tests/Microsoft.Identity.Test.E2e/ManagedIdentityImdsTests.cs
@@ -79,9 +79,29 @@ namespace Microsoft.Identity.Test.E2E
             Assert.IsFalse(string.IsNullOrEmpty(result.Location), "Location should be populated.");
             Assert.IsFalse(string.IsNullOrEmpty(result.VmSize), "VmSize should be populated.");
             Assert.IsFalse(string.IsNullOrEmpty(result.AzEnvironment), "AzEnvironment should be populated.");
-            Assert.IsNotNull(result.SecurityProfile, "SecurityProfile should not be null.");
-            Assert.IsNotNull(result.SecurityProfile.SecureBootEnabled, "SecureBootEnabled should be populated.");
-            Assert.IsNotNull(result.SecurityProfile.VirtualTpmEnabled, "VirtualTpmEnabled should be populated.");
+
+            // securityProfile is not guaranteed to be present on all VM types/generations.
+            // When it is returned, validate the boolean-like values that are present.
+            if (result.SecurityProfile != null)
+            {
+                AssertOptionalBooleanString(
+                    result.SecurityProfile.SecureBootEnabled,
+                    nameof(result.SecurityProfile.SecureBootEnabled));
+
+                AssertOptionalBooleanString(
+                    result.SecurityProfile.VirtualTpmEnabled,
+                    nameof(result.SecurityProfile.VirtualTpmEnabled));
+            }
+        }
+
+        private static void AssertOptionalBooleanString(string value, string propertyName)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                Assert.IsTrue(
+                    bool.TryParse(value, out _),
+                    $"{propertyName} should be 'true' or 'false' when returned. Actual value: '{value}'.");
+            }
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ComputeMetadataTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ComputeMetadataTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task GetComputeMetadata_NoSecurityProfile_ReturnsNullSecurityProfile()
+        public async Task GetComputeMetadata_MissingSecurityProfile_ParsesCoreFieldsAndLeavesSecurityProfileNull()
         {
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager())
@@ -316,5 +316,88 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result);
             }
         }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_PartialSecurityProfile_ParsesAvailableFields()
+        {
+            string response = @"{
+                ""osType"": ""Linux"",
+                ""vmId"": ""vm-guid-9999"",
+                ""securityProfile"": {
+                    ""secureBootEnabled"": ""true""
+                }
+            }";
+
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage(response)
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual("Linux", result.OsType);
+                Assert.AreEqual("vm-guid-9999", result.VmId);
+                Assert.IsNotNull(result.SecurityProfile);
+                Assert.AreEqual("true", result.SecurityProfile.SecureBootEnabled);
+                Assert.IsNull(result.SecurityProfile.VirtualTpmEnabled);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_MalformedJson_ReturnsNull()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage("{ invalid json")
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNull(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_EmptyBody_ReturnsNull()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage(string.Empty)
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNull(result);
+            }
+        }
+
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ComputeMetadataTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ComputeMetadataTests.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
+{
+    [TestClass]
+    public class ComputeMetadataTests : TestBase
+    {
+        private const string FullComputeResponse = @"{
+            ""azEnvironment"": ""AzurePublicCloud"",
+            ""location"": ""westus2"",
+            ""name"": ""test-vm"",
+            ""osType"": ""Windows"",
+            ""resourceGroupName"": ""test-rg"",
+            ""resourceId"": ""/subscriptions/sub-id/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"",
+            ""subscriptionId"": ""sub-id"",
+            ""vmId"": ""vm-guid-1234"",
+            ""vmSize"": ""Standard_D4s_v5"",
+            ""securityProfile"": {
+                ""secureBootEnabled"": ""true"",
+                ""virtualTpmEnabled"": ""true""
+            }
+        }";
+
+        private const string NoSecurityProfileResponse = @"{
+            ""azEnvironment"": ""AzurePublicCloud"",
+            ""location"": ""eastus"",
+            ""name"": ""gen1-vm"",
+            ""osType"": ""Linux"",
+            ""vmId"": ""vm-guid-5678"",
+            ""vmSize"": ""Standard_B2s""
+        }";
+
+        private const string MinimalResponse = @"{
+            ""osType"": ""Linux""
+        }";
+
+        [TestMethod]
+        public async Task GetComputeMetadata_FullResponse_ParsesAllFields()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage(FullComputeResponse)
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual("AzurePublicCloud", result.AzEnvironment);
+                Assert.AreEqual("westus2", result.Location);
+                Assert.AreEqual("test-vm", result.Name);
+                Assert.AreEqual("Windows", result.OsType);
+                Assert.AreEqual("test-rg", result.ResourceGroupName);
+                Assert.AreEqual("sub-id", result.SubscriptionId);
+                Assert.AreEqual("vm-guid-1234", result.VmId);
+                Assert.AreEqual("Standard_D4s_v5", result.VmSize);
+                Assert.IsNotNull(result.SecurityProfile);
+                Assert.AreEqual("true", result.SecurityProfile.SecureBootEnabled);
+                Assert.AreEqual("true", result.SecurityProfile.VirtualTpmEnabled);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_NoSecurityProfile_ReturnsNullSecurityProfile()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage(NoSecurityProfileResponse)
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual("AzurePublicCloud", result.AzEnvironment);
+                Assert.AreEqual("eastus", result.Location);
+                Assert.AreEqual("Linux", result.OsType);
+                Assert.AreEqual("vm-guid-5678", result.VmId);
+                Assert.IsNull(result.SecurityProfile);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_MinimalResponse_ParsesAvailableFields()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage(MinimalResponse)
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual("Linux", result.OsType);
+                Assert.IsNull(result.AzEnvironment);
+                Assert.IsNull(result.Location);
+                Assert.IsNull(result.SecurityProfile);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_Non200Response_ReturnsNull()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateFailureMessage(HttpStatusCode.NotFound, "")
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNull(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_InternalServerError_ReturnsNull()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateFailureMessage(HttpStatusCode.InternalServerError, "")
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNull(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_HttpException_ReturnsNull()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateFailureMessage(HttpStatusCode.GatewayTimeout, ""),
+                        ExceptionToThrow = new HttpRequestException("IMDS unreachable")
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNull(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_SecurityProfileDisabled_ReturnsCorrectValues()
+        {
+            string response = @"{
+                ""osType"": ""Windows"",
+                ""securityProfile"": {
+                    ""secureBootEnabled"": ""false"",
+                    ""virtualTpmEnabled"": ""false""
+                }
+            }";
+
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage(response)
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result.SecurityProfile);
+                Assert.AreEqual("false", result.SecurityProfile.SecureBootEnabled);
+                Assert.AreEqual("false", result.SecurityProfile.VirtualTpmEnabled);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_EmptyJsonResponse_ReturnsEmptyObject()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateSuccessResponseMessage("{}")
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.IsNull(result.OsType);
+                Assert.IsNull(result.SecurityProfile);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_BadRequest_ReturnsNull()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ResponseMessage = MockHelpers.CreateFailureMessage(HttpStatusCode.BadRequest, "{\"error\":\"bad api version\"}")
+                    });
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNull(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetComputeMetadata_VerifiesCorrectEndpointAndHeaders()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                ImdsManagedIdentitySource.ResetEndpointCacheForTest();
+
+                var handler = new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedUrl = "http://169.254.169.254/metadata/instance/compute",
+                    ExpectedQueryParams = new Dictionary<string, string>
+                    {
+                        { "api-version", "2021-02-01" }
+                    },
+                    ExpectedRequestHeaders = new Dictionary<string, string>
+                    {
+                        { "Metadata", "true" }
+                    },
+                    ResponseMessage = MockHelpers.CreateSuccessResponseMessage(MinimalResponse)
+                };
+                httpManager.AddMockHandler(handler);
+
+                var result = await ImdsComputeMetadataManager
+                    .GetComputeMetadataAsync(httpManager, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Add static `GetComputeMetadataAsync` API for IMDS compute metadata retrieval

Adds a new static API `ManagedIdentityApplication.GetComputeMetadataAsync(CancellationToken)` that retrieves compute metadata from the Azure IMDS compute endpoint (`/metadata/instance/compute`). This enables Azure SDK, Identity Web, and other higher-level SDKs to detect VM security posture (KeyGuard, vTPM) and OS type before opting into mTLS PoP flows.

## Why

With MSI v2 IMDS endpoints rolling out to all VMs (including Gen1 without KeyGuard), the current endpoint-existence check is no longer a reliable proxy for mTLS PoP support. Per Nidhi's IMDS API design spec, `securityProfile` will remain in the compute API only — not in `getPlatformMetadata`. MSAL needs to expose this data for higher-level consumers.

## Changes

- **`ComputeMetadataResponse.cs`** — Response model with `ComputeSecurityProfile` (security posture, OS, location, VM size, etc.)
- **`ImdsComputeMetadataManager.cs`** — Internal helper that calls IMDS compute endpoint using MSAL's `IHttpManager`
- **`ManagedIdentityApplication.cs`** — Thin public static delegate to the manager
- **`ImdsManagedIdentitySource.cs`** — Added `ImdsComputePath` and `ImdsComputeApiVersion` constants
- **`MsalJsonSerializerContext.cs`** — Registered new types for System.Text.Json source generation
- **`PublicAPI.Unshipped.txt`** — Updated all 6 TFM files

## Tests

- **10 unit tests** (`ComputeMetadataTests.cs`) — full response parsing, missing security profile, minimal response, non-200 codes, empty JSON, HTTP exceptions, endpoint/header verification
- **1 E2E test** (`ManagedIdentityImdsTests.cs`) — `GetComputeMetadata_OnImds_Succeeds` runs on Azure VM pipeline

Fixes #5969
