### PR TITLE
Removed obsolete from the WithExtraBodyParameters function

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Client.Extensibility
                     if (trimmed.Any(char.IsWhiteSpace))
                     {
                         throw new ArgumentException(
-                            $"Attribute tokens must not contain whitespace. Invalid token: '{trimmed}'",
+                            "Attribute tokens must not contain whitespace.",
                             nameof(attributeTokens));
                     }
 

--- a/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs
@@ -50,7 +50,6 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <param name="extrabodyparams">List of additional body parameters</param>
         /// <returns></returns>
         [EditorBrowsable(EditorBrowsableState.Never)] // Soft deprecate; prefer the generic overload on AbstractConfidentialClientAcquireTokenParameterBuilderExtension that also supports OBO and AuthorizationCode.
-        [Obsolete("Use AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters instead, which also supports OBO and AuthorizationCode flows.", false)]
         public static AcquireTokenForClientParameterBuilder WithExtraBodyParameters(
             this AcquireTokenForClientParameterBuilder builder, 
             Dictionary<string, Func<CancellationToken, Task<string>>> extrabodyparams)

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtraBodyParametersTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtraBodyParametersTests.cs
@@ -11,8 +11,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.Identity.Client.Extensibility;
 
-#pragma warning disable CS0618 // Tests intentionally exercise the obsolete AcquireTokenForClientBuilderExtensions.WithExtraBodyParameters overload.
-
 namespace Microsoft.Identity.Test.Unit.PublicApiTests
 {
     [TestClass]

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/WithAttributeTokensTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/WithAttributeTokensTests.cs
@@ -638,7 +638,6 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                     .WithAttributeTokens(new[] { "valid", "invalid token", "another" }));
 
             Assert.Contains("Attribute tokens must not contain whitespace", ex.Message);
-            Assert.Contains("invalid token", ex.Message);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #6005
This pull request makes minor adjustments to error messaging and code annotations for clarity and consistency, as well as a small test cleanup. The changes do not affect core functionality.

Error message and annotation updates:

* The error message thrown by `WithAttributeTokens` when encountering whitespace in attribute tokens was simplified to remove the specific invalid token from the message. (`src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs`)
* The `[Obsolete]` attribute was removed from the `WithExtraBodyParameters` method in `AcquireTokenForClientBuilderExtensions`, though the method remains soft-deprecated via XML comments. (`src/client/Microsoft.Identity.Client/Extensibility/AcquireTokenForClientBuilderExtensions.cs`)

Test updates:

* The test for `WithAttributeTokens` was updated to no longer assert that the invalid token is included in the exception message, matching the new error message format. (`tests/Microsoft.Identity.Test.Unit/PublicApiTests/WithAttributeTokensTests.cs`)
* The pragma disabling obsolete warnings was removed from `ExtraBodyParametersTests.cs`, as the related method is no longer marked obsolete. (`tests/Microsoft.Identity.Test.Unit/PublicApiTests/ExtraBodyParametersTests.cs`)
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->


