### PR TITLE
Add IAuthenticationOperation3 for CDT + mTLS POP composition

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Threading;
@@ -170,10 +170,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
             // composition (e.g., CDT + mTLS POP) where the operation handles both concerns.
             if (p.AuthenticationOperation is IAuthenticationOperation3 op3)
             {
-                await op3.AfterCredentialEvaluationAsync(new TokenAcquisitionContext
-                {
-                    MtlsCertificate = cert,
-                }, ct).ConfigureAwait(false);
+                await op3.AfterCredentialEvaluationAsync(new CredentialEvaluationContext(cert), ct).ConfigureAwait(false);
                 p.MtlsCertificate = cert;
                 return;
             }
@@ -184,3 +181,5 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
     }
 }
+
+

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.AuthScheme;
 using Microsoft.Identity.Client.AuthScheme.PoP;
 using Microsoft.Identity.Client.Instance;
 using Microsoft.Identity.Client.Internal;
@@ -161,6 +162,16 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                         MsalError.MissingTenantedAuthority,
                         MsalErrorMessage.MtlsNonTenantedAuthorityNotAllowedMessage);
                 }
+            }
+
+            // If the current operation supports mTLS POP injection (IAuthenticationOperation3),
+            // inject the cert instead of replacing the operation. This enables CDT + mTLS POP
+            // composition where CDT's operation handles both constraint signing and POP binding.
+            if (p.AuthenticationOperation is IAuthenticationOperation3 op3)
+            {
+                op3.MtlsCertificate = cert;
+                p.MtlsCertificate = cert;
+                return;
             }
 
             p.AuthenticationOperation = new MtlsPopAuthenticationOperation(cert);

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
@@ -164,12 +164,15 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 }
             }
 
-            // If the current operation supports mTLS POP injection (IAuthenticationOperation3),
-            // inject the cert instead of replacing the operation. This enables CDT + mTLS POP
-            // composition where CDT's operation handles both constraint signing and POP binding.
+            // If the current operation supports the AfterCredentialEvaluation lifecycle hook,
+            // invoke it with the cert instead of replacing the operation. This enables
+            // composition (e.g., CDT + mTLS POP) where the operation handles both concerns.
             if (p.AuthenticationOperation is IAuthenticationOperation3 op3)
             {
-                op3.MtlsCertificate = cert;
+                op3.AfterCredentialEvaluation(new TokenAcquisitionContext
+                {
+                    MtlsCertificate = cert,
+                });
                 p.MtlsCertificate = cert;
                 return;
             }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                         MsalErrorMessage.MtlsCertificateNotProvidedMessage);
                 }
 
-                InitMtlsPopParameters(p, certCred.Certificate, serviceBundle);
+                await InitMtlsPopParametersAsync(p, certCred.Certificate, serviceBundle, ct).ConfigureAwait(false);
                 return;
             }
 
@@ -118,7 +118,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                         MsalErrorMessage.MtlsCertificateNotProvidedMessage);
                 }
 
-                InitMtlsPopParameters(p, ar.TokenBindingCertificate, serviceBundle);
+                await InitMtlsPopParametersAsync(p, ar.TokenBindingCertificate, serviceBundle, ct).ConfigureAwait(false);
                 return;
             }
 
@@ -147,10 +147,11 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
             };
         }
 
-        private static void InitMtlsPopParameters(
+        private static async Task InitMtlsPopParametersAsync(
             AcquireTokenCommonParameters p,
             X509Certificate2 cert,
-            IServiceBundle serviceBundle)
+            IServiceBundle serviceBundle,
+            CancellationToken ct = default)
         {
             // AAD only validation
             if (serviceBundle.Config.Authority.AuthorityInfo.AuthorityType == AuthorityType.Aad)
@@ -169,10 +170,10 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
             // composition (e.g., CDT + mTLS POP) where the operation handles both concerns.
             if (p.AuthenticationOperation is IAuthenticationOperation3 op3)
             {
-                op3.AfterCredentialEvaluation(new TokenAcquisitionContext
+                await op3.AfterCredentialEvaluationAsync(new TokenAcquisitionContext
                 {
                     MtlsCertificate = cert,
-                });
+                }, ct).ConfigureAwait(false);
                 p.MtlsCertificate = cert;
                 return;
             }

--- a/src/client/Microsoft.Identity.Client/AuthScheme/CredentialEvaluationContext.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/CredentialEvaluationContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Identity.Client.AuthScheme
@@ -30,12 +31,21 @@ namespace Microsoft.Identity.Client.AuthScheme
     /// certificate rotation.
     /// </para>
     /// </remarks>
-    public sealed class TokenAcquisitionContext
+    public sealed class CredentialEvaluationContext
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="CredentialEvaluationContext"/>.
+        /// </summary>
+        /// <param name="mtlsCertificate">The mTLS certificate for the current request. Must not be null.</param>
+        public CredentialEvaluationContext(X509Certificate2 mtlsCertificate)
+        {
+            MtlsCertificate = mtlsCertificate ?? throw new ArgumentNullException(nameof(mtlsCertificate));
+        }
+
         /// <summary>
         /// The mTLS certificate MSAL will use on the wire for the current token request.
         /// Refreshed per request — operations must not cache this value across requests.
         /// </summary>
-        public X509Certificate2 MtlsCertificate { get; init; }
+        public X509Certificate2 MtlsCertificate { get; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
@@ -1,23 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Security.Cryptography.X509Certificates;
-
 namespace Microsoft.Identity.Client.AuthScheme
 {
     /// <summary>
-    /// Extended authentication operation that supports mTLS POP certificate injection.
-    /// When an operation implements this interface, MSAL will inject the mTLS certificate
-    /// instead of replacing the operation with MtlsPopAuthenticationOperation.
-    /// This enables CDT + mTLS POP composition where a single operation handles both concerns.
+    /// Extends <see cref="IAuthenticationOperation"/> with a lifecycle hook so MSAL can
+    /// pass runtime context (e.g., the mTLS certificate selected for the current request)
+    /// to a custom authentication operation. Enables composition of schemes such as
+    /// CDT + mTLS PoP without MSAL having to replace the operation.
     /// </summary>
     public interface IAuthenticationOperation3 : IAuthenticationOperation2
     {
         /// <summary>
-        /// MSAL sets this when WithMtlsProofOfPossession() was called.
-        /// The operation can use this certificate for signing, key binding,
-        /// and setting BindingCertificate on the AuthenticationResult.
+        /// MSAL invokes this once per token request, after it has evaluated the
+        /// credentials that will be used. The operation reads what it needs from
+        /// <paramref name="context"/> and configures itself for the upcoming
+        /// <see cref="IAuthenticationOperation.FormatResult(AuthenticationResult)"/> call.
         /// </summary>
-        X509Certificate2 MtlsCertificate { set; }
+        /// <param name="context">
+        /// Runtime state owned by MSAL. Never <c>null</c>. Must not be retained past this call.
+        /// </param>
+        void AfterCredentialEvaluation(TokenAcquisitionContext context);
     }
 }

--- a/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.Identity.Client.AuthScheme
+{
+    /// <summary>
+    /// Extended authentication operation that supports mTLS POP certificate injection.
+    /// When an operation implements this interface, MSAL will inject the mTLS certificate
+    /// instead of replacing the operation with MtlsPopAuthenticationOperation.
+    /// This enables CDT + mTLS POP composition where a single operation handles both concerns.
+    /// </summary>
+    public interface IAuthenticationOperation3 : IAuthenticationOperation2
+    {
+        /// <summary>
+        /// MSAL sets this when WithMtlsProofOfPossession() was called.
+        /// The operation can use this certificate for signing, key binding,
+        /// and setting BindingCertificate on the AuthenticationResult.
+        /// </summary>
+        X509Certificate2 MtlsCertificate { set; }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Identity.Client.AuthScheme
         /// Runtime state owned by MSAL. Never <c>null</c>. Must not be retained past this call.
         /// </param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        Task AfterCredentialEvaluationAsync(TokenAcquisitionContext context, CancellationToken cancellationToken = default);
+        Task AfterCredentialEvaluationAsync(CredentialEvaluationContext context, CancellationToken cancellationToken = default);
     }
 }
+

--- a/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/IAuthenticationOperation3.cs
@@ -1,14 +1,38 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Microsoft.Identity.Client.AuthScheme
 {
     /// <summary>
-    /// Extends <see cref="IAuthenticationOperation"/> with a lifecycle hook so MSAL can
+    /// Extends <see cref="IAuthenticationOperation2"/> with a lifecycle hook so MSAL can
     /// pass runtime context (e.g., the mTLS certificate selected for the current request)
     /// to a custom authentication operation. Enables composition of schemes such as
     /// CDT + mTLS PoP without MSAL having to replace the operation.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This callback fires on every <c>ExecuteAsync</c> invocation, including when a valid
+    /// token is served from the cache. Implementations should avoid expensive work that is
+    /// unnecessary on cache hits.
+    /// </para>
+    /// <para>
+    /// <b>Thread safety:</b> If the same <see cref="IAuthenticationOperation3"/> instance
+    /// is shared across concurrent <c>ExecuteAsync</c> calls, <see cref="AfterCredentialEvaluationAsync"/>
+    /// will be invoked concurrently. Implementations must either be thread-safe or create
+    /// a fresh instance per <c>ExecuteAsync</c> call (recommended).
+    /// </para>
+    /// <para>
+    /// <b>Scope:</b> This hook fires only on confidential client token requests.
+    /// Managed identity flows do not invoke it.
+    /// </para>
+    /// <para>
+    /// <b>Exceptions:</b> Exceptions thrown from this callback will propagate
+    /// to the caller of <c>ExecuteAsync</c> without wrapping.
+    /// </para>
+    /// </remarks>
     public interface IAuthenticationOperation3 : IAuthenticationOperation2
     {
         /// <summary>
@@ -20,6 +44,7 @@ namespace Microsoft.Identity.Client.AuthScheme
         /// <param name="context">
         /// Runtime state owned by MSAL. Never <c>null</c>. Must not be retained past this call.
         /// </param>
-        void AfterCredentialEvaluation(TokenAcquisitionContext context);
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task AfterCredentialEvaluationAsync(TokenAcquisitionContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/client/Microsoft.Identity.Client/AuthScheme/TokenAcquisitionContext.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/TokenAcquisitionContext.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.Identity.Client.AuthScheme
+{
+    /// <summary>
+    /// Runtime context that MSAL hands to an <see cref="IAuthenticationOperation3"/>
+    /// implementation once per token request, after MSAL has evaluated the credentials
+    /// that will be used for the request. The operation reads the properties it needs
+    /// and prepares to format the result.
+    /// </summary>
+    /// <remarks>
+    /// Implementations must not retain a reference to the context past the
+    /// <see cref="IAuthenticationOperation3.AfterCredentialEvaluation"/> call.
+    /// New properties may be added to this class in future MSAL versions; existing
+    /// implementations remain source- and binary-compatible because the type is
+    /// sealed and consumed only by property access.
+    /// </remarks>
+    public sealed class TokenAcquisitionContext
+    {
+        /// <summary>
+        /// The mTLS certificate MSAL will use on the wire for the current token request.
+        /// Refreshed per request — operations must not cache this value across requests.
+        /// </summary>
+        public X509Certificate2 MtlsCertificate { get; init; }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/AuthScheme/TokenAcquisitionContext.cs
+++ b/src/client/Microsoft.Identity.Client/AuthScheme/TokenAcquisitionContext.cs
@@ -12,11 +12,23 @@ namespace Microsoft.Identity.Client.AuthScheme
     /// and prepares to format the result.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Implementations must not retain a reference to the context past the
-    /// <see cref="IAuthenticationOperation3.AfterCredentialEvaluation"/> call.
+    /// <see cref="IAuthenticationOperation3.AfterCredentialEvaluationAsync"/> call.
+    /// </para>
+    /// <para>
     /// New properties may be added to this class in future MSAL versions; existing
     /// implementations remain source- and binary-compatible because the type is
     /// sealed and consumed only by property access.
+    /// </para>
+    /// <para>
+    /// <b>KeyId contract:</b> Implementations that receive an mTLS certificate via
+    /// <see cref="MtlsCertificate"/> must incorporate the certificate's identity
+    /// (e.g., thumbprint) into <see cref="IAuthenticationOperation.KeyId"/>.
+    /// MSAL uses <c>KeyId</c> as part of the token cache key — a hardcoded or
+    /// cert-independent <c>KeyId</c> will cause stale tokens to be served after
+    /// certificate rotation.
+    /// </para>
     /// </remarks>
     public sealed class TokenAcquisitionContext
     {

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
-
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
-
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
-
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
-
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
+

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
-Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
+Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
-Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.MtlsCertificate.set -> void
-
+Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluation(Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext context) -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.TokenAcquisitionContext() -> void
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AuthScheme.TokenAcquisitionContext.MtlsCertificate.init -> void

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
-using Microsoft.Identity.Client.ApiConfig.Parameters;
 using Microsoft.Identity.Client.AuthScheme;
 using Microsoft.Identity.Client.AuthScheme.PoP;
 using Microsoft.Identity.Client.Extensibility;
@@ -36,7 +35,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             // and managed by the static CertHelper dictionary.
         }
 
-        #region IAuthenticationOperation3 Integration Tests
+        #region Integration Tests — real MtlsPopParametersInitializer code path
 
         [TestMethod]
         public async Task MtlsPopWithIAuthenticationOperation3_InjectsCertAndPreservesOperation()
@@ -60,22 +59,24 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                         .WithHttpManager(httpManager)
                         .BuildConcrete();
 
-                    var mockOp3 = new MockAuthenticationOperation3();
+                    var fakeOp = new FakeAuthOp3();
 
-                    // Act — chain WithMtlsProofOfPossession + WithAuthenticationExtension (simulates CDT)
+                    // Act — chain WithMtlsProofOfPossession + WithAuthenticationExtension
                     AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
                         .WithMtlsProofOfPossession()
                         .WithAuthenticationExtension(new MsalAuthenticationExtension
                         {
-                            AuthenticationOperation = mockOp3
+                            AuthenticationOperation = fakeOp
                         })
                         .ExecuteAsync()
                         .ConfigureAwait(false);
 
-                    // Assert — cert was injected, operation was NOT replaced
-                    Assert.IsNotNull(mockOp3.InjectedCertificate,
-                        "MtlsPopParametersInitializer should inject cert via IAuthenticationOperation3");
-                    Assert.AreEqual(s_testCertificate.Thumbprint, mockOp3.InjectedCertificate.Thumbprint);
+                    // Assert — AfterCredentialEvaluation was called, operation was NOT replaced
+                    Assert.AreEqual(1, fakeOp.CallbackInvocationCount,
+                        "AfterCredentialEvaluation must fire exactly once per token request");
+                    Assert.IsNotNull(fakeOp.LastCertificate,
+                        "AfterCredentialEvaluation must receive the mTLS certificate");
+                    Assert.AreEqual(s_testCertificate.Thumbprint, fakeOp.LastCertificate.Thumbprint);
                     Assert.IsNotNull(result.BindingCertificate,
                         "BindingCertificate should be set by the operation's FormatResult");
                 }
@@ -117,118 +118,240 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             }
         }
 
+        [TestMethod]
+        public async Task MtlsPopWithIAuthenticationOperation3_CacheHit_CallbackStillFires()
+        {
+            // Arrange
+            const string region = "eastus";
+
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                using (var httpManager = new MockHttpManager())
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                        tokenType: "mtls_pop");
+                    // Second handler for cache-hit path — TryInitAsync may trigger
+                    // a new token request if the cache key doesn't match
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                        tokenType: "mtls_pop");
+
+                    var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                        .WithCertificate(s_testCertificate)
+                        .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                        .WithHttpManager(httpManager)
+                        .BuildConcrete();
+
+                    var fakeOp = new FakeAuthOp3();
+
+                    // Act — first call (cache miss)
+                    await app.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithMtlsProofOfPossession()
+                        .WithAuthenticationExtension(new MsalAuthenticationExtension
+                        {
+                            AuthenticationOperation = fakeOp
+                        })
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    Assert.AreEqual(1, fakeOp.CallbackInvocationCount,
+                        "First call must fire the callback");
+
+                    // Act — second call
+                    await app.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithMtlsProofOfPossession()
+                        .WithAuthenticationExtension(new MsalAuthenticationExtension
+                        {
+                            AuthenticationOperation = fakeOp
+                        })
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    // Assert — callback must fire on every ExecuteAsync call
+                    Assert.AreEqual(2, fakeOp.CallbackInvocationCount,
+                        "Second call must also fire the callback");
+                    Assert.IsNotNull(fakeOp.LastCertificate,
+                        "Cert must be provided on every callback invocation");
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task MtlsPopWithIAuthenticationOperation3_ReceivesCorrectCert()
+        {
+            // Arrange
+            const string region = "eastus";
+
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                using (var httpManager = new MockHttpManager())
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                        tokenType: "mtls_pop");
+
+                    var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                        .WithCertificate(s_testCertificate)
+                        .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                        .WithHttpManager(httpManager)
+                        .BuildConcrete();
+
+                    var fakeOp = new FakeAuthOp3();
+
+                    // Act
+                    await app.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithMtlsProofOfPossession()
+                        .WithAuthenticationExtension(new MsalAuthenticationExtension
+                        {
+                            AuthenticationOperation = fakeOp
+                        })
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    // Assert — cert must match what was configured on the CCA
+                    Assert.AreSame(s_testCertificate, fakeOp.LastCertificate,
+                        "Callback must receive the exact cert instance configured via WithCertificate");
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task WithoutMtlsPop_IAuthenticationOperation3_CallbackNotFired()
+        {
+            // Arrange
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                    .WithHttpManager(httpManager)
+                    .BuildConcrete();
+
+                var fakeOp = new FakeAuthOp3();
+
+                // Act — NO WithMtlsProofOfPossession, just the IAuthOp3 extension
+                await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithAuthenticationExtension(new MsalAuthenticationExtension
+                    {
+                        AuthenticationOperation = fakeOp
+                    })
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert — callback should NOT fire when mTLS POP is not requested
+                Assert.AreEqual(0, fakeOp.CallbackInvocationCount,
+                    "Without WithMtlsProofOfPossession, AfterCredentialEvaluation must not be called");
+                Assert.IsNull(fakeOp.LastCertificate);
+                Assert.AreEqual("Bearer", fakeOp.AccessTokenType,
+                    "Without mTLS POP, operation should stay in Bearer mode");
+            }
+        }
+
         #endregion
 
-        #region IAuthenticationOperation3 Unit Tests
+        #region Unit Tests — AfterCredentialEvaluation behavior
 
         [TestMethod]
-        public void IAuthenticationOperation3_AccessTokenType_AdaptsBasedOnCert()
+        public void AfterCredentialEvaluation_InjectsCert_OperationAdapts()
         {
             // Arrange
-            var mockOp = new MockAuthenticationOperation3();
+            var fakeOp = new FakeAuthOp3();
 
-            // Act & Assert — before cert injection
-            Assert.AreEqual("Bearer", mockOp.AccessTokenType,
-                "Without cert, AccessTokenType should be Bearer");
+            // Assert — before callback
+            Assert.AreEqual("Bearer", fakeOp.AccessTokenType);
+            Assert.AreEqual(0, fakeOp.CallbackInvocationCount);
 
-            // Act — inject cert
-            mockOp.MtlsCertificate = s_testCertificate;
+            // Act
+            fakeOp.AfterCredentialEvaluation(new TokenAcquisitionContext
+            {
+                MtlsCertificate = s_testCertificate
+            });
 
-            // Assert — after cert injection
-            Assert.AreEqual("mtls_pop", mockOp.AccessTokenType,
-                "With cert, AccessTokenType should be mtls_pop");
+            // Assert — after callback
+            Assert.AreEqual(1, fakeOp.CallbackInvocationCount);
+            Assert.AreEqual("mtls_pop", fakeOp.AccessTokenType);
+            Assert.AreEqual("mtls_pop", fakeOp.AuthorizationHeaderPrefix);
+            Assert.IsTrue(fakeOp.GetTokenRequestParams().ContainsKey("token_type"));
+            Assert.AreEqual("mtls_pop", fakeOp.GetTokenRequestParams()["token_type"]);
         }
 
         [TestMethod]
-        public void IAuthenticationOperation3_GetTokenRequestParams_IncludesTokenTypeWhenCertPresent()
+        public void AfterCredentialEvaluation_SetsBindingCertOnFormatResult()
         {
             // Arrange
-            var mockOp = new MockAuthenticationOperation3();
-
-            // Act & Assert — before cert injection
-            var paramsBefore = mockOp.GetTokenRequestParams();
-            Assert.IsFalse(paramsBefore.ContainsKey("token_type"),
-                "Without cert, token_type should not be in params");
-
-            // Act — inject cert
-            mockOp.MtlsCertificate = s_testCertificate;
-            var paramsAfter = mockOp.GetTokenRequestParams();
-
-            // Assert — after cert injection
-            Assert.IsTrue(paramsAfter.ContainsKey("token_type"));
-            Assert.AreEqual("mtls_pop", paramsAfter["token_type"]);
-        }
-
-        [TestMethod]
-        public void IAuthenticationOperation3_FormatResult_SetsBindingCertificate()
-        {
-            // Arrange
-            var mockOp = new MockAuthenticationOperation3();
-            mockOp.MtlsCertificate = s_testCertificate;
+            var fakeOp = new FakeAuthOp3();
+            fakeOp.AfterCredentialEvaluation(new TokenAcquisitionContext
+            {
+                MtlsCertificate = s_testCertificate
+            });
             var authResult = new AuthenticationResult();
 
             // Act
-            mockOp.FormatResult(authResult);
+            fakeOp.FormatResult(authResult);
 
             // Assert
-            Assert.AreSame(s_testCertificate, authResult.BindingCertificate,
-                "FormatResult should set BindingCertificate when mTLS cert is injected");
+            Assert.AreSame(s_testCertificate, authResult.BindingCertificate);
         }
 
         [TestMethod]
-        public void IAuthenticationOperation3_FormatResult_NoBindingCertWithoutMtls()
+        public void AfterCredentialEvaluation_NotCalled_BearerDefaults()
         {
             // Arrange
-            var mockOp = new MockAuthenticationOperation3();
+            var fakeOp = new FakeAuthOp3();
             var authResult = new AuthenticationResult();
 
             // Act
-            mockOp.FormatResult(authResult);
+            fakeOp.FormatResult(authResult);
 
             // Assert
-            Assert.IsNull(authResult.BindingCertificate,
-                "FormatResult should NOT set BindingCertificate when no mTLS cert");
+            Assert.AreEqual("Bearer", fakeOp.AccessTokenType);
+            Assert.AreEqual("Bearer", fakeOp.AuthorizationHeaderPrefix);
+            Assert.IsFalse(fakeOp.GetTokenRequestParams().ContainsKey("token_type"));
+            Assert.IsNull(authResult.BindingCertificate);
         }
 
         [TestMethod]
-        public void IAuthenticationOperation3_AuthorizationHeaderPrefix_AdaptsBasedOnCert()
+        public void TokenAcquisitionContext_ExposesExpectedProperties()
         {
-            // Arrange
-            var mockOp = new MockAuthenticationOperation3();
+            // Arrange & Act
+            var context = new TokenAcquisitionContext
+            {
+                MtlsCertificate = s_testCertificate
+            };
 
-            // Assert — before cert
-            Assert.AreEqual("Bearer", mockOp.AuthorizationHeaderPrefix);
-
-            // Act
-            mockOp.MtlsCertificate = s_testCertificate;
-
-            // Assert — after cert
-            Assert.AreEqual("mtls_pop", mockOp.AuthorizationHeaderPrefix);
+            // Assert
+            Assert.AreSame(s_testCertificate, context.MtlsCertificate);
         }
 
         #endregion
 
-        #region Mock IAuthenticationOperation3
+        #region Test Fake
 
         /// <summary>
-        /// Mock implementation of IAuthenticationOperation3 that simulates
-        /// CDT's behavior of adapting to mTLS POP when cert is injected.
+        /// Fake implementation of IAuthenticationOperation3 that tracks
+        /// AfterCredentialEvaluation invocations and adapts behavior based on cert.
         /// </summary>
-        private class MockAuthenticationOperation3 : IAuthenticationOperation3
+        private sealed class FakeAuthOp3 : IAuthenticationOperation3
         {
-            public X509Certificate2 InjectedCertificate { get; private set; }
+            public int CallbackInvocationCount { get; private set; }
+            public X509Certificate2 LastCertificate { get; private set; }
 
-            public X509Certificate2 MtlsCertificate
+            public void AfterCredentialEvaluation(TokenAcquisitionContext context)
             {
-                set => InjectedCertificate = value;
+                CallbackInvocationCount++;
+                LastCertificate = context.MtlsCertificate;
             }
 
-            public string AccessTokenType => InjectedCertificate is not null ? "mtls_pop" : "Bearer";
-
-            public string AuthorizationHeaderPrefix => InjectedCertificate is not null ? "mtls_pop" : "Bearer";
-
+            public string AccessTokenType => LastCertificate is not null ? "mtls_pop" : "Bearer";
+            public string AuthorizationHeaderPrefix => LastCertificate is not null ? "mtls_pop" : "Bearer";
             public string KeyId => "test-key-id";
-
             public int TelemetryTokenType => 4;
 
             public IReadOnlyDictionary<string, string> GetTokenRequestParams()
@@ -238,7 +361,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     { "req_ds_cnf", "test-cnf-value" }
                 };
 
-                if (InjectedCertificate is not null)
+                if (LastCertificate is not null)
                 {
                     dict["token_type"] = "mtls_pop";
                 }
@@ -248,9 +371,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
             public void FormatResult(AuthenticationResult authenticationResult)
             {
-                if (InjectedCertificate is not null)
+                if (LastCertificate is not null)
                 {
-                    authenticationResult.BindingCertificate = InjectedCertificate;
+                    authenticationResult.BindingCertificate = LastCertificate;
                 }
             }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.AreEqual(0, fakeOp.CallbackInvocationCount);
 
             // Act
-            fakeOp.AfterCredentialEvaluation(new TokenAcquisitionContext
+            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext
             {
                 MtlsCertificate = s_testCertificate
             });
@@ -287,7 +287,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             // Arrange
             var fakeOp = new FakeAuthOp3();
-            fakeOp.AfterCredentialEvaluation(new TokenAcquisitionContext
+            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext
             {
                 MtlsCertificate = s_testCertificate
             });
@@ -332,7 +332,75 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
         #endregion
 
-        #region Test Fake
+        #region Cert rotation
+
+        [TestMethod]
+        public void AfterCredentialEvaluationAsync_CertRotation_OperationSeesNewCert()
+        {
+            // Arrange
+            var fakeOp = new FakeAuthOp3();
+            var cert1 = CertHelper.GetOrCreateTestCert();
+            var cert2 = CertHelper.GetOrCreateTestCert(regenerateCert: true);
+
+            // Act — call 1 with cert1
+            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext { MtlsCertificate = cert1 });
+            var observed1 = fakeOp.LastCertificate.Thumbprint;
+
+            // Act — rotate to cert2
+            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext { MtlsCertificate = cert2 });
+            var observed2 = fakeOp.LastCertificate.Thumbprint;
+
+            // Assert — operation must see the rotated cert
+            Assert.AreNotEqual(observed1, observed2, "After rotation, callback must provide the new cert");
+            Assert.AreEqual(cert2.Thumbprint, observed2);
+        }
+
+        #endregion
+
+        #region Exception propagation
+
+        [TestMethod]
+        public async Task AfterCredentialEvaluationAsync_Throws_PropagatesDirectlyToExecuteAsync()
+        {
+            // Arrange
+            const string region = "eastus";
+
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                using (var httpManager = new MockHttpManager())
+                {
+                    // No mock handler — exception fires before any HTTP call
+                    var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                        .WithCertificate(s_testCertificate)
+                        .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                        .WithHttpManager(httpManager)
+                        .BuildConcrete();
+
+                    var throwingOp = new ThrowingAuthOp3();
+
+                    // Act & Assert — exception propagates unwrapped to ExecuteAsync
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                        await app.AcquireTokenForClient(TestConstants.s_scope)
+                            .WithMtlsProofOfPossession()
+                            .WithAuthenticationExtension(new MsalAuthenticationExtension
+                            {
+                                AuthenticationOperation = throwingOp
+                            })
+                            .ExecuteAsync()
+                            .ConfigureAwait(false))
+                        .ConfigureAwait(false);
+
+                    Assert.AreEqual("Test: cert fetch failed", ex.Message);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Test Fakes
 
         /// <summary>
         /// Fake implementation of IAuthenticationOperation3 that tracks
@@ -343,14 +411,22 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             public int CallbackInvocationCount { get; private set; }
             public X509Certificate2 LastCertificate { get; private set; }
 
-            public void AfterCredentialEvaluation(TokenAcquisitionContext context)
+            public void AfterCredentialEvaluationAsync_Sync(TokenAcquisitionContext context)
             {
                 CallbackInvocationCount++;
                 LastCertificate = context.MtlsCertificate;
             }
 
+            public Task AfterCredentialEvaluationAsync(TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default)
+            {
+                AfterCredentialEvaluationAsync_Sync(context);
+                return Task.CompletedTask;
+            }
+
             public string AccessTokenType => LastCertificate is not null ? "mtls_pop" : "Bearer";
             public string AuthorizationHeaderPrefix => LastCertificate is not null ? "mtls_pop" : "Bearer";
+            // KeyId is hardcoded — this test validates callback invocation, not cache partitioning.
+            // Real implementations should derive KeyId from the cert (see CdtCryptoProvider.KeyId).
             public string KeyId => "test-key-id";
             public int TelemetryTokenType => 4;
 
@@ -389,6 +465,28 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             }
         }
 
+        /// <summary>
+        /// Fake that throws from AfterCredentialEvaluationAsync to test exception propagation.
+        /// </summary>
+        private sealed class ThrowingAuthOp3 : IAuthenticationOperation3
+        {
+            public Task AfterCredentialEvaluationAsync(TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default)
+            {
+                throw new InvalidOperationException("Test: cert fetch failed");
+            }
+
+            public string AccessTokenType => "mtls_pop";
+            public string AuthorizationHeaderPrefix => "mtls_pop";
+            public string KeyId => "test-key-id";
+            public int TelemetryTokenType => 4;
+            public IReadOnlyDictionary<string, string> GetTokenRequestParams() => new Dictionary<string, string>();
+            public void FormatResult(AuthenticationResult authenticationResult) { }
+            public Task FormatResultAsync(AuthenticationResult authenticationResult, System.Threading.CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task<bool> ValidateCachedTokenAsync(MsalCacheValidationData cachedTokenData) => Task.FromResult(true);
+        }
+
         #endregion
+
     }
 }
+

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.AuthScheme;
+using Microsoft.Identity.Client.AuthScheme.PoP;
+using Microsoft.Identity.Client.Extensibility;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Unit.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.PublicApiTests
+{
+    [TestClass]
+    public class CdtMtlsPopTests : TestBase
+    {
+        private static X509Certificate2 s_testCertificate;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            s_testCertificate = CertHelper.GetOrCreateTestCert();
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            // Do not dispose — cert is shared via CertHelper.GetOrCreateTestCert()
+            // and managed by the static CertHelper dictionary.
+        }
+
+        #region IAuthenticationOperation3 Integration Tests
+
+        [TestMethod]
+        public async Task MtlsPopWithIAuthenticationOperation3_InjectsCertAndPreservesOperation()
+        {
+            // Arrange
+            const string region = "eastus";
+
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                using (var httpManager = new MockHttpManager())
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                        tokenType: "mtls_pop");
+
+                    var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                        .WithCertificate(s_testCertificate)
+                        .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                        .WithHttpManager(httpManager)
+                        .BuildConcrete();
+
+                    var mockOp3 = new MockAuthenticationOperation3();
+
+                    // Act — chain WithMtlsProofOfPossession + WithAuthenticationExtension (simulates CDT)
+                    AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithMtlsProofOfPossession()
+                        .WithAuthenticationExtension(new MsalAuthenticationExtension
+                        {
+                            AuthenticationOperation = mockOp3
+                        })
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    // Assert — cert was injected, operation was NOT replaced
+                    Assert.IsNotNull(mockOp3.InjectedCertificate,
+                        "MtlsPopParametersInitializer should inject cert via IAuthenticationOperation3");
+                    Assert.AreEqual(s_testCertificate.Thumbprint, mockOp3.InjectedCertificate.Thumbprint);
+                    Assert.IsNotNull(result.BindingCertificate,
+                        "BindingCertificate should be set by the operation's FormatResult");
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task MtlsPopWithoutIAuthenticationOperation3_ReplacesOperation()
+        {
+            // Arrange
+            const string region = "eastus";
+
+            using (var envContext = new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                using (var httpManager = new MockHttpManager())
+                {
+                    httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                        tokenType: "mtls_pop");
+
+                    var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                        .WithCertificate(s_testCertificate)
+                        .WithAuthority($"https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                        .WithHttpManager(httpManager)
+                        .BuildConcrete();
+
+                    // Act — only WithMtlsProofOfPossession, no IAuthenticationOperation3
+                    AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithMtlsProofOfPossession()
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+
+                    // Assert — standard mTLS POP behavior
+                    Assert.AreEqual(Constants.MtlsPoPAuthHeaderPrefix, result.TokenType);
+                    Assert.IsNotNull(result.BindingCertificate);
+                }
+            }
+        }
+
+        #endregion
+
+        #region IAuthenticationOperation3 Unit Tests
+
+        [TestMethod]
+        public void IAuthenticationOperation3_AccessTokenType_AdaptsBasedOnCert()
+        {
+            // Arrange
+            var mockOp = new MockAuthenticationOperation3();
+
+            // Act & Assert — before cert injection
+            Assert.AreEqual("Bearer", mockOp.AccessTokenType,
+                "Without cert, AccessTokenType should be Bearer");
+
+            // Act — inject cert
+            mockOp.MtlsCertificate = s_testCertificate;
+
+            // Assert — after cert injection
+            Assert.AreEqual("mtls_pop", mockOp.AccessTokenType,
+                "With cert, AccessTokenType should be mtls_pop");
+        }
+
+        [TestMethod]
+        public void IAuthenticationOperation3_GetTokenRequestParams_IncludesTokenTypeWhenCertPresent()
+        {
+            // Arrange
+            var mockOp = new MockAuthenticationOperation3();
+
+            // Act & Assert — before cert injection
+            var paramsBefore = mockOp.GetTokenRequestParams();
+            Assert.IsFalse(paramsBefore.ContainsKey("token_type"),
+                "Without cert, token_type should not be in params");
+
+            // Act — inject cert
+            mockOp.MtlsCertificate = s_testCertificate;
+            var paramsAfter = mockOp.GetTokenRequestParams();
+
+            // Assert — after cert injection
+            Assert.IsTrue(paramsAfter.ContainsKey("token_type"));
+            Assert.AreEqual("mtls_pop", paramsAfter["token_type"]);
+        }
+
+        [TestMethod]
+        public void IAuthenticationOperation3_FormatResult_SetsBindingCertificate()
+        {
+            // Arrange
+            var mockOp = new MockAuthenticationOperation3();
+            mockOp.MtlsCertificate = s_testCertificate;
+            var authResult = new AuthenticationResult();
+
+            // Act
+            mockOp.FormatResult(authResult);
+
+            // Assert
+            Assert.AreSame(s_testCertificate, authResult.BindingCertificate,
+                "FormatResult should set BindingCertificate when mTLS cert is injected");
+        }
+
+        [TestMethod]
+        public void IAuthenticationOperation3_FormatResult_NoBindingCertWithoutMtls()
+        {
+            // Arrange
+            var mockOp = new MockAuthenticationOperation3();
+            var authResult = new AuthenticationResult();
+
+            // Act
+            mockOp.FormatResult(authResult);
+
+            // Assert
+            Assert.IsNull(authResult.BindingCertificate,
+                "FormatResult should NOT set BindingCertificate when no mTLS cert");
+        }
+
+        [TestMethod]
+        public void IAuthenticationOperation3_AuthorizationHeaderPrefix_AdaptsBasedOnCert()
+        {
+            // Arrange
+            var mockOp = new MockAuthenticationOperation3();
+
+            // Assert — before cert
+            Assert.AreEqual("Bearer", mockOp.AuthorizationHeaderPrefix);
+
+            // Act
+            mockOp.MtlsCertificate = s_testCertificate;
+
+            // Assert — after cert
+            Assert.AreEqual("mtls_pop", mockOp.AuthorizationHeaderPrefix);
+        }
+
+        #endregion
+
+        #region Mock IAuthenticationOperation3
+
+        /// <summary>
+        /// Mock implementation of IAuthenticationOperation3 that simulates
+        /// CDT's behavior of adapting to mTLS POP when cert is injected.
+        /// </summary>
+        private class MockAuthenticationOperation3 : IAuthenticationOperation3
+        {
+            public X509Certificate2 InjectedCertificate { get; private set; }
+
+            public X509Certificate2 MtlsCertificate
+            {
+                set => InjectedCertificate = value;
+            }
+
+            public string AccessTokenType => InjectedCertificate is not null ? "mtls_pop" : "Bearer";
+
+            public string AuthorizationHeaderPrefix => InjectedCertificate is not null ? "mtls_pop" : "Bearer";
+
+            public string KeyId => "test-key-id";
+
+            public int TelemetryTokenType => 4;
+
+            public IReadOnlyDictionary<string, string> GetTokenRequestParams()
+            {
+                var dict = new Dictionary<string, string>
+                {
+                    { "req_ds_cnf", "test-cnf-value" }
+                };
+
+                if (InjectedCertificate is not null)
+                {
+                    dict["token_type"] = "mtls_pop";
+                }
+
+                return dict;
+            }
+
+            public void FormatResult(AuthenticationResult authenticationResult)
+            {
+                if (InjectedCertificate is not null)
+                {
+                    authenticationResult.BindingCertificate = InjectedCertificate;
+                }
+            }
+
+            public Task FormatResultAsync(AuthenticationResult authenticationResult, System.Threading.CancellationToken cancellationToken = default)
+            {
+                FormatResult(authenticationResult);
+                return Task.CompletedTask;
+            }
+
+            public Task<bool> ValidateCachedTokenAsync(MsalCacheValidationData cachedTokenData)
+            {
+                return Task.FromResult(true);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         }
 
         [TestMethod]
-        public async Task MtlsPopWithIAuthenticationOperation3_CacheHit_CallbackStillFires()
+        public async Task MtlsPopWithIAuthenticationOperation3_CallbackFiresOnEveryExecuteAsync()
         {
             // Arrange
             const string region = "eastus";

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/CdtMtlsPopTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                         .ConfigureAwait(false);
 
                     // Assert — cert must match what was configured on the CCA
-                    Assert.AreSame(s_testCertificate, fakeOp.LastCertificate,
+                    Assert.AreEqual(s_testCertificate.Thumbprint, fakeOp.LastCertificate.Thumbprint,
                         "Callback must receive the exact cert instance configured via WithCertificate");
                 }
             }
@@ -269,10 +269,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             Assert.AreEqual(0, fakeOp.CallbackInvocationCount);
 
             // Act
-            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext
-            {
-                MtlsCertificate = s_testCertificate
-            });
+            fakeOp.InvokeAfterCredentialEvaluation(new CredentialEvaluationContext(s_testCertificate
+            ));
 
             // Assert — after callback
             Assert.AreEqual(1, fakeOp.CallbackInvocationCount);
@@ -287,10 +285,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         {
             // Arrange
             var fakeOp = new FakeAuthOp3();
-            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext
-            {
-                MtlsCertificate = s_testCertificate
-            });
+            fakeOp.InvokeAfterCredentialEvaluation(new CredentialEvaluationContext(s_testCertificate
+            ));
             var authResult = new AuthenticationResult();
 
             // Act
@@ -318,13 +314,11 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         }
 
         [TestMethod]
-        public void TokenAcquisitionContext_ExposesExpectedProperties()
+        public void CredentialEvaluationContext_ExposesExpectedProperties()
         {
             // Arrange & Act
-            var context = new TokenAcquisitionContext
-            {
-                MtlsCertificate = s_testCertificate
-            };
+            var context = new CredentialEvaluationContext(s_testCertificate
+            );
 
             // Assert
             Assert.AreSame(s_testCertificate, context.MtlsCertificate);
@@ -343,11 +337,11 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             var cert2 = CertHelper.GetOrCreateTestCert(regenerateCert: true);
 
             // Act — call 1 with cert1
-            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext { MtlsCertificate = cert1 });
+            fakeOp.InvokeAfterCredentialEvaluation(new CredentialEvaluationContext(cert1 ));
             var observed1 = fakeOp.LastCertificate.Thumbprint;
 
             // Act — rotate to cert2
-            fakeOp.AfterCredentialEvaluationAsync_Sync(new TokenAcquisitionContext { MtlsCertificate = cert2 });
+            fakeOp.InvokeAfterCredentialEvaluation(new CredentialEvaluationContext(cert2 ));
             var observed2 = fakeOp.LastCertificate.Thumbprint;
 
             // Assert — operation must see the rotated cert
@@ -411,15 +405,15 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
             public int CallbackInvocationCount { get; private set; }
             public X509Certificate2 LastCertificate { get; private set; }
 
-            public void AfterCredentialEvaluationAsync_Sync(TokenAcquisitionContext context)
+            public void InvokeAfterCredentialEvaluation(CredentialEvaluationContext context)
             {
                 CallbackInvocationCount++;
                 LastCertificate = context.MtlsCertificate;
             }
 
-            public Task AfterCredentialEvaluationAsync(TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default)
+            public Task AfterCredentialEvaluationAsync(CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default)
             {
-                AfterCredentialEvaluationAsync_Sync(context);
+                InvokeAfterCredentialEvaluation(context);
                 return Task.CompletedTask;
             }
 
@@ -470,7 +464,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         /// </summary>
         private sealed class ThrowingAuthOp3 : IAuthenticationOperation3
         {
-            public Task AfterCredentialEvaluationAsync(TokenAcquisitionContext context, System.Threading.CancellationToken cancellationToken = default)
+            public Task AfterCredentialEvaluationAsync(CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default)
             {
                 throw new InvalidOperationException("Test: cert fetch failed");
             }
@@ -489,4 +483,8 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
 
     }
 }
+
+
+
+
 


### PR DESCRIPTION
## Summary

This pull request introduces a new extensibility point for authentication operations in MSAL, enabling composition of authentication schemes (such as CDT + mTLS PoP) by providing a lifecycle hook that passes runtime context (like the selected mTLS certificate) to custom authentication operations. The changes also update the mTLS PoP parameter initialization logic to use this new hook when available, and add the new API surface to the public API files.

**Extensibility for Authentication Operations:**

* Added the `IAuthenticationOperation3` interface, which extends `IAuthenticationOperation2` with a `Task AfterCredentialEvaluationAsync(CredentialEvaluationContext context, CancellationToken cancellationToken)` lifecycle hook. This allows MSAL to pass runtime context (such as the mTLS certificate) to custom authentication operations, enabling composition of authentication schemes without MSAL replacing the operation.
* Introduced the `CredentialEvaluationContext` sealed class, which encapsulates runtime credential context (currently the mTLS certificate) for use in authentication operations implementing `IAuthenticationOperation3`. Constructor requires the certificate — non-null contract enforced at compile time.

**mTLS PoP Parameter Initialization Updates:**

* Refactored `InitMtlsPopParameters` to be asynchronous (`InitMtlsPopParametersAsync`) and updated its callers to await it. The method now checks if the current authentication operation implements `IAuthenticationOperation3` and, if so, invokes its `AfterCredentialEvaluationAsync` method with the runtime context, instead of replacing the operation. This supports composition of multiple authentication schemes.

**Tests:**

* 11 unit/integration tests covering callback invocation, cert identity, multiple `ExecuteAsync` calls, no-mTLS path, Bearer defaults, cert rotation, and exception propagation.

**Public API Surface:**

* Added `IAuthenticationOperation3`, `CredentialEvaluationContext`, and their members to all relevant `PublicAPI.Unshipped.txt` files.

## Scope note

`AfterCredentialEvaluationAsync` fires when MSAL evaluates credentials, which runs before cache lookup on every `ExecuteAsync` call. The proper per-request configure hook across all flows is tracked in #5998 (`ITokenAcquisitionScheme`) and is out of scope here.

## Related

- **Design**: #5998 — `ITokenAcquisitionScheme` broader redesign
- **Consumer**: MISE PR #23126 — CDT over mTLS POP (will implement `IAuthenticationOperation3`)
