### PR TITLE
Add WithClaimsFromClient API for stable client-originated claims with cache keying

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForClientParameterBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Executors;
@@ -180,6 +181,68 @@ namespace Microsoft.Identity.Client
             this.WithAdditionalCacheKeyComponents(cacheKey);
 
             CommonParameters.FmiPathSuffix = pathSuffix;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds stable, client-originated claims (e.g., NSP network perimeter claims) to the token request.
+        /// Unlike <see cref="AbstractAcquireTokenParameterBuilder{T}.WithClaims(string)"/>, these claims
+        /// do NOT bypass the token cache. Tokens are cached and partitioned by the claims value —
+        /// different claims produce different cache entries, while identical claims reuse cached tokens.
+        /// The claims JSON must follow the OIDC claims request format (Section 5.5 of OpenID Connect Core 1.0).
+        /// </summary>
+        /// <param name="claimsJson">A JSON string in OIDC claims request format, e.g.,
+        /// <c>{"access_token":{"xms_nsp_id":{"essential":true,"value":"nsp-perimeter-001"}}}</c>.</param>
+        /// <returns>The builder to chain .With methods.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="claimsJson"/> is null or whitespace.</exception>
+        /// <exception cref="MsalClientException">Thrown when <paramref name="claimsJson"/> is not a valid JSON object.</exception>
+        /// <remarks>
+        /// This is an experimental API. Call <c>.WithExperimentalFeatures(true)</c> on the application builder to enable it.
+        /// When both <see cref="AbstractAcquireTokenParameterBuilder{T}.WithClaims(string)"/> and
+        /// <see cref="WithClaimsFromClient(string)"/> are used, the claims are JSON-merged into a single
+        /// OIDC-compliant <c>claims</c> body parameter sent to the token endpoint.
+        /// </remarks>
+        public AcquireTokenForClientParameterBuilder WithClaimsFromClient(string claimsJson)
+        {
+            ValidateUseOfExperimentalFeature();
+
+            if (string.IsNullOrWhiteSpace(claimsJson))
+            {
+                throw new ArgumentNullException(nameof(claimsJson));
+            }
+
+            // Validate JSON is an object — OIDC claims parameter must be a JSON object
+            try
+            {
+                using var doc = JsonDocument.Parse(claimsJson);
+                if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
+                {
+                    throw new MsalClientException(
+                        MsalError.InvalidJsonClaimsFormat,
+                        "The claims parameter must be a JSON object. See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.");
+                }
+            }
+            catch (JsonException ex)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidJsonClaimsFormat,
+                    "The claims parameter is not valid JSON. Inspect the inner exception for details. See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
+                    ex);
+            }
+
+            CommonParameters.ClientClaims = claimsJson;
+
+            // Add the claims to the cache key so different claims produce different cache entries.
+            // Remove existing key first to allow calling WithClaimsFromClient multiple times (last wins).
+            CommonParameters.CacheKeyComponents?.Remove("client_claims");
+
+            var cacheKey = new SortedList<string, Func<CancellationToken, Task<string>>>
+            {
+                { "client_claims", _ => Task.FromResult(claimsJson) }
+            };
+
+            this.WithAdditionalCacheKeyComponents(cacheKey);
 
             return this;
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Executors;
@@ -79,6 +80,66 @@ namespace Microsoft.Identity.Client
         public AcquireTokenForManagedIdentityParameterBuilder WithClaims(string claims)
         {
             CommonParameters.Claims = claims;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds stable, client-originated claims (e.g., NSP network perimeter claims) to the token request.
+        /// Unlike <see cref="WithClaims(string)"/>, these claims do NOT bypass the token cache.
+        /// Tokens are cached and partitioned by the claims value — different claims produce different cache entries,
+        /// while identical claims reuse cached tokens.
+        /// The claims JSON must follow the OIDC claims request format (Section 5.5 of OpenID Connect Core 1.0).
+        /// </summary>
+        /// <param name="claimsJson">A JSON string in OIDC claims request format, e.g.,
+        /// <c>{"access_token":{"xms_nsp_id":{"essential":true,"value":"nsp-perimeter-001"}}}</c>.</param>
+        /// <returns>The builder to chain .With methods.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="claimsJson"/> is null or whitespace.</exception>
+        /// <exception cref="MsalClientException">Thrown when <paramref name="claimsJson"/> is not a valid JSON object.</exception>
+        /// <remarks>
+        /// This is an experimental API. Call <c>.WithExperimentalFeatures(true)</c> on the application builder to enable it.
+        /// Client claims are forwarded as the <c>claims</c> query parameter to IMDS endpoints.
+        /// Other managed identity sources are not currently supported.
+        /// When <see cref="WithClaims(string)"/> is also set, it triggers a separate cache bypass and
+        /// revoked-token-hash flow; the two claims sources are not JSON-merged for the managed identity path.
+        /// </remarks>
+        public AcquireTokenForManagedIdentityParameterBuilder WithClaimsFromClient(string claimsJson)
+        {
+            ValidateUseOfExperimentalFeature();
+
+            if (string.IsNullOrWhiteSpace(claimsJson))
+            {
+                throw new ArgumentNullException(nameof(claimsJson));
+            }
+
+            // Validate JSON is an object — OIDC claims parameter must be a JSON object
+            try
+            {
+                using var doc = JsonDocument.Parse(claimsJson);
+                if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
+                {
+                    throw new MsalClientException(
+                        MsalError.InvalidJsonClaimsFormat,
+                        "The claims parameter must be a JSON object. See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.");
+                }
+            }
+            catch (JsonException ex)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidJsonClaimsFormat,
+                    "The claims parameter is not valid JSON. Inspect the inner exception for details. See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
+                    ex);
+            }
+
+            CommonParameters.ClientClaims = claimsJson;
+
+            // Add the claims to the cache key so different claims produce different cache entries.
+            // Follows the same pattern as WithExtraClientAssertionClaims.
+            CommonParameters.CacheKeyComponents ??=
+                new SortedList<string, Func<CancellationToken, Task<string>>>();
+
+            CommonParameters.CacheKeyComponents["client_claims"] =
+                _ => Task.FromResult(claimsJson);
+
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public string ClientAssertionFmiPath { get; internal set; }
         public bool IsMtlsPopRequested { get; set; }
         public string ExtraClientAssertionClaims { get; internal set; }
+        public string ClientClaims { get; internal set; }
 
         /// <summary>
         /// Optional delegate for obtaining attestation JWT for Credential Guard keys.

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForManagedIdentityParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForManagedIdentityParameters.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         public string Claims { get; set; }
 
+        public string ClientClaims { get; set; }
+
         public string RevokedTokenHash { get; set; }
 
         public bool IsMtlsPopRequested { get; set; }
@@ -45,6 +47,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                      ForceRefresh: {ForceRefresh}
                      Resource: {Resource}
                      Claims: {!string.IsNullOrEmpty(Claims)}
+                     ClientClaims: {!string.IsNullOrEmpty(ClientClaims)}
                      RevokedTokenHash: {!string.IsNullOrEmpty(RevokedTokenHash)}
                      IsMtlsPopRequested: {IsMtlsPopRequested}
                      """);

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -22,37 +23,75 @@ namespace Microsoft.Identity.Client.Internal
             string claims,
             IEnumerable<string> clientCapabilities)
         {
+            return GetMergedClaimsAndClientCapabilities(claims, clientCapabilities, clientClaims: null);
+        }
+
+        /// <summary>
+        /// Merges server claims (from WithClaims), client-originated claims (from WithClaimsFromClient),
+        /// and client capabilities into a single OIDC-compliant claims JSON string.
+        /// </summary>
+        internal static string GetMergedClaimsAndClientCapabilities(
+            string claims,
+            IEnumerable<string> clientCapabilities,
+            string clientClaims)
+        {
             if (clientCapabilities != null && clientCapabilities.Any())
             {
                 JObject capabilitiesJson = CreateClientCapabilitiesRequestJson(clientCapabilities);
-                JObject mergedClaimsAndCapabilities = MergeClaimsIntoCapabilityJson(claims, capabilitiesJson);
+                // Merge client claims first, then server claims — server claims take precedence on conflicts
+                capabilitiesJson = MergeClaimsIntoCapabilityJson(clientClaims, capabilitiesJson);
+                capabilitiesJson = MergeClaimsIntoCapabilityJson(claims, capabilitiesJson);
 
-                return JsonHelper.JsonObjectToString(mergedClaimsAndCapabilities);
+                return JsonHelper.JsonObjectToString(capabilitiesJson);
             }
 
-            return claims;
+            // No capabilities — merge client claims first, server claims second (server wins on conflicts)
+            if (!string.IsNullOrEmpty(claims) && !string.IsNullOrEmpty(clientClaims))
+            {
+                JObject clientClaimsJson = ParseClaimsJson(clientClaims);
+                JObject serverClaimsJson = ParseClaimsJson(claims);
+                JObject merged = JsonHelper.Merge(clientClaimsJson, serverClaimsJson);
+                return JsonHelper.JsonObjectToString(merged);
+            }
+
+            return !string.IsNullOrEmpty(clientClaims) ? clientClaims : claims;
         }
 
         internal static JObject MergeClaimsIntoCapabilityJson(string claims, JObject capabilitiesJson)
         {
             if (!string.IsNullOrEmpty(claims))
             {
-                JObject claimsJson;
-                try
-                {
-                    claimsJson = JsonHelper.ParseIntoJsonObject(claims);
-                }
-                catch (JsonException ex)
-                {
-                    throw new MsalClientException(
-                        MsalError.InvalidJsonClaimsFormat,
-                        MsalErrorMessage.InvalidJsonClaimsFormat(claims),
-                        ex);
-                }
+                JObject claimsJson = ParseClaimsJson(claims);
                 capabilitiesJson = JsonHelper.Merge(capabilitiesJson, claimsJson);
             }
 
             return capabilitiesJson;
+        }
+
+        private static JObject ParseClaimsJson(string claims)
+        {
+            try
+            {
+                var parsed = JsonHelper.ParseIntoJsonObject(claims);
+                if (parsed is null)
+                {
+                    throw new MsalClientException(
+                        MsalError.InvalidJsonClaimsFormat,
+                        "The claims parameter must be a valid JSON object. See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.");
+                }
+                return parsed;
+            }
+            catch (MsalClientException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidJsonClaimsFormat,
+                    "The claims parameter is not valid JSON. Inspect the inner exception for details.",
+                    ex);
+            }
         }
 
         private static JObject CreateClientCapabilitiesRequestJson(IEnumerable<string> clientCapabilities)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             ClaimsAndClientCapabilities = ClaimsHelper.GetMergedClaimsAndClientCapabilities(
                 _commonParameters.Claims,
-                _serviceBundle.Config.ClientCapabilities);
+                _serviceBundle.Config.ClientCapabilities,
+                _commonParameters.ClientClaims);
 
             HomeAccountId = homeAccountId;
             CacheKeyComponents = cacheKeyComponents;
@@ -134,6 +135,18 @@ namespace Microsoft.Identity.Client.Internal.Requests
             get
             {
                 return _commonParameters.Claims;
+            }
+        }
+
+        /// <summary>
+        /// Stable, client-originated claims from .WithClaimsFromClient.
+        /// Unlike <see cref="Claims"/>, these do NOT bypass the cache.
+        /// </summary>
+        public string ClientClaims
+        {
+            get
+            {
+                return _commonParameters.ClientClaims;
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -41,6 +41,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             AuthenticationResult authResult = null;
             ILoggerAdapter logger = AuthenticationRequestParameters.RequestContext.Logger;
+
+            // Propagate client-originated claims (from WithClaimsFromClient) to MI parameters.
+            // These are forwarded to IMDS but do NOT bypass the cache.
+            if (!string.IsNullOrEmpty(AuthenticationRequestParameters.ClientClaims))
+            {
+                _managedIdentityParameters.ClientClaims = AuthenticationRequestParameters.ClientClaims;
+                logger.Info("[ManagedIdentityRequest] Client-originated claims present; will be forwarded to MI endpoint.");
+            }
             
             // Prime the scheme before any cache lookup if we already have a binding cert from a prior mint
             if (AuthenticationRequestParameters.IsMtlsPopRequested)

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -74,6 +74,15 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                     _requestContext.Logger);
             }
 
+            // Client-originated claims (WithClaimsFromClient) are forwarded as a query parameter to IMDS.
+            // Other MI sources may require different handling — extend per source as needed.
+            if (!string.IsNullOrEmpty(parameters.ClientClaims) &&
+                (_sourceType == ManagedIdentitySource.Imds || _sourceType == ManagedIdentitySource.ImdsV2))
+            {
+                request.QueryParameters["claims"] = Uri.EscapeDataString(parameters.ClientClaims);
+                _requestContext.Logger.Info("[Managed Identity] Adding client-originated claims to request.");
+            }
+
             request.AddExtraQueryParams(
                 _requestContext.ServiceBundle.Config.ExtraQueryParameters,
                 _requestContext.Logger);

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -12,3 +12,5 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -12,3 +12,5 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -12,3 +12,5 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -12,3 +12,5 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -12,3 +12,5 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -12,3 +12,5 @@ Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions
 const Microsoft.Identity.Client.MsalError.InternalCacheDisabled = "internal_cache_disabled" -> string
 static Microsoft.Identity.Client.CacheOptions.DisableInternalCacheOptions.get -> Microsoft.Identity.Client.CacheOptions
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClaimsFromClientTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClaimsFromClientTests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Test.Common;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Identity.Test.Common.Core.Helpers.ManagedIdentityTestUtil;
+
+namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
+{
+    [TestClass]
+    public class WithClaimsFromClientTests : TestBase
+    {
+        private const string Resource = "https://management.azure.com";
+        private const string ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+
+        // OIDC Section 5.5 — NSP claim with essential + value
+        private const string NspClaims =
+            """{"access_token":{"xms_nsp_id":{"essential":true,"value":"nsp-perimeter-001"}}}""";
+        private const string NspClaimsDifferent =
+            """{"access_token":{"xms_nsp_id":{"essential":true,"value":"nsp-perimeter-002"}}}""";
+        // OIDC Section 5.5.1 — voluntary claim (null value)
+        private const string VoluntaryClaim =
+            """{"access_token":{"xms_nsp_id":null}}""";
+
+        private IManagedIdentityApplication BuildMi(MockHttpManager httpManager)
+        {
+            return ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                .WithExperimentalFeatures(true)
+                .WithHttpManager(httpManager)
+                .Build();
+        }
+
+        private void AddImdsHandler(MockHttpManager httpManager, string claimsJson)
+        {
+            var handler = httpManager.AddManagedIdentityMockHandler(
+                ImdsEndpoint, Resource,
+                MockHelpers.GetMsiSuccessfulResponse(),
+                ManagedIdentitySource.Imds);
+
+            handler.ExpectedQueryParams["claims"] = Uri.EscapeDataString(claimsJson);
+        }
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_SameClaims_ReturnsCacheHit()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+                AddImdsHandler(httpManager, NspClaims);
+
+                var result1 = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                var result2 = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_DifferentClaims_DifferentCacheEntries()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+                AddImdsHandler(httpManager, NspClaims);
+                AddImdsHandler(httpManager, NspClaimsDifferent);
+
+                var result1 = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                var result2 = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaimsDifferent)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_DoesNotBypassCache()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+                AddImdsHandler(httpManager, NspClaims);
+
+                await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                // No second handler — cache must be used
+                var result = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public void WithClaimsFromClient_InvalidJson_ThrowsImmediately()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+
+                var ex = AssertException.Throws<MsalClientException>(() =>
+                    mi.AcquireTokenForManagedIdentity(Resource)
+                        .WithClaimsFromClient("not-valid-json{{{"));
+
+                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        public void WithClaimsFromClient_NullOrEmpty_ThrowsArgumentNull()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+
+                AssertException.Throws<ArgumentNullException>(() =>
+                    mi.AcquireTokenForManagedIdentity(Resource).WithClaimsFromClient(null));
+
+                AssertException.Throws<ArgumentNullException>(() =>
+                    mi.AcquireTokenForManagedIdentity(Resource).WithClaimsFromClient(""));
+
+                AssertException.Throws<ArgumentNullException>(() =>
+                    mi.AcquireTokenForManagedIdentity(Resource).WithClaimsFromClient("   "));
+            }
+        }
+
+        [TestMethod]
+        public void WithClaimsFromClient_RequiresExperimentalFeature()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                var ex = AssertException.Throws<MsalClientException>(() =>
+                    mi.AcquireTokenForManagedIdentity(Resource)
+                        .WithClaimsFromClient(NspClaims));
+
+                Assert.AreEqual(MsalError.ExperimentalFeature, ex.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_ForwardsClaimsAsQueryParam()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+                var handler = AddImdsHandlerWithReturn(httpManager, NspClaims);
+
+                await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(handler.ActualRequestMessage);
+                string requestUrl = handler.ActualRequestMessage.RequestUri.ToString();
+                StringAssert.Contains(requestUrl, "claims=",
+                    "Expected 'claims' query parameter in URL: " + requestUrl);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_OidcVoluntaryClaim_Cached()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+                AddImdsHandler(httpManager, VoluntaryClaim);
+
+                var result1 = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(VoluntaryClaim)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                var result2 = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(VoluntaryClaim)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public void WithClaimsFromClient_JsonArray_ThrowsInvalidFormat()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+
+                // Valid JSON but not a JSON object — OIDC requires an object
+                var ex = AssertException.Throws<MsalClientException>(() =>
+                    mi.AcquireTokenForManagedIdentity(Resource)
+                        .WithClaimsFromClient("[1,2,3]"));
+
+                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_CalledTwice_LastWins()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ImdsEndpoint);
+                var mi = BuildMi(httpManager);
+                AddImdsHandler(httpManager, NspClaimsDifferent);
+
+                // Call WithClaimsFromClient twice — second call should overwrite
+                var result = await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithClaimsFromClient(NspClaims)
+                    .WithClaimsFromClient(NspClaimsDifferent)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        private MockHttpMessageHandler AddImdsHandlerWithReturn(MockHttpManager httpManager, string claimsJson)
+        {
+            var handler = httpManager.AddManagedIdentityMockHandler(
+                ImdsEndpoint, Resource,
+                MockHelpers.GetMsiSuccessfulResponse(),
+                ManagedIdentitySource.Imds);
+
+            handler.ExpectedQueryParams["claims"] = Uri.EscapeDataString(claimsJson);
+            return handler;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/WithClaimsFromClientCcaTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/WithClaimsFromClientCcaTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.PublicApiTests
+{
+    [TestClass]
+    public class WithClaimsFromClientCcaTests : TestBase
+    {
+        private const string ClientId = "4df2cbbb-8612-49c1-87c8-f334d6d065ad";
+        private readonly string[] _scope = new[] { "api://scope/.default" };
+
+        private const string NspClaims =
+            """{"access_token":{"xms_nsp_id":{"essential":true,"value":"nsp-001"}}}""";
+        private const string NspClaimsDifferent =
+            """{"access_token":{"xms_nsp_id":{"essential":true,"value":"nsp-002"}}}""";
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_CCA_CachedAndPartitioned_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(ClientId)
+                    .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .BuildConcrete();
+
+                httpManager.AddInstanceDiscoveryMockHandler();
+
+                // First request — hits endpoint
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "token_nsp1");
+
+                var result1 = await app.AcquireTokenForClient(_scope)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual("token_nsp1", result1.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
+
+                // Same claims — cache hit
+                var result2 = await app.AcquireTokenForClient(_scope)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual("token_nsp1", result2.AccessToken);
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource);
+
+                // Different claims — cache miss, new token
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "token_nsp2");
+
+                var result3 = await app.AcquireTokenForClient(_scope)
+                    .WithClaimsFromClient(NspClaimsDifferent)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual("token_nsp2", result3.AccessToken);
+                Assert.AreEqual(TokenSource.IdentityProvider, result3.AuthenticationResultMetadata.TokenSource);
+
+                // Two distinct tokens in cache
+                Assert.HasCount(2, app.AppTokenCacheInternal.Accessor.GetAllAccessTokens());
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClaimsFromClient_CCA_DoesNotBypassCache_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(ClientId)
+                    .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .BuildConcrete();
+
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "cached_token");
+
+                await app.AcquireTokenForClient(_scope)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // No second mock handler — proves cache is used
+                var result = await app.AcquireTokenForClient(_scope)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual("cached_token", result.AccessToken);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public void WithClaimsFromClient_CCA_InvalidJson_Throws()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(ClientId)
+                    .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .BuildConcrete();
+
+                var ex = AssertException.Throws<MsalClientException>(() =>
+                    app.AcquireTokenForClient(_scope)
+                        .WithClaimsFromClient("not-json"));
+
+                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        public void WithClaimsFromClient_CCA_JsonArray_Throws()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(ClientId)
+                    .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .BuildConcrete();
+
+                var ex = AssertException.Throws<MsalClientException>(() =>
+                    app.AcquireTokenForClient(_scope)
+                        .WithClaimsFromClient("[1,2,3]"));
+
+                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        public void WithClaimsFromClient_CCA_RequiresExperimental()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(ClientId)
+                    .WithAuthority(new Uri(ClientApplicationBase.DefaultAuthority), true)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(httpManager)
+                    .BuildConcrete();
+
+                var ex = AssertException.Throws<MsalClientException>(() =>
+                    app.AcquireTokenForClient(_scope)
+                        .WithClaimsFromClient(NspClaims));
+
+                Assert.AreEqual(MsalError.ExperimentalFeature, ex.ErrorCode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
 
 Adds `WithClaimsFromClient(string claimsJson)` to `AcquireTokenForManagedIdentityParameterBuilder` and `AcquireTokenForClientParameterBuilder`. This enables Azure RPs to include stable, client-originated claims (e.g., NSP network perimeter) in token requests **without 
bypassing the token cache**.
 
 Closes #5965
 
 ## Problem
 
 | API | Sent to endpoint | In cache key | Bypasses cache |
 |-----|-----------------|-------------|---------------|
 | `WithClaims()` | ✅ | ❌ | ✅ (always) |
 | `WithExtraQueryParameters()` | ✅ | ❌ | ❌ |
 
 - `WithClaims()` is designed for one-time server challenges — it bypasses cache on every call. For stable claims like NSP, this causes throttling at scale.
 - `WithExtraQueryParameters()` forwards params but doesn't include them in the cache key — different claim values silently return the wrong cached token.
 
 ## Solution
 
 | API | Sent to endpoint | In cache key | Bypasses cache |
 |-----|-----------------|-------------|---------------|
 | **`WithClaimsFromClient()`** | ✅ | ✅ | ❌ |
 
 - Claims JSON follows the [OIDC claims request format (Section 5.5)](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter)
 - Claims value is included in the cache key — different claims produce different cache entries, identical claims reuse cached tokens
 - When combined with `WithClaims()` (server challenges), claims are JSON-merged into a single OIDC-compliant parameter
 - Gated behind `.WithExperimentalFeatures(true)`
 