### PR TITLE
feat: Introduce IAuthorityHandler and AuthorityRegistry

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityRegistry.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityRegistry.cs
@@ -32,11 +32,23 @@ namespace Microsoft.Identity.Client.Instance
 
         /// <summary>
         /// Detects the correct handler by inspecting a raw authority URI.
+        /// URI components are parsed once and passed to each handler to avoid redundant string operations.
         /// Used when parsing a new authority string (will replace GetAuthorityType).
         /// </summary>
         internal static IAuthorityHandler DetectFromUri(Uri authorityUri)
         {
-            return s_handlers.FirstOrDefault(h => h.CanHandle(authorityUri))
+            string host = authorityUri.Host;
+            string firstPathSegment;
+            try
+            {
+                firstPathSegment = AuthorityInfo.GetFirstPathSegment(authorityUri);
+            }
+            catch (InvalidOperationException)
+            {
+                firstPathSegment = null;
+            }
+
+            return s_handlers.FirstOrDefault(h => h.CanHandle(authorityUri, host, firstPathSegment))
                 ?? throw new MsalClientException(
                     MsalError.InvalidAuthorityType,
                     $"No authority handler found for URI: {authorityUri}");

--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityRegistry.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityRegistry.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Identity.Client.Instance.Handlers;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance
+{
+    /// <summary>
+    /// Central registry of <see cref="IAuthorityHandler"/> implementations.
+    /// Replaces the scattered switch statements and hardcoded string checks for authority type detection,
+    /// instantiation, and validator creation.
+    /// </summary>
+    internal static class AuthorityRegistry
+    {
+        // Order matters: more-specific URI matchers must precede less-specific ones.
+        // CIAM uses host-suffix matching and must appear before AAD, which is the URI catch-all.
+        // GenericAuthorityHandler.CanHandle always returns false and is only reachable via GetByType.
+        private static readonly IReadOnlyList<IAuthorityHandler> s_handlers = new List<IAuthorityHandler>
+        {
+            new CiamAuthorityHandler(),
+            new AdfsAuthorityHandler(),
+            new DstsAuthorityHandler(),
+            new B2CAuthorityHandler(),
+            new AadAuthorityHandler(),
+            new GenericAuthorityHandler(),
+        };
+
+        /// <summary>
+        /// Detects the correct handler by inspecting a raw authority URI.
+        /// Used when parsing a new authority string (will replace GetAuthorityType).
+        /// </summary>
+        internal static IAuthorityHandler DetectFromUri(Uri authorityUri)
+        {
+            return s_handlers.FirstOrDefault(h => h.CanHandle(authorityUri))
+                ?? throw new MsalClientException(
+                    MsalError.InvalidAuthorityType,
+                    $"No authority handler found for URI: {authorityUri}");
+        }
+
+        /// <summary>
+        /// Looks up the handler for an already-resolved <see cref="AuthorityType"/>.
+        /// Used when the type is known (e.g. constructing an Authority from an existing AuthorityInfo).
+        /// </summary>
+        internal static IAuthorityHandler GetByType(AuthorityType authorityType)
+        {
+            return s_handlers.FirstOrDefault(h => h.AuthorityType == authorityType)
+                ?? throw new MsalClientException(
+                    MsalError.InvalidAuthorityType,
+                    $"No authority handler registered for type: {authorityType}");
+        }
+
+        /// <summary>Creates the concrete Authority subclass for the given AuthorityInfo.</summary>
+        internal static Authority Create(AuthorityInfo authorityInfo)
+            => GetByType(authorityInfo.AuthorityType).Create(authorityInfo);
+
+        /// <summary>Creates the appropriate validator for the given AuthorityInfo.</summary>
+        internal static IAuthorityValidator CreateValidator(AuthorityInfo authorityInfo, RequestContext requestContext)
+            => GetByType(authorityInfo.AuthorityType).CreateValidator(requestContext);
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/AadAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/AadAuthorityHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Identity.Client.Instance.Handlers
         /// Catch-all: any URI not claimed by a more-specific handler is treated as AAD.
         /// This handler must be registered last among URI-detectable handlers.
         /// </summary>
-        public bool CanHandle(Uri authorityUri) => true;
+        public bool CanHandle(Uri authorityUri, string host, string firstPathSegment) => true;
 
         public Authority Create(AuthorityInfo authorityInfo)
             => new AadAuthority(authorityInfo);

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/AadAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/AadAuthorityHandler.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance.Handlers
+{
+    /// <summary>
+    /// Handler for AAD authorities. Acts as the URI catch-all (CanHandle always returns true)
+    /// and must be registered after all more-specific handlers.
+    /// </summary>
+    internal sealed class AadAuthorityHandler : IAuthorityHandler
+    {
+        public AuthorityType AuthorityType => AuthorityType.Aad;
+
+        /// <summary>
+        /// Catch-all: any URI not claimed by a more-specific handler is treated as AAD.
+        /// This handler must be registered last among URI-detectable handlers.
+        /// </summary>
+        public bool CanHandle(Uri authorityUri) => true;
+
+        public Authority Create(AuthorityInfo authorityInfo)
+            => new AadAuthority(authorityInfo);
+
+        public IAuthorityValidator CreateValidator(RequestContext requestContext)
+            => new AadAuthorityValidator(requestContext);
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/AdfsAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/AdfsAuthorityHandler.cs
@@ -14,20 +14,8 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public AuthorityType AuthorityType => AuthorityType.Adfs;
 
-        public bool CanHandle(Uri authorityUri)
-        {
-            try
-            {
-                return string.Equals(
-                    AuthorityInfo.GetFirstPathSegment(authorityUri),
-                    AdfsPathSegment,
-                    StringComparison.OrdinalIgnoreCase);
-            }
-            catch (InvalidOperationException)
-            {
-                return false;
-            }
-        }
+        public bool CanHandle(Uri authorityUri, string host, string firstPathSegment)
+            => string.Equals(firstPathSegment, AdfsPathSegment, StringComparison.OrdinalIgnoreCase);
 
         public Authority Create(AuthorityInfo authorityInfo)
             => new AdfsAuthority(authorityInfo);

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/AdfsAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/AdfsAuthorityHandler.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance.Handlers
+{
+    /// <summary>Handler for ADFS authorities (path begins with "adfs").</summary>
+    internal sealed class AdfsAuthorityHandler : IAuthorityHandler
+    {
+        private const string AdfsPathSegment = "adfs";
+
+        public AuthorityType AuthorityType => AuthorityType.Adfs;
+
+        public bool CanHandle(Uri authorityUri)
+        {
+            try
+            {
+                return string.Equals(
+                    AuthorityInfo.GetFirstPathSegment(authorityUri),
+                    AdfsPathSegment,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+
+        public Authority Create(AuthorityInfo authorityInfo)
+            => new AdfsAuthority(authorityInfo);
+
+        public IAuthorityValidator CreateValidator(RequestContext requestContext)
+            => new AdfsAuthorityValidator(requestContext);
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/B2CAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/B2CAuthorityHandler.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance.Handlers
+{
+    /// <summary>Handler for B2C authorities (path begins with "tfp").</summary>
+    internal sealed class B2CAuthorityHandler : IAuthorityHandler
+    {
+        public AuthorityType AuthorityType => AuthorityType.B2C;
+
+        public bool CanHandle(Uri authorityUri)
+        {
+            try
+            {
+                return string.Equals(
+                    AuthorityInfo.GetFirstPathSegment(authorityUri),
+                    B2CAuthority.Prefix,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+
+        public Authority Create(AuthorityInfo authorityInfo)
+            => new B2CAuthority(authorityInfo);
+
+        public IAuthorityValidator CreateValidator(RequestContext requestContext)
+            => new NullAuthorityValidator();
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/B2CAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/B2CAuthorityHandler.cs
@@ -12,20 +12,8 @@ namespace Microsoft.Identity.Client.Instance.Handlers
     {
         public AuthorityType AuthorityType => AuthorityType.B2C;
 
-        public bool CanHandle(Uri authorityUri)
-        {
-            try
-            {
-                return string.Equals(
-                    AuthorityInfo.GetFirstPathSegment(authorityUri),
-                    B2CAuthority.Prefix,
-                    StringComparison.OrdinalIgnoreCase);
-            }
-            catch (InvalidOperationException)
-            {
-                return false;
-            }
-        }
+        public bool CanHandle(Uri authorityUri, string host, string firstPathSegment)
+            => string.Equals(firstPathSegment, B2CAuthority.Prefix, StringComparison.OrdinalIgnoreCase);
 
         public Authority Create(AuthorityInfo authorityInfo)
             => new B2CAuthority(authorityInfo);

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/CiamAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/CiamAuthorityHandler.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Identity.Client.Instance.Handlers
     {
         public AuthorityType AuthorityType => AuthorityType.Ciam;
 
-        public bool CanHandle(Uri authorityUri)
-            => authorityUri.Host.EndsWith(Constants.CiamAuthorityHostSuffix, StringComparison.OrdinalIgnoreCase);
+        public bool CanHandle(Uri authorityUri, string host, string firstPathSegment)
+            => host.EndsWith(Constants.CiamAuthorityHostSuffix, StringComparison.OrdinalIgnoreCase);
 
         public Authority Create(AuthorityInfo authorityInfo)
             => new CiamAuthority(authorityInfo);

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/CiamAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/CiamAuthorityHandler.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance.Handlers
+{
+    /// <summary>
+    /// Handler for CIAM authorities (host ends with ".ciamlogin.com").
+    /// Must be registered before <see cref="AadAuthorityHandler"/>.
+    /// </summary>
+    internal sealed class CiamAuthorityHandler : IAuthorityHandler
+    {
+        public AuthorityType AuthorityType => AuthorityType.Ciam;
+
+        public bool CanHandle(Uri authorityUri)
+            => authorityUri.Host.EndsWith(Constants.CiamAuthorityHostSuffix, StringComparison.OrdinalIgnoreCase);
+
+        public Authority Create(AuthorityInfo authorityInfo)
+            => new CiamAuthority(authorityInfo);
+
+        public IAuthorityValidator CreateValidator(RequestContext requestContext)
+            => new NullAuthorityValidator();
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/DstsAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/DstsAuthorityHandler.cs
@@ -14,20 +14,8 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public AuthorityType AuthorityType => AuthorityType.Dsts;
 
-        public bool CanHandle(Uri authorityUri)
-        {
-            try
-            {
-                return string.Equals(
-                    AuthorityInfo.GetFirstPathSegment(authorityUri),
-                    DstsPathSegment,
-                    StringComparison.OrdinalIgnoreCase);
-            }
-            catch (InvalidOperationException)
-            {
-                return false;
-            }
-        }
+        public bool CanHandle(Uri authorityUri, string host, string firstPathSegment)
+            => string.Equals(firstPathSegment, DstsPathSegment, StringComparison.OrdinalIgnoreCase);
 
         public Authority Create(AuthorityInfo authorityInfo)
             => new DstsAuthority(authorityInfo);

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/DstsAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/DstsAuthorityHandler.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance.Handlers
+{
+    /// <summary>Handler for DSTS authorities (path begins with "dstsv2").</summary>
+    internal sealed class DstsAuthorityHandler : IAuthorityHandler
+    {
+        private const string DstsPathSegment = "dstsv2";
+
+        public AuthorityType AuthorityType => AuthorityType.Dsts;
+
+        public bool CanHandle(Uri authorityUri)
+        {
+            try
+            {
+                return string.Equals(
+                    AuthorityInfo.GetFirstPathSegment(authorityUri),
+                    DstsPathSegment,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+
+        public Authority Create(AuthorityInfo authorityInfo)
+            => new DstsAuthority(authorityInfo);
+
+        public IAuthorityValidator CreateValidator(RequestContext requestContext)
+            => new NullAuthorityValidator();
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/GenericAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/GenericAuthorityHandler.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance.Handlers
+{
+    /// <summary>
+    /// Handler for Generic authorities.
+    /// Generic authorities are never auto-detected from a URI; they are created explicitly
+    /// via <see cref="AuthorityInfo.FromGenericAuthority"/>. CanHandle always returns false,
+    /// so this handler is only reachable via <see cref="AuthorityRegistry.GetByType"/>.
+    /// </summary>
+    internal sealed class GenericAuthorityHandler : IAuthorityHandler
+    {
+        public AuthorityType AuthorityType => AuthorityType.Generic;
+
+        /// <summary>Generic authorities are never URI-detected; return false always.</summary>
+        public bool CanHandle(Uri authorityUri) => false;
+
+        public Authority Create(AuthorityInfo authorityInfo)
+            => new GenericAuthority(authorityInfo);
+
+        public IAuthorityValidator CreateValidator(RequestContext requestContext)
+            => new NullAuthorityValidator();
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/GenericAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/GenericAuthorityHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client.Instance.Handlers
         public AuthorityType AuthorityType => AuthorityType.Generic;
 
         /// <summary>Generic authorities are never URI-detected; return false always.</summary>
-        public bool CanHandle(Uri authorityUri) => false;
+        public bool CanHandle(Uri authorityUri, string host, string firstPathSegment) => false;
 
         public Authority Create(AuthorityInfo authorityInfo)
             => new GenericAuthority(authorityInfo);

--- a/src/client/Microsoft.Identity.Client/Instance/IAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/IAuthorityHandler.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+
+namespace Microsoft.Identity.Client.Instance
+{
+    /// <summary>
+    /// Encapsulates authority-type-specific logic: URI detection, object creation, and validation.
+    /// Implementations are registered in <see cref="AuthorityRegistry"/> in priority order.
+    /// </summary>
+    internal interface IAuthorityHandler
+    {
+        /// <summary>The authority type this handler manages.</summary>
+        AuthorityType AuthorityType { get; }
+
+        /// <summary>
+        /// Returns true if this handler can process the given authority URI.
+        /// Handlers are evaluated in registration order; the first match wins.
+        /// </summary>
+        bool CanHandle(Uri authorityUri);
+
+        /// <summary>Creates the concrete <see cref="Authority"/> subclass for the given info.</summary>
+        Authority Create(AuthorityInfo authorityInfo);
+
+        /// <summary>Creates the appropriate validator for this authority type.</summary>
+        IAuthorityValidator CreateValidator(RequestContext requestContext);
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Instance/IAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/IAuthorityHandler.cs
@@ -19,8 +19,10 @@ namespace Microsoft.Identity.Client.Instance
         /// <summary>
         /// Returns true if this handler can process the given authority URI.
         /// Handlers are evaluated in registration order; the first match wins.
+        /// The <paramref name="host"/> and <paramref name="firstPathSegment"/> are pre-computed
+        /// by <see cref="AuthorityRegistry.DetectFromUri"/> so that URI parsing happens only once.
         /// </summary>
-        bool CanHandle(Uri authorityUri);
+        bool CanHandle(Uri authorityUri, string host, string firstPathSegment);
 
         /// <summary>Creates the concrete <see cref="Authority"/> subclass for the given info.</summary>
         Authority Create(AuthorityInfo authorityInfo);

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AuthorityRegistryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AuthorityRegistryTests.cs
@@ -299,9 +299,9 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         public void GenericHandler_CanHandle_AlwaysReturnsFalse()
         {
             var handler = AuthorityRegistry.GetByType(AuthorityType.Generic);
-            Assert.IsFalse(handler.CanHandle(new Uri("https://somegenericidp.com/")));
-            Assert.IsFalse(handler.CanHandle(new Uri("https://login.microsoftonline.com/common/")));
-            Assert.IsFalse(handler.CanHandle(new Uri("https://mytenant.ciamlogin.com/")));
+            Assert.IsFalse(handler.CanHandle(new Uri("https://somegenericidp.com/"), "somegenericidp.com", null));
+            Assert.IsFalse(handler.CanHandle(new Uri("https://login.microsoftonline.com/common/"), "login.microsoftonline.com", "common"));
+            Assert.IsFalse(handler.CanHandle(new Uri("https://mytenant.ciamlogin.com/"), "mytenant.ciamlogin.com", null));
         }
 
         #endregion

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AuthorityRegistryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AuthorityRegistryTests.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Instance;
+using Microsoft.Identity.Client.Instance.Handlers;
+using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
+{
+    [TestClass]
+    public class AuthorityRegistryTests
+    {
+        #region DetectFromUri
+
+        [TestMethod]
+        public void DetectFromUri_AadAuthority_ReturnsAadHandler()
+        {
+            var uri = new Uri("https://login.microsoftonline.com/common/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Aad, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(AadAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void DetectFromUri_AdfsAuthority_ReturnsAdfsHandler()
+        {
+            var uri = new Uri("https://someAdfs.com/adfs/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Adfs, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(AdfsAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void DetectFromUri_AdfsAuthority_CaseInsensitive()
+        {
+            var uri = new Uri("https://someAdfs.com/ADFS/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Adfs, handler.AuthorityType);
+        }
+
+        [TestMethod]
+        public void DetectFromUri_B2CAuthority_ReturnsB2CHandler()
+        {
+            var uri = new Uri("https://mytenant.b2clogin.com/tfp/mytenant.onmicrosoft.com/policy/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.B2C, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(B2CAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void DetectFromUri_B2CAuthority_CaseInsensitive()
+        {
+            var uri = new Uri("https://mytenant.b2clogin.com/TFP/mytenant.onmicrosoft.com/policy/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.B2C, handler.AuthorityType);
+        }
+
+        [TestMethod]
+        public void DetectFromUri_CiamAuthority_ReturnsCiamHandler()
+        {
+            var uri = new Uri("https://mytenant.ciamlogin.com/mytenant.onmicrosoft.com/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Ciam, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(CiamAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void DetectFromUri_CiamAuthority_CaseInsensitive()
+        {
+            var uri = new Uri("https://mytenant.CIAMLOGIN.COM/mytenant.onmicrosoft.com/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Ciam, handler.AuthorityType);
+        }
+
+        [TestMethod]
+        public void DetectFromUri_CiamAuthority_SubdomainVariation()
+        {
+            var uri = new Uri("https://contoso.ciamlogin.com/contoso.onmicrosoft.com/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Ciam, handler.AuthorityType);
+        }
+
+        [TestMethod]
+        public void DetectFromUri_DstsAuthority_ReturnsDstsHandler()
+        {
+            var uri = new Uri("https://dsts.core.azure.net/dstsv2/tenant/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Dsts, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(DstsAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void DetectFromUri_DstsAuthority_CaseInsensitive()
+        {
+            var uri = new Uri("https://dsts.core.azure.net/DSTSV2/tenant/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Dsts, handler.AuthorityType);
+        }
+
+        #endregion
+
+        #region DetectFromUri ordering — CIAM before AAD
+
+        [TestMethod]
+        public void DetectFromUri_CiamUrl_NotDetectedAsAad()
+        {
+            // CIAM must be detected BEFORE AAD, since AAD is the catch-all
+            var ciamUri = new Uri("https://mytenant.ciamlogin.com/mytenant.onmicrosoft.com/");
+            var handler = AuthorityRegistry.DetectFromUri(ciamUri);
+            Assert.AreNotEqual(AuthorityType.Aad, handler.AuthorityType,
+                "A .ciamlogin.com URL must be detected as CIAM, not AAD.");
+            Assert.AreEqual(AuthorityType.Ciam, handler.AuthorityType);
+        }
+
+        [TestMethod]
+        public void DetectFromUri_StandardAadUrl_DetectedAsAad()
+        {
+            // A normal AAD URL (no special path or host) should be the catch-all AAD
+            var aadUri = new Uri("https://login.microsoftonline.com/tenantid/");
+            var handler = AuthorityRegistry.DetectFromUri(aadUri);
+            Assert.AreEqual(AuthorityType.Aad, handler.AuthorityType);
+        }
+
+        #endregion
+
+        #region GetByType
+
+        [TestMethod]
+        public void GetByType_Aad_ReturnsAadHandler()
+        {
+            var handler = AuthorityRegistry.GetByType(AuthorityType.Aad);
+            Assert.AreEqual(AuthorityType.Aad, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(AadAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void GetByType_Adfs_ReturnsAdfsHandler()
+        {
+            var handler = AuthorityRegistry.GetByType(AuthorityType.Adfs);
+            Assert.AreEqual(AuthorityType.Adfs, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(AdfsAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void GetByType_B2C_ReturnsB2CHandler()
+        {
+            var handler = AuthorityRegistry.GetByType(AuthorityType.B2C);
+            Assert.AreEqual(AuthorityType.B2C, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(B2CAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void GetByType_Ciam_ReturnsCiamHandler()
+        {
+            var handler = AuthorityRegistry.GetByType(AuthorityType.Ciam);
+            Assert.AreEqual(AuthorityType.Ciam, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(CiamAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void GetByType_Dsts_ReturnsDstsHandler()
+        {
+            var handler = AuthorityRegistry.GetByType(AuthorityType.Dsts);
+            Assert.AreEqual(AuthorityType.Dsts, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(DstsAuthorityHandler));
+        }
+
+        [TestMethod]
+        public void GetByType_Generic_ReturnsGenericHandler()
+        {
+            var handler = AuthorityRegistry.GetByType(AuthorityType.Generic);
+            Assert.AreEqual(AuthorityType.Generic, handler.AuthorityType);
+            Assert.IsInstanceOfType(handler, typeof(GenericAuthorityHandler));
+        }
+
+        #endregion
+
+        #region Create — correct Authority subclass
+
+        [TestMethod]
+        public void Create_AadAuthorityInfo_ReturnsAadAuthority()
+        {
+            var info = AuthorityInfo.FromAuthorityUri("https://login.microsoftonline.com/common/", false);
+            var authority = AuthorityRegistry.Create(info);
+            Assert.IsInstanceOfType(authority, typeof(AadAuthority));
+        }
+
+        [TestMethod]
+        public void Create_AdfsAuthorityInfo_ReturnsAdfsAuthority()
+        {
+            var info = AuthorityInfo.FromAdfsAuthority("https://someAdfs.com/adfs/", false);
+            var authority = AuthorityRegistry.Create(info);
+            Assert.IsInstanceOfType(authority, typeof(AdfsAuthority));
+        }
+
+        [TestMethod]
+        public void Create_B2CAuthorityInfo_ReturnsB2CAuthority()
+        {
+            var info = AuthorityInfo.FromB2CAuthority("https://mytenant.b2clogin.com/tfp/mytenant.onmicrosoft.com/policy/");
+            var authority = AuthorityRegistry.Create(info);
+            Assert.IsInstanceOfType(authority, typeof(B2CAuthority));
+        }
+
+        [TestMethod]
+        public void Create_CiamAuthorityInfo_ReturnsCiamAuthority()
+        {
+            var info = AuthorityInfo.FromAuthorityUri("https://mytenant.ciamlogin.com/mytenant.onmicrosoft.com/", false);
+            var authority = AuthorityRegistry.Create(info);
+            Assert.IsInstanceOfType(authority, typeof(CiamAuthority));
+        }
+
+        [TestMethod]
+        public void Create_DstsAuthorityInfo_ReturnsDstsAuthority()
+        {
+            var info = new AuthorityInfo(AuthorityType.Dsts, "https://dsts.core.azure.net/dstsv2/tenant/", false);
+            var authority = AuthorityRegistry.Create(info);
+            Assert.IsInstanceOfType(authority, typeof(DstsAuthority));
+        }
+
+        [TestMethod]
+        public void Create_GenericAuthorityInfo_ReturnsGenericAuthority()
+        {
+            var info = AuthorityInfo.FromGenericAuthority("https://somegenericidp.com/");
+            var authority = AuthorityRegistry.Create(info);
+            Assert.IsInstanceOfType(authority, typeof(GenericAuthority));
+        }
+
+        #endregion
+
+        #region CreateValidator — correct validator type
+
+        [TestMethod]
+        public void CreateValidator_AadAuthority_ReturnsAadAuthorityValidator()
+        {
+            var info = AuthorityInfo.FromAuthorityUri("https://login.microsoftonline.com/common/", false);
+            var validator = AuthorityRegistry.CreateValidator(info, null);
+            Assert.IsInstanceOfType(validator, typeof(AadAuthorityValidator));
+        }
+
+        [TestMethod]
+        public void CreateValidator_AdfsAuthority_ReturnsAdfsAuthorityValidator()
+        {
+            var info = AuthorityInfo.FromAdfsAuthority("https://someAdfs.com/adfs/", false);
+            var validator = AuthorityRegistry.CreateValidator(info, null);
+            Assert.IsInstanceOfType(validator, typeof(AdfsAuthorityValidator));
+        }
+
+        [TestMethod]
+        public void CreateValidator_B2CAuthority_ReturnsNullAuthorityValidator()
+        {
+            var info = AuthorityInfo.FromB2CAuthority("https://mytenant.b2clogin.com/tfp/mytenant.onmicrosoft.com/policy/");
+            var validator = AuthorityRegistry.CreateValidator(info, null);
+            Assert.IsInstanceOfType(validator, typeof(NullAuthorityValidator));
+        }
+
+        [TestMethod]
+        public void CreateValidator_CiamAuthority_ReturnsNullAuthorityValidator()
+        {
+            var info = AuthorityInfo.FromAuthorityUri("https://mytenant.ciamlogin.com/mytenant.onmicrosoft.com/", false);
+            var validator = AuthorityRegistry.CreateValidator(info, null);
+            Assert.IsInstanceOfType(validator, typeof(NullAuthorityValidator));
+        }
+
+        [TestMethod]
+        public void CreateValidator_DstsAuthority_ReturnsNullAuthorityValidator()
+        {
+            var info = new AuthorityInfo(AuthorityType.Dsts, "https://dsts.core.azure.net/dstsv2/tenant/", false);
+            var validator = AuthorityRegistry.CreateValidator(info, null);
+            Assert.IsInstanceOfType(validator, typeof(NullAuthorityValidator));
+        }
+
+        [TestMethod]
+        public void CreateValidator_GenericAuthority_ReturnsNullAuthorityValidator()
+        {
+            var info = AuthorityInfo.FromGenericAuthority("https://somegenericidp.com/");
+            var validator = AuthorityRegistry.CreateValidator(info, null);
+            Assert.IsInstanceOfType(validator, typeof(NullAuthorityValidator));
+        }
+
+        #endregion
+
+        #region GenericAuthorityHandler — never URI-detected
+
+        [TestMethod]
+        public void DetectFromUri_GenericNotAutoDetected_FallsBackToAad()
+        {
+            // Generic authorities are never auto-detected from URI; any unknown URL falls through to AAD catch-all
+            var uri = new Uri("https://somegenericidp.com/");
+            var handler = AuthorityRegistry.DetectFromUri(uri);
+            Assert.AreEqual(AuthorityType.Aad, handler.AuthorityType,
+                "A generic URL should fall through to the AAD catch-all handler.");
+        }
+
+        [TestMethod]
+        public void GenericHandler_CanHandle_AlwaysReturnsFalse()
+        {
+            var handler = AuthorityRegistry.GetByType(AuthorityType.Generic);
+            Assert.IsFalse(handler.CanHandle(new Uri("https://somegenericidp.com/")));
+            Assert.IsFalse(handler.CanHandle(new Uri("https://login.microsoftonline.com/common/")));
+            Assert.IsFalse(handler.CanHandle(new Uri("https://mytenant.ciamlogin.com/")));
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

Part 1 of 3 for #5780 — authority refactor.

Introduces the registry pattern infrastructure alongside the existing authority code **without modifying any existing code**. This is purely additive and safe to merge independently.

## New files

- `IAuthorityHandler` — interface encapsulating per-type: URI detection, Authority creation, validator creation
- `AuthorityRegistry` — static registry with `DetectFromUri`, `GetByType`, `Create`, `CreateValidator`
- `Handlers/` folder — 6 implementations (Aad, Adfs, B2C, Ciam, Dsts, Generic)
- `AuthorityRegistryTests` — extensive unit tests

## Handler priority

Registration order matters for URI detection:
| Order | Handler | Detection rule |
|---|---|---|
| 1 | CIAM | host ends with `.ciamlogin.com` |
| 2 | ADFS | first path segment = `adfs` |
| 3 | DSTS | first path segment = `dstsv2` |
| 4 | B2C | first path segment = `tfp` |
| 5 | AAD | catch-all (CanHandle = true) |
| 6 | Generic | never URI-detected (CanHandle = false) |

## No behavioral change

The old `GetAuthorityType()`, `CreateAuthority()`, and `CreateAuthorityValidator()` switches in `AuthorityInfo` are untouched. They will be replaced in PR 2.