### PR TITLE
refactor: Move ResolveForRequestAsync logic into authority handlers

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AuthorityInfo.cs
@@ -481,74 +481,8 @@ namespace Microsoft.Identity.Client
 
                 await ValidateSameHostAsync(requestAuthorityInfo, requestContext).ConfigureAwait(false);
 
-                AuthorityInfo requestOrConfig = requestAuthorityInfo ?? configAuthorityInfo;
-
-                switch (configAuthorityInfo.AuthorityType)
-                {
-                    // ADFS is tenant-less, no need to consider tenant
-                    case AuthorityType.Adfs:
-                        return new AdfsAuthority(requestOrConfig);
-
-                    case AuthorityType.Dsts:
-                        return new DstsAuthority(requestOrConfig);
-
-                    case AuthorityType.B2C:
-                        return new B2CAuthority(requestOrConfig);
-
-                    case AuthorityType.Ciam:
-                        return new CiamAuthority(requestOrConfig);
-
-                    case AuthorityType.Generic:
-                        return new GenericAuthority(requestOrConfig);
-
-                    case AuthorityType.Aad:
-
-                        bool updateEnvironment = requestContext.ServiceBundle.Config.MultiCloudSupportEnabled && account != null && !PublicClientApplication.IsOperatingSystemAccount(account);
-
-                        if (requestAuthorityInfo == null)
-                        {
-                            return updateEnvironment ?
-                                CreateAuthorityWithTenant(
-                                    CreateAuthorityWithEnvironment(configAuthorityInfo, account.Environment),
-                                    account?.HomeAccountId?.TenantId,
-                                    forceSpecifiedTenant: false) :
-                                CreateAuthorityWithTenant(
-                                    configAuthority,
-                                    account?.HomeAccountId?.TenantId,
-                                    forceSpecifiedTenant: false);
-                        }
-
-                        // In case the authority is defined only at the request level
-                        if (configAuthorityInfo.IsDefaultAuthority &&
-                            requestAuthorityInfo.AuthorityType != AuthorityType.Aad)
-                        {
-                            return requestAuthorityInfo.CreateAuthority();
-                        }
-
-                        var requestAuthority = updateEnvironment ?
-                            new AadAuthority(CreateAuthorityWithEnvironment(requestAuthorityInfo, account?.Environment).AuthorityInfo) :
-                            new AadAuthority(requestAuthorityInfo);
-                        if (!requestAuthority.IsCommonOrganizationsOrConsumersTenant() ||
-                            requestAuthority.IsOrganizationsTenantWithMsaPassthroughEnabled(requestContext.ServiceBundle.Config.IsBrokerEnabled && requestContext.ServiceBundle.Config.BrokerOptions != null && requestContext.ServiceBundle.Config.BrokerOptions.MsaPassthrough, account?.HomeAccountId?.TenantId))
-                        {
-                            return requestAuthority;
-                        }
-
-                        return updateEnvironment ?
-                                CreateAuthorityWithTenant(
-                                    CreateAuthorityWithEnvironment(configAuthorityInfo, account.Environment),
-                                    account?.HomeAccountId?.TenantId,
-                                    forceSpecifiedTenant: false) :
-                                CreateAuthorityWithTenant(
-                                    configAuthority,
-                                    account?.HomeAccountId?.TenantId,
-                                    forceSpecifiedTenant: false);
-
-                    default:
-                        throw new MsalClientException(
-                            MsalError.InvalidAuthorityType,
-                            "Unsupported authority type");
-                }
+                return await AuthorityRegistry.ResolveForRequestAsync(
+                    configAuthority, requestAuthorityInfo, account, requestContext).ConfigureAwait(false);
             }
 
             internal static Authority CreateAuthorityWithTenant(Authority authority, string tenantId, bool forceSpecifiedTenant)

--- a/src/client/Microsoft.Identity.Client/Instance/AuthorityRegistry.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/AuthorityRegistry.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Handlers;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
@@ -73,5 +74,14 @@ namespace Microsoft.Identity.Client.Instance
         /// <summary>Creates the appropriate validator for the given AuthorityInfo.</summary>
         internal static IAuthorityValidator CreateValidator(AuthorityInfo authorityInfo, RequestContext requestContext)
             => GetByType(authorityInfo.AuthorityType).CreateValidator(requestContext);
+
+        /// <summary>Resolves the authority for a token request, dispatching to the correct handler.</summary>
+        internal static Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext)
+            => GetByType(configAuthority.AuthorityInfo.AuthorityType)
+                .ResolveForRequestAsync(configAuthority, requestAuthorityInfo, account, requestContext);
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/AadAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/AadAuthorityHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
 
@@ -26,5 +27,66 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public IAuthorityValidator CreateValidator(RequestContext requestContext)
             => new AadAuthorityValidator(requestContext);
+
+        public Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext)
+        {
+            var configAuthorityInfo = configAuthority.AuthorityInfo;
+
+            bool updateEnvironment = requestContext.ServiceBundle.Config.MultiCloudSupportEnabled
+                && account != null
+                && !PublicClientApplication.IsOperatingSystemAccount(account);
+
+            if (requestAuthorityInfo == null)
+            {
+                Authority result = updateEnvironment
+                    ? AuthorityInfo.AuthorityInfoHelper.CreateAuthorityWithTenant(
+                        AuthorityInfo.AuthorityInfoHelper.CreateAuthorityWithEnvironment(configAuthorityInfo, account.Environment),
+                        account?.HomeAccountId?.TenantId,
+                        forceSpecifiedTenant: false)
+                    : AuthorityInfo.AuthorityInfoHelper.CreateAuthorityWithTenant(
+                        configAuthority,
+                        account?.HomeAccountId?.TenantId,
+                        forceSpecifiedTenant: false);
+
+                return Task.FromResult(result);
+            }
+
+            // In case the authority is defined only at the request level
+            if (configAuthorityInfo.IsDefaultAuthority &&
+                requestAuthorityInfo.AuthorityType != AuthorityType.Aad)
+            {
+                return Task.FromResult(requestAuthorityInfo.CreateAuthority());
+            }
+
+            var requestAadAuthority = updateEnvironment
+                ? new AadAuthority(AuthorityInfo.AuthorityInfoHelper.CreateAuthorityWithEnvironment(requestAuthorityInfo, account?.Environment).AuthorityInfo)
+                : new AadAuthority(requestAuthorityInfo);
+
+            if (!requestAadAuthority.IsCommonOrganizationsOrConsumersTenant() ||
+                requestAadAuthority.IsOrganizationsTenantWithMsaPassthroughEnabled(
+                    requestContext.ServiceBundle.Config.IsBrokerEnabled
+                    && requestContext.ServiceBundle.Config.BrokerOptions != null
+                    && requestContext.ServiceBundle.Config.BrokerOptions.MsaPassthrough,
+                    account?.HomeAccountId?.TenantId))
+            {
+                return Task.FromResult((Authority)requestAadAuthority);
+            }
+
+            Authority final = updateEnvironment
+                ? AuthorityInfo.AuthorityInfoHelper.CreateAuthorityWithTenant(
+                    AuthorityInfo.AuthorityInfoHelper.CreateAuthorityWithEnvironment(configAuthorityInfo, account.Environment),
+                    account?.HomeAccountId?.TenantId,
+                    forceSpecifiedTenant: false)
+                : AuthorityInfo.AuthorityInfoHelper.CreateAuthorityWithTenant(
+                    configAuthority,
+                    account?.HomeAccountId?.TenantId,
+                    forceSpecifiedTenant: false);
+
+            return Task.FromResult(final);
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/AdfsAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/AdfsAuthorityHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
 
@@ -22,5 +23,15 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public IAuthorityValidator CreateValidator(RequestContext requestContext)
             => new AdfsAuthorityValidator(requestContext);
+
+        public Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext)
+        {
+            AuthorityInfo requestOrConfig = requestAuthorityInfo ?? configAuthority.AuthorityInfo;
+            return Task.FromResult(Create(requestOrConfig));
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/B2CAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/B2CAuthorityHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
 
@@ -20,5 +21,15 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public IAuthorityValidator CreateValidator(RequestContext requestContext)
             => new NullAuthorityValidator();
+
+        public Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext)
+        {
+            AuthorityInfo requestOrConfig = requestAuthorityInfo ?? configAuthority.AuthorityInfo;
+            return Task.FromResult(Create(requestOrConfig));
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/CiamAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/CiamAuthorityHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
 
@@ -23,5 +24,15 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public IAuthorityValidator CreateValidator(RequestContext requestContext)
             => new NullAuthorityValidator();
+
+        public Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext)
+        {
+            AuthorityInfo requestOrConfig = requestAuthorityInfo ?? configAuthority.AuthorityInfo;
+            return Task.FromResult(Create(requestOrConfig));
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/DstsAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/DstsAuthorityHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
 
@@ -22,5 +23,15 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public IAuthorityValidator CreateValidator(RequestContext requestContext)
             => new NullAuthorityValidator();
+
+        public Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext)
+        {
+            AuthorityInfo requestOrConfig = requestAuthorityInfo ?? configAuthority.AuthorityInfo;
+            return Task.FromResult(Create(requestOrConfig));
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/Handlers/GenericAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Handlers/GenericAuthorityHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
 
@@ -25,5 +26,15 @@ namespace Microsoft.Identity.Client.Instance.Handlers
 
         public IAuthorityValidator CreateValidator(RequestContext requestContext)
             => new NullAuthorityValidator();
+
+        public Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext)
+        {
+            AuthorityInfo requestOrConfig = requestAuthorityInfo ?? configAuthority.AuthorityInfo;
+            return Task.FromResult(Create(requestOrConfig));
+        }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Instance/IAuthorityHandler.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/IAuthorityHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client.Instance.Validation;
 using Microsoft.Identity.Client.Internal;
 
@@ -29,5 +30,16 @@ namespace Microsoft.Identity.Client.Instance
 
         /// <summary>Creates the appropriate validator for this authority type.</summary>
         IAuthorityValidator CreateValidator(RequestContext requestContext);
+
+        /// <summary>
+        /// Resolves the final authority to use for a token request, applying any type-specific
+        /// tenant or environment overrides. Shared validation (type mismatch, same host) is
+        /// performed by the caller before this method is invoked.
+        /// </summary>
+        Task<Authority> ResolveForRequestAsync(
+            Authority configAuthority,
+            AuthorityInfo requestAuthorityInfo,
+            IAccount account,
+            RequestContext requestContext);
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AuthorityRegistryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AuthorityRegistryTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Instance.Handlers;
 using Microsoft.Identity.Client.Instance.Validation;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Test.Common.Core.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
@@ -305,5 +308,112 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         }
 
         #endregion
+    }
+
+    [TestClass]
+    public class AuthorityHandlerResolveTests : TestBase
+    {
+        // Test: simple handlers return requestAuthorityInfo when provided
+        [TestMethod]
+        public async Task AdfsHandler_WithRequestAuthority_ReturnsRequestAuthority()
+        {
+            using var harness = CreateTestHarness();
+            var requestContext = new RequestContext(harness.ServiceBundle, Guid.NewGuid(), null);
+            var configInfo = AuthorityInfo.FromAdfsAuthority("https://fs.contoso.com/adfs/", false);
+            requestContext.ServiceBundle.Config.Authority = new AdfsAuthority(configInfo);
+
+            var requestInfo = AuthorityInfo.FromAdfsAuthority("https://fs.contoso.com/adfs/", false);
+            var configAuthority = Authority.CreateAuthority(configInfo);
+            var handler = new AdfsAuthorityHandler();
+
+            var result = await handler.ResolveForRequestAsync(configAuthority, requestInfo, null, requestContext).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType(result, typeof(AdfsAuthority));
+            Assert.AreEqual(configInfo.CanonicalAuthority, result.AuthorityInfo.CanonicalAuthority);
+        }
+
+        // Test: simple handlers fall back to config when no request authority
+        [TestMethod]
+        public async Task AdfsHandler_WithNoRequestAuthority_ReturnsConfigAuthority()
+        {
+            using var harness = CreateTestHarness();
+            var requestContext = new RequestContext(harness.ServiceBundle, Guid.NewGuid(), null);
+            var configInfo = AuthorityInfo.FromAdfsAuthority("https://fs.contoso.com/adfs/", false);
+            requestContext.ServiceBundle.Config.Authority = new AdfsAuthority(configInfo);
+
+            var configAuthority = Authority.CreateAuthority(configInfo);
+            var handler = new AdfsAuthorityHandler();
+
+            var result = await handler.ResolveForRequestAsync(configAuthority, null, null, requestContext).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType(result, typeof(AdfsAuthority));
+            Assert.AreEqual(configInfo.CanonicalAuthority, result.AuthorityInfo.CanonicalAuthority);
+        }
+
+        // Test: AAD handler falls back to config when no request authority and no account
+        [TestMethod]
+        public async Task AadHandler_WithNoRequestAuthority_NoAccount_ReturnsConfigAuthority()
+        {
+            using var harness = CreateTestHarness();
+            var requestContext = new RequestContext(harness.ServiceBundle, Guid.NewGuid(), null);
+            var configAuthority = Authority.CreateAuthority("https://login.microsoftonline.com/mytenant/");
+            requestContext.ServiceBundle.Config.Authority = configAuthority;
+            var handler = new AadAuthorityHandler();
+
+            var result = await handler.ResolveForRequestAsync(configAuthority, null, null, requestContext).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType(result, typeof(AadAuthority));
+        }
+
+        // Test: B2C handler returns config authority when no request authority
+        [TestMethod]
+        public async Task B2CHandler_WithNoRequestAuthority_ReturnsConfigAuthority()
+        {
+            using var harness = CreateTestHarness();
+            var requestContext = new RequestContext(harness.ServiceBundle, Guid.NewGuid(), null);
+            var configInfo = AuthorityInfo.FromB2CAuthority("https://mytenant.b2clogin.com/tfp/mytenant.onmicrosoft.com/policy/");
+            requestContext.ServiceBundle.Config.Authority = new B2CAuthority(configInfo);
+
+            var configAuthority = Authority.CreateAuthority(configInfo);
+            var handler = new B2CAuthorityHandler();
+
+            var result = await handler.ResolveForRequestAsync(configAuthority, null, null, requestContext).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType(result, typeof(B2CAuthority));
+            Assert.AreEqual(configInfo.CanonicalAuthority, result.AuthorityInfo.CanonicalAuthority);
+        }
+
+        // Test: registry dispatches ResolveForRequestAsync through the correct handler
+        [TestMethod]
+        public async Task AuthorityRegistry_ResolveForRequestAsync_DispatchesToCorrectHandler()
+        {
+            using var harness = CreateTestHarness();
+            var requestContext = new RequestContext(harness.ServiceBundle, Guid.NewGuid(), null);
+            var configInfo = AuthorityInfo.FromAdfsAuthority("https://fs.contoso.com/adfs/", false);
+            requestContext.ServiceBundle.Config.Authority = new AdfsAuthority(configInfo);
+            var configAuthority = requestContext.ServiceBundle.Config.Authority;
+
+            var result = await AuthorityRegistry.ResolveForRequestAsync(
+                configAuthority, null, null, requestContext).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType(result, typeof(AdfsAuthority));
+        }
+
+        // Test: generic handler falls back to config when no request authority
+        [TestMethod]
+        public async Task GenericHandler_WithNoRequestAuthority_ReturnsConfigAuthority()
+        {
+            using var harness = CreateTestHarness();
+            var requestContext = new RequestContext(harness.ServiceBundle, Guid.NewGuid(), null);
+            var configInfo = AuthorityInfo.FromGenericAuthority("https://somegenericidp.com/");
+            requestContext.ServiceBundle.Config.Authority = new GenericAuthority(configInfo);
+
+            var configAuthority = Authority.CreateAuthority(configInfo);
+            var handler = new GenericAuthorityHandler();
+
+            var result = await handler.ResolveForRequestAsync(configAuthority, null, null, requestContext).ConfigureAwait(false);
+
+            Assert.IsInstanceOfType(result, typeof(GenericAuthority));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Part 3 of 3 for #5780.

Extracts the final per-type branching from CreateAuthorityForRequestAsync into IAuthorityHandler.ResolveForRequestAsync implementations, completing the registry pattern refactor.

## Changes

### IAuthorityHandler
Added ResolveForRequestAsync(Authority, AuthorityInfo, IAccount, RequestContext) to the interface.

### Handler implementations

| Handler | ResolveForRequestAsync logic |
|---|---|
| AdfsAuthorityHandler | Create(requestAuthorityInfo ?? configAuthority.AuthorityInfo) |
| DstsAuthorityHandler | Same as Adfs |
| B2CAuthorityHandler | Same as Adfs |
| CiamAuthorityHandler | Same as Adfs |
| GenericAuthorityHandler | Same as Adfs |
| AadAuthorityHandler | Full multi-cloud / tenant / MSA passthrough logic (moved verbatim from the old switch case) |

### AuthorityRegistry
Added ResolveForRequestAsync dispatch helper.

### AuthorityInfoHelper.CreateAuthorityForRequestAsync
Replaced the 70-line switch with a single AuthorityRegistry.ResolveForRequestAsync call.

## Result: adding a new authority type is now self-contained

Before: required editing GetAuthorityType(), CreateAuthority(), CreateAuthorityValidator(), and CreateAuthorityForRequestAsync() in shared files.

After: requires only a new IAuthorityHandler implementation registered in AuthorityRegistry.