### PR TITLE
WithClientClaims() - forward client-originated claims across MSI and confidential client flows

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,9 +60,9 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.35.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="MSTest.Analyzers" Version="4.2.2" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.2.2" />
+    <PackageVersion Include="MSTest.Analyzers" Version="4.0.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,9 +60,9 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.SignedHttpRequest" Version="6.35.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="MSTest.Analyzers" Version="4.0.2" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.0.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageVersion Include="MSTest.Analyzers" Version="4.2.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.2.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Executors;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
-using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.ManagedIdentity;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.Utils;
@@ -91,7 +90,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="claimsJson">A JSON string containing the client claims. Must be valid JSON.</param>
         /// <returns>The builder to chain .With methods.</returns>
-        public AcquireTokenForManagedIdentityParameterBuilder WithClientClaims(string claimsJson)
+        public AcquireTokenForManagedIdentityParameterBuilder WithClaimsFromClient(string claimsJson)
         {
             if (string.IsNullOrWhiteSpace(claimsJson))
             {
@@ -100,11 +99,10 @@ namespace Microsoft.Identity.Client
 
             ValidateUseOfExperimentalFeature();
 
-            string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);
-            CommonParameters.ClientClaims = normalized;
+            CommonParameters.ClientClaims = claimsJson;
 
             CommonParameters.CacheKeyComponents ??= new SortedList<string, Func<CancellationToken, Task<string>>>();
-            CommonParameters.CacheKeyComponents["client_claims"] = _ => Task.FromResult(normalized);
+            CommonParameters.CacheKeyComponents["client_claims"] = _ => Task.FromResult(claimsJson);
 
             return this;
         }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.ApiConfig.Executors;
 using Microsoft.Identity.Client.ApiConfig.Parameters;
+using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.ManagedIdentity;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 using Microsoft.Identity.Client.Utils;
@@ -79,6 +80,30 @@ namespace Microsoft.Identity.Client
         public AcquireTokenForManagedIdentityParameterBuilder WithClaims(string claims)
         {
             CommonParameters.Claims = claims;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies client-originated claims to include in the token request.
+        /// Unlike <see cref="WithClaims(string)"/> (for server-issued claims challenges), tokens acquired
+        /// with client claims are cached and keyed on the claims value. Different claim values produce
+        /// separate cache entries. Use stable, non-dynamic claim values to avoid cache fragmentation.
+        /// </summary>
+        /// <param name="claimsJson">A JSON string containing the client claims. Must be valid JSON.</param>
+        /// <returns>The builder to chain .With methods.</returns>
+        public AcquireTokenForManagedIdentityParameterBuilder WithClientClaims(string claimsJson)
+        {
+            if (string.IsNullOrWhiteSpace(claimsJson))
+            {
+                return this;
+            }
+
+            string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);
+            CommonParameters.ClientClaims = normalized;
+
+            CommonParameters.CacheKeyComponents ??= new SortedList<string, Func<CancellationToken, Task<string>>>();
+            CommonParameters.CacheKeyComponents["client_claims"] = _ => Task.FromResult(normalized);
+
             return this;
         }
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenForManagedIdentityParameterBuilder.cs
@@ -98,6 +98,8 @@ namespace Microsoft.Identity.Client
                 return this;
             }
 
+            ValidateUseOfExperimentalFeature();
+
             string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);
             CommonParameters.ClientClaims = normalized;
 

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public IEnumerable<string> Scopes { get; set; }
         public IDictionary<string, string> ExtraQueryParameters { get; set; }
         public string Claims { get; set; }
+        public string ClientClaims { get; internal set; }
         public AuthorityInfo AuthorityOverride { get; set; }
         public IAuthenticationOperation AuthenticationOperation { get; set; } = new BearerAuthenticationOperation();
         public IDictionary<string, string> ExtraHttpHeaders { get; set; }

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForManagedIdentityParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenForManagedIdentityParameters.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
 
         public string Claims { get; set; }
 
+        /// <summary>
+        /// Client-originated claims to be sent to the identity endpoint.
+        /// Unlike <see cref="Claims"/> (server-issued), these are cached and keyed on the claims value.
+        /// </summary>
+        public string ClientClaims { get; set; }
+
         public string RevokedTokenHash { get; set; }
 
         public bool IsMtlsPopRequested { get; set; }
@@ -45,6 +51,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                      ForceRefresh: {ForceRefresh}
                      Resource: {Resource}
                      Claims: {!string.IsNullOrEmpty(Claims)}
+                     ClientClaims: {!string.IsNullOrEmpty(ClientClaims)}
                      RevokedTokenHash: {!string.IsNullOrEmpty(RevokedTokenHash)}
                      IsMtlsPopRequested: {IsMtlsPopRequested}
                      """);

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -26,6 +26,10 @@ namespace Microsoft.Identity.Client.Extensibility
         /// is keyed on the normalized claims value. Different claims values produce separate cache entries.
         /// Use stable, non-dynamic values to avoid unbounded cache growth.
         /// </summary>
+        /// <remarks>
+        /// This API is intended for MSI and cert/FIC flows (e.g., NSP claims for Azure Redis Cache).
+        /// Behavior for B2C, ADFS, and dSTS is undefined and unsupported.
+        /// </remarks>
         /// <typeparam name="T">The concrete confidential client builder type.</typeparam>
         /// <param name="builder">The builder to chain options to.</param>
         /// <param name="claimsJson">A JSON string containing the client-originated claims. Must be valid JSON.</param>

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -56,6 +56,21 @@ namespace Microsoft.Identity.Client.Extensibility
                     "Client claims are intended for token-acquisition flows (AcquireTokenForClient, AcquireTokenOnBehalfOf).");
             }
 
+            // User-token flows (auth code, username/password, federated identity) cache tokens
+            // that AcquireTokenSilent would later retrieve — but AcquireTokenSilent has no
+            // WithClientClaims equivalent, so those tokens can never be found silently. Block
+            // these flows to avoid permanent cache pollution.
+            if (builder is AcquireTokenByAuthorizationCodeParameterBuilder ||
+                builder is AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder ||
+                builder is AcquireTokenByUserFederatedIdentityCredentialParameterBuilder)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidRequest,
+                    "WithClientClaims is not supported for user-token flows (AcquireTokenByAuthorizationCode, " +
+                    "AcquireTokenByUsernameAndPassword, AcquireTokenByUserFederatedIdentityCredential). " +
+                    "Use WithClientClaims with AcquireTokenForClient or AcquireTokenOnBehalfOf.");
+            }
+
             builder.ValidateUseOfExperimentalFeature();
 
             string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -40,15 +40,14 @@ namespace Microsoft.Identity.Client.Extensibility
                 return (T)builder;
             }
 
+            builder.ValidateUseOfExperimentalFeature();
+
             string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);
             builder.CommonParameters.ClientClaims = normalized;
 
-            var cacheKey = new SortedList<string, Func<CancellationToken, Task<string>>>
-            {
-                { "client_claims", _ => Task.FromResult(normalized) }
-            };
-
-            WithAdditionalCacheKeyComponents(builder, cacheKey);
+            // Use indexer (not SortedList.Add) so repeated calls are last-write-wins rather than throwing.
+            builder.CommonParameters.CacheKeyComponents ??= new SortedList<string, Func<CancellationToken, Task<string>>>();
+            builder.CommonParameters.CacheKeyComponents["client_claims"] = _ => Task.FromResult(normalized);
 
             return (T)builder;
         }

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.OAuth2;
 
 namespace Microsoft.Identity.Client.Extensibility
@@ -23,18 +22,14 @@ namespace Microsoft.Identity.Client.Extensibility
         /// Specifies client-originated claims to include in the token request.
         /// Unlike <see cref="AbstractAcquireTokenParameterBuilder{T}.WithClaims"/> (for server-issued
         /// claims challenges), tokens acquired with client claims <b>are cached</b> and the cache entry
-        /// is keyed on the normalized claims value. Different claims values produce separate cache entries.
+        /// is keyed on the claims value. Different claims values produce separate cache entries.
         /// Use stable, non-dynamic values to avoid unbounded cache growth.
         /// </summary>
-        /// <remarks>
-        /// This API is intended for MSI and cert/FIC flows (e.g., NSP claims for Azure Redis Cache).
-        /// Behavior for B2C, ADFS, and dSTS is undefined and unsupported.
-        /// </remarks>
         /// <typeparam name="T">The concrete confidential client builder type.</typeparam>
         /// <param name="builder">The builder to chain options to.</param>
         /// <param name="claimsJson">A JSON string containing the client-originated claims. Must be valid JSON.</param>
         /// <returns>The builder to chain the .With methods.</returns>
-        public static T WithClientClaims<T>(
+        public static T WithClaimsFromClient<T>(
             this AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder,
             string claimsJson)
             where T : AbstractConfidentialClientAcquireTokenParameterBuilder<T>
@@ -44,41 +39,13 @@ namespace Microsoft.Identity.Client.Extensibility
                 return (T)builder;
             }
 
-            // Client claims must not appear in front-channel authorization URLs because they can
-            // contain sensitive data and because the resulting cache key cannot be reproduced by
-            // silent token calls. Only token-acquisition flows (AcquireTokenForClient, OBO, etc.)
-            // are supported.
-            if (builder is GetAuthorizationRequestUrlParameterBuilder)
-            {
-                throw new MsalClientException(
-                    MsalError.InvalidRequest,
-                    "WithClientClaims is not supported for GetAuthorizationRequestUrl. " +
-                    "Client claims are intended for token-acquisition flows (AcquireTokenForClient, AcquireTokenOnBehalfOf).");
-            }
-
-            // User-token flows (auth code, username/password, federated identity) cache tokens
-            // that AcquireTokenSilent would later retrieve — but AcquireTokenSilent has no
-            // WithClientClaims equivalent, so those tokens can never be found silently. Block
-            // these flows to avoid permanent cache pollution.
-            if (builder is AcquireTokenByAuthorizationCodeParameterBuilder ||
-                builder is AcquireTokenByUsernameAndPasswordConfidentialParameterBuilder ||
-                builder is AcquireTokenByUserFederatedIdentityCredentialParameterBuilder)
-            {
-                throw new MsalClientException(
-                    MsalError.InvalidRequest,
-                    "WithClientClaims is not supported for user-token flows (AcquireTokenByAuthorizationCode, " +
-                    "AcquireTokenByUsernameAndPassword, AcquireTokenByUserFederatedIdentityCredential). " +
-                    "Use WithClientClaims with AcquireTokenForClient or AcquireTokenOnBehalfOf.");
-            }
-
             builder.ValidateUseOfExperimentalFeature();
 
-            string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);
-            builder.CommonParameters.ClientClaims = normalized;
+            builder.CommonParameters.ClientClaims = claimsJson;
 
             // Use indexer (not SortedList.Add) so repeated calls are last-write-wins rather than throwing.
             builder.CommonParameters.CacheKeyComponents ??= new SortedList<string, Func<CancellationToken, Task<string>>>();
-            builder.CommonParameters.CacheKeyComponents["client_claims"] = _ => Task.FromResult(normalized);
+            builder.CommonParameters.CacheKeyComponents["client_claims"] = _ => Task.FromResult(claimsJson);
 
             return (T)builder;
         }

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.OAuth2;
 
 namespace Microsoft.Identity.Client.Extensibility
@@ -19,7 +20,41 @@ namespace Microsoft.Identity.Client.Extensibility
     public static class AbstractConfidentialClientAcquireTokenParameterBuilderExtension
     {
         /// <summary>
-        /// Intervenes in the request pipeline, by executing a user provided delegate before MSAL makes the token request. 
+        /// Specifies client-originated claims to include in the token request.
+        /// Unlike <see cref="AbstractAcquireTokenParameterBuilder{T}.WithClaims"/> (for server-issued
+        /// claims challenges), tokens acquired with client claims <b>are cached</b> and the cache entry
+        /// is keyed on the normalized claims value. Different claims values produce separate cache entries.
+        /// Use stable, non-dynamic values to avoid unbounded cache growth.
+        /// </summary>
+        /// <typeparam name="T">The concrete confidential client builder type.</typeparam>
+        /// <param name="builder">The builder to chain options to.</param>
+        /// <param name="claimsJson">A JSON string containing the client-originated claims. Must be valid JSON.</param>
+        /// <returns>The builder to chain the .With methods.</returns>
+        public static T WithClientClaims<T>(
+            this AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder,
+            string claimsJson)
+            where T : AbstractConfidentialClientAcquireTokenParameterBuilder<T>
+        {
+            if (string.IsNullOrWhiteSpace(claimsJson))
+            {
+                return (T)builder;
+            }
+
+            string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);
+            builder.CommonParameters.ClientClaims = normalized;
+
+            var cacheKey = new SortedList<string, Func<CancellationToken, Task<string>>>
+            {
+                { "client_claims", _ => Task.FromResult(normalized) }
+            };
+
+            WithAdditionalCacheKeyComponents(builder, cacheKey);
+
+            return (T)builder;
+        }
+
+        /// <summary>
+        /// Intervenes in the request pipeline, by executing a user provided delegate before MSAL makes the token request.
         /// The delegate can modify the request payload by adding or removing  body parameters and headers. <see cref="OnBeforeTokenRequestData"/>
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -44,6 +44,18 @@ namespace Microsoft.Identity.Client.Extensibility
                 return (T)builder;
             }
 
+            // Client claims must not appear in front-channel authorization URLs because they can
+            // contain sensitive data and because the resulting cache key cannot be reproduced by
+            // silent token calls. Only token-acquisition flows (AcquireTokenForClient, OBO, etc.)
+            // are supported.
+            if (builder is GetAuthorizationRequestUrlParameterBuilder)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidRequest,
+                    "WithClientClaims is not supported for GetAuthorizationRequestUrl. " +
+                    "Client claims are intended for token-acquisition flows (AcquireTokenForClient, AcquireTokenOnBehalfOf).");
+            }
+
             builder.ValidateUseOfExperimentalFeature();
 
             string normalized = ClaimsHelper.NormalizeClaimsJson(claimsJson);

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Identity.Client.Internal
                 // Do not include the raw claimsJson in the message — it may contain sensitive data.
                 throw new MsalClientException(
                     MsalError.InvalidJsonClaimsFormat,
-                    "The client_claims value is not valid JSON. Inspect the inner exception for parsing details. " +
+                    "The claims value is not a valid JSON object. Inspect the inner exception for parsing details. " +
                     "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
                     ex);
             }
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client.Internal
                 // Do not include the raw claimsJson in the message — it may contain sensitive data.
                 throw new MsalClientException(
                     MsalError.InvalidJsonClaimsFormat,
-                    "The client_claims value is not valid JSON. Inspect the inner exception for parsing details. " +
+                    "The claims value is not a valid JSON object. Inspect the inner exception for parsing details. " +
                     "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
                     ex);
             }

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Identity.Client.Utils;
@@ -18,37 +15,6 @@ namespace Microsoft.Identity.Client.Internal
     {
         private const string AccessTokenClaim = "access_token";
         private const string XmsClientCapability = "xms_cc";
-
-        /// <summary>
-        /// Normalizes a claims JSON string so that semantically identical claims always produce
-        /// the same string. This prevents cache key fragmentation when callers pass the same
-        /// logical claims in different whitespace or key-ordering variants.
-        /// </summary>
-        internal static string NormalizeClaimsJson(string claimsJson)
-        {
-            if (string.IsNullOrWhiteSpace(claimsJson))
-            {
-                return claimsJson;
-            }
-
-            try
-            {
-                JObject parsed = JsonHelper.ParseIntoJsonObject(claimsJson);
-                JObject sorted = SortJsonObjectKeys(parsed);
-                return JsonHelper.JsonObjectToString(sorted);
-            }
-            catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
-            {
-                // InvalidOperationException is thrown by JsonNode.AsObject() when the root token is
-                // valid JSON but not an object (e.g. an array or a scalar).
-                // Do not include the raw claimsJson in the message — it may contain sensitive data.
-                throw new MsalClientException(
-                    MsalError.InvalidJsonClaimsFormat,
-                    "The claims value is not a valid JSON object. Inspect the inner exception for parsing details. " +
-                    "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
-                    ex);
-            }
-        }
 
         /// <summary>
         /// Merges two JSON claims objects. If either is null/empty the other is returned as-is.
@@ -76,28 +42,6 @@ namespace Microsoft.Identity.Client.Internal
                     "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
                     ex);
             }
-        }
-
-        private static JObject SortJsonObjectKeys(JObject obj)
-        {
-            var sorted = new JObject();
-            foreach (var key in obj.Select(kvp => kvp.Key).OrderBy(k => k, StringComparer.Ordinal))
-            {
-                var value = obj[key];
-                if (value is JObject nestedObj)
-                {
-                    sorted[key] = SortJsonObjectKeys(nestedObj);
-                }
-                else
-                {
-                    // Array elements are cloned as-is. Per OIDC §5.5, array element *order* is
-                    // semantically significant (e.g. acr.values preference order), so we must not
-                    // reorder elements. NSP claims do not use arrays-of-objects, so there is no
-                    // cache-fragmentation risk from not sorting inside array elements.
-                    sorted[key] = value is null ? null : JsonNode.Parse(value.ToJsonString());
-                }
-            }
-            return sorted;
         }
 
         internal static string GetMergedClaimsAndClientCapabilities(

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,7 +11,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Identity.Client.Utils;
 using JObject = System.Text.Json.Nodes.JsonObject;
-using System;
 
 namespace Microsoft.Identity.Client.Internal
 {
@@ -90,7 +90,10 @@ namespace Microsoft.Identity.Client.Internal
                 }
                 else
                 {
-                    // JsonNode.DeepClone is .NET 6+; use Parse(ToJsonString()) for portability.
+                    // Array elements are cloned as-is. Per OIDC §5.5, array element *order* is
+                    // semantically significant (e.g. acr.values preference order), so we must not
+                    // reorder elements. NSP claims do not use arrays-of-objects, so there is no
+                    // cache-fragmentation risk from not sorting inside array elements.
                     sorted[key] = value is null ? null : JsonNode.Parse(value.ToJsonString());
                 }
             }
@@ -121,11 +124,15 @@ namespace Microsoft.Identity.Client.Internal
                 {
                     claimsJson = JsonHelper.ParseIntoJsonObject(claims);
                 }
-                catch (JsonException ex)
+                catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
                 {
+                    // InvalidOperationException is thrown by JsonNode.AsObject() when the root token is
+                    // valid JSON but not an object (e.g. an array, a scalar, or the literal 'null').
+                    // This method also handles server-issued claims from .WithClaims(), so use a neutral
+                    // message rather than naming client_claims specifically.
                     throw new MsalClientException(
                         MsalError.InvalidJsonClaimsFormat,
-                        "The client_claims value is not valid JSON. Inspect the inner exception for parsing details. " +
+                        "The claims value is not a valid JSON object. Inspect the inner exception for parsing details. " +
                         "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
                         ex);
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -67,11 +67,13 @@ namespace Microsoft.Identity.Client.Internal
             }
             catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
             {
-                // InvalidOperationException is thrown by JsonNode.AsObject() when a value is
-                // valid JSON but not an object (e.g. an array or a scalar).
+                // InvalidOperationException is thrown by JsonNode.AsObject() when the root token is
+                // valid JSON but not an object (e.g. an array, a scalar, or the literal 'null').
+                // Do not include the raw claimsJson in the message — it may contain sensitive data.
                 throw new MsalClientException(
                     MsalError.InvalidJsonClaimsFormat,
-                    MsalErrorMessage.InvalidJsonClaimsFormat(claims1),
+                    "The client_claims value is not valid JSON. Inspect the inner exception for parsing details. " +
+                    "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
                     ex);
             }
         }
@@ -123,7 +125,8 @@ namespace Microsoft.Identity.Client.Internal
                 {
                     throw new MsalClientException(
                         MsalError.InvalidJsonClaimsFormat,
-                        MsalErrorMessage.InvalidJsonClaimsFormat(claims),
+                        "The client_claims value is not valid JSON. Inspect the inner exception for parsing details. " +
+                        "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
                         ex);
                 }
                 capabilitiesJson = JsonHelper.Merge(capabilitiesJson, claimsJson);

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -37,8 +37,10 @@ namespace Microsoft.Identity.Client.Internal
                 JObject sorted = SortJsonObjectKeys(parsed);
                 return JsonHelper.JsonObjectToString(sorted);
             }
-            catch (JsonException ex)
+            catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
             {
+                // InvalidOperationException is thrown by JsonNode.AsObject() when the root token is
+                // valid JSON but not an object (e.g. an array or a scalar).
                 // Do not include the raw claimsJson in the message — it may contain sensitive data.
                 throw new MsalClientException(
                     MsalError.InvalidJsonClaimsFormat,
@@ -63,8 +65,10 @@ namespace Microsoft.Identity.Client.Internal
                 JObject merged = JsonHelper.Merge(obj1, obj2);
                 return JsonHelper.JsonObjectToString(merged);
             }
-            catch (JsonException ex)
+            catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
             {
+                // InvalidOperationException is thrown by JsonNode.AsObject() when a value is
+                // valid JSON but not an object (e.g. an array or a scalar).
                 throw new MsalClientException(
                     MsalError.InvalidJsonClaimsFormat,
                     MsalErrorMessage.InvalidJsonClaimsFormat(claims1),
@@ -84,6 +88,10 @@ namespace Microsoft.Identity.Client.Internal
                 }
                 else
                 {
+                    // TODO: Objects nested inside arrays are not recursively key-sorted here.
+                    // In practice the OIDC §5.5 claims parameter uses string arrays (e.g. acr.values),
+                    // so this gap is theoretical for current callers. If support for object-valued array
+                    // elements is needed in the future, recurse into JsonArray elements here.
                     // JsonNode.DeepClone is .NET 6+; use Parse(ToJsonString()) for portability.
                     sorted[key] = value is null ? null : JsonNode.Parse(value.ToJsonString());
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Identity.Client.Utils;
 using JObject = System.Text.Json.Nodes.JsonObject;
+using System;
 
 namespace Microsoft.Identity.Client.Internal
 {
@@ -17,6 +18,66 @@ namespace Microsoft.Identity.Client.Internal
     {
         private const string AccessTokenClaim = "access_token";
         private const string XmsClientCapability = "xms_cc";
+
+        /// <summary>
+        /// Normalizes a claims JSON string so that semantically identical claims always produce
+        /// the same string. This prevents cache key fragmentation when callers pass the same
+        /// logical claims in different whitespace or key-ordering variants.
+        /// </summary>
+        internal static string NormalizeClaimsJson(string claimsJson)
+        {
+            if (string.IsNullOrWhiteSpace(claimsJson))
+            {
+                return claimsJson;
+            }
+
+            try
+            {
+                JObject parsed = JsonHelper.ParseIntoJsonObject(claimsJson);
+                JObject sorted = SortJsonObjectKeys(parsed);
+                return JsonHelper.JsonObjectToString(sorted);
+            }
+            catch (JsonException ex)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidJsonClaimsFormat,
+                    MsalErrorMessage.InvalidJsonClaimsFormat(claimsJson),
+                    ex);
+            }
+        }
+
+        /// <summary>
+        /// Merges two JSON claims objects. If either is null/empty the other is returned as-is.
+        /// </summary>
+        internal static string MergeClaimsObjects(string claims1, string claims2)
+        {
+            if (string.IsNullOrEmpty(claims1)) return claims2;
+            if (string.IsNullOrEmpty(claims2)) return claims1;
+
+            JObject obj1 = JsonHelper.ParseIntoJsonObject(claims1);
+            JObject obj2 = JsonHelper.ParseIntoJsonObject(claims2);
+            JObject merged = JsonHelper.Merge(obj1, obj2);
+            return JsonHelper.JsonObjectToString(merged);
+        }
+
+        private static JObject SortJsonObjectKeys(JObject obj)
+        {
+            var sorted = new JObject();
+            foreach (var key in obj.Select(kvp => kvp.Key).OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var value = obj[key];
+                if (value is JObject nestedObj)
+                {
+                    sorted[key] = SortJsonObjectKeys(nestedObj);
+                }
+                else
+                {
+                    // JsonNode.DeepClone is .NET 6+; use Parse(ToJsonString()) for portability.
+                    sorted[key] = value is null ? null : JsonNode.Parse(value.ToJsonString());
+                }
+            }
+            return sorted;
+        }
 
         internal static string GetMergedClaimsAndClientCapabilities(
             string claims,

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -17,6 +17,30 @@ namespace Microsoft.Identity.Client.Internal
         private const string XmsClientCapability = "xms_cc";
 
         /// <summary>
+        /// Parses a claims JSON string into a <see cref="JObject"/>, throwing a friendly
+        /// <see cref="MsalClientException"/> (error code <see cref="MsalError.InvalidJsonClaimsFormat"/>)
+        /// if the value is not a valid JSON object. The raw claims value is never included in the
+        /// exception message — it may contain sensitive data.
+        /// </summary>
+        internal static JObject ParseClaimsOrThrow(string claims)
+        {
+            try
+            {
+                return JsonHelper.ParseIntoJsonObject(claims);
+            }
+            catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
+            {
+                // InvalidOperationException is thrown by JsonNode.AsObject() when the root token is
+                // valid JSON but not an object (e.g. an array, a scalar, or the literal 'null').
+                throw new MsalClientException(
+                    MsalError.InvalidJsonClaimsFormat,
+                    "The claims value is not a valid JSON object. Inspect the inner exception for parsing details. " +
+                    "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
+                    ex);
+            }
+        }
+
+        /// <summary>
         /// Merges two JSON claims objects. If either is null/empty the other is returned as-is.
         /// </summary>
         internal static string MergeClaimsObjects(string claims1, string claims2)
@@ -24,24 +48,10 @@ namespace Microsoft.Identity.Client.Internal
             if (string.IsNullOrEmpty(claims1)) return claims2;
             if (string.IsNullOrEmpty(claims2)) return claims1;
 
-            try
-            {
-                JObject obj1 = JsonHelper.ParseIntoJsonObject(claims1);
-                JObject obj2 = JsonHelper.ParseIntoJsonObject(claims2);
-                JObject merged = JsonHelper.Merge(obj1, obj2);
-                return JsonHelper.JsonObjectToString(merged);
-            }
-            catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
-            {
-                // InvalidOperationException is thrown by JsonNode.AsObject() when the root token is
-                // valid JSON but not an object (e.g. an array, a scalar, or the literal 'null').
-                // Do not include the raw claimsJson in the message — it may contain sensitive data.
-                throw new MsalClientException(
-                    MsalError.InvalidJsonClaimsFormat,
-                    "The claims value is not a valid JSON object. Inspect the inner exception for parsing details. " +
-                    "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
-                    ex);
-            }
+            JObject obj1 = ParseClaimsOrThrow(claims1);
+            JObject obj2 = ParseClaimsOrThrow(claims2);
+            JObject merged = JsonHelper.Merge(obj1, obj2);
+            return JsonHelper.JsonObjectToString(merged);
         }
 
         internal static string GetMergedClaimsAndClientCapabilities(
@@ -63,23 +73,7 @@ namespace Microsoft.Identity.Client.Internal
         {
             if (!string.IsNullOrEmpty(claims))
             {
-                JObject claimsJson;
-                try
-                {
-                    claimsJson = JsonHelper.ParseIntoJsonObject(claims);
-                }
-                catch (Exception ex) when (ex is JsonException || ex is InvalidOperationException)
-                {
-                    // InvalidOperationException is thrown by JsonNode.AsObject() when the root token is
-                    // valid JSON but not an object (e.g. an array, a scalar, or the literal 'null').
-                    // This method also handles server-issued claims from .WithClaims(), so use a neutral
-                    // message rather than naming client_claims specifically.
-                    throw new MsalClientException(
-                        MsalError.InvalidJsonClaimsFormat,
-                        "The claims value is not a valid JSON object. Inspect the inner exception for parsing details. " +
-                        "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
-                        ex);
-                }
+                JObject claimsJson = ParseClaimsOrThrow(claims);
                 capabilitiesJson = JsonHelper.Merge(capabilitiesJson, claimsJson);
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -88,10 +88,6 @@ namespace Microsoft.Identity.Client.Internal
                 }
                 else
                 {
-                    // TODO: Objects nested inside arrays are not recursively key-sorted here.
-                    // In practice the OIDC §5.5 claims parameter uses string arrays (e.g. acr.values),
-                    // so this gap is theoretical for current callers. If support for object-valued array
-                    // elements is needed in the future, recurse into JsonArray elements here.
                     // JsonNode.DeepClone is .NET 6+; use Parse(ToJsonString()) for portability.
                     sorted[key] = value is null ? null : JsonNode.Parse(value.ToJsonString());
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClaimsHelper.cs
@@ -39,9 +39,11 @@ namespace Microsoft.Identity.Client.Internal
             }
             catch (JsonException ex)
             {
+                // Do not include the raw claimsJson in the message — it may contain sensitive data.
                 throw new MsalClientException(
                     MsalError.InvalidJsonClaimsFormat,
-                    MsalErrorMessage.InvalidJsonClaimsFormat(claimsJson),
+                    "The client_claims value is not valid JSON. Inspect the inner exception for parsing details. " +
+                    "See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter.",
                     ex);
             }
         }
@@ -54,10 +56,20 @@ namespace Microsoft.Identity.Client.Internal
             if (string.IsNullOrEmpty(claims1)) return claims2;
             if (string.IsNullOrEmpty(claims2)) return claims1;
 
-            JObject obj1 = JsonHelper.ParseIntoJsonObject(claims1);
-            JObject obj2 = JsonHelper.ParseIntoJsonObject(claims2);
-            JObject merged = JsonHelper.Merge(obj1, obj2);
-            return JsonHelper.JsonObjectToString(merged);
+            try
+            {
+                JObject obj1 = JsonHelper.ParseIntoJsonObject(claims1);
+                JObject obj2 = JsonHelper.ParseIntoJsonObject(claims2);
+                JObject merged = JsonHelper.Merge(obj1, obj2);
+                return JsonHelper.JsonObjectToString(merged);
+            }
+            catch (JsonException ex)
+            {
+                throw new MsalClientException(
+                    MsalError.InvalidJsonClaimsFormat,
+                    MsalErrorMessage.InvalidJsonClaimsFormat(claims1),
+                    ex);
+            }
         }
 
         private static JObject SortJsonObjectKeys(JObject obj)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -69,8 +69,15 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 }
             }
 
-            ClaimsAndClientCapabilities = ClaimsHelper.GetMergedClaimsAndClientCapabilities(
+            // Merge server-issued claims and client-originated claims before computing
+            // ClaimsAndClientCapabilities. Server claims drive cache bypass (handled by request handlers);
+            // client claims are stable and cached — they just need to appear in the ESTS body.
+            string mergedClaims = ClaimsHelper.MergeClaimsObjects(
                 _commonParameters.Claims,
+                _commonParameters.ClientClaims);
+
+            ClaimsAndClientCapabilities = ClaimsHelper.GetMergedClaimsAndClientCapabilities(
+                mergedClaims,
                 _serviceBundle.Config.ClientCapabilities);
 
             HomeAccountId = homeAccountId;
@@ -136,6 +143,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 return _commonParameters.Claims;
             }
         }
+
+        /// <summary>
+        /// Client-originated claims set via .WithClientClaims(). These are cached (no bypass) and
+        /// keyed on the normalized claims value.
+        /// </summary>
+        public string ClientClaims => _commonParameters.ClientClaims;
 
         private IAuthenticationOperation _requestOverrideScheme;
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         private readonly IServiceBundle _serviceBundle;
         private readonly AcquireTokenCommonParameters _commonParameters;
         private string _loginHint;
+        private Lazy<string> _claimsAndClientCapabilities;
 
         public AuthenticationRequestParameters(
             IServiceBundle serviceBundle,
@@ -69,20 +70,16 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 }
             }
 
-            // Merge server-issued claims and client-originated claims before computing
-            // ClaimsAndClientCapabilities. Server claims drive cache bypass (handled by request handlers);
-            // client claims are stable and cached — they just need to appear in the ESTS body.
-            string mergedClaims = ClaimsHelper.MergeClaimsObjects(
-                _commonParameters.Claims,
-                _commonParameters.ClientClaims);
-
-            ClaimsAndClientCapabilities = ClaimsHelper.GetMergedClaimsAndClientCapabilities(
-                mergedClaims,
-                _serviceBundle.Config.ClientCapabilities);
-
             HomeAccountId = homeAccountId;
             CacheKeyComponents = cacheKeyComponents;
             SendOfflineAccessScope = commonParameters.SendOfflineAccessScope;
+
+            // Defer JSON merge to first access — cache hits never read ClaimsAndClientCapabilities,
+            // so we avoid parsing on the hot path.
+            _claimsAndClientCapabilities = new Lazy<string>(() =>
+                ClaimsHelper.GetMergedClaimsAndClientCapabilities(
+                    ClaimsHelper.MergeClaimsObjects(_commonParameters.Claims, _commonParameters.ClientClaims),
+                    _serviceBundle.Config.ClientCapabilities));
         }
 
         public ApplicationConfiguration AppConfig => _serviceBundle.Config;
@@ -115,7 +112,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public IDictionary<string, string> ExtraQueryParameters { get; }
 
-        public string ClaimsAndClientCapabilities { get; private set; }
+        public string ClaimsAndClientCapabilities => _claimsAndClientCapabilities.Value;
 
         public Guid CorrelationId => _commonParameters.CorrelationId;
 
@@ -146,8 +143,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
         }
 
         /// <summary>
-        /// Client-originated claims set via .WithClientClaims(). These are cached (no bypass) and
-        /// keyed on the normalized claims value.
+        /// Client-originated claims set via .WithClaimsFromClient(). These are cached (no bypass) and
+        /// keyed on the raw claims string as passed by the caller.
         /// </summary>
         public string ClientClaims => _commonParameters.ClientClaims;
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -216,6 +216,13 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             _managedIdentityParameters.IsMtlsPopRequested = AuthenticationRequestParameters.IsMtlsPopRequested;
 
+            // Propagate client-originated claims to the MI parameters for transport.
+            // Unlike server-issued Claims (which bypass the cache), ClientClaims are cached normally.
+            if (!string.IsNullOrEmpty(AuthenticationRequestParameters.ClientClaims))
+            {
+                _managedIdentityParameters.ClientClaims = AuthenticationRequestParameters.ClientClaims;
+            }
+
             ManagedIdentityResponse managedIdentityResponse =
                 await _managedIdentityClient
                 .SendTokenRequestForManagedIdentityAsync(AuthenticationRequestParameters.RequestContext, _managedIdentityParameters, cancellationToken)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -217,7 +217,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
             _managedIdentityParameters.IsMtlsPopRequested = AuthenticationRequestParameters.IsMtlsPopRequested;
 
             // Propagate client-originated claims to the MI parameters for transport.
-            // Unlike server-issued Claims (which bypass the cache), ClientClaims are cached normally.
+            // Unlike server-issued Claims (which bypass the cache), ClientClaims participate in caching
+            // via CacheKeyComponents set on the builder — tokens are keyed per distinct claims value.
             if (!string.IsNullOrEmpty(AuthenticationRequestParameters.ClientClaims))
             {
                 _managedIdentityParameters.ClientClaims = AuthenticationRequestParameters.ClientClaims;

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -57,6 +57,23 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
             ManagedIdentityRequest request = await CreateRequestAsync(resource).ConfigureAwait(false);
 
+            // Forward client-originated claims to the correct location:
+            // - GET requests (IMDS/MSIv1): append as "claims" query parameter
+            // - POST requests (ImdsV2 / ESTS): append as "claims" body parameter
+            if (!string.IsNullOrEmpty(parameters.ClientClaims))
+            {
+                if (request.Method == System.Net.Http.HttpMethod.Get)
+                {
+                    request.QueryParameters["claims"] = parameters.ClientClaims;
+                    _requestContext.Logger.Info("[Managed Identity] Adding client claims to IMDS request as query parameter.");
+                }
+                else
+                {
+                    request.BodyParameters["claims"] = parameters.ClientClaims;
+                    _requestContext.Logger.Info("[Managed Identity] Adding client claims to ESTS POST body.");
+                }
+            }
+
             // When IMDSv2 mints a binding certificate during this request (via CSR),
             // it's exposed via request.MtlsCertificate. Bubble it up so the request
             // layer can set the mtls_pop scheme

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 {
                     throw new MsalClientException(
                         MsalError.InvalidRequest,
-                        $"WithClientClaims is only supported for IMDS-based managed identity sources. " +
+                        $"WithClaimsFromClient is only supported for IMDS-based managed identity sources. " +
                         $"The detected source is {_sourceType}. " +
                         "Only ManagedIdentitySource.Imds and ManagedIdentitySource.ImdsV2 support the 'claims' parameter.");
                 }
@@ -380,7 +380,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                         MsalError.InvalidRequest,
                         $"MSIv1 (IMDS v1) only supports the `{XmsAzNwperimid}` custom claim. " +
                         $"The claims JSON contained the unsupported key `{kvp.Key}`. " +
-                        $"Remove all keys other than `{XmsAzNwperimid}` when using WithClientClaims with MSIv1.");
+                        $"Remove all keys other than `{XmsAzNwperimid}` when using WithClaimsFromClient with MSIv1.");
                 }
             }
         }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         /// </summary>
         private static void ValidateMsiv1Claims(string claimsJson)
         {
-            var parsed = JsonHelper.ParseIntoJsonObject(claimsJson);
+            var parsed = ClaimsHelper.ParseClaimsOrThrow(claimsJson);
             foreach (var kvp in parsed)
             {
                 if (!string.Equals(kvp.Key, XmsAzNwperimid, StringComparison.Ordinal))

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             _sourceType = sourceType;
         }
 
+        private const string XmsAzNwperimid = "xms_az_nwperimid";
+
         public virtual async Task<ManagedIdentityResponse> AuthenticateAsync(
             AcquireTokenForManagedIdentityParameters parameters,
             CancellationToken cancellationToken)
@@ -70,6 +72,11 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                         $"WithClientClaims is only supported for IMDS-based managed identity sources. " +
                         $"The detected source is {_sourceType}. " +
                         "Only ManagedIdentitySource.Imds and ManagedIdentitySource.ImdsV2 support the 'claims' parameter.");
+                }
+
+                if (_sourceType == ManagedIdentitySource.Imds)
+                {
+                    ValidateMsiv1Claims(parameters.ClientClaims);
                 }
 
                 if (request.Method == System.Net.Http.HttpMethod.Get)
@@ -355,6 +362,27 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 null);
 
             throw exception;
+        }
+
+        /// <summary>
+        /// MSIv1 (IMDS v1) only supports a single custom claim: <c>xms_az_nwperimid</c>.
+        /// Any other top-level key in the claims JSON will cause IMDS to return HTTP 400 Bad Request
+        /// with no useful diagnostic. Validate early so the caller gets a clear MSAL error.
+        /// </summary>
+        private static void ValidateMsiv1Claims(string claimsJson)
+        {
+            var parsed = JsonHelper.ParseIntoJsonObject(claimsJson);
+            foreach (var kvp in parsed)
+            {
+                if (!string.Equals(kvp.Key, XmsAzNwperimid, StringComparison.Ordinal))
+                {
+                    throw new MsalClientException(
+                        MsalError.InvalidRequest,
+                        $"MSIv1 (IMDS v1) only supports the `{XmsAzNwperimid}` custom claim. " +
+                        $"The claims JSON contained the unsupported key `{kvp.Key}`. " +
+                        $"Remove all keys other than `{XmsAzNwperimid}` when using WithClientClaims with MSIv1.");
+                }
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -59,11 +59,19 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
             // Forward client-originated claims to the correct location for IMDS/MSIv2 only.
             // Other MI sources (App Service, Azure Arc, Service Fabric, etc.) do not have a
-            // confirmed contract for the "claims" parameter; forwarding to them could cause
-            // token-acquisition failures or cache keying on a parameter that was ignored.
-            if (!string.IsNullOrEmpty(parameters.ClientClaims) &&
-                (_sourceType == ManagedIdentitySource.Imds || _sourceType == ManagedIdentitySource.ImdsV2))
+            // confirmed contract for the "claims" parameter; fail fast rather than silently
+            // ignoring the value and polluting the cache with keys the endpoint never saw.
+            if (!string.IsNullOrEmpty(parameters.ClientClaims))
             {
+                if (_sourceType != ManagedIdentitySource.Imds && _sourceType != ManagedIdentitySource.ImdsV2)
+                {
+                    throw new MsalClientException(
+                        MsalError.InvalidRequest,
+                        $"WithClientClaims is only supported for IMDS-based managed identity sources. " +
+                        $"The detected source is {_sourceType}. " +
+                        "Only ManagedIdentitySource.Imds and ManagedIdentitySource.ImdsV2 support the 'claims' parameter.");
+                }
+
                 if (request.Method == System.Net.Http.HttpMethod.Get)
                 {
                     request.QueryParameters["claims"] = Uri.EscapeDataString(parameters.ClientClaims);

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             {
                 if (request.Method == System.Net.Http.HttpMethod.Get)
                 {
-                    request.QueryParameters["claims"] = parameters.ClientClaims;
+                    request.QueryParameters["claims"] = Uri.EscapeDataString(parameters.ClientClaims);
                     _requestContext.Logger.Info("[Managed Identity] Adding client claims to IMDS request as query parameter.");
                 }
                 else

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -57,10 +57,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
             ManagedIdentityRequest request = await CreateRequestAsync(resource).ConfigureAwait(false);
 
-            // Forward client-originated claims to the correct location:
-            // - GET requests (IMDS/MSIv1): append as "claims" query parameter
-            // - POST requests (ImdsV2 / ESTS): append as "claims" body parameter
-            if (!string.IsNullOrEmpty(parameters.ClientClaims))
+            // Forward client-originated claims to the correct location for IMDS/MSIv2 only.
+            // Other MI sources (App Service, Azure Arc, Service Fabric, etc.) do not have a
+            // confirmed contract for the "claims" parameter; forwarding to them could cause
+            // token-acquisition failures or cache keying on a parameter that was ignored.
+            if (!string.IsNullOrEmpty(parameters.ClientClaims) &&
+                (_sourceType == ManagedIdentitySource.Imds || _sourceType == ManagedIdentitySource.ImdsV2))
             {
                 if (request.Method == System.Net.Http.HttpMethod.Get)
                 {

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClaimsFromClient<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClaimsFromClient<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClaimsFromClient<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClaimsFromClient<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClaimsFromClient<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClientClaims(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClientClaims<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
+Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder.WithClaimsFromClient(string claimsJson) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithClaimsFromClient<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, string claimsJson) -> T
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3
 Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEvaluationAsync(Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext

--- a/src/client/Microsoft.Identity.Client/Utils/JsonHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/JsonHelper.cs
@@ -124,7 +124,18 @@ namespace Microsoft.Identity.Client.Utils
 
         internal static string JsonObjectToString(JsonObject jsonObject) => jsonObject.ToJsonString();
 
-        internal static JsonObject ParseIntoJsonObject(string json) => JsonNode.Parse(json).AsObject();
+        internal static JsonObject ParseIntoJsonObject(string json)
+        {
+            var node = JsonNode.Parse(json);
+            if (node is null)
+            {
+                // JsonNode.Parse("null") returns null — treat the JSON literal 'null' the same as
+                // any other non-object value so callers get InvalidOperationException, not NRE.
+                throw new InvalidOperationException("The JSON value is the literal 'null', not a JSON object.");
+            }
+
+            return node.AsObject();
+        }
 
         internal static JsonObject ToJsonObject(JsonNode jsonNode) => jsonNode.AsObject();
 

--- a/src/client/Microsoft.Identity.Client/Utils/JsonHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/JsonHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Text.Json;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Internal;
@@ -12,106 +11,6 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
     [TestClass]
     public class ClaimsHelperTests
     {
-        #region NormalizeClaimsJson
-
-        [TestMethod]
-        public void NormalizeClaimsJson_SortsTopLevelKeys()
-        {
-            // Arrange
-            string unordered = @"{""z"":1,""a"":2,""m"":3}";
-
-            // Act
-            string result = ClaimsHelper.NormalizeClaimsJson(unordered);
-
-            // Assert — keys must appear in ordinal ascending order
-            Assert.AreEqual(@"{""a"":2,""m"":3,""z"":1}", result);
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_SameClaimsWithDifferentKeyOrdering_ProduceSameString()
-        {
-            // Arrange
-            string variant1 = @"{""b"":{""essential"":true},""a"":{""value"":""foo""}}";
-            string variant2 = @"{""a"":{""value"":""foo""},""b"":{""essential"":true}}";
-
-            // Act
-            string result1 = ClaimsHelper.NormalizeClaimsJson(variant1);
-            string result2 = ClaimsHelper.NormalizeClaimsJson(variant2);
-
-            // Assert
-            Assert.AreEqual(result1, result2);
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_StripsInsignificantWhitespace()
-        {
-            // Arrange
-            string withSpaces = "{ \"z\" : 1 , \"a\" : 2 }";
-            string compact = @"{""z"":1,""a"":2}";
-
-            // Act
-            string result1 = ClaimsHelper.NormalizeClaimsJson(withSpaces);
-            string result2 = ClaimsHelper.NormalizeClaimsJson(compact);
-
-            // Assert — both should normalize to the same compact, sorted string
-            Assert.AreEqual(result1, result2);
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_NestedObjectsAreSorted()
-        {
-            // Arrange
-            string input = @"{""userinfo"":{""z"":true,""a"":false}}";
-
-            // Act
-            string result = ClaimsHelper.NormalizeClaimsJson(input);
-
-            // Assert — nested keys must also be sorted
-            Assert.AreEqual(@"{""userinfo"":{""a"":false,""z"":true}}", result);
-        }
-
-        [TestMethod]
-        [DataRow(null)]
-        [DataRow("")]
-        [DataRow("   ")]
-        public void NormalizeClaimsJson_NullOrWhitespace_ReturnsInputUnchanged(string input)
-        {
-            // Act
-            string result = ClaimsHelper.NormalizeClaimsJson(input);
-
-            // Assert
-            Assert.AreEqual(input, result);
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_InvalidJson_ThrowsMsalClientException()
-        {
-            // Arrange
-            string badJson = "not-json";
-
-            // Act & Assert
-            MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
-                () => ClaimsHelper.NormalizeClaimsJson(badJson));
-
-            Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
-        }
-
-        [TestMethod]
-        [DataRow("[]")]          // JSON array — valid JSON but not an object
-        [DataRow("[1,2,3]")]
-        [DataRow("\"string\"")]  // JSON string — valid JSON but not an object
-        [DataRow("42")]          // JSON number
-        public void NormalizeClaimsJson_ValidJsonButNotObject_ThrowsMsalClientException(string nonObjectJson)
-        {
-            // Act & Assert — InvalidOperationException from JsonNode.AsObject() must be translated
-            MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
-                () => ClaimsHelper.NormalizeClaimsJson(nonObjectJson));
-
-            Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
-        }
-
-        #endregion
-
         #region MergeClaimsObjects
 
         [TestMethod]
@@ -222,91 +121,6 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
                 () => ClaimsHelper.MergeClaimsObjects(nonObjectJson, valid));
 
             Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
-        }
-
-        #endregion
-
-        #region OIDC §5.5 canonicalization edge cases
-
-        [TestMethod]
-        public void NormalizeClaimsJson_ArrayElementOrderIsPreserved()
-        {
-            // Arrange — OIDC §5.5 acr.values array; element order is semantically meaningful
-            string input = @"{""id_token"":{""acr"":{""values"":[""urn:mace:incommon:iap:bronze"",""urn:mace:incommon:iap:silver""]}}}";
-
-            // Act
-            string result = ClaimsHelper.NormalizeClaimsJson(input);
-            string result2 = ClaimsHelper.NormalizeClaimsJson(result);
-
-            // Assert — array order must be preserved after normalization
-            Assert.IsLessThan(result.IndexOf("silver", StringComparison.Ordinal), result.IndexOf("bronze", StringComparison.Ordinal),
-                "Array element order must be preserved — bronze must come before silver.");
-
-            // Idempotency: normalizing twice gives the same result
-            Assert.AreEqual(result, result2, "NormalizeClaimsJson must be idempotent.");
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_NullClaimValue_IsPreserved()
-        {
-            // Arrange — voluntary claim with null value (OIDC §5.5)
-            string input = @"{""userinfo"":{""picture"":null}}";
-
-            // Act
-            string result = ClaimsHelper.NormalizeClaimsJson(input);
-
-            // Assert
-            using var doc = System.Text.Json.JsonDocument.Parse(result);
-            var picture = doc.RootElement.GetProperty("userinfo").GetProperty("picture");
-            Assert.AreEqual(System.Text.Json.JsonValueKind.Null, picture.ValueKind, "null claim value must be preserved.");
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_Idempotent()
-        {
-            // Arrange — complex real-world claims value
-            string input = @"{""z"":{""essential"":true},""a"":{""values"":[""v2"",""v1""]},""m"":null}";
-
-            // Act
-            string once = ClaimsHelper.NormalizeClaimsJson(input);
-            string twice = ClaimsHelper.NormalizeClaimsJson(once);
-
-            // Assert
-            Assert.AreEqual(once, twice, "Normalize(Normalize(x)) must equal Normalize(x).");
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_UriNamedClaim_IsHandled()
-        {
-            // Arrange — URI-named claim (valid per OIDC §5.5)
-            string input = @"{""http://example.info/claims/groups"":{""essential"":true}}";
-
-            // Act
-            string result = ClaimsHelper.NormalizeClaimsJson(input);
-
-            // Assert — round-trips cleanly
-            using var doc = System.Text.Json.JsonDocument.Parse(result);
-            Assert.IsTrue(doc.RootElement.TryGetProperty("http://example.info/claims/groups", out _),
-                "URI-named claim key must survive normalization.");
-        }
-
-        [TestMethod]
-        public void NormalizeClaimsJson_CombinedUserinfoAndIdToken_BothKeysPresent()
-        {
-            // Arrange — canonical OIDC §5.5 shape with both top-level sections
-            string input = @"{""userinfo"":{""given_name"":{""essential"":true},""email"":null},""id_token"":{""auth_time"":{""essential"":true},""acr"":{""values"":[""urn:mace:incommon:iap:silver""]}}}";
-
-            // Act
-            string result = ClaimsHelper.NormalizeClaimsJson(input);
-
-            // Assert — both top-level keys survive, sorted (id_token < userinfo)
-            using var doc = System.Text.Json.JsonDocument.Parse(result);
-            Assert.IsTrue(doc.RootElement.TryGetProperty("userinfo", out _), "userinfo must be present.");
-            Assert.IsTrue(doc.RootElement.TryGetProperty("id_token", out _), "id_token must be present.");
-
-            // id_token sorts before userinfo (ordinal: 'i' < 'u')
-            Assert.IsLessThan(result.IndexOf("id_token", StringComparison.Ordinal), result.IndexOf("userinfo", StringComparison.Ordinal),
-                "id_token must appear before userinfo after ordinal key sort.");
         }
 
         #endregion

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
+{
+    [TestClass]
+    public class ClaimsHelperTests
+    {
+        #region NormalizeClaimsJson
+
+        [TestMethod]
+        public void NormalizeClaimsJson_SortsTopLevelKeys()
+        {
+            // Arrange
+            string unordered = @"{""z"":1,""a"":2,""m"":3}";
+
+            // Act
+            string result = ClaimsHelper.NormalizeClaimsJson(unordered);
+
+            // Assert — keys must appear in ordinal ascending order
+            Assert.AreEqual(@"{""a"":2,""m"":3,""z"":1}", result);
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_SameClaimsWithDifferentKeyOrdering_ProduceSameString()
+        {
+            // Arrange
+            string variant1 = @"{""b"":{""essential"":true},""a"":{""value"":""foo""}}";
+            string variant2 = @"{""a"":{""value"":""foo""},""b"":{""essential"":true}}";
+
+            // Act
+            string result1 = ClaimsHelper.NormalizeClaimsJson(variant1);
+            string result2 = ClaimsHelper.NormalizeClaimsJson(variant2);
+
+            // Assert
+            Assert.AreEqual(result1, result2);
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_StripsInsignificantWhitespace()
+        {
+            // Arrange
+            string withSpaces = "{ \"z\" : 1 , \"a\" : 2 }";
+            string compact = @"{""z"":1,""a"":2}";
+
+            // Act
+            string result1 = ClaimsHelper.NormalizeClaimsJson(withSpaces);
+            string result2 = ClaimsHelper.NormalizeClaimsJson(compact);
+
+            // Assert — both should normalize to the same compact, sorted string
+            Assert.AreEqual(result1, result2);
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_NestedObjectsAreSorted()
+        {
+            // Arrange
+            string input = @"{""userinfo"":{""z"":true,""a"":false}}";
+
+            // Act
+            string result = ClaimsHelper.NormalizeClaimsJson(input);
+
+            // Assert — nested keys must also be sorted
+            Assert.AreEqual(@"{""userinfo"":{""a"":false,""z"":true}}", result);
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public void NormalizeClaimsJson_NullOrWhitespace_ReturnsInputUnchanged(string input)
+        {
+            // Act
+            string result = ClaimsHelper.NormalizeClaimsJson(input);
+
+            // Assert
+            Assert.AreEqual(input, result);
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_InvalidJson_ThrowsMsalClientException()
+        {
+            // Arrange
+            string badJson = "not-json";
+
+            // Act & Assert
+            MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
+                () => ClaimsHelper.NormalizeClaimsJson(badJson));
+
+            Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+        }
+
+        #endregion
+
+        #region MergeClaimsObjects
+
+        [TestMethod]
+        public void MergeClaimsObjects_BothNull_ReturnsNull()
+        {
+            // Act
+            string result = ClaimsHelper.MergeClaimsObjects(null, null);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void MergeClaimsObjects_FirstNull_ReturnsSecond()
+        {
+            // Arrange
+            string claims2 = @"{""a"":1}";
+
+            // Act
+            string result = ClaimsHelper.MergeClaimsObjects(null, claims2);
+
+            // Assert
+            Assert.AreEqual(claims2, result);
+        }
+
+        [TestMethod]
+        public void MergeClaimsObjects_SecondNull_ReturnsFirst()
+        {
+            // Arrange
+            string claims1 = @"{""a"":1}";
+
+            // Act
+            string result = ClaimsHelper.MergeClaimsObjects(claims1, null);
+
+            // Assert
+            Assert.AreEqual(claims1, result);
+        }
+
+        [TestMethod]
+        public void MergeClaimsObjects_NonOverlapping_ReturnsMergedObject()
+        {
+            // Arrange
+            string claims1 = @"{""nsp"":{""essential"":true}}";
+            string claims2 = @"{""userinfo"":{""given_name"":{""essential"":true}}}";
+
+            // Act
+            string result = ClaimsHelper.MergeClaimsObjects(claims1, claims2);
+
+            // Assert — both top-level keys must be present
+            using var doc = JsonDocument.Parse(result);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("nsp", out _), "nsp key should be present");
+            Assert.IsTrue(doc.RootElement.TryGetProperty("userinfo", out _), "userinfo key should be present");
+        }
+
+        [TestMethod]
+        public void MergeClaimsObjects_OverlappingKeys_SecondObjectWins()
+        {
+            // Arrange — both have 'nsp' but with different values
+            string claims1 = @"{""nsp"":{""value"":""v1""}}";
+            string claims2 = @"{""nsp"":{""value"":""v2""}}";
+
+            // Act
+            string result = ClaimsHelper.MergeClaimsObjects(claims1, claims2);
+
+            // Assert — second value wins
+            using var doc = JsonDocument.Parse(result);
+            string nspValue = doc.RootElement.GetProperty("nsp").GetProperty("value").GetString();
+            Assert.AreEqual("v2", nspValue);
+        }
+
+        [TestMethod]
+        public void MergeClaimsObjects_EmptyStrings_TreatedAsNull()
+        {
+            // Arrange
+            string claims1 = @"{""a"":1}";
+
+            // Act
+            string result = ClaimsHelper.MergeClaimsObjects(claims1, "");
+
+            // Assert — empty string is treated as null, so first is returned
+            Assert.AreEqual(claims1, result);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -239,8 +239,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             string result2 = ClaimsHelper.NormalizeClaimsJson(result);
 
             // Assert — array order must be preserved after normalization
-            Assert.IsTrue(
-                result.IndexOf("bronze", StringComparison.Ordinal) < result.IndexOf("silver", StringComparison.Ordinal),
+            Assert.IsLessThan(result.IndexOf("silver", StringComparison.Ordinal), result.IndexOf("bronze", StringComparison.Ordinal),
                 "Array element order must be preserved — bronze must come before silver.");
 
             // Idempotency: normalizing twice gives the same result
@@ -306,8 +305,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             Assert.IsTrue(doc.RootElement.TryGetProperty("id_token", out _), "id_token must be present.");
 
             // id_token sorts before userinfo
-            Assert.IsTrue(
-                result.IndexOf("id_token", StringComparison.Ordinal) < result.IndexOf("userinfo", StringComparison.Ordinal),
+            Assert.IsLessThan(result.IndexOf("userinfo", StringComparison.Ordinal), result.IndexOf("id_token", StringComparison.Ordinal),
                 "id_token must appear before userinfo after ordinal key sort.");
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             string result2 = ClaimsHelper.NormalizeClaimsJson(result);
 
             // Assert — array order must be preserved after normalization
-            Assert.IsLessThan(result.IndexOf("silver", StringComparison.Ordinal), result.IndexOf("bronze", StringComparison.Ordinal),
+            Assert.IsLessThan(result.IndexOf("bronze", StringComparison.Ordinal), result.IndexOf("silver", StringComparison.Ordinal),
                 "Array element order must be preserved — bronze must come before silver.");
 
             // Idempotency: normalizing twice gives the same result
@@ -305,7 +305,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             Assert.IsTrue(doc.RootElement.TryGetProperty("id_token", out _), "id_token must be present.");
 
             // id_token sorts before userinfo
-            Assert.IsLessThan(result.IndexOf("userinfo", StringComparison.Ordinal), result.IndexOf("id_token", StringComparison.Ordinal),
+            Assert.IsLessThan(result.IndexOf("id_token", StringComparison.Ordinal), result.IndexOf("userinfo", StringComparison.Ordinal),
                 "id_token must appear before userinfo after ordinal key sort.");
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Text.Json;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Internal;
@@ -178,6 +179,105 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
 
             // Assert — empty string is treated as null, so first is returned
             Assert.AreEqual(claims1, result);
+        }
+
+        [TestMethod]
+        public void MergeClaimsObjects_InvalidJson_ThrowsMsalClientException()
+        {
+            // Arrange — one side is invalid JSON
+            string valid = @"{""a"":1}";
+            string invalid = "not-json";
+
+            // Act & Assert
+            MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
+                () => ClaimsHelper.MergeClaimsObjects(invalid, valid));
+
+            Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+        }
+
+        #endregion
+
+        #region OIDC §5.5 canonicalization edge cases
+
+        [TestMethod]
+        public void NormalizeClaimsJson_ArrayElementOrderIsPreserved()
+        {
+            // Arrange — OIDC §5.5 acr.values array; element order is semantically meaningful
+            string input = @"{""id_token"":{""acr"":{""values"":[""urn:mace:incommon:iap:bronze"",""urn:mace:incommon:iap:silver""]}}}";
+
+            // Act
+            string result = ClaimsHelper.NormalizeClaimsJson(input);
+            string result2 = ClaimsHelper.NormalizeClaimsJson(result);
+
+            // Assert — array order must be preserved after normalization
+            Assert.IsLessThan(result.IndexOf("silver", StringComparison.Ordinal), result.IndexOf("bronze", StringComparison.Ordinal),
+                "Array element order must be preserved — bronze must come before silver.");
+
+            // Idempotency: normalizing twice gives the same result
+            Assert.AreEqual(result, result2, "NormalizeClaimsJson must be idempotent.");
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_NullClaimValue_IsPreserved()
+        {
+            // Arrange — voluntary claim with null value (OIDC §5.5)
+            string input = @"{""userinfo"":{""picture"":null}}";
+
+            // Act
+            string result = ClaimsHelper.NormalizeClaimsJson(input);
+
+            // Assert
+            using var doc = System.Text.Json.JsonDocument.Parse(result);
+            var picture = doc.RootElement.GetProperty("userinfo").GetProperty("picture");
+            Assert.AreEqual(System.Text.Json.JsonValueKind.Null, picture.ValueKind, "null claim value must be preserved.");
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_Idempotent()
+        {
+            // Arrange — complex real-world claims value
+            string input = @"{""z"":{""essential"":true},""a"":{""values"":[""v2"",""v1""]},""m"":null}";
+
+            // Act
+            string once = ClaimsHelper.NormalizeClaimsJson(input);
+            string twice = ClaimsHelper.NormalizeClaimsJson(once);
+
+            // Assert
+            Assert.AreEqual(once, twice, "Normalize(Normalize(x)) must equal Normalize(x).");
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_UriNamedClaim_IsHandled()
+        {
+            // Arrange — URI-named claim (valid per OIDC §5.5)
+            string input = @"{""http://example.info/claims/groups"":{""essential"":true}}";
+
+            // Act
+            string result = ClaimsHelper.NormalizeClaimsJson(input);
+
+            // Assert — round-trips cleanly
+            using var doc = System.Text.Json.JsonDocument.Parse(result);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("http://example.info/claims/groups", out _),
+                "URI-named claim key must survive normalization.");
+        }
+
+        [TestMethod]
+        public void NormalizeClaimsJson_CombinedUserinfoAndIdToken_BothKeysPresent()
+        {
+            // Arrange — canonical OIDC §5.5 shape with both top-level sections
+            string input = @"{""userinfo"":{""given_name"":{""essential"":true},""email"":null},""id_token"":{""auth_time"":{""essential"":true},""acr"":{""values"":[""urn:mace:incommon:iap:silver""]}}}";
+
+            // Act
+            string result = ClaimsHelper.NormalizeClaimsJson(input);
+
+            // Assert — both top-level keys survive, sorted (id_token < userinfo)
+            using var doc = System.Text.Json.JsonDocument.Parse(result);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("userinfo", out _), "userinfo must be present.");
+            Assert.IsTrue(doc.RootElement.TryGetProperty("id_token", out _), "id_token must be present.");
+
+            // id_token sorts before userinfo
+            Assert.IsLessThan(result.IndexOf("userinfo", StringComparison.Ordinal), result.IndexOf("id_token", StringComparison.Ordinal),
+                "id_token must appear before userinfo after ordinal key sort.");
         }
 
         #endregion

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -239,7 +239,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             string result2 = ClaimsHelper.NormalizeClaimsJson(result);
 
             // Assert — array order must be preserved after normalization
-            Assert.IsLessThan(result.IndexOf("bronze", StringComparison.Ordinal), result.IndexOf("silver", StringComparison.Ordinal),
+            Assert.IsTrue(
+                result.IndexOf("bronze", StringComparison.Ordinal) < result.IndexOf("silver", StringComparison.Ordinal),
                 "Array element order must be preserved — bronze must come before silver.");
 
             // Idempotency: normalizing twice gives the same result
@@ -305,7 +306,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             Assert.IsTrue(doc.RootElement.TryGetProperty("id_token", out _), "id_token must be present.");
 
             // id_token sorts before userinfo
-            Assert.IsLessThan(result.IndexOf("id_token", StringComparison.Ordinal), result.IndexOf("userinfo", StringComparison.Ordinal),
+            Assert.IsTrue(
+                result.IndexOf("id_token", StringComparison.Ordinal) < result.IndexOf("userinfo", StringComparison.Ordinal),
                 "id_token must appear before userinfo after ordinal key sort.");
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -96,6 +96,20 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
         }
 
+        [TestMethod]
+        [DataRow("[]")]          // JSON array — valid JSON but not an object
+        [DataRow("[1,2,3]")]
+        [DataRow("\"string\"")]  // JSON string — valid JSON but not an object
+        [DataRow("42")]          // JSON number
+        public void NormalizeClaimsJson_ValidJsonButNotObject_ThrowsMsalClientException(string nonObjectJson)
+        {
+            // Act & Assert — InvalidOperationException from JsonNode.AsObject() must be translated
+            MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
+                () => ClaimsHelper.NormalizeClaimsJson(nonObjectJson));
+
+            Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+        }
+
         #endregion
 
         #region MergeClaimsObjects
@@ -191,6 +205,21 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             // Act & Assert
             MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
                 () => ClaimsHelper.MergeClaimsObjects(invalid, valid));
+
+            Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        [DataRow("[]")]
+        [DataRow("\"string\"")]
+        public void MergeClaimsObjects_ValidJsonButNotObject_ThrowsMsalClientException(string nonObjectJson)
+        {
+            // Arrange — valid JSON that is not an object triggers InvalidOperationException in ParseIntoJsonObject
+            string valid = @"{""a"":1}";
+
+            // Act & Assert — must be translated to MsalClientException, not leak InvalidOperationException
+            MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
+                () => ClaimsHelper.MergeClaimsObjects(nonObjectJson, valid));
 
             Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
         }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsHelperTests.cs
@@ -304,8 +304,8 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
             Assert.IsTrue(doc.RootElement.TryGetProperty("userinfo", out _), "userinfo must be present.");
             Assert.IsTrue(doc.RootElement.TryGetProperty("id_token", out _), "id_token must be present.");
 
-            // id_token sorts before userinfo
-            Assert.IsLessThan(result.IndexOf("userinfo", StringComparison.Ordinal), result.IndexOf("id_token", StringComparison.Ordinal),
+            // id_token sorts before userinfo (ordinal: 'i' < 'u')
+            Assert.IsLessThan(result.IndexOf("id_token", StringComparison.Ordinal), result.IndexOf("userinfo", StringComparison.Ordinal),
                 "id_token must appear before userinfo after ordinal key sort.");
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsTest.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/OAuth2Tests/ClaimsTest.cs
@@ -228,8 +228,13 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.OAuth2Tests
         [TestMethod]
         public async Task Claims_Fail_WhenClaimsIsNotJson_Async()
         {
+            // Use a loopback redirect URI so that the AcquireTokenInteractive path on .NET 8
+            // passes its loopback validation and reaches the claims merge -- otherwise the
+            // loopback check would throw MsalError.LoopbackRedirectUri before any claims
+            // parsing runs (since ClaimsAndClientCapabilities is computed lazily).
             var app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
                             .WithClientCapabilities(TestConstants.s_clientCapabilities)
+                            .WithRedirectUri("http://localhost")
                             .BuildConcrete();
 
             var ex = await AssertException.TaskThrowsAsync<MsalClientException>(

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -17,20 +17,16 @@ using static Microsoft.Identity.Test.Common.Core.Helpers.ManagedIdentityTestUtil
 namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 {
     /// <summary>
-    /// Unit tests for <c>WithClientClaims()</c> across all three auth flows:
+    /// Unit tests for <c>WithClaimsFromClient()</c> across all three auth flows:
     ///   1. MSIv1 (IMDS GET — claims as query parameter)
     ///   2. Confidential Client / AcquireTokenForClient (claims merged into ESTS POST body)
     ///   3. Cache-key isolation — different claims values produce separate cache entries
     /// </summary>
     [TestClass]
-    public class WithClientClaimsTests : TestBase
+    public class WithClaimsFromClientTests : TestBase
     {
         // A simple NSP-style claims payload used across tests.
         private const string NspClaims = @"{""nsp"":{""essential"":true}}";
-
-        // Same logical claims as NspClaims but with extra whitespace/different key ordering.
-        // After normalization these must equal NspClaims.
-        private const string NspClaimsWithWhitespace = @"{ ""nsp"" : { ""essential"" : true } }";
 
         // A second, distinct claims value used to exercise separate-cache-entry behaviour.
         private const string OtherClaims = @"{""region"":{""value"":""eastus""}}";
@@ -43,7 +39,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         [DataRow(null)]
         [DataRow("")]
         [DataRow("   ")]
-        public void WithClientClaims_NullOrWhitespace_IsNoOp(string emptyClaims)
+        public void WithClaimsFromClient_NullOrWhitespace_IsNoOp(string emptyClaims)
         {
             // Arrange
             using (new EnvVariableContext())
@@ -55,7 +51,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act — should not throw
                 var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(emptyClaims);
+                    .WithClaimsFromClient(emptyClaims);
 
                 // Assert — ClientClaims must remain unset (no cache component added)
                 Assert.IsNull(builder.CommonParameters.ClientClaims,
@@ -66,7 +62,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public void WithClientClaims_SetsClientClaimsOnCommonParameters()
+        public void WithClaimsFromClient_SetsClientClaimsOnCommonParameters()
         {
             // Arrange
             using (new EnvVariableContext())
@@ -79,7 +75,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims);
+                    .WithClaimsFromClient(NspClaims);
 
                 // Assert — normalized claims are stored
                 Assert.IsNotNull(builder.CommonParameters.ClientClaims,
@@ -92,9 +88,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public void WithClientClaims_DoesNotSetCommonParametersClaims()
+        public void WithClaimsFromClient_DoesNotSetCommonParametersClaims()
         {
-            // WithClientClaims must NOT touch CommonParameters.Claims — doing so would
+            // WithClaimsFromClient must NOT touch CommonParameters.Claims — doing so would
             // incorrectly bypass the token cache (Claims is the server-issued bypass signal).
             using (new EnvVariableContext())
             {
@@ -106,38 +102,11 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims);
+                    .WithClaimsFromClient(NspClaims);
 
                 // Assert — CommonParameters.Claims (the cache-bypass property) must be null
                 Assert.IsNull(builder.CommonParameters.Claims,
-                    "WithClientClaims must NOT set CommonParameters.Claims — that would bypass the cache.");
-            }
-        }
-
-        [TestMethod]
-        public void WithClientClaims_NormalizesJsonBeforeStoring()
-        {
-            // The same logical JSON passed with different whitespace must produce an identical
-            // stored value (preventing cache key fragmentation).
-            using (new EnvVariableContext())
-            {
-                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
-                var mi = ManagedIdentityApplicationBuilder
-                    .Create(ManagedIdentityId.SystemAssigned)
-                    .WithExperimentalFeatures(true)
-                    .Build();
-
-                // Act
-                var builder1 = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims);
-                var builder2 = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaimsWithWhitespace);
-
-                // Assert
-                Assert.AreEqual(
-                    builder1.CommonParameters.ClientClaims,
-                    builder2.CommonParameters.ClientClaims,
-                    "Logically identical claims with different whitespace must normalize to the same string.");
+                    "WithClaimsFromClient must NOT set CommonParameters.Claims — that would bypass the cache.");
             }
         }
 
@@ -146,7 +115,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         // ---------------------------------------------------------------------------------
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_ForwardsClaimsAsQueryParameterAsync()
+        public async Task WithClaimsFromClient_Imds_ForwardsClaimsAsQueryParameterAsync()
         {
             // Arrange
             using (new EnvVariableContext())
@@ -164,7 +133,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // The mock handler is set up to expect claims=<normalizedNspClaims> in the query string.
                 // If the MSAL code does NOT send the parameter, the handler will not match and the
                 // test will throw InvalidOperationException (no handler matched).
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedClaims = NspClaims;
                 httpManager.AddManagedIdentityMockHandler(
                     ManagedIdentityTests.ImdsEndpoint,
                     ManagedIdentityTests.Resource,
@@ -174,7 +143,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims)
+                    .WithClaimsFromClient(NspClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -184,7 +153,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_TokenIsCached_SecondCallDoesNotHitNetworkAsync()
+        public async Task WithClaimsFromClient_Imds_TokenIsCached_SecondCallDoesNotHitNetworkAsync()
         {
             // Arrange
             using (new EnvVariableContext())
@@ -200,7 +169,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .Build();
 
                 // Only one network mock — second call must come from cache.
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedClaims = NspClaims;
                 httpManager.AddManagedIdentityMockHandler(
                     ManagedIdentityTests.ImdsEndpoint,
                     ManagedIdentityTests.Resource,
@@ -210,13 +179,13 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act — first call
                 var result1 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims)
+                    .WithClaimsFromClient(NspClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 // Act — second call (no new mock handler added)
                 var result2 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims)
+                    .WithClaimsFromClient(NspClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -229,52 +198,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_SameClaimsNormalized_SameCacheEntryAsync()
-        {
-            // Logically identical claims passed with different whitespace must map to the same
-            // cache entry — only one network call should occur.
-            using (new EnvVariableContext())
-            using (var httpManager = new MockHttpManager())
-            {
-                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
-
-                var mi = ManagedIdentityApplicationBuilder
-                    .Create(ManagedIdentityId.SystemAssigned)
-                    .WithHttpManager(httpManager)
-                    .WithExperimentalFeatures(true)
-
-                    .Build();
-
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
-
-                // Only one network mock
-                httpManager.AddManagedIdentityMockHandler(
-                    ManagedIdentityTests.ImdsEndpoint,
-                    ManagedIdentityTests.Resource,
-                    MockHelpers.GetMsiSuccessfulResponse(),
-                    ManagedIdentitySource.Imds,
-                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedClaims) } });
-
-                // Act
-                var result1 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims)
-                    .ExecuteAsync()
-                    .ConfigureAwait(false);
-
-                var result2 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaimsWithWhitespace)  // same logic, different whitespace
-                    .ExecuteAsync()
-                    .ConfigureAwait(false);
-
-                // Assert
-                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
-                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource,
-                    "Whitespace-variant of the same claims must hit the same cache entry.");
-            }
-        }
-
-        [TestMethod]
-        public async Task WithClientClaims_Imds_DifferentClaims_ProduceSeparateCacheEntriesAsync()
+        public async Task WithClaimsFromClient_Imds_DifferentClaims_ProduceSeparateCacheEntriesAsync()
         {
             // Two calls with distinct claims values must each produce a separate network call.
             using (new EnvVariableContext())
@@ -289,8 +213,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                     .Build();
 
-                string normalizedNsp = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
-                string normalizedOther = Client.Internal.ClaimsHelper.NormalizeClaimsJson(OtherClaims);
+                string normalizedNsp = NspClaims;
+                string normalizedOther = OtherClaims;
 
                 // Two distinct network mocks — each must be consumed
                 httpManager.AddManagedIdentityMockHandler(
@@ -309,12 +233,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var result1 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims)
+                    .WithClaimsFromClient(NspClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 var result2 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(OtherClaims)
+                    .WithClaimsFromClient(OtherClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -327,10 +251,10 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_DoesNotBypassCache_UnlikeWithClaimsAsync()
+        public async Task WithClaimsFromClient_Imds_DoesNotBypassCache_UnlikeWithClaimsAsync()
         {
             // WithClaims() bypasses the cache on every call.
-            // WithClientClaims() must NOT bypass the cache — second call should be a cache hit.
+            // WithClaimsFromClient() must NOT bypass the cache — second call should be a cache hit.
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager())
             {
@@ -343,7 +267,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                     .Build();
 
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedClaims = NspClaims;
 
                 // Only one mock handler — if the second call also hits the network it will throw
                 httpManager.AddManagedIdentityMockHandler(
@@ -355,23 +279,23 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims)
+                    .WithClaimsFromClient(NspClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims)
+                    .WithClaimsFromClient(NspClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 // Assert — second call must be a cache hit, not a network call
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource,
-                    "WithClientClaims must use the cache (unlike WithClaims which always bypasses).");
+                    "WithClaimsFromClient must use the cache (unlike WithClaims which always bypasses).");
             }
         }
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_NoClaims_ClaimsParamAbsentFromRequestAsync()
+        public async Task WithClaimsFromClient_Imds_NoClaims_ClaimsParamAbsentFromRequestAsync()
         {
             // When no client claims are specified, the `claims` query parameter must be absent.
             using (new EnvVariableContext())
@@ -393,7 +317,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     MockHelpers.GetMsiSuccessfulResponse(),
                     ManagedIdentitySource.Imds);
 
-                // Act — no WithClientClaims call
+                // Act — no WithClaimsFromClient call
                 var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
@@ -408,7 +332,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         // ---------------------------------------------------------------------------------
 
         [TestMethod]
-        public async Task WithClientClaims_ConfidentialClient_SendsClaimsInEstsBodyAsync()
+        public async Task WithClaimsFromClient_ConfidentialClient_SendsClaimsInEstsBodyAsync()
         {
             // Arrange
             using (var harness = CreateTestHarness())
@@ -423,7 +347,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedClaims = NspClaims;
 
                 // The POST body must contain claims=<normalizedClaims>
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
@@ -436,7 +360,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedClaims)
+                    .WithClaimsFromClient(normalizedClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -447,7 +371,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_ConfidentialClient_TokenIsCached_SecondCallFromCacheAsync()
+        public async Task WithClaimsFromClient_ConfidentialClient_TokenIsCached_SecondCallFromCacheAsync()
         {
             // Arrange
             using (var harness = CreateTestHarness())
@@ -462,7 +386,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedClaims = NspClaims;
 
                 // Only one mock — second call must come from cache
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
@@ -471,12 +395,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var result1 = await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedClaims)
+                    .WithClaimsFromClient(normalizedClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 var result2 = await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedClaims)
+                    .WithClaimsFromClient(normalizedClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -489,7 +413,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_ConfidentialClient_DifferentClaims_SeparateCacheEntriesAsync()
+        public async Task WithClaimsFromClient_ConfidentialClient_DifferentClaims_SeparateCacheEntriesAsync()
         {
             // Arrange
             using (var harness = CreateTestHarness())
@@ -504,8 +428,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
-                string normalizedNsp = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
-                string normalizedOther = Client.Internal.ClaimsHelper.NormalizeClaimsJson(OtherClaims);
+                string normalizedNsp = NspClaims;
+                string normalizedOther = OtherClaims;
 
                 // Two distinct network mocks
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
@@ -518,12 +442,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var result1 = await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedNsp)
+                    .WithClaimsFromClient(normalizedNsp)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 var result2 = await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedOther)
+                    .WithClaimsFromClient(normalizedOther)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -536,7 +460,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_ConfidentialClient_DoesNotBypassCacheAsync()
+        public async Task WithClaimsFromClient_ConfidentialClient_DoesNotBypassCacheAsync()
         {
             // Arrange
             using (var harness = CreateTestHarness())
@@ -551,7 +475,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedClaims = NspClaims;
 
                 // Only one mock — if second call also hits the network it will throw
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
@@ -560,26 +484,26 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedClaims)
+                    .WithClaimsFromClient(normalizedClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 var result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedClaims)
+                    .WithClaimsFromClient(normalizedClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
                 // Assert
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource,
-                    "WithClientClaims must not bypass the cache on repeated calls.");
+                    "WithClaimsFromClient must not bypass the cache on repeated calls.");
             }
         }
 
         [TestMethod]
-        public async Task WithClientClaims_ConfidentialClient_WithServerClaims_ServerClaimsBypassesCacheAsync()
+        public async Task WithClaimsFromClient_ConfidentialClient_WithServerClaims_ServerClaimsBypassesCacheAsync()
         {
             // WithClaims (server-issued) always bypasses the cache.
-            // WithClientClaims (client-originated) does not.
+            // WithClaimsFromClient (client-originated) does not.
             // When both are used together, the server claim should still bypass the cache.
             using (var harness = CreateTestHarness())
             {
@@ -593,7 +517,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
-                string normalizedClientClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedClientClaims = NspClaims;
 
                 // First call — populate cache with client claims
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
@@ -601,17 +525,17 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
 
                 await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedClientClaims)
+                    .WithClaimsFromClient(normalizedClientClaims)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
-                // Second call — with WithClaims (server bypass) in addition to WithClientClaims
+                // Second call — with WithClaims (server bypass) in addition to WithClaimsFromClient
                 harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
                     TestConstants.AuthorityUtidTenant,
                     responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
 
                 var result = await app.AcquireTokenForClient(TestConstants.s_scope)
-                    .WithClientClaims(normalizedClientClaims)
+                    .WithClaimsFromClient(normalizedClientClaims)
                     .WithClaims(TestConstants.Claims)   // server-issued → bypasses cache
                     .ExecuteAsync()
                     .ConfigureAwait(false);
@@ -623,7 +547,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_ConfidentialClient_NoClaims_ClaimsParamAbsentFromBodyAsync()
+        public async Task WithClaimsFromClient_ConfidentialClient_NoClaims_ClaimsParamAbsentFromBodyAsync()
         {
             // When no client claims are specified, the `claims` body parameter must not appear.
             using (var harness = CreateTestHarness())
@@ -643,7 +567,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     TestConstants.AuthorityUtidTenant,
                     responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
 
-                // Act — no WithClientClaims
+                // Act — no WithClaimsFromClient
                 var result = await app.AcquireTokenForClient(TestConstants.s_scope)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
@@ -658,7 +582,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         // ---------------------------------------------------------------------------------
 
         [TestMethod]
-        public void WithClientClaims_InvalidJson_ThrowsMsalClientException()
+        public void WithClaimsFromClient_InvalidJson_ThrowsMsalClientException()
         {
             // Arrange
             using (new EnvVariableContext())
@@ -672,14 +596,14 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // Act & Assert
                 MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
                     () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                            .WithClientClaims("not-valid-json"));
+                            .WithClaimsFromClient("not-valid-json"));
 
                 Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
             }
         }
 
         [TestMethod]
-        public void WithClientClaims_JsonNullLiteral_ThrowsMsalClientException()
+        public void WithClaimsFromClient_JsonNullLiteral_ThrowsMsalClientException()
         {
             // "null" is valid JSON but not a JSON object — must produce MsalClientException,
             // not a raw NullReferenceException from JsonNode.AsObject().
@@ -694,7 +618,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // Act & Assert
                 MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
                     () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                            .WithClientClaims("null"));
+                            .WithClaimsFromClient("null"));
 
                 Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
             }
@@ -705,9 +629,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         // ---------------------------------------------------------------------------------
 
         [TestMethod]
-        public void WithClientClaims_NonImdsSource_SetsBuilderParameterButThrowsOnExecution()
+        public void WithClaimsFromClient_NonImdsSource_SetsBuilderParameterButThrowsOnExecution()
         {
-            // WithClientClaims() sets the builder parameter for any MI source — the guard that
+            // WithClaimsFromClient() sets the builder parameter for any MI source — the guard that
             // rejects non-IMDS sources fires at request-execution time (in AbstractManagedIdentity),
             // not at builder construction time. This test verifies the builder state; a full
             // execution-level test requires mocking the App Service endpoint and is deferred.
@@ -721,7 +645,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(NspClaims);
+                    .WithClaimsFromClient(NspClaims);
 
                 // Assert — parameter is stored on the builder regardless of source;
                 // MsalClientException is thrown later when the request is executed.
@@ -741,7 +665,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         private const string MixedClaims = @"{""xms_az_nwperimid"":{""values"":[""perimid-1234""]},""other_claim"":{""essential"":true}}";
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_ValidXmsAzNwperimid_SucceedsAsync()
+        public async Task WithClaimsFromClient_Imds_ValidXmsAzNwperimid_SucceedsAsync()
         {
             // xms_az_nwperimid is the only allowed claim for MSIv1; a request carrying it must succeed.
             using (new EnvVariableContext())
@@ -755,7 +679,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithExperimentalFeatures(true)
                     .Build();
 
-                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(ValidNspClaim);
+                string normalizedClaims = ValidNspClaim;
                 httpManager.AddManagedIdentityMockHandler(
                     ManagedIdentityTests.ImdsEndpoint,
                     ManagedIdentityTests.Resource,
@@ -765,7 +689,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act
                 var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                    .WithClientClaims(ValidNspClaim)
+                    .WithClaimsFromClient(ValidNspClaim)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
@@ -775,7 +699,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_UnsupportedClaim_ThrowsMsalClientExceptionAsync()
+        public async Task WithClaimsFromClient_Imds_UnsupportedClaim_ThrowsMsalClientExceptionAsync()
         {
             // Any claim key other than xms_az_nwperimid must be rejected before the network call,
             // so the caller gets a clear error instead of an opaque HTTP 400 from IMDS.
@@ -793,7 +717,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // Act & Assert — MsalClientException must be thrown before any HTTP request is made
                 MsalClientException ex = await Assert.ThrowsExactlyAsync<MsalClientException>(
                     () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                            .WithClientClaims(UnsupportedClaim)
+                            .WithClaimsFromClient(UnsupportedClaim)
                             .ExecuteAsync())
                     .ConfigureAwait(false);
 
@@ -803,7 +727,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public async Task WithClientClaims_Imds_MixedClaims_ThrowsMsalClientExceptionAsync()
+        public async Task WithClaimsFromClient_Imds_MixedClaims_ThrowsMsalClientExceptionAsync()
         {
             // Even if xms_az_nwperimid is present, any additional claims must be rejected.
             using (new EnvVariableContext())
@@ -820,7 +744,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // Act & Assert
                 MsalClientException ex = await Assert.ThrowsExactlyAsync<MsalClientException>(
                     () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                            .WithClientClaims(MixedClaims)
+                            .WithClaimsFromClient(MixedClaims)
                             .ExecuteAsync())
                     .ConfigureAwait(false);
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -705,12 +705,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         // ---------------------------------------------------------------------------------
 
         [TestMethod]
-        public void WithClientClaims_NonImdsSource_SetsBuilderParameter()
+        public void WithClientClaims_NonImdsSource_SetsBuilderParameterButThrowsOnExecution()
         {
-            // WithClientClaims() is available on AcquireTokenForManagedIdentity regardless of
-            // the underlying MI source. This test verifies the builder sets the parameter for
-            // a non-IMDS source (App Service). Whether and how the claim is forwarded on the
-            // wire is source-specific and subject to the POC open question on scope.
+            // WithClientClaims() sets the builder parameter for any MI source — the guard that
+            // rejects non-IMDS sources fires at request-execution time (in AbstractManagedIdentity),
+            // not at builder construction time. This test verifies the builder state; a full
+            // execution-level test requires mocking the App Service endpoint and is deferred.
             using (new EnvVariableContext())
             {
                 SetEnvironmentVariables(ManagedIdentitySource.AppService, "http://127.0.0.1:41564/msi/token");
@@ -723,7 +723,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
                     .WithClientClaims(NspClaims);
 
-                // Assert — parameter is stored regardless of source
+                // Assert — parameter is stored on the builder regardless of source;
+                // MsalClientException is thrown later when the request is executed.
                 Assert.IsNotNull(builder.CommonParameters.ClientClaims,
                     "ClientClaims must be set on the builder even for non-IMDS sources.");
                 Assert.IsTrue(builder.CommonParameters.CacheKeyComponents.ContainsKey("client_claims"),

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -1,0 +1,661 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
+using Microsoft.Identity.Client.Extensibility;
+using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Identity.Test.Common.Core.Helpers.ManagedIdentityTestUtil;
+
+namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
+{
+    /// <summary>
+    /// Unit tests for <c>WithClientClaims()</c> across all three auth flows:
+    ///   1. MSIv1 (IMDS GET — claims as query parameter)
+    ///   2. Confidential Client / AcquireTokenForClient (claims merged into ESTS POST body)
+    ///   3. Cache-key isolation — different claims values produce separate cache entries
+    /// </summary>
+    [TestClass]
+    public class WithClientClaimsTests : TestBase
+    {
+        // A simple NSP-style claims payload used across tests.
+        private const string NspClaims = @"{""nsp"":{""essential"":true}}";
+
+        // Same logical claims as NspClaims but with extra whitespace/different key ordering.
+        // After normalization these must equal NspClaims.
+        private const string NspClaimsWithWhitespace = @"{ ""nsp"" : { ""essential"" : true } }";
+
+        // A second, distinct claims value used to exercise separate-cache-entry behaviour.
+        private const string OtherClaims = @"{""region"":{""value"":""eastus""}}";
+
+        // ---------------------------------------------------------------------------------
+        // Builder-level unit tests (no HTTP)
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public void WithClientClaims_NullOrWhitespace_IsNoOp(string emptyClaims)
+        {
+            // Arrange
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .Build();
+
+                // Act — should not throw
+                var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(emptyClaims);
+
+                // Assert — ClientClaims must remain unset (no cache component added)
+                Assert.IsNull(builder.CommonParameters.ClientClaims,
+                    "Empty/null claims should not set ClientClaims.");
+                Assert.IsNull(builder.CommonParameters.CacheKeyComponents,
+                    "Empty/null claims should not add cache key components.");
+            }
+        }
+
+        [TestMethod]
+        public void WithClientClaims_SetsClientClaimsOnCommonParameters()
+        {
+            // Arrange
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .Build();
+
+                // Act
+                var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims);
+
+                // Assert — normalized claims are stored
+                Assert.IsNotNull(builder.CommonParameters.ClientClaims,
+                    "ClientClaims must be set.");
+                Assert.IsNotNull(builder.CommonParameters.CacheKeyComponents,
+                    "CacheKeyComponents must be populated.");
+                Assert.IsTrue(builder.CommonParameters.CacheKeyComponents.ContainsKey("client_claims"),
+                    "client_claims cache key component must be present.");
+            }
+        }
+
+        [TestMethod]
+        public void WithClientClaims_DoesNotSetCommonParametersClaims()
+        {
+            // WithClientClaims must NOT touch CommonParameters.Claims — doing so would
+            // incorrectly bypass the token cache (Claims is the server-issued bypass signal).
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .Build();
+
+                // Act
+                var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims);
+
+                // Assert — CommonParameters.Claims (the cache-bypass property) must be null
+                Assert.IsNull(builder.CommonParameters.Claims,
+                    "WithClientClaims must NOT set CommonParameters.Claims — that would bypass the cache.");
+            }
+        }
+
+        [TestMethod]
+        public void WithClientClaims_NormalizesJsonBeforeStoring()
+        {
+            // The same logical JSON passed with different whitespace must produce an identical
+            // stored value (preventing cache key fragmentation).
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .Build();
+
+                // Act
+                var builder1 = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims);
+                var builder2 = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaimsWithWhitespace);
+
+                // Assert
+                Assert.AreEqual(
+                    builder1.CommonParameters.ClientClaims,
+                    builder2.CommonParameters.ClientClaims,
+                    "Logically identical claims with different whitespace must normalize to the same string.");
+            }
+        }
+
+        // ---------------------------------------------------------------------------------
+        // MSIv1 (IMDS GET) — claims forwarded as a query parameter
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_ForwardsClaimsAsQueryParameterAsync()
+        {
+            // Arrange
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                // The mock handler is set up to expect claims=<normalizedNspClaims> in the query string.
+                // If the MSAL code does NOT send the parameter, the handler will not match and the
+                // test will throw InvalidOperationException (no handler matched).
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds,
+                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedClaims) } });
+
+                // Act
+                var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_TokenIsCached_SecondCallDoesNotHitNetworkAsync()
+        {
+            // Arrange
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                // Only one network mock — second call must come from cache.
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds,
+                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedClaims) } });
+
+                // Act — first call
+                var result1 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Act — second call (no new mock handler added)
+                var result2 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
+                    "First call should hit the network.");
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource,
+                    "Second call with identical claims must be served from cache.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_SameClaimsNormalized_SameCacheEntryAsync()
+        {
+            // Logically identical claims passed with different whitespace must map to the same
+            // cache entry — only one network call should occur.
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+
+                // Only one network mock
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds,
+                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedClaims) } });
+
+                // Act
+                var result1 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var result2 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaimsWithWhitespace)  // same logic, different whitespace
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource,
+                    "Whitespace-variant of the same claims must hit the same cache entry.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_DifferentClaims_ProduceSeparateCacheEntriesAsync()
+        {
+            // Two calls with distinct claims values must each produce a separate network call.
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                string normalizedNsp = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedOther = Client.Internal.ClaimsHelper.NormalizeClaimsJson(OtherClaims);
+
+                // Two distinct network mocks — each must be consumed
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds,
+                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedNsp) } });
+
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds,
+                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedOther) } });
+
+                // Act
+                var result1 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var result2 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(OtherClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert — both calls must have hit the network (different cache partitions)
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
+                    "First claims value should hit the network.");
+                Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource,
+                    "Different claims value should produce a separate cache entry and hit the network.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_DoesNotBypassCache_UnlikeWithClaimsAsync()
+        {
+            // WithClaims() bypasses the cache on every call.
+            // WithClientClaims() must NOT bypass the cache — second call should be a cache hit.
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+
+                // Only one mock handler — if the second call also hits the network it will throw
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds,
+                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedClaims) } });
+
+                // Act
+                await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert — second call must be a cache hit, not a network call
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource,
+                    "WithClientClaims must use the cache (unlike WithClaims which always bypasses).");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_NoClaims_ClaimsParamAbsentFromRequestAsync()
+        {
+            // When no client claims are specified, the `claims` query parameter must be absent.
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                // Standard mock handler with no claims expectation
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds);
+
+                // Act — no WithClientClaims call
+                var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert — should succeed normally
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Confidential Client / AcquireTokenForClient — claims merged into ESTS POST body
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task WithClientClaims_ConfidentialClient_SendsClaimsInEstsBodyAsync()
+        {
+            // Arrange
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+
+                // The POST body must contain claims=<normalizedClaims>
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    bodyParameters: new Dictionary<string, string>
+                    {
+                        { OAuth2Parameter.Claims, normalizedClaims }
+                    },
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                // Act
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_ConfidentialClient_TokenIsCached_SecondCallFromCacheAsync()
+        {
+            // Arrange
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+
+                // Only one mock — second call must come from cache
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                // Act
+                var result1 = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var result2 = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
+                    "First call should hit the network.");
+                Assert.AreEqual(TokenSource.Cache, result2.AuthenticationResultMetadata.TokenSource,
+                    "Second call with identical claims must be served from cache.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_ConfidentialClient_DifferentClaims_SeparateCacheEntriesAsync()
+        {
+            // Arrange
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                string normalizedNsp = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+                string normalizedOther = Client.Internal.ClaimsHelper.NormalizeClaimsJson(OtherClaims);
+
+                // Two distinct network mocks
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                // Act
+                var result1 = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedNsp)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var result2 = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedOther)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
+                    "First claims value should hit the network.");
+                Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource,
+                    "Different claims value should produce a separate cache entry and hit the network.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_ConfidentialClient_DoesNotBypassCacheAsync()
+        {
+            // Arrange
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+
+                // Only one mock — if second call also hits the network it will throw
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                // Act
+                await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource,
+                    "WithClientClaims must not bypass the cache on repeated calls.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_ConfidentialClient_WithServerClaims_ServerClaimsBypassesCacheAsync()
+        {
+            // WithClaims (server-issued) always bypasses the cache.
+            // WithClientClaims (client-originated) does not.
+            // When both are used together, the server claim should still bypass the cache.
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                string normalizedClientClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
+
+                // First call — populate cache with client claims
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedClientClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Second call — with WithClaims (server bypass) in addition to WithClientClaims
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithClientClaims(normalizedClientClaims)
+                    .WithClaims(TestConstants.Claims)   // server-issued → bypasses cache
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert — server claims bypass forces a network call even though the token is cached
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource,
+                    "WithClaims (server-issued) must always bypass the cache.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_ConfidentialClient_NoClaims_ClaimsParamAbsentFromBodyAsync()
+        {
+            // When no client claims are specified, the `claims` body parameter must not appear.
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(harness.HttpManager)
+                    .BuildConcrete();
+
+                // Standard success response — no body parameter expectation
+                harness.HttpManager.AddSuccessTokenResponseMockHandlerForPost(
+                    TestConstants.AuthorityUtidTenant,
+                    responseMessage: MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage());
+
+                // Act — no WithClientClaims
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert — normal token acquisition succeeds
+                Assert.IsNotNull(result);
+            }
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Invalid JSON
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void WithClientClaims_InvalidJson_ThrowsMsalClientException()
+        {
+            // Arrange
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .Build();
+
+                // Act & Assert
+                MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
+                    () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                            .WithClientClaims("not-valid-json"));
+
+                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
     [TestClass]
     public class WithClaimsFromClientTests : TestBase
     {
-        // A simple NSP-style claims payload used across tests.
-        private const string NspClaims = @"{""nsp"":{""essential"":true}}";
+        // A simple NSP-style claims payload used across tests. MSIv1 only allows the `xms_az_nwperimid` key.
+        private const string NspClaims = @"{""xms_az_nwperimid"":{""essential"":true}}";
 
         // A second, distinct claims value used to exercise separate-cache-entry behaviour.
-        private const string OtherClaims = @"{""region"":{""value"":""eastus""}}";
+        private const string OtherClaims = @"{""xms_az_nwperimid"":{""values"":[""eastus""]}}";
 
         // ---------------------------------------------------------------------------------
         // Builder-level unit tests (no HTTP)
@@ -580,49 +580,15 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         // ---------------------------------------------------------------------------------
         // Invalid JSON
         // ---------------------------------------------------------------------------------
-
-        [TestMethod]
-        public void WithClaimsFromClient_InvalidJson_ThrowsMsalClientException()
-        {
-            // Arrange
-            using (new EnvVariableContext())
-            {
-                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
-                var mi = ManagedIdentityApplicationBuilder
-                    .Create(ManagedIdentityId.SystemAssigned)
-                    .WithExperimentalFeatures(true)
-                    .Build();
-
-                // Act & Assert
-                MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
-                    () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                            .WithClaimsFromClient("not-valid-json"));
-
-                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
-            }
-        }
-
-        [TestMethod]
-        public void WithClaimsFromClient_JsonNullLiteral_ThrowsMsalClientException()
-        {
-            // "null" is valid JSON but not a JSON object — must produce MsalClientException,
-            // not a raw NullReferenceException from JsonNode.AsObject().
-            using (new EnvVariableContext())
-            {
-                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
-                var mi = ManagedIdentityApplicationBuilder
-                    .Create(ManagedIdentityId.SystemAssigned)
-                    .WithExperimentalFeatures(true)
-                    .Build();
-
-                // Act & Assert
-                MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
-                    () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
-                            .WithClaimsFromClient("null"));
-
-                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
-            }
-        }
+        //
+        // Note: WithClaimsFromClient intentionally does NOT validate the JSON at builder time.
+        // Per reviewer feedback (Bogdan), MSAL stores the raw caller string verbatim and does no
+        // parsing on the hot path. Invalid JSON (e.g. "not-valid-json", "null") is forwarded as-is
+        // and will surface as an MsalServiceException from the wire when IMDS/ESTS rejects it, or
+        // as an MsalClientException from MergeClaimsObjects on cache miss when a server-issued
+        // claims challenge is also present. Builder-time fail-fast tests were removed when the
+        // NormalizeClaimsJson code path was deleted.
+        // ---------------------------------------------------------------------------------
 
         // ---------------------------------------------------------------------------------
         // Non-IMDS sources — builder behavior

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
@@ -76,6 +74,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
+                    .WithExperimentalFeatures(true)
                     .Build();
 
                 // Act
@@ -102,6 +101,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
+                    .WithExperimentalFeatures(true)
                     .Build();
 
                 // Act
@@ -124,6 +124,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
+                    .WithExperimentalFeatures(true)
                     .Build();
 
                 // Act
@@ -156,6 +157,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
                     .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+
                     .Build();
 
                 // The mock handler is set up to expect claims=<normalizedNspClaims> in the query string.
@@ -192,6 +195,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
                     .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+
                     .Build();
 
                 // Only one network mock — second call must come from cache.
@@ -236,6 +241,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
                     .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+
                     .Build();
 
                 string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -278,6 +285,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
                     .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+
                     .Build();
 
                 string normalizedNsp = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -330,6 +339,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
                     .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+
                     .Build();
 
                 string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -371,6 +382,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
                     .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+
                     .Build();
 
                 // Standard mock handler with no claims expectation
@@ -407,6 +420,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(harness.HttpManager)
+                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -445,6 +459,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(harness.HttpManager)
+                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -486,6 +501,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(harness.HttpManager)
+                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 string normalizedNsp = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -532,6 +548,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(harness.HttpManager)
+                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -573,6 +590,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(harness.HttpManager)
+                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 string normalizedClientClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(NspClaims);
@@ -617,6 +635,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     .WithAuthority(AzureCloudInstance.AzurePublic, TestConstants.Utid)
                     .WithClientSecret(TestConstants.ClientSecret)
                     .WithHttpManager(harness.HttpManager)
+                    .WithExperimentalFeatures(true)
                     .BuildConcrete();
 
                 // Standard success response — no body parameter expectation
@@ -647,6 +666,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
                 var mi = ManagedIdentityApplicationBuilder
                     .Create(ManagedIdentityId.SystemAssigned)
+                    .WithExperimentalFeatures(true)
                     .Build();
 
                 // Act & Assert
@@ -659,3 +679,5 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
     }
 }
+
+

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -295,6 +295,66 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
+        public async Task WithClaimsFromClient_Imds_CombinedWithWithClaims_ForwardsClientClaimsAndBypassesCacheAsync()
+        {
+            // When both .WithClaims (server-issued challenge) and .WithClaimsFromClient (client claims)
+            // are supplied on the same MSI request:
+            //   - Only the client claims are forwarded to IMDS as the `claims` query parameter
+            //     (server-issued challenges are not a recognised IMDS contract).
+            //   - .WithClaims causes the request to bypass the cache on every call, so two back-to-back
+            //     calls with identical inputs must each hit the network.
+            const string ServerClaims = @"{""access_token"":{""nbf"":{""essential"":true}}}";
+
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .Build();
+
+                // Two mocks — both expect ONLY the client claims in the `claims` parameter, never
+                // a merged value that includes ServerClaims. If MSAL accidentally merges them or
+                // forwards the server-issued claims, neither handler will match and the test fails.
+                for (int i = 0; i < 2; i++)
+                {
+                    httpManager.AddManagedIdentityMockHandler(
+                        ManagedIdentityTests.ImdsEndpoint,
+                        ManagedIdentityTests.Resource,
+                        MockHelpers.GetMsiSuccessfulResponse(),
+                        ManagedIdentitySource.Imds,
+                        extraQueryParameters: new Dictionary<string, string>
+                        {
+                            { "claims", Uri.EscapeDataString(NspClaims) }
+                        });
+                }
+
+                // Act — first call
+                var result1 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClaims(ServerClaims)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Act — second call with identical inputs; .WithClaims must force a network round-trip
+                var result2 = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClaims(ServerClaims)
+                    .WithClaimsFromClient(NspClaims)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.IdentityProvider, result1.AuthenticationResultMetadata.TokenSource,
+                    "First call should hit the network.");
+                Assert.AreEqual(TokenSource.IdentityProvider, result2.AuthenticationResultMetadata.TokenSource,
+                    "WithClaims must bypass the cache even when WithClaimsFromClient is also set.");
+            }
+        }
+
+        [TestMethod]
         public async Task WithClaimsFromClient_Imds_NoClaims_ClaimsParamAbsentFromRequestAsync()
         {
             // When no client claims are specified, the `claims` query parameter must be absent.
@@ -619,6 +679,42 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     "ClientClaims must be set on the builder even for non-IMDS sources.");
                 Assert.IsTrue(builder.CommonParameters.CacheKeyComponents.ContainsKey("client_claims"),
                     "Cache key component must be registered.");
+            }
+        }
+
+        [TestMethod]
+        [DataRow(ManagedIdentitySource.AppService, "http://127.0.0.1:41564/msi/token")]
+        [DataRow(ManagedIdentitySource.AzureArc, "http://127.0.0.1:40342/metadata/identity/oauth2/token")]
+        [DataRow(ManagedIdentitySource.CloudShell, "http://localhost:50342/oauth2/token")]
+        [DataRow(ManagedIdentitySource.ServiceFabric, "https://127.0.0.1:2377/metadata/identity/oauth2/token")]
+        [DataRow(ManagedIdentitySource.MachineLearning, "http://localhost:7071/msi/token")]
+        public async Task WithClaimsFromClient_NonImdsSource_ExecuteThrowsMsalClientExceptionAsync(
+            ManagedIdentitySource source,
+            string endpoint)
+        {
+            // Only IMDS / IMDSv2 are wired to forward client claims today. Any other source must
+            // fail fast with MsalClientException at execute time so callers don't silently lose
+            // their claims (and so the cache doesn't pollute with keys the endpoint never saw).
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(source, endpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithExperimentalFeatures(true)
+                    .Build();
+
+                MsalClientException ex = await Assert.ThrowsExactlyAsync<MsalClientException>(
+                    () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                            .WithClaimsFromClient(NspClaims)
+                            .ExecuteAsync())
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.InvalidRequest, ex.ErrorCode);
+                Assert.Contains(source.ToString(), ex.Message,
+                    "Error message should name the detected source.");
+                Assert.Contains("IMDS", ex.Message,
+                    "Error message should explain only IMDS sources are supported.");
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -677,6 +677,59 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
             }
         }
+
+        [TestMethod]
+        public void WithClientClaims_JsonNullLiteral_ThrowsMsalClientException()
+        {
+            // "null" is valid JSON but not a JSON object — must produce MsalClientException,
+            // not a raw NullReferenceException from JsonNode.AsObject().
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithExperimentalFeatures(true)
+                    .Build();
+
+                // Act & Assert
+                MsalClientException ex = Assert.ThrowsExactly<MsalClientException>(
+                    () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                            .WithClientClaims("null"));
+
+                Assert.AreEqual(MsalError.InvalidJsonClaimsFormat, ex.ErrorCode);
+            }
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Non-IMDS sources — builder behavior
+        // ---------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void WithClientClaims_NonImdsSource_SetsBuilderParameter()
+        {
+            // WithClientClaims() is available on AcquireTokenForManagedIdentity regardless of
+            // the underlying MI source. This test verifies the builder sets the parameter for
+            // a non-IMDS source (App Service). Whether and how the claim is forwarded on the
+            // wire is source-specific and subject to the POC open question on scope.
+            using (new EnvVariableContext())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.AppService, "http://127.0.0.1:41564/msi/token");
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithExperimentalFeatures(true)
+                    .Build();
+
+                // Act
+                var builder = mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(NspClaims);
+
+                // Assert — parameter is stored regardless of source
+                Assert.IsNotNull(builder.CommonParameters.ClientClaims,
+                    "ClientClaims must be set on the builder even for non-IMDS sources.");
+                Assert.IsTrue(builder.CommonParameters.CacheKeyComponents.ContainsKey("client_claims"),
+                    "Cache key component must be registered.");
+            }
+        }
     }
 }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WithClientClaimsTests.cs
@@ -731,6 +731,102 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     "Cache key component must be registered.");
             }
         }
+
+        // ---------------------------------------------------------------------------------
+        // MSIv1 claim allowlist validation — only xms_az_nwperimid is permitted
+        // ---------------------------------------------------------------------------------
+
+        private const string ValidNspClaim = @"{""xms_az_nwperimid"":{""values"":[""perimid-1234""]}}";
+        private const string UnsupportedClaim = @"{""custom_claim"":{""essential"":true}}";
+        private const string MixedClaims = @"{""xms_az_nwperimid"":{""values"":[""perimid-1234""]},""other_claim"":{""essential"":true}}";
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_ValidXmsAzNwperimid_SucceedsAsync()
+        {
+            // xms_az_nwperimid is the only allowed claim for MSIv1; a request carrying it must succeed.
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .Build();
+
+                string normalizedClaims = Client.Internal.ClaimsHelper.NormalizeClaimsJson(ValidNspClaim);
+                httpManager.AddManagedIdentityMockHandler(
+                    ManagedIdentityTests.ImdsEndpoint,
+                    ManagedIdentityTests.Resource,
+                    MockHelpers.GetMsiSuccessfulResponse(),
+                    ManagedIdentitySource.Imds,
+                    extraQueryParameters: new Dictionary<string, string> { { "claims", Uri.EscapeDataString(normalizedClaims) } });
+
+                // Act
+                var result = await mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithClientClaims(ValidNspClaim)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_UnsupportedClaim_ThrowsMsalClientExceptionAsync()
+        {
+            // Any claim key other than xms_az_nwperimid must be rejected before the network call,
+            // so the caller gets a clear error instead of an opaque HTTP 400 from IMDS.
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .Build();
+
+                // Act & Assert — MsalClientException must be thrown before any HTTP request is made
+                MsalClientException ex = await Assert.ThrowsExactlyAsync<MsalClientException>(
+                    () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                            .WithClientClaims(UnsupportedClaim)
+                            .ExecuteAsync())
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.InvalidRequest, ex.ErrorCode);
+                Assert.Contains("xms_az_nwperimid", ex.Message, "Error message should name the only allowed claim.");
+            }
+        }
+
+        [TestMethod]
+        public async Task WithClientClaims_Imds_MixedClaims_ThrowsMsalClientExceptionAsync()
+        {
+            // Even if xms_az_nwperimid is present, any additional claims must be rejected.
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, ManagedIdentityTests.ImdsEndpoint);
+
+                var mi = ManagedIdentityApplicationBuilder
+                    .Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures(true)
+                    .Build();
+
+                // Act & Assert
+                MsalClientException ex = await Assert.ThrowsExactlyAsync<MsalClientException>(
+                    () => mi.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                            .WithClientClaims(MixedClaims)
+                            .ExecuteAsync())
+                    .ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.InvalidRequest, ex.ErrorCode);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implementation of `WithClaimsFromClient(string claimsJson)` — a new per-request API that lets clients forward a JSON claims payload (e.g., NSP `xms_az_nwperimid`) to ESTS / IMDS. Companion to the design doc in #5982 (now merged).

## What this PR does

Adds the API on:
- `AcquireTokenForManagedIdentityParameterBuilder` (MSI flows — currently MSIv1 only; MSIv2 design pending IMDS team)
- `AcquireTokenForClientParameterBuilder` and the FIC builder, via `AbstractConfidentialClientAcquireTokenParameterBuilderExtension`

Wires the claims through to the existing claims/capabilities merge pipeline so they participate correctly in cache keying and are sent on the wire as a standard OAuth `claims` parameter (body for ESTS, query string for IMDS v1).

## Out of scope (tracked separately)

- MSIv1 single-claim allowlist on IMDS (Raghu — canary by end June)
- MSIv2 `/issuecredential` boolean parameter (blocked on IMDS team design)
- E2E tests against a real VM in an NSP (blocked on test infra coordination with Redis Cache team)
