### PR TITLE
Fix Copilot review noise: restructure instructions for 4K limit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,7 +41,7 @@ These patterns are correct in this repo. Do not suggest changes:
 
 ## Testing standards
 
-- MSTest SDK v3 with NSubstitute for mocking
+- MSTest SDK v4 with NSubstitute for mocking
 - Use `// Arrange`, `// Act`, `// Assert` comments
 - Prefer deterministic tests (no timing flakiness)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,26 +1,68 @@
-Carefully review all markdown documents in the ../.clinerules folder. Those are your custom instructions.
+# Code Review Rules
+
+These rules apply to Copilot code review. Read all rules before commenting.
+
+## Review scope
+
+- Only comment on lines added or modified in the PR diff
+- Do not comment on pre-existing code unless the PR directly introduces the issue
+- Do not comment on style, formatting, or indentation
+- Focus exclusively on: bugs, security issues, logic errors, API contract violations
+- If unsure whether something is a bug, do not comment
+- Prefer no comment over a speculative comment
+- Do not re-post a comment already made on an earlier commit in the same PR
+
+## Repo-specific patterns — do NOT flag these
+
+These patterns are correct in this repo. Do not suggest changes:
+
+- `[RunOn]` inherits from `TestMethodAttribute`. Do not flag as missing `[TestMethod]`
+- `Client.AppConfig.X` resolves via parent namespace `Microsoft.Identity`. Do not flag as unresolved namespace
+- `Assert.IsTrue(bool?)` is a valid MSTest overload. Do not flag nullable bool as a type mismatch
+- `Assert.DoesNotContain(substring, value)` — MSTest v4 signature is substring first, value second
+- `ConfigureAwait(false)` is intentional in library code. Do not suggest removal
+
+## ConcurrentDictionary.GetOrAdd — always use factory delegate
+
+`GetOrAdd(key, value)` eagerly evaluates the value arg. Flag any call where the second argument is not a delegate/lambda/method group:
+
+- Bad: `pool.GetOrAdd(key, new ExpensiveObject());`
+- Good: `pool.GetOrAdd(key, _ => new ExpensiveObject());`
+
+## C# coding standards
+
+- Use `is null` / `is not null` instead of `== null` / `!= null`
+- No reflection in product code (`/src`). Acceptable in tests
+- Static fields: `s_camelCase` (e.g., `s_knownHosts`)
+- Ordinal string comparisons for protocol values, identifiers, cache keys
+- Validate inputs at method boundaries (fail fast with specific exception types)
+- Do not include secrets/tokens/PII in exception messages or logs
+- Use `nameof` instead of string literals for member names
+
+## Testing standards
+
+- MSTest SDK v3 with NSubstitute for mocking
+- Use `// Arrange`, `// Act`, `// Assert` comments
+- Prefer deterministic tests (no timing flakiness)
+
+## Public API changes
+
+- Update `PublicAPI.Unshipped.txt` for any public API additions/removals
+- XML doc comments required on all public APIs
+- Maintain backward compatibility
+
+## MSAL-specific rules
+
+- Use certificate-based auth over client secrets when possible
+- Use async APIs consistently
+- Keep dependencies minimal and well-justified
 
 ---
 
-# Code Review Rules
+<!-- Everything below this line is for Copilot Chat and Copilot Agent only. -->
+<!-- Copilot code review reads only the first 4,000 characters of this file. -->
 
-## ConcurrentDictionary.GetOrAdd — always use the factory delegate overload
-
-`ConcurrentDictionary.GetOrAdd(key, value)` **eagerly evaluates** the second argument before checking the dictionary. If the value is a constructor call or method invocation (e.g., `new HttpClient(...)`, `CreateFoo()`), a new object is created and discarded on every cache hit.
-
-**Bad** — object created on every call, discarded on cache hit:
-```csharp
-pool.GetOrAdd(key, new ExpensiveObject());
-pool.GetOrAdd(key, CreateExpensiveObject());
-```
-
-**Good** — factory lambda only runs on cache miss:
-```csharp
-pool.GetOrAdd(key, _ => new ExpensiveObject());
-pool.GetOrAdd(key, _ => CreateExpensiveObject());
-```
-
-When reviewing code, flag any `GetOrAdd` call where the second argument is **not** a delegate/lambda/method group. All other usages of GetOrAdd(key, value) should be justified.
+Carefully review all markdown documents in the ../.clinerules folder. Those are your custom instructions.
 
 ---
 

--- a/.github/instructions/src.instructions.md
+++ b/.github/instructions/src.instructions.md
@@ -8,24 +8,16 @@ These rules apply when reviewing production source code in this repository.
 
 - `Client.AppConfig.X`, `Client.Internal.X`, and similar short namespace references resolve via parent namespace `Microsoft.Identity`. Do not flag as unresolved.
 
-## Coding standards
-
-- Use `is null` / `is not null` instead of `== null` / `!= null`
-- No reflection (`System.Reflection`, `Activator.CreateInstance`, `dynamic`). If reflection exists, it is a bug unless there is a comment justifying it.
-- Static fields: `s_camelCase` (e.g., `s_knownHosts`)
-- Private instance fields: `_camelCase`
-- Ordinal string comparisons (`StringComparison.Ordinal` / `OrdinalIgnoreCase`) for protocol values, identifiers, hostnames, cache keys
-- Validate inputs at method boundaries with specific exception types (`ArgumentNullException`, `ArgumentException`)
-- Do not include secrets, tokens, or PII in exception messages or logs
-- Use `nameof` instead of string literals for member names
-- `ConfigureAwait(false)` is intentional in library code. Do not suggest removal.
-
 ## ConcurrentDictionary.GetOrAdd
 
 `GetOrAdd(key, value)` eagerly evaluates the value argument. Flag any call where the second argument is not a delegate/lambda/method group:
 
 - Bad: `pool.GetOrAdd(key, new ExpensiveObject());`
 - Good: `pool.GetOrAdd(key, _ => new ExpensiveObject());`
+
+## `ConfigureAwait(false)`
+
+`ConfigureAwait(false)` is intentional in library code. Do not suggest removal.
 
 ## Public API changes
 
@@ -35,13 +27,11 @@ These rules apply when reviewing production source code in this repository.
 
 ## MSAL-specific
 
-- Use certificate-based authentication over client secrets when possible
-- Use async APIs consistently
 - Keep dependencies minimal and well-justified
 
 ## Scope
 
 - Only comment on source code added or modified in the PR diff
 - Do not comment on pre-existing code unless the PR directly introduces the issue
-- Do not comment on style or formatting
+- Do not comment on style or formatting — coding standards are enforced via .editorconfig
 - Focus on: bugs, security issues, logic errors, API contract violations

--- a/.github/instructions/src.instructions.md
+++ b/.github/instructions/src.instructions.md
@@ -1,0 +1,47 @@
+# Source code review rules
+
+Applies to: src/**/*.cs
+
+These rules apply when reviewing production source code in this repository.
+
+## Namespace resolution — do NOT flag
+
+- `Client.AppConfig.X`, `Client.Internal.X`, and similar short namespace references resolve via parent namespace `Microsoft.Identity`. Do not flag as unresolved.
+
+## Coding standards
+
+- Use `is null` / `is not null` instead of `== null` / `!= null`
+- No reflection (`System.Reflection`, `Activator.CreateInstance`, `dynamic`). If reflection exists, it is a bug unless there is a comment justifying it.
+- Static fields: `s_camelCase` (e.g., `s_knownHosts`)
+- Private instance fields: `_camelCase`
+- Ordinal string comparisons (`StringComparison.Ordinal` / `OrdinalIgnoreCase`) for protocol values, identifiers, hostnames, cache keys
+- Validate inputs at method boundaries with specific exception types (`ArgumentNullException`, `ArgumentException`)
+- Do not include secrets, tokens, or PII in exception messages or logs
+- Use `nameof` instead of string literals for member names
+- `ConfigureAwait(false)` is intentional in library code. Do not suggest removal.
+
+## ConcurrentDictionary.GetOrAdd
+
+`GetOrAdd(key, value)` eagerly evaluates the value argument. Flag any call where the second argument is not a delegate/lambda/method group:
+
+- Bad: `pool.GetOrAdd(key, new ExpensiveObject());`
+- Good: `pool.GetOrAdd(key, _ => new ExpensiveObject());`
+
+## Public API changes
+
+- Any public API additions or removals must be reflected in `PublicAPI.Unshipped.txt`
+- XML doc comments are required on all public APIs
+- Maintain backward compatibility — breaking changes require explicit justification
+
+## MSAL-specific
+
+- Use certificate-based authentication over client secrets when possible
+- Use async APIs consistently
+- Keep dependencies minimal and well-justified
+
+## Scope
+
+- Only comment on source code added or modified in the PR diff
+- Do not comment on pre-existing code unless the PR directly introduces the issue
+- Do not comment on style or formatting
+- Focus on: bugs, security issues, logic errors, API contract violations

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -13,7 +13,7 @@ These rules apply when reviewing test files in this repository.
 
 ## Test conventions
 
-- Use MSTest SDK v3 with NSubstitute for mocking
+- Use MSTest SDK v4 with NSubstitute for mocking
 - Use `// Arrange`, `// Act`, `// Assert` comments
 - Prefer deterministic tests: avoid `Thread.Sleep`, timing dependencies, or environment-specific behavior
 - Copy existing style in nearby files for test method names

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,25 @@
+# Test file review rules
+
+Applies to: tests/**/*.cs
+
+These rules apply when reviewing test files in this repository.
+
+## Test framework patterns — do NOT flag
+
+- `[RunOn]` inherits from `TestMethodAttribute` (see `tests/Microsoft.Identity.Test.Integration.netcore/Infrastructure/TargetFramework.cs` line 15). Tests decorated with `[RunOn]` WILL be discovered by MSTest. Do not flag as missing `[TestMethod]`.
+- `Assert.IsTrue(bool?)` is a valid MSTest overload. Do not flag nullable bool arguments as type mismatches.
+- `Assert.DoesNotContain(substring, value)` — in MSTest v4, the first argument is the substring and the second is the value to search. Do not suggest swapping arguments.
+- `Assert.HasCount(expected, collection)` — valid MSTest v4 assertion. Do not suggest `Assert.AreEqual` for count checks.
+
+## Test conventions
+
+- Use MSTest SDK v3 with NSubstitute for mocking
+- Use `// Arrange`, `// Act`, `// Assert` comments
+- Prefer deterministic tests: avoid `Thread.Sleep`, timing dependencies, or environment-specific behavior
+- Copy existing style in nearby files for test method names
+
+## Scope
+
+- Only comment on test code that is added or modified in the PR diff
+- Do not comment on pre-existing test patterns or style
+- Do not re-post comments already made on earlier commits


### PR DESCRIPTION
## Summary

Copilot code review only reads the first 4,000 characters of \.github/copilot-instructions.md\. The previous layout consumed this budget with Copilot Chat skills documentation, so the reviewer never saw any coding rules — causing **328 false-positive comments across 40 PRs (77%)** since March 6.

## Changes

| File | Change |
|------|--------|
| \.github/copilot-instructions.md\ | Move code review rules to first 2,500 chars (within 4K limit). Push Chat/Agent skills docs below cutoff. |
| \.github/instructions/tests.instructions.md\ | **New** — path-specific rules for test files: \[RunOn]\ inherits \TestMethodAttribute\, MSTest patterns, deterministic tests |
| \.github/instructions/src.instructions.md\ | **New** — path-specific rules for source files: namespace resolution, reflection ban, GetOrAdd, public API tracking |

## What the reviewer now sees (first 4K)

1. **Review scope** — only comment on changed lines, no style/formatting, no re-posting, prefer silence over speculation
2. **False-positive suppressions** — \[RunOn]\, \Client.AppConfig.X\ namespace, \Assert.IsTrue(bool?)\, \Assert.DoesNotContain\ arg order, \ConfigureAwait(false)\
3. **Coding standards** — \is null\, no reflection, \s_camelCase\, ordinal comparisons, input validation
4. **Testing/API rules** — MSTest v3, \PublicAPI.Unshipped.txt\, backward compatibility

## What was previously in the first 4K

Skills documentation, discovery prompts, and Chat-only content — zero review rules.

## Path-specific instructions

\.github/instructions/*.instructions.md\ files are **not subject to the 4K limit** and provide targeted context per file type. This addresses the re-posting problem by giving the reviewer explicit scope rules in context.

## Not addressed (requires ruleset change)

- \eview_on_push: true\ still triggers per-commit reviews
- \eview_draft_pull_requests: true\ still reviews WIP

Resolves #5967