### PR TITLE
refactor: Route authority switches through AuthorityRegistry

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Identity.Client
 
             canonicalAuthorityUri = TransformIfCiamAuthority(canonicalAuthorityUri);
 
-            var authorityType = GetAuthorityType(canonicalAuthorityUri);
+            var authorityType = AuthorityRegistry.DetectFromUri(canonicalAuthorityUri).AuthorityType;
 
             // Authority validation is only supported for AAD 
             if (authorityType == AuthorityType.B2C || authorityType == AuthorityType.Generic)
@@ -311,31 +311,7 @@ namespace Microsoft.Identity.Client
 
         internal Authority CreateAuthority()
         {
-            switch (AuthorityType)
-            {
-                case AuthorityType.Adfs:
-                    return new AdfsAuthority(this);
-
-                case AuthorityType.B2C:
-                    return new B2CAuthority(this);
-
-                case AuthorityType.Aad:
-                    return new AadAuthority(this);
-
-                case AuthorityType.Dsts:
-                    return new DstsAuthority(this);
-
-                case AuthorityType.Ciam:
-                    return new CiamAuthority(this);
-
-                case AuthorityType.Generic:
-                    return new GenericAuthority(this);
-
-                default:
-                    throw new MsalClientException(
-                        MsalError.InvalidAuthorityType,
-                        $"Unsupported authority type {AuthorityType}");
-            }
+            return AuthorityRegistry.Create(this);
         }
 
         #endregion
@@ -466,20 +442,7 @@ namespace Microsoft.Identity.Client
         {
             public static IAuthorityValidator CreateAuthorityValidator(AuthorityInfo authorityInfo, RequestContext requestContext)
             {
-                switch (authorityInfo.AuthorityType)
-                {
-                    case AuthorityType.Adfs:
-                        return new AdfsAuthorityValidator(requestContext);
-                    case AuthorityType.Aad:
-                        return new AadAuthorityValidator(requestContext);
-                    case AuthorityType.B2C:
-                    case AuthorityType.Dsts:
-                    case AuthorityType.Ciam:
-                    case AuthorityType.Generic:
-                        return new NullAuthorityValidator();
-                    default:
-                        throw new InvalidOperationException("Invalid AuthorityType");
-                }
+                return AuthorityRegistry.CreateValidator(authorityInfo, requestContext);
             }
 
             /// <summary>


### PR DESCRIPTION
## Summary

Part 2 of 3 for #5780.

Routes the three switch statements and hardcoded string logic in AuthorityInfo.cs through the AuthorityRegistry introduced in PR 1, then deletes the dead code.

## Changes to AuthorityInfo.cs

- GetAuthorityType(Uri) deleted -- replaced by AuthorityRegistry.DetectFromUri(uri).AuthorityType
- CreateAuthority() switch replaced by return AuthorityRegistry.Create(this);
- AuthorityInfoHelper.CreateAuthorityValidator() switch replaced by return AuthorityRegistry.CreateValidator(authorityInfo, requestContext);

IsCiamAuthority(Uri) is retained -- still used by TransformIfCiamAuthority and ValidateAndCreateAuthorityUri.

## No behavioral change

All three switches delegate to the same handler implementations that were verified in PR 1 tests.