### PR TITLE
Do not review - added a fix for oidc different cloud

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/KnownMetadataProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Utils;
 
@@ -17,6 +18,15 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 
         private static readonly ISet<string> s_knownEnvironments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly ISet<string> s_knownPublicEnvironments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Shape check for the {region} label in a regional host, e.g. "westus2" in
+        // "westus2.login.microsoft.com". DNS-label rules per RFC 1035/1123:
+        // lowercase alphanumeric + optional internal hyphens, max 63 chars.
+        // Uri.Host is already lowercased, so IgnoreCase isn't needed. The real allow-list
+        // is the base-host lookup in TryResolveKnownCloud.
+        private static readonly Regex s_regionPrefixRegex = new Regex(
+            "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         static KnownMetadataProvider()
         {
@@ -146,6 +156,60 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         public static bool IsKnownEnvironment(string environment)
         {
             return s_knownEnvironments.Contains(environment);
+        }
+
+        /// <summary>
+        /// True only when both hosts resolve to the same Microsoft sovereign cloud.
+        /// e.g. (login.microsoftonline.com, sts.windows.net) → true; (Public, China) → false;
+        /// either host unknown → false. Regional variants share their base host's cloud.
+        /// </summary>
+        internal static bool AreInSameCloud(string hostA, string hostB)
+        {
+            if (!TryResolveKnownCloud(hostA, out InstanceDiscoveryMetadataEntry entryA))
+            {
+                return false;
+            }
+
+            if (!TryResolveKnownCloud(hostB, out InstanceDiscoveryMetadataEntry entryB))
+            {
+                return false;
+            }
+
+            return ReferenceEquals(entryA, entryB);
+        }
+
+        // Exact lookup, else strip a single well-formed regional prefix ("westus2.") and
+        // re-lookup the base host. Anything else (multi-label, bad shape) → false.
+        // Returns the singleton entry per cloud (see ctor); callers may compare via ReferenceEquals.
+        internal static bool TryResolveKnownCloud(string host, out InstanceDiscoveryMetadataEntry entry)
+        {
+            if (string.IsNullOrEmpty(host))
+            {
+                entry = null;
+                return false;
+            }
+
+            if (s_knownEntries.TryGetValue(host, out entry))
+            {
+                return true;
+            }
+
+            int firstDot = host.IndexOf('.');
+            if (firstDot > 0 && firstDot < host.Length - 1)
+            {
+                string regionPrefix = host.Substring(0, firstDot);
+                if (s_regionPrefixRegex.IsMatch(regionPrefix))
+                {
+                    string baseHost = host.Substring(firstDot + 1);
+                    if (s_knownEntries.TryGetValue(baseHost, out entry))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            entry = null;
+            return false;
         }
 
         public static bool TryGetKnownEnviromentPreferredNetwork(string environment, out string preferredNetworkEnvironment)

--- a/src/client/Microsoft.Identity.Client/Instance/Oidc/OidcRetrieverWithCache.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Oidc/OidcRetrieverWithCache.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,7 +52,16 @@ namespace Microsoft.Identity.Client.Instance.Oidc
 
                 // Validate the issuer before caching the configuration
                 requestContext.Logger.Verbose(() => $"[OIDC Discovery] Validating issuer: {configuration.Issuer} against authority: {authority}");
-                ValidateIssuer(new Uri(authority), configuration.Issuer);
+                Uri authorityUri = new Uri(authority);
+                ValidateIssuer(authorityUri, configuration.Issuer);
+
+                // Endpoint same-cloud check: when the configured authority is a known Microsoft
+                // host, both token_endpoint and authorization_endpoint MUST resolve to the SAME
+                // sovereign cloud. Catches a tampered discovery doc that swaps the endpoint to
+                // a different MS cloud OR to an unrelated host. Runs BEFORE the cache write so
+                // a bad doc never gets cached.
+                EnsureKnownAuthorityEndpointSameCloud(authorityUri, configuration.TokenEndpoint, "token_endpoint", requestContext.Logger);
+                EnsureKnownAuthorityEndpointSameCloud(authorityUri, configuration.AuthorizationEndpoint, "authorization_endpoint", requestContext.Logger);
 
                 s_cache[authority] = configuration;
                 requestContext.Logger.Verbose(() => $"[OIDC Discovery] OIDC discovery retrieved metadata from the network for {authority}");
@@ -77,54 +87,43 @@ namespace Microsoft.Identity.Client.Instance.Oidc
         }
 
         /// <summary>
-        /// Validates that the issuer in the OIDC metadata matches the authority.
-        /// An issuer is valid if any of the following is true:
-        /// 1. Same scheme and host as the authority (path can differ)
-        /// 2. The issuer host is a well-known Microsoft authority host (HTTPS only)
-        /// 3. The issuer host is a regional variant of a well-known host (HTTPS only)
-        /// 4. CIAM-specific: the issuer matches {tenant}.ciamlogin.com patterns
+        /// Accepts an issuer if any of:
+        ///   1. Scheme + host match the authority (path may differ).
+        ///      e.g. authority <c>login.microsoftonline.com/contoso</c>, issuer <c>login.microsoftonline.com/contoso/v2.0</c>.
+        ///   2. HTTPS issuer hosted on a known Microsoft cloud, AND either:
+        ///      2a. Authority host is a custom domain (federation case, issue #5927).
+        ///          e.g. authority <c>clientlogin.test.parentpay.com/...</c>, issuer <c>login.microsoftonline.com/...</c>.
+        ///      2b. Authority host is also a known Microsoft host in the SAME sovereign cloud.
+        ///          Rejects e.g. Public authority + China issuer.
+        ///   3. CIAM: issuer matches <c>{tenant}.ciamlogin.com</c>.
         /// </summary>
-        /// <param name="authority">The authority URL.</param>
-        /// <param name="issuer">The issuer from the OIDC metadata - the single source of truth.</param>
-        /// <exception cref="MsalServiceException">Thrown when issuer validation fails.</exception>
         internal static void ValidateIssuer(Uri authority, string issuer)
         {
-            // Normalize both URLs to handle trailing slash differences
-            string normalizedAuthority = authority.AbsoluteUri.TrimEnd('/');
             string normalizedIssuer = issuer?.TrimEnd('/');
 
-            // OIDC validation: if the issuer's scheme and host match the authority's, consider it valid
             if (!string.IsNullOrEmpty(issuer) && Uri.TryCreate(issuer, UriKind.Absolute, out Uri issuerUri))
             {
-                // Rule 1: Same scheme and host
+                // Rule 1
                 if (string.Equals(authority.Scheme, issuerUri.Scheme, StringComparison.OrdinalIgnoreCase) &&
                     string.Equals(authority.Host, issuerUri.Host, StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }
 
-                // Rule 2: The issuer host is a well-known Microsoft authority host (HTTPS only)
+                // Rule 2: known-MS issuer over HTTPS. Single lookup per host (no double-resolve).
                 if (string.Equals(issuerUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
-                    KnownMetadataProvider.IsKnownEnvironment(issuerUri.Host))
+                    KnownMetadataProvider.TryResolveKnownCloud(issuerUri.Host, out InstanceDiscoveryMetadataEntry issuerEntry))
                 {
-                    return;
-                }
-
-                // Rule 3: The issuer host is a regional variant ({region}.{host}) of a well-known host
-                // (HTTPS only). E.g. westus2.login.microsoft.com
-                if (string.Equals(issuerUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-                {
-                    string issuerHost = issuerUri.Host;
-                    int firstDot = issuerHost.IndexOf('.');
-                    if (firstDot > 0 && firstDot < issuerHost.Length - 1)
+                    // 2a: custom-domain authority federating with Microsoft (#5927)
+                    if (!KnownMetadataProvider.TryResolveKnownCloud(authority.Host, out InstanceDiscoveryMetadataEntry authorityEntry))
                     {
-                        string hostWithoutRegion = issuerHost.Substring(firstDot + 1);
+                        return;
+                    }
 
-                        // Regional variant of a well-known host (e.g. westus2.login.microsoft.com)
-                        if (KnownMetadataProvider.IsKnownEnvironment(hostWithoutRegion))
-                        {
-                            return;
-                        }
+                    // 2b: known-MS authority must share the issuer's cloud (singleton entry per cloud)
+                    if (ReferenceEquals(issuerEntry, authorityEntry))
+                    {
+                        return;
                     }
                 }
             }
@@ -166,6 +165,42 @@ namespace Microsoft.Identity.Client.Instance.Oidc
             throw new MsalServiceException(
                 MsalError.AuthorityValidationFailed,
                 string.Format(MsalErrorMessage.IssuerValidationFailed, authority, issuer));
+        }
+
+        // Defense-in-depth endpoint check. When the configured authority is itself a known
+        // Microsoft cloud host, every endpoint published by the discovery doc MUST resolve to
+        // the same sovereign cloud. Custom-domain authorities (federation, third-party IdPs)
+        // are not constrained: the caller has chosen to trust that domain.
+        // e.g. authority=login.microsoftonline.com (Public)
+        //      token_endpoint=login.chinacloudapi.cn (China)        -> throw
+        //      token_endpoint=attacker.example.com                  -> throw
+        //      token_endpoint=sts.windows.net (Public alias)        -> pass
+        private static void EnsureKnownAuthorityEndpointSameCloud(Uri authority, string endpoint, string endpointName, ILoggerAdapter logger)
+        {
+            if (string.IsNullOrEmpty(endpoint) || !Uri.TryCreate(endpoint, UriKind.Absolute, out Uri endpointUri))
+            {
+                return;
+            }
+
+            if (!KnownMetadataProvider.TryResolveKnownCloud(authority.Host, out InstanceDiscoveryMetadataEntry authorityEntry))
+            {
+                return;
+            }
+
+            if (!KnownMetadataProvider.TryResolveKnownCloud(endpointUri.Host, out InstanceDiscoveryMetadataEntry endpointEntry) ||
+                !ReferenceEquals(authorityEntry, endpointEntry))
+            {
+                string message = string.Format(
+                    CultureInfo.InvariantCulture,
+                    MsalErrorMessage.CrossCloudEndpointMismatch,
+                    authority.AbsoluteUri,
+                    endpointName,
+                    endpoint);
+
+                logger.Error("[OIDC Discovery] " + message);
+
+                throw new MsalServiceException(MsalError.CrossCloudEndpointMismatch, message);
+            }
         }
 
         // For testing purposes only

--- a/src/client/Microsoft.Identity.Client/MsalError.cs
+++ b/src/client/Microsoft.Identity.Client/MsalError.cs
@@ -1278,5 +1278,20 @@ namespace Microsoft.Identity.Client
         /// or use another interactive flow, as appropriate for your application.
         /// </summary>
         public const string InternalCacheDisabled = "internal_cache_disabled";
+
+        /// <summary>
+        /// <para>What happens?</para> An OIDC discovery document returned an endpoint
+        /// (<c>token_endpoint</c> or <c>authorization_endpoint</c>) whose host does not belong
+        /// to the same Microsoft sovereign cloud as the configured authority. MSAL refused to
+        /// use that endpoint because doing so would risk crossing a trust boundary (e.g. an
+        /// authority in the Public cloud being asked to POST credentials to a host in the China
+        /// or US Gov cloud, or to an unrelated host entirely).
+        /// <para>Mitigation</para> Verify the OIDC discovery endpoint is not being intercepted
+        /// (no rogue proxy, MITM, or DNS hijack) and that the configured authority points at the
+        /// correct sovereign cloud for your tenant. This check only fires when the configured
+        /// authority host is itself a recognized Microsoft cloud host; custom-domain OIDC
+        /// identity providers are not constrained.
+        /// </summary>
+        public const string CrossCloudEndpointMismatch = "cross_cloud_endpoint_mismatch";
     }
 }

--- a/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
+++ b/src/client/Microsoft.Identity.Client/MsalErrorMessage.cs
@@ -473,5 +473,9 @@ namespace Microsoft.Identity.Client
         public const string InternalCacheDisabledNotSupportedForPublicClient =
             "CacheOptions.DisableInternalCacheOptions is not supported for public client applications. " +
             "This option is intended for confidential client flows where the application manages its own token cache.";
+
+        public const string CrossCloudEndpointMismatch =
+            "OIDC discovery for authority '{0}' returned a {1} '{2}' whose host is not in the same Microsoft sovereign cloud as the authority. " +
+            "MSAL refused to use that endpoint. Verify the OIDC discovery endpoint is not being intercepted and that the configured authority points at the correct sovereign cloud.";
     }
 }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalError.CrossCloudEndpointMismatch = "cross_cloud_endpoint_mismatch" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalError.CrossCloudEndpointMismatch = "cross_cloud_endpoint_mismatch" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalError.CrossCloudEndpointMismatch = "cross_cloud_endpoint_mismatch" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalError.CrossCloudEndpointMismatch = "cross_cloud_endpoint_mismatch" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalError.CrossCloudEndpointMismatch = "cross_cloud_endpoint_mismatch" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalError.CrossCloudEndpointMismatch = "cross_cloud_endpoint_mismatch" -> string

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/GenericAuthorityTests.cs
@@ -469,6 +469,138 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             }
         }
 
+        // When the discovery document publishes a token_endpoint whose host belongs to a
+        // different Microsoft sovereign cloud than the configured authority, MSAL must
+        // refuse the document at retrieval time so the bad doc never gets cached and no
+        // outbound POST ever happens. The discovery response here is internally consistent
+        // (issuer matches the configured authority, passes Rule 1) - the endpoint check
+        // catches the cross-cloud token_endpoint swap.
+        [TestMethod]
+        public async Task OidcDiscovery_CrossCloudTokenEndpoint_Refused_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                string authority = "https://login.microsoftonline.com/contoso";
+                string spoofedTokenEndpoint = "https://login.partner.microsoftonline.cn/contoso/oauth2/v2.0/token";
+
+                IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithHttpManager(httpManager)
+                    .WithOidcAuthority(authority)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .Build();
+
+                // Build an OIDC document where the issuer matches the configured authority
+                // (passes Rule 1) but the token_endpoint points at a *different* MS cloud.
+                string oidcDocument = TestConstants.GetOidcResponse(authority);
+                oidcDocument = oidcDocument.Replace(
+                    $"{authority}/connect/token",
+                    spoofedTokenEndpoint);
+
+                httpManager.AddMockHandler(new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedUrl = $"{authority}/{Constants.WellKnownOpenIdConfigurationPath}",
+                    ResponseMessage = MockHelpers.CreateSuccessResponseMessage(oidcDocument)
+                });
+
+                var ex = await AssertException.TaskThrowsAsync<MsalServiceException>(() =>
+                    app.AcquireTokenForClient(new[] { "api" }).ExecuteAsync()
+                ).ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.CrossCloudEndpointMismatch, ex.ErrorCode);
+                Assert.Contains(spoofedTokenEndpoint, ex.Message,
+                    "Error message should mention the spoofed token_endpoint.");
+
+                // Critical: no token request must have been made. Only the OIDC discovery
+                // GET should be in flight; the POST to the spoofed endpoint must never happen.
+                Assert.AreEqual(0, httpManager.QueueSize,
+                    "Outbound credentials must not be sent to a cross-cloud token_endpoint.");
+            }
+        }
+
+        // A known-MS authority must not accept a custom (attacker-controlled) token_endpoint
+        // either. The endpoint check fires whenever the configured authority is a known MS
+        // host: the endpoint MUST resolve to the SAME sovereign cloud (custom hosts cannot).
+        [TestMethod]
+        public async Task OidcDiscovery_KnownAuthority_CustomEndpoint_Refused_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                string authority = "https://login.microsoftonline.com/contoso";
+                string attackerTokenEndpoint = "https://attacker.example.com/oauth2/v2.0/token";
+
+                IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithHttpManager(httpManager)
+                    .WithOidcAuthority(authority)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .Build();
+
+                string oidcDocument = TestConstants.GetOidcResponse(authority);
+                oidcDocument = oidcDocument.Replace(
+                    $"{authority}/connect/token",
+                    attackerTokenEndpoint);
+
+                httpManager.AddMockHandler(new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedUrl = $"{authority}/{Constants.WellKnownOpenIdConfigurationPath}",
+                    ResponseMessage = MockHelpers.CreateSuccessResponseMessage(oidcDocument)
+                });
+
+                var ex = await AssertException.TaskThrowsAsync<MsalServiceException>(() =>
+                    app.AcquireTokenForClient(new[] { "api" }).ExecuteAsync()
+                ).ConfigureAwait(false);
+
+                Assert.AreEqual(MsalError.CrossCloudEndpointMismatch, ex.ErrorCode);
+                Assert.Contains(attackerTokenEndpoint, ex.Message);
+                Assert.AreEqual(0, httpManager.QueueSize,
+                    "Outbound credentials must not be sent to a custom endpoint under a known-MS authority.");
+            }
+        }
+
+        // Custom OIDC IdPs are NOT subject to the endpoint same-cloud check: legitimate
+        // custom identity providers may publish endpoints on any host. The check fires
+        // only when the configured authority is itself a known Microsoft cloud host.
+        // Uses a unique authority host (not shared with other tests in this file) so the
+        // process-static OidcRetrieverWithCache.s_cache cannot leak state between tests.
+        [TestMethod]
+        public async Task OidcDiscovery_CustomIdpEndpoint_Allowed_Async()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                string authority = "https://idp.example.com";
+
+                IConfidentialClientApplication app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithHttpManager(httpManager)
+                    .WithOidcAuthority(authority)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .Build();
+
+                httpManager.AddMockHandler(
+                    CreateOidcHttpHandler(authority + @"/" + Constants.WellKnownOpenIdConfigurationPath, authority));
+
+                httpManager.AddMockHandler(
+                    CreateTokenResponseHttpHandler(
+                        authority + "/connect/token",
+                        scopesInRequest: "api",
+                        scopesInResponse: "api",
+                        grant: "client_credentials"));
+
+                AuthenticationResult result = await app
+                    .AcquireTokenForClient(new[] { "api" })
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(0, httpManager.QueueSize,
+                    "Custom OIDC IdPs must not be blocked by the cross-cloud endpoint check.");
+            }
+        }
+
         private static MockHttpMessageHandler CreateTokenResponseHttpHandler(
             string tokenEndpoint,
             string scopesInRequest,

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/OidcIssuerValidationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/OidcIssuerValidationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Instance.Discovery;
 using Microsoft.Identity.Client.Instance.Oidc;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -27,6 +28,10 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             "https://login.microsoftonline.com/tenant/",
             "https://login.microsoftonline.com/tenant",
             DisplayName = "Rule1_TrailingSlashNormalization")]
+        [DataRow(
+            "https://demo.duendesoftware.com/",
+            "https://demo.duendesoftware.com",
+            DisplayName = "Rule1_CustomOidc_ExactMatch")]
         public void ValidateIssuer_Rule1_SameSchemeAndHost_ShouldPass(string authority, string issuer)
         {
             OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
@@ -34,128 +39,117 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 
         #endregion
 
-        #region Rule 2 - Well-Known Microsoft Authority Host
+        #region Rule 2 - Same Cloud (well-known issuer + well-known authority in the same cloud)
 
+        // Pre-PR Rule 2 was a flat known-host fallback that accepted ANY known
+        // Microsoft cloud host as a valid issuer regardless of which sovereign cloud
+        // the configured authority pointed at. That permitted MS-to-MS cross-cloud
+        // OIDC discovery acceptance (e.g. authority in Public, issuer in China).
+        // Rule 2b is now narrowed: when BOTH sides are known Microsoft hosts they
+        // must belong to the SAME sovereign cloud.
         [TestMethod]
         [DataRow(
-            "https://clientlogin.test.parentpay.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
-            "https://login.microsoftonline.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
-            DisplayName = "Rule2_OriginalUserScenario_CustomDomain_WellKnownIssuer")]
-        [DataRow(
-            "https://clientlogin.test.parentpay.com/ebdf0e4c/v2.0",
-            "https://login.microsoftonline.com/ebdf0e4c/v2.0",
-            DisplayName = "Rule2_CustomDomain_WellKnownIssuer")]
-        [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.com/tenant",
             "https://login.windows.net/tenant",
-            DisplayName = "Rule2_WellKnown_LoginWindowsNet")]
+            DisplayName = "Rule2_Public_LoginWindowsNet")]
         [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.com/tenant",
             "https://sts.windows.net/tenant",
-            DisplayName = "Rule2_WellKnown_StsWindowsNet")]
+            DisplayName = "Rule2_Public_StsWindowsNet")]
         [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.microsoftonline.us/tenant",
-            DisplayName = "Rule2_WellKnown_USGov")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.chinacloudapi.cn/tenant",
-            DisplayName = "Rule2_WellKnown_China")]
-        [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.com/tenant",
             "https://login.microsoft.com/tenant",
-            DisplayName = "Rule2_WellKnown_LoginMicrosoft")]
+            DisplayName = "Rule2_Public_LoginMicrosoft")]
         [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.partner.microsoftonline.cn/tenant",
-            DisplayName = "Rule2_WellKnown_ChinaPartner")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.microsoftonline.de/tenant",
-            DisplayName = "Rule2_WellKnown_Germany")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login-us.microsoftonline.com/tenant",
-            DisplayName = "Rule2_WellKnown_LoginUS")]
-        [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.us/tenant",
             "https://login.usgovcloudapi.net/tenant",
-            DisplayName = "Rule2_WellKnown_USGovApi")]
+            DisplayName = "Rule2_USGov_LoginUsgovcloudapi")]
         [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.sovcloud-identity.fr/tenant",
-            DisplayName = "Rule2_WellKnown_BleuCloud")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.sovcloud-identity.de/tenant",
-            DisplayName = "Rule2_WellKnown_DelosCloud")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.sovcloud-identity.sg/tenant",
-            DisplayName = "Rule2_WellKnown_GovSG")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.windows-ppe.net/tenant",
-            DisplayName = "Rule2_WellKnown_LoginWindowsPpe")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://sts.windows-ppe.net/tenant",
-            DisplayName = "Rule2_WellKnown_StsWindowsPpe")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://login.microsoft-ppe.com/tenant",
-            DisplayName = "Rule2_WellKnown_LoginMicrosoftPpe")]
-        public void ValidateIssuer_Rule2_WellKnownHost_ShouldPass(string authority, string issuer)
+            "https://login.partner.microsoftonline.cn/tenant",
+            "https://login.chinacloudapi.cn/tenant",
+            DisplayName = "Rule2_China_LoginChinacloudapi")]
+        public void ValidateIssuer_Rule2_KnownIssuer_SameCloud_ShouldPass(string authority, string issuer)
         {
             OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
         }
 
         #endregion
 
-        #region Rule 3 - Regional Variant of Well-Known Host
+        #region Rule 2a - Custom-Domain Federation with Microsoft (regression for issue #5927)
 
+        // Documented WithOidcAuthority scenario: a customer-deployed OIDC facade
+        // (custom domain) legitimately federates with Microsoft and publishes a
+        // Microsoft cloud host as its issuer. Rule 2a accepts this combination.
+        // Rationale: an attacker who can substitute the discovery response for a
+        // custom-domain authority must already have broken transport trust for that
+        // domain, at which point intercepting the token POST directly is strictly
+        // easier than the cross-cloud swap. The endpoint same-cloud check in
+        // OidcRetrieverWithCache deliberately does not constrain custom-domain
+        // authorities for this reason.
         [TestMethod]
+        [DataRow(
+            "https://clientlogin.test.parentpay.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
+            "https://login.microsoftonline.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
+            DisplayName = "Rule2a_OriginalUserScenario_CustomDomain_WellKnownIssuer_5927")]
+        [DataRow(
+            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.com/tenant",
+            DisplayName = "Rule2a_CustomAuthority_PublicIssuer")]
+        [DataRow(
+            "https://custom.example.com/tenant",
+            "https://sts.windows.net/tenant",
+            DisplayName = "Rule2a_CustomAuthority_PublicAliasIssuer")]
+        [DataRow(
+            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.us/tenant",
+            DisplayName = "Rule2a_CustomAuthority_USGovIssuer")]
+        [DataRow(
+            "https://custom.example.com/tenant",
+            "https://login.partner.microsoftonline.cn/tenant",
+            DisplayName = "Rule2a_CustomAuthority_ChinaIssuer")]
         [DataRow(
             "https://custom.example.com/tenant",
             "https://westus2.login.microsoft.com/tenant",
-            DisplayName = "Rule3_Regional_LoginMicrosoft_WestUS2")]
+            DisplayName = "Rule2a_CustomAuthority_RegionalPublicIssuer")]
+        public void ValidateIssuer_Rule2a_CustomDomain_KnownIssuer_ShouldPass(string authority, string issuer)
+        {
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        #endregion
+
+        #region Rule 3 - Regional Variant of Well-Known Host (Same Cloud)
+
+        [TestMethod]
         [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.com/tenant",
+            "https://westus2.login.microsoft.com/tenant",
+            DisplayName = "Rule3_Public_Regional_LoginMicrosoft_WestUS2")]
+        [DataRow(
+            "https://login.microsoftonline.com/tenant",
             "https://eastus.login.microsoftonline.com/tenant",
-            DisplayName = "Rule3_Regional_LoginMicrosoftonline_EastUS")]
+            DisplayName = "Rule3_Public_Regional_LoginMicrosoftonline_EastUS")]
         [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.windows.net/tenant",
             "https://centralus.login.windows.net/tenant/v2.0",
-            DisplayName = "Rule3_Regional_LoginWindowsNet_CentralUS")]
+            DisplayName = "Rule3_Public_Regional_LoginWindowsNet_CentralUS")]
         [DataRow(
-            "https://custom.example.com/tenant",
-            "https://westeurope.sts.windows.net/tenant",
-            DisplayName = "Rule3_Regional_StsWindowsNet_WestEurope")]
-        [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.us/tenant",
             "https://usdodcentral.login.microsoftonline.us/tenant",
-            DisplayName = "Rule3_Regional_USGov_USDoDCentral")]
+            DisplayName = "Rule3_USGov_Regional_USDoDCentral")]
         [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.partner.microsoftonline.cn/tenant",
             "https://chinaeast2.login.chinacloudapi.cn/tenant",
-            DisplayName = "Rule3_Regional_China_ChinaEast2")]
+            DisplayName = "Rule3_China_Regional_ChinaEast2")]
         [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.sovcloud-identity.fr/tenant",
             "https://francecentral.login.sovcloud-identity.fr/tenant",
-            DisplayName = "Rule3_Regional_BleuCloud")]
+            DisplayName = "Rule3_Bleu_Regional")]
         [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.sovcloud-identity.de/tenant",
             "https://germanywestcentral.login.sovcloud-identity.de/tenant",
-            DisplayName = "Rule3_Regional_DelosCloud")]
-        [DataRow(
-            "https://clientlogin.test.parentpay.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
-            "https://westeurope.login.microsoftonline.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
-            DisplayName = "Rule3_OriginalUserScenario_Regional_CustomDomain_WellKnown")]
-        [DataRow(
-            "https://custom.example.com/tenant",
-            "https://westus2.login.windows-ppe.net/tenant",
-            DisplayName = "Rule3_Regional_LoginWindowsPpe")]
-        public void ValidateIssuer_Rule3_RegionalWellKnown_ShouldPass(string authority, string issuer)
+            DisplayName = "Rule3_Delos_Regional")]
+        public void ValidateIssuer_Rule3_RegionalKnown_SameCloud_ShouldPass(string authority, string issuer)
         {
             OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
         }
@@ -184,23 +178,114 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 
         #endregion
 
-        #region Failing Tests
+        #region Cross-Cloud Rejection (covers required matrix cases 2-5)
 
+        // Cross-cloud Microsoft-to-Microsoft must be rejected. These cases would all have been
+        // accepted by the old flat known-host fallback, which was the cross-cloud OIDC discovery
+        // acceptance flaw being fixed.
+        [TestMethod]
+        [DataRow(
+            "https://login.microsoftonline.com/tenant",
+            "https://login.partner.microsoftonline.cn/tenant",
+            DisplayName = "CrossCloud_Public_to_China")]
+        [DataRow(
+            "https://login.microsoftonline.com/tenant",
+            "https://login.chinacloudapi.cn/tenant",
+            DisplayName = "CrossCloud_Public_to_ChinaAlias")]
+        [DataRow(
+            "https://login.microsoftonline.com/tenant",
+            "https://login.microsoftonline.us/tenant",
+            DisplayName = "CrossCloud_Public_to_USGov")]
+        [DataRow(
+            "https://login.microsoftonline.com/tenant",
+            "https://login.usgovcloudapi.net/tenant",
+            DisplayName = "CrossCloud_Public_to_USGovAlias")]
+        [DataRow(
+            "https://login.microsoftonline.com/tenant",
+            "https://login.microsoftonline.de/tenant",
+            DisplayName = "CrossCloud_Public_to_Germany")]
+        [DataRow(
+            "https://login.microsoftonline.us/tenant",
+            "https://login.microsoftonline.com/tenant",
+            DisplayName = "CrossCloud_USGov_to_Public")]
+        [DataRow(
+            "https://login.microsoftonline.us/tenant",
+            "https://login.partner.microsoftonline.cn/tenant",
+            DisplayName = "CrossCloud_USGov_to_China")]
+        [DataRow(
+            "https://login.partner.microsoftonline.cn/tenant",
+            "https://login.microsoftonline.com/tenant",
+            DisplayName = "CrossCloud_China_to_Public")]
+        [DataRow(
+            "https://login.microsoftonline.de/tenant",
+            "https://login.microsoftonline.com/tenant",
+            DisplayName = "CrossCloud_Germany_to_Public")]
+        [DataRow(
+            "https://login.sovcloud-identity.fr/tenant",
+            "https://login.sovcloud-identity.de/tenant",
+            DisplayName = "CrossCloud_Bleu_to_Delos")]
+        [DataRow(
+            "https://login.sovcloud-identity.sg/tenant",
+            "https://login.microsoftonline.com/tenant",
+            DisplayName = "CrossCloud_GovSG_to_Public")]
+        [DataRow(
+            "https://login.windows-ppe.net/tenant",
+            "https://login.microsoftonline.com/tenant",
+            DisplayName = "CrossCloud_PPE_to_Public")]
+        // Regional variants of one cloud must not be accepted under a different cloud.
+        [DataRow(
+            "https://login.microsoftonline.com/tenant",
+            "https://chinaeast2.login.chinacloudapi.cn/tenant",
+            DisplayName = "CrossCloud_Regional_Public_to_RegionalChina")]
+        [DataRow(
+            "https://login.microsoftonline.us/tenant",
+            "https://westus2.login.microsoft.com/tenant",
+            DisplayName = "CrossCloud_Regional_USGov_to_RegionalPublic")]
+        public void ValidateIssuer_CrossCloud_ShouldThrow(string authority, string issuer)
+        {
+            var ex = AssertException.Throws<MsalServiceException>(
+                () => OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        #endregion
+
+        #region Custom-Authority Rejection (issuer is NOT a known Microsoft host)
+
+        // When the configured authority is a custom OIDC IdP host AND the issuer
+        // is also not a known Microsoft cloud host, only Rule 1 (exact host match)
+        // can accept. Any unrelated host must be rejected. (Custom authority + a
+        // KNOWN Microsoft issuer is the legitimate #5927 federation case and is
+        // covered by Rule 2a above.)
         [TestMethod]
         [DataRow(
             "https://custom.example.com/tenant",
             "https://evil.example.net/tenant",
-            DisplayName = "Fail_UnknownIssuer")]
+            DisplayName = "CustomAuthority_UnknownIssuer_Rejected")]
         [DataRow(
             "https://custom.example.com/tenant",
             "https://fakeb2clogin.com/tenant",
-            DisplayName = "Fail_SpoofedB2C_NoDotPrefix")]
+            DisplayName = "CustomAuthority_SpoofedB2CLooking_Rejected")]
+        public void ValidateIssuer_CustomAuthority_NonExactIssuer_ShouldThrow(string authority, string issuer)
+        {
+            var ex = AssertException.Throws<MsalServiceException>(
+                () => OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        #endregion
+
+        #region Other Failing Cases
+
+        [TestMethod]
         [DataRow(
             "https://login.microsoftonline.com/tenant",
             "http://login.microsoftonline.com/tenant",
             DisplayName = "Fail_HttpScheme_WellKnown")]
         [DataRow(
-            "https://custom.example.com/tenant",
+            "https://login.microsoftonline.com/tenant",
             "http://westus2.login.microsoft.com/tenant",
             DisplayName = "Fail_HttpScheme_Regional")]
         [DataRow(
@@ -253,6 +338,250 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                     new Uri("https://custom.example.com/tenant"), ""));
 
             Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        #endregion
+
+        #region Behavior Matrix (single-source-of-truth: Before vs. After)
+
+        // This region documents every distinguishable (authority shape, issuer shape)
+        // case in one place, with the BEFORE behavior (PR #5931 - flat known-host
+        // fallback) and the AFTER behavior (this PR - two-pronged Rule 2 plus the
+        // retrieval-time endpoint same-cloud check in OidcRetrieverWithCache).
+        // Each row is exercised here to make any future regression visible at a glance.
+        //
+        // Legend:
+        //   AUTH      : custom = unknown host;       msPublic = login.microsoftonline.com (Public alias);
+        //               msUSGov = login.microsoftonline.us; msChina = login.partner.microsoftonline.cn;
+        //               msRegion = westus2.login.microsoft.com (regional Public).
+        //   ISSUER    : same shorthand.
+        //   Before    : pass / throw under the OLD flat known-host fallback.
+        //   After     : pass / throw under THIS PR (column under test).
+        //   Why-after : which rule (1 / 2a / 2b / 3) accepted, or why we now reject.
+
+        // ----- ROWS THAT PASS BEFORE AND AFTER (no behavior change) -----
+
+        [TestMethod]
+        // # | AUTH               | ISSUER                  | Before | After | Rule
+        // 1 | msPublic/contoso   | msPublic/contoso/v2.0   | pass   | pass  | Rule 1 exact host
+        [DataRow(
+            "https://login.microsoftonline.com/contoso",
+            "https://login.microsoftonline.com/contoso/v2.0",
+            DisplayName = "Matrix_01_Pass_BeforeAndAfter_Rule1_PublicExact")]
+        // 2 | custom/x           | custom/y                | pass   | pass  | Rule 1 exact host (custom)
+        [DataRow(
+            "https://demo.duendesoftware.com/x",
+            "https://demo.duendesoftware.com/y",
+            DisplayName = "Matrix_02_Pass_BeforeAndAfter_Rule1_CustomExact")]
+        // 3 | msPublic/contoso   | sts.windows.net/contoso | pass   | pass  | Rule 2b same Public cloud
+        [DataRow(
+            "https://login.microsoftonline.com/contoso",
+            "https://sts.windows.net/contoso",
+            DisplayName = "Matrix_03_Pass_BeforeAndAfter_Rule2b_PublicAlias")]
+        // 4 | msPublic/contoso   | msRegion/contoso        | pass   | pass  | Rule 2b same Public cloud (regional variant)
+        [DataRow(
+            "https://login.microsoftonline.com/contoso",
+            "https://westus2.login.microsoft.com/contoso",
+            DisplayName = "Matrix_04_Pass_BeforeAndAfter_Rule2b_PublicRegional")]
+        // 5 | msUSGov/contoso    | login.usgovcloudapi/c   | pass   | pass  | Rule 2b same US Gov cloud
+        [DataRow(
+            "https://login.microsoftonline.us/contoso",
+            "https://login.usgovcloudapi.net/contoso",
+            DisplayName = "Matrix_05_Pass_BeforeAndAfter_Rule2b_USGovAlias")]
+        // 6 | msChina/contoso    | chinacloudapi.cn/c      | pass   | pass  | Rule 2b same China cloud
+        [DataRow(
+            "https://login.partner.microsoftonline.cn/contoso",
+            "https://login.chinacloudapi.cn/contoso",
+            DisplayName = "Matrix_06_Pass_BeforeAndAfter_Rule2b_ChinaAlias")]
+        // 7 | customdomain/x     | x.ciamlogin.com/x       | pass   | pass  | Rule 3 CIAM tenant pattern
+        [DataRow(
+            "https://customdomain.com/contoso",
+            "https://contoso.ciamlogin.com/contoso/v2.0",
+            DisplayName = "Matrix_07_Pass_BeforeAndAfter_Rule3_CIAM")]
+        // 8 (#5927) | custom/tid | msPublic/tid            | pass   | pass  | Rule 2a custom-domain federation
+        [DataRow(
+            "https://clientlogin.test.parentpay.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
+            "https://login.microsoftonline.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
+            DisplayName = "Matrix_08_Pass_BeforeAndAfter_Rule2a_5927_CustomDomainFederation")]
+        public void Matrix_PassBeforeAndAfter(string authority, string issuer)
+        {
+            // Both old and new behavior accept these. They must continue to pass.
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        // ----- ROWS THAT PASSED BEFORE BUT NOW THROW (the actual fix) -----
+
+        [TestMethod]
+        // #  | AUTH              | ISSUER                       | Before | After | Why now
+        // 9  | msPublic/c        | msChina/c                    | pass   | THROW | Rule 2b same-cloud rejects (cross-cloud)
+        [DataRow(
+            "https://login.microsoftonline.com/contoso",
+            "https://login.partner.microsoftonline.cn/contoso",
+            DisplayName = "Matrix_09_Throw_PassBefore_CrossCloud_Public_China")]
+        // 10 | msPublic/c        | msUSGov/c                    | pass   | THROW | Rule 2b same-cloud rejects
+        [DataRow(
+            "https://login.microsoftonline.com/contoso",
+            "https://login.microsoftonline.us/contoso",
+            DisplayName = "Matrix_10_Throw_PassBefore_CrossCloud_Public_USGov")]
+        // 11 | msUSGov/c         | msPublic/c                   | pass   | THROW | Rule 2b same-cloud rejects
+        [DataRow(
+            "https://login.microsoftonline.us/contoso",
+            "https://login.microsoftonline.com/contoso",
+            DisplayName = "Matrix_11_Throw_PassBefore_CrossCloud_USGov_Public")]
+        // 12 | msChina/c         | msPublic/c                   | pass   | THROW | Rule 2b same-cloud rejects
+        [DataRow(
+            "https://login.partner.microsoftonline.cn/contoso",
+            "https://login.microsoftonline.com/contoso",
+            DisplayName = "Matrix_12_Throw_PassBefore_CrossCloud_China_Public")]
+        // 13 | msPublic/c        | regionalChina/c              | pass   | THROW | Rule 2b same-cloud rejects (regional cross-cloud)
+        [DataRow(
+            "https://login.microsoftonline.com/contoso",
+            "https://chinaeast2.login.chinacloudapi.cn/contoso",
+            DisplayName = "Matrix_13_Throw_PassBefore_CrossCloud_Public_RegionalChina")]
+        // 14 | msUSGov/c         | regionalPublic/c             | pass   | THROW | Rule 2b same-cloud rejects (regional cross-cloud)
+        [DataRow(
+            "https://login.microsoftonline.us/contoso",
+            "https://westus2.login.microsoft.com/contoso",
+            DisplayName = "Matrix_14_Throw_PassBefore_CrossCloud_USGov_RegionalPublic")]
+        // 15 | bleu/c            | delos/c                      | pass   | THROW | Rule 2b same-cloud rejects (sovereign-to-sovereign)
+        [DataRow(
+            "https://login.sovcloud-identity.fr/contoso",
+            "https://login.sovcloud-identity.de/contoso",
+            DisplayName = "Matrix_15_Throw_PassBefore_CrossCloud_Bleu_Delos")]
+        public void Matrix_PassedBefore_NowThrows_CrossCloud(string authority, string issuer)
+        {
+            // BEFORE this PR: these all wrongly passed via the flat known-host fallback.
+            // AFTER this PR: Rule 2b (MS authority + MS issuer => MUST be same cloud)
+            // rejects every cross-cloud combination.
+            var ex = AssertException.Throws<MsalServiceException>(
+                () => OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        // ----- ROWS THAT THROW BEFORE AND AFTER (no behavior change) -----
+
+        [TestMethod]
+        // #  | AUTH       | ISSUER                            | Before | After | Why
+        // 16 | msPublic/c | http://msPublic/c                 | throw  | throw | non-HTTPS issuer
+        [DataRow(
+            "https://login.microsoftonline.com/contoso",
+            "http://login.microsoftonline.com/contoso",
+            DisplayName = "Matrix_16_Throw_BeforeAndAfter_HttpScheme")]
+        // 17 | custom/c   | evil.example.net/c                | throw  | throw | unknown issuer + custom authority
+        [DataRow(
+            "https://custom.example.com/contoso",
+            "https://evil.example.net/contoso",
+            DisplayName = "Matrix_17_Throw_BeforeAndAfter_UnknownIssuer_CustomAuthority")]
+        // 18 | custom/A   | tenantB.ciamlogin.com/B/v2.0      | throw  | throw | CIAM tenant mismatch
+        [DataRow(
+            "https://customdomain.com/tenantA",
+            "https://tenantB.ciamlogin.com/tenantB/v2.0",
+            DisplayName = "Matrix_18_Throw_BeforeAndAfter_CIAM_TenantMismatch")]
+        // 19 | custom/c   | attacker.evil.login.microsoft.com | throw  | throw | regional shape stops at first dot, base is not a known host
+        [DataRow(
+            "https://custom.example.com/contoso",
+            "https://attacker.evil.login.microsoft.com/contoso",
+            DisplayName = "Matrix_19_Throw_BeforeAndAfter_MultiLabelRegionalLooking")]
+        public void Matrix_ThrowBeforeAndAfter(string authority, string issuer)
+        {
+            // Both old and new behavior reject these. They must continue to throw.
+            var ex = AssertException.Throws<MsalServiceException>(
+                () => OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer));
+
+            Assert.AreEqual(MsalError.AuthorityValidationFailed, ex.ErrorCode);
+        }
+
+        // ----- ROWS THAT THREW BEFORE BUT NOW PASS (only #5927 falls here) -----
+
+        [TestMethod]
+        // The only case in this category is the #5927 regression set: a custom-domain
+        // authority federating with a known Microsoft issuer. The pre-#5931 library
+        // threw on these (issuer != authority host) and the operator workaround was to
+        // configure login.microsoftonline.com directly, losing the customer's branded
+        // domain. PR #5931 made these pass via the flat known-host fallback (which
+        // also opened the cross-cloud hole). This PR keeps them passing via Rule 2a
+        // while closing the cross-cloud hole at Rule 2b plus the retrieval-time
+        // endpoint same-cloud check in OidcRetrieverWithCache.
+        // #  | AUTH                                | ISSUER                | Before-#5931 | After this PR | Rule
+        // 20 | parentpay-style custom domain       | login.microsoftonline | throw        | pass          | Rule 2a custom-domain federation
+        [DataRow(
+            "https://clientlogin.test.parentpay.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
+            "https://login.microsoftonline.com/ebdf0e4c-ebe2-4793-af52-ceaf96f82741/v2.0",
+            DisplayName = "Matrix_20_Pass_FormerlyThrew_5927_ParentPay")]
+        // 21 | generic custom authority            | sts.windows.net       | throw        | pass          | Rule 2a (Public alias under custom domain)
+        [DataRow(
+            "https://custom.example.com/tenant",
+            "https://sts.windows.net/tenant",
+            DisplayName = "Matrix_21_Pass_FormerlyThrew_CustomAuthority_PublicAlias")]
+        // 22 | generic custom authority            | regional Public       | throw        | pass          | Rule 2a (Public regional under custom domain)
+        [DataRow(
+            "https://custom.example.com/tenant",
+            "https://westus2.login.microsoft.com/tenant",
+            DisplayName = "Matrix_22_Pass_FormerlyThrew_CustomAuthority_RegionalPublic")]
+        public void Matrix_FormerlyThrew_NowPass_CustomDomainFederation(string authority, string issuer)
+        {
+            // Rule 2a is the single rule that lights up here.
+            OidcRetrieverWithCache.ValidateIssuer(new Uri(authority), issuer);
+        }
+
+        #endregion
+
+        #region KnownMetadataProvider.AreInSameCloud helper
+
+        [TestMethod]
+        [DataRow("login.microsoftonline.com", "login.windows.net", DisplayName = "SameCloud_Public_PublicAlias")]
+        [DataRow("login.microsoftonline.com", "westus2.login.microsoft.com", DisplayName = "SameCloud_Public_RegionalPublic")]
+        [DataRow("login.microsoftonline.us", "login.usgovcloudapi.net", DisplayName = "SameCloud_USGov_USGovAlias")]
+        [DataRow("login.partner.microsoftonline.cn", "login.chinacloudapi.cn", DisplayName = "SameCloud_China_ChinaAlias")]
+        [DataRow("login.partner.microsoftonline.cn", "chinaeast2.login.chinacloudapi.cn", DisplayName = "SameCloud_China_RegionalChina")]
+        [DataRow("login.sovcloud-identity.fr", "francecentral.login.sovcloud-identity.fr", DisplayName = "SameCloud_Bleu_Regional")]
+        public void AreInSameCloud_ReturnsTrue_ForSameCloud(string hostA, string hostB)
+        {
+            Assert.IsTrue(KnownMetadataProvider.AreInSameCloud(hostA, hostB));
+            Assert.IsTrue(KnownMetadataProvider.AreInSameCloud(hostB, hostA));
+        }
+
+        [TestMethod]
+        [DataRow("login.microsoftonline.com", "login.partner.microsoftonline.cn", DisplayName = "DifferentCloud_Public_China")]
+        [DataRow("login.microsoftonline.com", "login.microsoftonline.us", DisplayName = "DifferentCloud_Public_USGov")]
+        [DataRow("login.microsoftonline.us", "login.chinacloudapi.cn", DisplayName = "DifferentCloud_USGov_China")]
+        [DataRow("login.microsoftonline.com", "login.microsoftonline.de", DisplayName = "DifferentCloud_Public_Germany")]
+        [DataRow("login.sovcloud-identity.fr", "login.sovcloud-identity.de", DisplayName = "DifferentCloud_Bleu_Delos")]
+        [DataRow("login.windows-ppe.net", "login.microsoftonline.com", DisplayName = "DifferentCloud_PPE_Public")]
+        // Unknown / custom hosts never match anything (default-deny).
+        [DataRow("login.microsoftonline.com", "custom.example.com", DisplayName = "Unknown_Public_Custom")]
+        [DataRow("custom.example.com", "another.example.org", DisplayName = "Unknown_Custom_Custom")]
+        [DataRow("custom.example.com", null, DisplayName = "Unknown_Null")]
+        [DataRow(null, "login.microsoftonline.com", DisplayName = "Null_Public")]
+        // Regional-prefix shape constraint: only lowercase alphanumeric (with optional
+        // internal hyphens) DNS-label-shaped prefixes (max 63 chars per RFC 1035) are
+        // accepted as regional variants. Anything else must NOT resolve to the base cloud entry.
+        [DataRow("login.microsoftonline.com", "attacker.evil.login.microsoft.com", DisplayName = "RegionalPrefix_MultiLabel_Rejected")]
+        [DataRow("login.microsoftonline.com", "weird_prefix.login.microsoft.com", DisplayName = "RegionalPrefix_Underscore_Rejected")]
+        [DataRow("login.microsoftonline.com", "PREFIX.login.microsoft.com", DisplayName = "RegionalPrefix_Uppercase_Rejected")]
+        [DataRow("login.microsoftonline.com", "-leading.login.microsoft.com", DisplayName = "RegionalPrefix_LeadingHyphen_Rejected")]
+        [DataRow("login.microsoftonline.com", "trailing-.login.microsoft.com", DisplayName = "RegionalPrefix_TrailingHyphen_Rejected")]
+        // 64 chars (one over the RFC 1035 DNS-label cap of 63).
+        [DataRow("login.microsoftonline.com", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.login.microsoft.com", DisplayName = "RegionalPrefix_TooLong_Rejected")]
+        public void AreInSameCloud_ReturnsFalse_ForDifferentOrUnknown(string hostA, string hostB)
+        {
+            Assert.IsFalse(KnownMetadataProvider.AreInSameCloud(hostA, hostB));
+        }
+
+        [TestMethod]
+        // Positive coverage for region prefixes that the constraint must continue to allow.
+        // Real Azure regions, including hyphenated forms and the longest published names.
+        [DataRow("westus2", DisplayName = "RegionalPrefix_Westus2")]
+        [DataRow("eastus2euap", DisplayName = "RegionalPrefix_Eastus2Euap")]
+        [DataRow("chinaeast2", DisplayName = "RegionalPrefix_ChinaEast2")]
+        [DataRow("usgovvirginia", DisplayName = "RegionalPrefix_UsGovVirginia")]
+        [DataRow("francecentral", DisplayName = "RegionalPrefix_FranceCentral")]
+        [DataRow("southafricanorth", DisplayName = "RegionalPrefix_SouthAfricaNorth")]
+        public void AreInSameCloud_AcceptsKnownRegionPrefixes(string regionPrefix)
+        {
+            string regionalHost = regionPrefix + ".login.microsoft.com";
+            Assert.IsTrue(KnownMetadataProvider.AreInSameCloud(regionalHost, "login.microsoftonline.com"));
         }
 
         #endregion


### PR DESCRIPTION
Fixes #
This pull request introduces a new security check to the OIDC discovery process to ensure that endpoints returned by the discovery document belong to the same Microsoft sovereign cloud as the configured authority. This helps prevent cross-cloud misconfigurations and potential security risks, such as sending credentials to an unintended or malicious endpoint. The changes also refactor and clarify issuer validation logic, and add new error codes/messages for this scenario.

**Security and validation improvements:**

* Added a defense-in-depth check in `OidcRetrieverWithCache.cs` to ensure that both `token_endpoint` and `authorization_endpoint` in the OIDC discovery document resolve to the same Microsoft sovereign cloud as the configured authority. If not, an error is thrown and the discovery result is not cached. 
* Refactored issuer validation logic in `OidcRetrieverWithCache.cs` to clarify and tighten the rules for accepting an issuer, especially around known Microsoft hosts and custom domains.

**Cloud environment resolution enhancements:**

* Added `AreInSameCloud` and `TryResolveKnownCloud` methods to `KnownMetadataProvider.cs` to robustly determine if two hosts belong to the same Microsoft cloud, including support for regional hostnames. Introduced a regex for validating regional prefixes. 

**Error handling and API surface:**

* Introduced a new error code `CrossCloudEndpointMismatch` in `MsalError.cs` and corresponding error message in `MsalErrorMessage.cs` for cross-cloud endpoint mismatches detected during OIDC discovery. [
* Added the new error code to all relevant `PublicAPI.Unshipped.txt` files for public API documentation.
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Documentation**
- [ ] All relevant documentation is updated.
