### PR TITLE
[Do not review] Agent ID support through minimal changes

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractConfidentialClientAcquireTokenParameterBuilder.cs
@@ -62,6 +62,27 @@ namespace Microsoft.Identity.Client
         internal IConfidentialClientApplicationExecutor ConfidentialClientApplicationExecutor { get; }
 
         /// <summary>
+        /// Overrides the client_id sent in the token request body and used in cache key
+        /// computation for this request only. The CCA's configured credentials are still
+        /// used for authentication (client_assertion), but the client_id in the request
+        /// body and all cache lookups will use the specified value instead.
+        /// </summary>
+        /// <param name="clientId">The client ID to use for this request.</param>
+        /// <returns>The builder to chain .With methods.</returns>
+        /// <remarks>
+        /// This is designed for federated identity scenarios where an app (blueprint)
+        /// authenticates on behalf of another app (agent) that has a different client ID.
+        /// The CCA's own credentials prove the blueprint's identity, while the overridden
+        /// client_id tells the token service which app the token is being requested for.
+        /// </remarks>
+        public T WithClientIdOverride(string clientId)
+        {
+            ValidateUseOfExperimentalFeature();
+            CommonParameters.ClientIdOverride = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            return this as T;
+        }
+
+        /// <summary>
         ///  Modifies the token acquisition request so that the acquired token is a Proof-of-Possession token (PoP), rather than a Bearer token. 
         ///  PoP tokens are similar to Bearer tokens, but are bound to the HTTP request and to a cryptographic key, which MSAL can manage on Windows.
         ///  See https://aka.ms/msal-net-pop

--- a/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AcquireTokenSilentParameterBuilder.cs
@@ -70,6 +70,34 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
+        /// Overrides the client ID used for cache lookups and token refresh requests.
+        /// Use this when tokens were acquired with a different client ID than the one configured on the application,
+        /// for example in agent identity scenarios where <c>WithClientIdOverride</c> was used during acquisition.
+        /// </summary>
+        /// <param name="clientId">The client ID to use for cache lookup and token refresh.</param>
+        /// <returns>The builder to chain the .With methods.</returns>
+        /// <remarks>
+        /// This is an experimental API. It is only supported on confidential client applications.
+        /// </remarks>
+#if !SUPPORTS_CONFIDENTIAL_CLIENT
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+#endif
+        public AcquireTokenSilentParameterBuilder WithClientIdOverride(string clientId)
+        {
+            ValidateUseOfExperimentalFeature();
+
+            if (!ServiceBundle.Config.IsConfidentialClient)
+            {
+                throw new MsalClientException(
+                    MsalError.ExperimentalFeature,
+                    "WithClientIdOverride is only supported on confidential client applications.");
+            }
+
+            CommonParameters.ClientIdOverride = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            return this;
+        }
+
+        /// <summary>
         /// Specifies if the client application should ignore access tokens when reading the token cache.
         /// Refresh tokens will still be used. Any new tokens from the Identity Provider will still be written to the token cache.
         /// By default the token is taken from the the user token cache (forceRefresh=false)

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public string ClientAssertionFmiPath { get; internal set; }
         public bool IsMtlsPopRequested { get; set; }
         public string ExtraClientAssertionClaims { get; internal set; }
+        public string ClientIdOverride { get; internal set; }
 
         /// <summary>
         /// Optional delegate for obtaining attestation JWT for Credential Guard keys.

--- a/src/client/Microsoft.Identity.Client/Cache/CacheKeyFactory.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/CacheKeyFactory.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Identity.Client.Cache
                 requestParameters.ApiId == ApiEvent.ApiIds.AcquireTokenForUserAssignedManagedIdentity)
             {
                 string tenantId = requestParameters.Authority.TenantId ?? "";
-                key = GetAppTokenCacheItemKey(requestParameters.AppConfig.ClientId, tenantId, requestParameters.AuthenticationScheme?.KeyId, requestParameters.CacheKeyComponents);
+                key = GetAppTokenCacheItemKey(requestParameters.EffectiveClientId, tenantId, requestParameters.AuthenticationScheme?.KeyId, requestParameters.CacheKeyComponents);
                 return true;
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -207,6 +207,17 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public string ExtraClientAssertionClaims => _commonParameters.ExtraClientAssertionClaims;
 
+        /// <summary>
+        /// Per-request client ID override. When set, this value is used instead of AppConfig.ClientId
+        /// in the HTTP body and in all cache key computations.
+        /// </summary>
+        public string ClientIdOverride => _commonParameters.ClientIdOverride;
+
+        /// <summary>
+        /// Returns the effective client ID for this request: the override if set, otherwise AppConfig.ClientId.
+        /// </summary>
+        public string EffectiveClientId => ClientIdOverride ?? AppConfig.ClientId;
+
         public void LogParameters()
         {
             var logger = RequestContext.Logger;

--- a/src/client/Microsoft.Identity.Client/OAuth2/TokenClient.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/TokenClient.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Identity.Client.OAuth2
             string tokenEndpoint,
             CancellationToken cancellationToken)
         {
-            _oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientId, _requestParams.AppConfig.ClientId);
+            _oAuth2Client.AddBodyParameter(OAuth2Parameter.ClientId, _requestParams.EffectiveClientId);
 
             // credentialToUse can be null, e.g. for public client apps (no client credential configured).
             IClientCredential credentialToUse = _serviceBundle.Config.ClientCredential;

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEv
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T>.WithClientIdOverride(string clientId) -> T
+Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEv
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T>.WithClientIdOverride(string clientId) -> T
+Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEv
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -4,3 +4,4 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
+Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T>.WithClientIdOverride(string clientId) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEv
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -4,3 +4,4 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder
+Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T>.WithClientIdOverride(string clientId) -> T

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEv
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T>.WithClientIdOverride(string clientId) -> T
+Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AuthScheme.IAuthenticationOperation3.AfterCredentialEv
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvaluationContext(System.Security.Cryptography.X509Certificates.X509Certificate2 mtlsCertificate) -> void
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
+Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T>.WithClientIdOverride(string clientId) -> T
+Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder.WithClientIdOverride(string clientId) -> Microsoft.Identity.Client.AcquireTokenSilentParameterBuilder

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Client
                 msalAccessTokenCacheItem =
                     new MsalAccessTokenCacheItem(
                         instanceDiscoveryMetadata.PreferredCache,
-                        requestParams.AppConfig.ClientId,
+                        requestParams.EffectiveClientId,
                         response,
                         tenantId,
                         homeAccountId,
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Client
 
                 msalRefreshTokenCacheItem = new MsalRefreshTokenCacheItem(
                                     instanceDiscoveryMetadata.PreferredCache,
-                                    requestParams.AppConfig.ClientId,
+                                    requestParams.EffectiveClientId,
                                     response,
                                     homeAccountId)
                 {
@@ -125,7 +125,7 @@ namespace Microsoft.Identity.Client
 
                 msalIdTokenCacheItem = new MsalIdTokenCacheItem(
                     instanceDiscoveryMetadata.PreferredCache,
-                    requestParams.AppConfig.ClientId,
+                    requestParams.EffectiveClientId,
                     response,
                     tenantId,
                     homeAccountId);
@@ -489,7 +489,7 @@ namespace Microsoft.Identity.Client
             FilterTokensByTokenType(accessTokens, requestParams);
             FilterTokensByScopes(accessTokens, requestParams);
             accessTokens = await FilterTokensByEnvironmentAsync(accessTokens, requestParams).ConfigureAwait(false);
-            FilterTokensByClientId(accessTokens);
+            FilterTokensByClientId(accessTokens, requestParams);
             FilterTokensByAdditionalKeyComponents(accessTokens, requestParams);
 
             CacheRefreshReason cacheInfoTelemetry = CacheRefreshReason.NotApplicable;
@@ -784,6 +784,12 @@ namespace Microsoft.Identity.Client
             tokenCacheItems.RemoveAll(x => !x.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase));
         }
 
+        private void FilterTokensByClientId<T>(List<T> tokenCacheItems, AuthenticationRequestParameters requestParams) where T : MsalCredentialCacheItemBase
+        {
+            string effectiveClientId = requestParams.EffectiveClientId;
+            tokenCacheItems.RemoveAll(x => !x.ClientId.Equals(effectiveClientId, StringComparison.OrdinalIgnoreCase));
+        }
+
         /// <summary>
         /// For testing purposes only. Expires ALL access tokens in memory and fires OnAfterAccessAsync event with no cache key
         /// </summary>
@@ -881,7 +887,7 @@ namespace Microsoft.Identity.Client
                     requestParams.RequestContext.Logger,
                     LegacyCachePersistence,
                     aliases,
-                    requestParams.AppConfig.ClientId,
+                    requestParams.EffectiveClientId,
                     requestParams.Account);
             }
 
@@ -924,7 +930,7 @@ namespace Microsoft.Identity.Client
             if (string.IsNullOrEmpty(familyId))
             {
                 cacheItems.FilterWithLogging(item => item.ClientId.Equals(
-                            requestParams.AppConfig.ClientId, StringComparison.OrdinalIgnoreCase),
+                            requestParams.EffectiveClientId, StringComparison.OrdinalIgnoreCase),
                             requestParams.RequestContext.Logger,
                             "Filtering RT by client id");
             }
@@ -988,7 +994,7 @@ namespace Microsoft.Identity.Client
             if (filterByClientId)
             {
                 refreshTokenCacheItems.FilterWithLogging(item =>
-                    string.Equals(item.ClientId, ClientId, StringComparison.OrdinalIgnoreCase),
+                    string.Equals(item.ClientId, requestParameters.EffectiveClientId, StringComparison.OrdinalIgnoreCase),
                     logger,
                     "[GetAccounts] Filtering RTs by clientID",
                     true);
@@ -1042,7 +1048,7 @@ namespace Microsoft.Identity.Client
             {
                 foreach (MsalAccountCacheItem account in accountCacheItems)
                 {
-                    if (RtMatchesAccount(rtItem, account))
+                    if (RtMatchesAccount(rtItem, account, requestParameters.EffectiveClientId))
                     {
                         var tenantProfiles = await GetTenantProfilesAsync(requestParameters, account.HomeAccountId).ConfigureAwait(false);
 

--- a/src/client/Microsoft.Identity.Client/TokenCache.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Identity.Client
 
             foreach (var accessToken in Accessor.GetAllAccessTokens(partitionKeyFromResponse))
             {
-                if (accessToken.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase) &&
+                if (accessToken.ClientId.Equals(requestParams.EffectiveClientId, StringComparison.OrdinalIgnoreCase) &&
                     environmentAliases.Contains(accessToken.Environment) &&
                     string.Equals(accessToken.TokenType ?? "", tokenType ?? "", StringComparison.OrdinalIgnoreCase) &&
                     string.Equals(accessToken.TenantId ?? "", tenantId ?? "", StringComparison.OrdinalIgnoreCase) &&
@@ -207,12 +207,12 @@ namespace Microsoft.Identity.Client
                 msalAccessTokenCacheItem.ExtendedExpiresOn);
         }
 
-        private bool RtMatchesAccount(MsalRefreshTokenCacheItem rtItem, MsalAccountCacheItem account)
+        private bool RtMatchesAccount(MsalRefreshTokenCacheItem rtItem, MsalAccountCacheItem account, string effectiveClientId = null)
         {
             bool homeAccIdMatch = rtItem.HomeAccountId.Equals(account.HomeAccountId, StringComparison.OrdinalIgnoreCase);
             bool clientIdMatch =
                 rtItem.IsFRT || // Cannot filter by client ID if the RT can be used by multiple clients
-                rtItem.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase);
+                rtItem.ClientId.Equals(effectiveClientId ?? ClientId, StringComparison.OrdinalIgnoreCase);
 
             return homeAccIdMatch && clientIdMatch;
         }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/Agentic.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/Agentic.cs
@@ -133,5 +133,302 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
 
             return result.AccessToken;
         }
+
+        #region Single-CCA Agent Identity Tests (WithClientIdOverride)
+
+        [TestMethod]
+        public async Task SingleCca_AgentUserIdentity_WithCacheHit_Test()
+        {
+            // This test demonstrates the agent identity flow using a SINGLE CCA instance
+            // and the new WithClientIdOverride parameter, instead of requiring multiple CCAs.
+            //
+            // Flow:
+            //   Leg 1: Blueprint CCA acquires FMI token (T1) targeting the agent app
+            //   Leg 2: Same CCA acquires instance token (T2) using T1 as credential, with client_id override
+            //   Leg 3: Same CCA acquires user token using T2, with client_id override
+            //   Silent: AcquireTokenSilent returns the cached user token
+
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+
+            // Single CCA — configured as the blueprint app
+            var cca = ConfidentialClientApplicationBuilder
+                .Create(ClientId)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .WithCertificate(cert, sendX5C: true)
+                .Build();
+
+            // Leg 1: Acquire FMI token (T1) — uses blueprint's own client_id
+            var leg1Result = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithFmiPath(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(leg1Result.AccessToken, "T1 should not be null");
+            Assert.AreEqual(TokenSource.IdentityProvider, leg1Result.AuthenticationResultMetadata.TokenSource);
+            Trace.WriteLine($"Leg 1 (T1) acquired from: {leg1Result.AuthenticationResultMetadata.TokenSource}");
+
+            // Leg 2: Acquire instance token (T2) — override client_id to agentAppId, use T1 as assertion
+            string t1Token = leg1Result.AccessToken;
+            var leg2Result = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    // Override the client_assertion to use T1 instead of the certificate
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(leg2Result.AccessToken, "T2 should not be null");
+            Assert.AreEqual(TokenSource.IdentityProvider, leg2Result.AuthenticationResultMetadata.TokenSource);
+            Trace.WriteLine($"Leg 2 (T2) acquired from: {leg2Result.AuthenticationResultMetadata.TokenSource}");
+
+            // Leg 3: Acquire user token — override client_id to agentAppId
+            var leg3Result = await ((IByUserFederatedIdentityCredential)cca)
+                .AcquireTokenByUserFederatedIdentityCredential([Scope], UserUpn, leg2Result.AccessToken)
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    // Override the client_assertion to use T1 instead of the certificate
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(leg3Result.AccessToken, "User token should not be null");
+            Assert.IsNotNull(leg3Result.Account, "Account should not be null");
+            Assert.AreEqual(TokenSource.IdentityProvider, leg3Result.AuthenticationResultMetadata.TokenSource);
+            Trace.WriteLine($"Leg 3 (user token) acquired from: {leg3Result.AuthenticationResultMetadata.TokenSource}");
+
+            // Verify cache hits: repeat all 3 legs, all should come from cache
+            var leg1Cached = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithFmiPath(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+            Assert.AreEqual(TokenSource.Cache, leg1Cached.AuthenticationResultMetadata.TokenSource, "Leg 1 should be cached");
+
+            var leg2Cached = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+            Assert.AreEqual(TokenSource.Cache, leg2Cached.AuthenticationResultMetadata.TokenSource, "Leg 2 should be cached");
+
+            // Verify no cache collision between Leg 1 and Leg 2 (same scope, different client IDs)
+            Assert.AreNotEqual(leg1Result.AccessToken, leg2Result.AccessToken,
+                "T1 and T2 should be distinct tokens despite same scope");
+
+            // Silent: Use the account from Leg 3 directly with WithClientIdOverride
+            var silentResult = await cca
+                .AcquireTokenSilent([Scope], leg3Result.Account)
+                .WithClientIdOverride(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, silentResult.AuthenticationResultMetadata.TokenSource, "Token should come from cache");
+            Assert.AreEqual(leg3Result.AccessToken, silentResult.AccessToken, "Cached token should match original");
+            Trace.WriteLine($"Silent result from: {silentResult.AuthenticationResultMetadata.TokenSource}");
+
+            // Silent with ForceRefresh: verify the refresh token path also works with the override
+            var silentRefreshed = await cca
+                .AcquireTokenSilent([Scope], leg3Result.Account)
+                .WithClientIdOverride(AgentIdentity)
+                .WithForceRefresh(true)
+                .OnBeforeTokenRequest(data =>
+                {
+                    // Refresh token request also needs the agent's client_assertion
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.IdentityProvider, silentRefreshed.AuthenticationResultMetadata.TokenSource, "Force refresh should hit identity provider");
+            Assert.IsNotNull(silentRefreshed.AccessToken, "Refreshed token should not be null");
+            Trace.WriteLine($"Force-refreshed result from: {silentRefreshed.AuthenticationResultMetadata.TokenSource}");
+        }
+
+        [TestMethod]
+        public async Task SingleCca_AgentUserIdentity_TwoUsers_NoCacheCollision_Test()
+        {
+            // This test verifies that two different users' tokens don't collide in the cache
+            // when using the same single CCA + WithClientIdOverride pattern.
+            //
+            // We acquire tokens for user1, then user1 again (should be cache hit),
+            // verifying the basic cache isolation by homeAccountId.
+
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+
+            var cca = ConfidentialClientApplicationBuilder
+                .Create(ClientId)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .WithCertificate(cert, sendX5C: true)
+                .Build();
+
+            // --- First user flow ---
+            var leg1Result = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithFmiPath(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            string t1Token = leg1Result.AccessToken;
+
+            var leg2Result = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            var user1Result = await ((IByUserFederatedIdentityCredential)cca)
+                .AcquireTokenByUserFederatedIdentityCredential([Scope], UserUpn, leg2Result.AccessToken)
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(user1Result.AccessToken);
+            Trace.WriteLine($"User 1 token acquired from: {user1Result.AuthenticationResultMetadata.TokenSource}");
+
+            // --- Verify Leg 1 and Leg 2 are cached (reuse for second call) ---
+            var leg1Cached = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithFmiPath(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, leg1Cached.AuthenticationResultMetadata.TokenSource,
+                "Leg 1 token should be served from cache on second call");
+
+            var leg2Cached = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, leg2Cached.AuthenticationResultMetadata.TokenSource,
+                "Leg 2 token should be served from cache on second call");
+
+            // --- User 1 silent with WithClientIdOverride ---
+            var user1Silent = await cca
+                .AcquireTokenSilent([Scope], user1Result.Account)
+                .WithClientIdOverride(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, user1Silent.AuthenticationResultMetadata.TokenSource,
+                "User 1 silent should hit cache");
+            Assert.AreEqual(user1Result.AccessToken, user1Silent.AccessToken);
+
+            // --- Verify no collision: Leg 1 token (blueprint clientId) vs Leg 2 token (agent clientId) ---
+            // Both target the same scope (api://AzureADTokenExchange/.default) but should be distinct cache entries
+            Assert.AreNotEqual(leg1Result.AccessToken, leg2Result.AccessToken,
+                "T1 and T2 should be different tokens despite same scope");
+        }
+
+        [TestMethod]
+        public async Task SingleCca_Leg1AndLeg2_DifferentCachePartitions_Test()
+        {
+            // This test verifies that Leg 1 and Leg 2 tokens don't collide in the app cache
+            // even though they both target api://AzureADTokenExchange/.default.
+            // They should be in different cache partitions because:
+            //   Leg 1: clientId = blueprintClientId (no override)
+            //   Leg 2: clientId = agentAppId (via WithClientIdOverride)
+
+            X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+
+            var cca = ConfidentialClientApplicationBuilder
+                .Create(ClientId)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .WithCertificate(cert, sendX5C: true)
+                .Build();
+
+            // Leg 1
+            var leg1 = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithFmiPath(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Leg 2
+            string t1Token = leg1.AccessToken;
+            var leg2 = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Repeat Leg 1 — should come from cache (proving Leg 2 didn't overwrite it)
+            var leg1Again = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithFmiPath(AgentIdentity)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, leg1Again.AuthenticationResultMetadata.TokenSource,
+                "Leg 1 token should still be cached after Leg 2 was stored");
+            Assert.AreEqual(leg1.AccessToken, leg1Again.AccessToken,
+                "Leg 1 cached token should be the same as the original");
+
+            // Repeat Leg 2 — should come from cache (proving Leg 1 repeat didn't overwrite it)
+            var leg2Again = await cca
+                .AcquireTokenForClient([TokenExchangeUrl])
+                .WithClientIdOverride(AgentIdentity)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = t1Token;
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, leg2Again.AuthenticationResultMetadata.TokenSource,
+                "Leg 2 token should still be cached after Leg 1 was re-read");
+            Assert.AreEqual(leg2.AccessToken, leg2Again.AccessToken,
+                "Leg 2 cached token should be the same as the original");
+        }
+
+        #endregion
     }
 }

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/Agentic.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/Agentic.cs
@@ -264,13 +264,11 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         }
 
         [TestMethod]
-        public async Task SingleCca_AgentUserIdentity_TwoUsers_NoCacheCollision_Test()
+        public async Task SingleCca_AgentUserIdentity_AppTokenCacheIsolation_Test()
         {
-            // This test verifies that two different users' tokens don't collide in the cache
-            // when using the same single CCA + WithClientIdOverride pattern.
-            //
-            // We acquire tokens for user1, then user1 again (should be cache hit),
-            // verifying the basic cache isolation by homeAccountId.
+            // This test verifies that Leg 1 (blueprint) and Leg 2 (agent) app tokens
+            // are correctly isolated in the cache despite targeting the same scope,
+            // and that subsequent calls are served from cache.
 
             X509Certificate2 cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
 
@@ -281,7 +279,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .WithCertificate(cert, sendX5C: true)
                 .Build();
 
-            // --- First user flow ---
+            // Leg 1: Blueprint acquires FMI token
             var leg1Result = await cca
                 .AcquireTokenForClient([TokenExchangeUrl])
                 .WithFmiPath(AgentIdentity)
@@ -289,7 +287,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .ConfigureAwait(false);
 
             string t1Token = leg1Result.AccessToken;
+            Assert.AreEqual(TokenSource.IdentityProvider, leg1Result.AuthenticationResultMetadata.TokenSource);
 
+            // Leg 2: Agent instance token (same scope, different clientId via override)
             var leg2Result = await cca
                 .AcquireTokenForClient([TokenExchangeUrl])
                 .WithClientIdOverride(AgentIdentity)
@@ -302,22 +302,13 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .ExecuteAsync()
                 .ConfigureAwait(false);
 
-            var user1Result = await ((IByUserFederatedIdentityCredential)cca)
-                .AcquireTokenByUserFederatedIdentityCredential([Scope], UserUpn, leg2Result.AccessToken)
-                .WithClientIdOverride(AgentIdentity)
-                .OnBeforeTokenRequest(data =>
-                {
-                    data.BodyParameters["client_assertion"] = t1Token;
-                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
-                    return Task.CompletedTask;
-                })
-                .ExecuteAsync()
-                .ConfigureAwait(false);
+            Assert.AreEqual(TokenSource.IdentityProvider, leg2Result.AuthenticationResultMetadata.TokenSource);
 
-            Assert.IsNotNull(user1Result.AccessToken);
-            Trace.WriteLine($"User 1 token acquired from: {user1Result.AuthenticationResultMetadata.TokenSource}");
+            // Verify no collision: same scope, different tokens
+            Assert.AreNotEqual(leg1Result.AccessToken, leg2Result.AccessToken,
+                "T1 and T2 should be different tokens despite same scope");
 
-            // --- Verify Leg 1 and Leg 2 are cached (reuse for second call) ---
+            // Verify Leg 1 cache hit
             var leg1Cached = await cca
                 .AcquireTokenForClient([TokenExchangeUrl])
                 .WithFmiPath(AgentIdentity)
@@ -325,8 +316,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .ConfigureAwait(false);
 
             Assert.AreEqual(TokenSource.Cache, leg1Cached.AuthenticationResultMetadata.TokenSource,
-                "Leg 1 token should be served from cache on second call");
+                "Leg 1 should be served from cache");
 
+            // Verify Leg 2 cache hit
             var leg2Cached = await cca
                 .AcquireTokenForClient([TokenExchangeUrl])
                 .WithClientIdOverride(AgentIdentity)
@@ -340,23 +332,7 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 .ConfigureAwait(false);
 
             Assert.AreEqual(TokenSource.Cache, leg2Cached.AuthenticationResultMetadata.TokenSource,
-                "Leg 2 token should be served from cache on second call");
-
-            // --- User 1 silent with WithClientIdOverride ---
-            var user1Silent = await cca
-                .AcquireTokenSilent([Scope], user1Result.Account)
-                .WithClientIdOverride(AgentIdentity)
-                .ExecuteAsync()
-                .ConfigureAwait(false);
-
-            Assert.AreEqual(TokenSource.Cache, user1Silent.AuthenticationResultMetadata.TokenSource,
-                "User 1 silent should hit cache");
-            Assert.AreEqual(user1Result.AccessToken, user1Silent.AccessToken);
-
-            // --- Verify no collision: Leg 1 token (blueprint clientId) vs Leg 2 token (agent clientId) ---
-            // Both target the same scope (api://AzureADTokenExchange/.default) but should be distinct cache entries
-            Assert.AreNotEqual(leg1Result.AccessToken, leg2Result.AccessToken,
-                "T1 and T2 should be different tokens despite same scope");
+                "Leg 2 should be served from cache");
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/RequestsTests/AgentIdentityCacheIsolationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/RequestsTests/AgentIdentityCacheIsolationTests.cs
@@ -1,0 +1,498 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
+using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Unit.RequestsTests
+{
+    /// <summary>
+    /// Tests that verify cache isolation when using WithClientIdOverride for agent identity scenarios.
+    /// These tests use mocked HTTP responses to simulate multiple users and agents,
+    /// ensuring no cache collisions occur within a single ConfidentialClientApplication instance.
+    /// </summary>
+    [TestClass]
+    public class AgentIdentityCacheIsolationTests : TestBase
+    {
+        // Blueprint app (the CCA's configured client ID)
+        private const string BlueprintClientId = "urn:microsoft:identity:fmi";
+
+        // Agent app (the override client ID for legs 2 & 3)
+        private const string AgentAppId = "agent-app-id-1111";
+
+        // Second agent app (to test multi-agent isolation)
+        private const string AgentAppId2 = "agent-app-id-2222";
+
+        private const string TokenExchangeScope = "api://AzureADTokenExchange/.default";
+        private const string GraphScope = "https://graph.microsoft.com/.default";
+        private const string FmiPath = "some/fmi/path";
+
+        // User 1 identifiers
+        private const string User1Uid = "user1-uid-aaaa";
+        private const string User1Utid = "tenant-utid-1111";
+        private const string User1Upn = "user1@contoso.com";
+
+        // User 2 identifiers
+        private const string User2Uid = "user2-uid-bbbb";
+        private const string User2Utid = "tenant-utid-1111"; // same tenant
+        private const string User2Upn = "user2@contoso.com";
+
+        [TestMethod]
+        public async Task TwoUsers_SameAgent_NoCacheCollision_Test()
+        {
+            // This test verifies that tokens for two different users acquired through
+            // the same agent identity flow do NOT collide in the cache.
+            // Each user should have their own distinct AT, RT, and IDT entries.
+
+            using var httpManager = new MockHttpManager();
+            httpManager.AddInstanceDiscoveryMockHandler();
+
+            var app = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithAuthority(ClientApplicationBase.DefaultAuthority, true)
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithExperimentalFeatures(true)
+                .WithHttpManager(httpManager)
+                .BuildConcrete();
+
+            // === User 1 flow ===
+
+            // Leg 1: FMI token (app token, blueprint clientId)
+            httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                token: "t1-fmi-token-user1");
+
+            var leg1User1 = await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithFmiPath(FmiPath)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.IdentityProvider, leg1User1.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("t1-fmi-token-user1", leg1User1.AccessToken);
+
+            // Leg 2: Instance token (app token, agent clientId via override)
+            httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                token: "t2-instance-token-user1");
+
+            var leg2User1 = await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-fmi-token-user1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.IdentityProvider, leg2User1.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("t2-instance-token-user1", leg2User1.AccessToken);
+
+            // Leg 3: User token (user cache, agent clientId)
+            httpManager.AddMockHandler(CreateUserFicMockHandler(
+                uid: User1Uid, utid: User1Utid, displayName: User1Upn,
+                accessToken: "user1-graph-token", refreshToken: "user1-rt",
+                scope: GraphScope));
+
+            var leg3User1 = await ((IByUserFederatedIdentityCredential)app)
+                .AcquireTokenByUserFederatedIdentityCredential(new[] { GraphScope }, User1Upn, "t2-instance-token-user1")
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-fmi-token-user1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.IdentityProvider, leg3User1.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("user1-graph-token", leg3User1.AccessToken);
+            Assert.IsNotNull(leg3User1.Account);
+
+            // === User 2 flow ===
+            // Leg 1 is shared (same FMI token), so should come from cache
+            var leg1User2 = await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithFmiPath(FmiPath)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, leg1User2.AuthenticationResultMetadata.TokenSource,
+                "Leg 1 FMI token should be cached and shared across users");
+
+            // Leg 2 is also shared (same agent instance token, same scope)
+            var leg2User2 = await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-fmi-token-user1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, leg2User2.AuthenticationResultMetadata.TokenSource,
+                "Leg 2 instance token should be cached and shared across users");
+
+            // Leg 3: Different user — must go to IdP (different homeAccountId)
+            httpManager.AddMockHandler(CreateUserFicMockHandler(
+                uid: User2Uid, utid: User2Utid, displayName: User2Upn,
+                accessToken: "user2-graph-token", refreshToken: "user2-rt",
+                scope: GraphScope));
+
+            var leg3User2 = await ((IByUserFederatedIdentityCredential)app)
+                .AcquireTokenByUserFederatedIdentityCredential(new[] { GraphScope }, User2Upn, "t2-instance-token-user1")
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-fmi-token-user1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.IdentityProvider, leg3User2.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("user2-graph-token", leg3User2.AccessToken);
+            Assert.IsNotNull(leg3User2.Account);
+
+            // === Verify cache isolation ===
+
+            // App cache should have exactly 2 entries: Leg1 (blueprint) + Leg2 (agent override)
+            var appTokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
+            Assert.HasCount(2, appTokens, "Should have 2 app tokens: one for Leg 1 (blueprint), one for Leg 2 (agent)");
+
+            var leg1Token = appTokens.Single(t => t.ClientId == BlueprintClientId);
+            var leg2Token = appTokens.Single(t => t.ClientId == AgentAppId);
+            Assert.AreNotEqual(leg1Token.CacheKey, leg2Token.CacheKey,
+                "Leg 1 and Leg 2 should have different cache keys");
+
+            // User cache should have 2 access tokens (one per user), 2 refresh tokens, 2 id tokens
+            var userAccessTokens = app.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
+            Assert.HasCount(2, userAccessTokens, "Should have 2 user access tokens (one per user)");
+
+            // Both user tokens should have the agent's clientId
+            Assert.IsTrue(userAccessTokens.All(t => t.ClientId == AgentAppId),
+                "Both user tokens should be stored with the agent's clientId");
+
+            // They should have different HomeAccountIds (different users)
+            var homeAccountIds = userAccessTokens.Select(t => t.HomeAccountId).Distinct().ToList();
+            Assert.HasCount(2, homeAccountIds, "User tokens should have distinct HomeAccountIds");
+
+            // Verify refresh tokens are also distinct
+            var refreshTokens = app.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();
+            Assert.HasCount(2, refreshTokens, "Should have 2 refresh tokens (one per user)");
+            Assert.IsTrue(refreshTokens.All(t => t.ClientId == AgentAppId),
+                "Both refresh tokens should be stored with the agent's clientId");
+            var rtHomeAccountIds = refreshTokens.Select(t => t.HomeAccountId).Distinct().ToList();
+            Assert.HasCount(2, rtHomeAccountIds, "Refresh tokens should have distinct HomeAccountIds");
+
+            // === Verify silent calls retrieve correct tokens (no cross-user pollution) ===
+            var user1Silent = await app
+                .AcquireTokenSilent(new[] { GraphScope }, leg3User1.Account)
+                .WithClientIdOverride(AgentAppId)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, user1Silent.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("user1-graph-token", user1Silent.AccessToken,
+                "Silent for user1 should return user1's token, not user2's");
+
+            var user2Silent = await app
+                .AcquireTokenSilent(new[] { GraphScope }, leg3User2.Account)
+                .WithClientIdOverride(AgentAppId)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, user2Silent.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("user2-graph-token", user2Silent.AccessToken,
+                "Silent for user2 should return user2's token, not user1's");
+        }
+
+        [TestMethod]
+        public async Task TwoAgents_SameUser_NoCacheCollision_Test()
+        {
+            // This test verifies that tokens for the same user acquired through
+            // TWO DIFFERENT agents do NOT collide in the cache.
+
+            using var httpManager = new MockHttpManager();
+            httpManager.AddInstanceDiscoveryMockHandler();
+
+            var app = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithAuthority(ClientApplicationBase.DefaultAuthority, true)
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithExperimentalFeatures(true)
+                .WithHttpManager(httpManager)
+                .BuildConcrete();
+
+            // === Agent 1 flow ===
+
+            // Leg 1
+            httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "t1-agent1");
+
+            await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithFmiPath(FmiPath)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Leg 2 for Agent 1
+            httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "t2-agent1");
+
+            var leg2Agent1 = await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-agent1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Leg 3 for Agent 1 + User 1
+            httpManager.AddMockHandler(CreateUserFicMockHandler(
+                uid: User1Uid, utid: User1Utid, displayName: User1Upn,
+                accessToken: "user1-via-agent1", refreshToken: "user1-rt-agent1",
+                scope: GraphScope));
+
+            var user1Agent1 = await ((IByUserFederatedIdentityCredential)app)
+                .AcquireTokenByUserFederatedIdentityCredential(new[] { GraphScope }, User1Upn, leg2Agent1.AccessToken)
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-agent1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual("user1-via-agent1", user1Agent1.AccessToken);
+
+            // === Agent 2 flow (same user, different agent) ===
+
+            // Leg 2 for Agent 2 (Leg 1 is shared)
+            httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "t2-agent2");
+
+            var leg2Agent2 = await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithClientIdOverride(AgentAppId2)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-agent1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Leg 3 for Agent 2 + User 1 (same user, different agent)
+            httpManager.AddMockHandler(CreateUserFicMockHandler(
+                uid: User1Uid, utid: User1Utid, displayName: User1Upn,
+                accessToken: "user1-via-agent2", refreshToken: "user1-rt-agent2",
+                scope: GraphScope));
+
+            var user1Agent2 = await ((IByUserFederatedIdentityCredential)app)
+                .AcquireTokenByUserFederatedIdentityCredential(new[] { GraphScope }, User1Upn, leg2Agent2.AccessToken)
+                .WithClientIdOverride(AgentAppId2)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-agent1";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual("user1-via-agent2", user1Agent2.AccessToken);
+
+            // === Verify cache isolation ===
+
+            // App cache: Leg1 (blueprint) + Leg2 (agent1) + Leg2 (agent2) = 3 tokens
+            var appTokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
+            Assert.HasCount(3, appTokens, "Should have 3 app tokens: Leg1 + Leg2(agent1) + Leg2(agent2)");
+            Assert.AreEqual(1, appTokens.Count(t => t.ClientId == BlueprintClientId));
+            Assert.AreEqual(1, appTokens.Count(t => t.ClientId == AgentAppId));
+            Assert.AreEqual(1, appTokens.Count(t => t.ClientId == AgentAppId2));
+
+            // User cache: 2 access tokens (same user, different agents = different clientIds)
+            var userAccessTokens = app.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
+            Assert.HasCount(2, userAccessTokens,
+                "Should have 2 user access tokens (same user, different agents)");
+
+            var agent1UserToken = userAccessTokens.Single(t => t.ClientId == AgentAppId);
+            var agent2UserToken = userAccessTokens.Single(t => t.ClientId == AgentAppId2);
+
+            // Same user (same HomeAccountId) but different clientIds = different cache keys
+            Assert.AreEqual(agent1UserToken.HomeAccountId, agent2UserToken.HomeAccountId,
+                "Same user should have same HomeAccountId");
+            Assert.AreNotEqual(agent1UserToken.CacheKey, agent2UserToken.CacheKey,
+                "Different agents should produce different cache keys for same user");
+
+            // Verify refresh tokens are also isolated by agent
+            var refreshTokens = app.UserTokenCacheInternal.Accessor.GetAllRefreshTokens();
+            Assert.HasCount(2, refreshTokens, "Should have 2 refresh tokens (one per agent)");
+            Assert.AreEqual(1, refreshTokens.Count(t => t.ClientId == AgentAppId));
+            Assert.AreEqual(1, refreshTokens.Count(t => t.ClientId == AgentAppId2));
+
+            // === Verify silent calls retrieve correct per-agent tokens ===
+            var silentAgent1 = await app
+                .AcquireTokenSilent(new[] { GraphScope }, user1Agent1.Account)
+                .WithClientIdOverride(AgentAppId)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, silentAgent1.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("user1-via-agent1", silentAgent1.AccessToken,
+                "Silent with agent1 override should return agent1's token");
+
+            var silentAgent2 = await app
+                .AcquireTokenSilent(new[] { GraphScope }, user1Agent2.Account)
+                .WithClientIdOverride(AgentAppId2)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, silentAgent2.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual("user1-via-agent2", silentAgent2.AccessToken,
+                "Silent with agent2 override should return agent2's token");
+        }
+
+        [TestMethod]
+        public async Task AgentUserToken_DoesNotCollide_WithBlueprintUserToken_Test()
+        {
+            // This test verifies that a user token acquired through the agent identity flow
+            // (with WithClientIdOverride) does NOT collide with a user token acquired directly
+            // by the blueprint app (without override) for the same user and scope.
+
+            using var httpManager = new MockHttpManager();
+            httpManager.AddInstanceDiscoveryMockHandler();
+
+            var app = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithAuthority(ClientApplicationBase.DefaultAuthority, true)
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithExperimentalFeatures(true)
+                .WithHttpManager(httpManager)
+                .BuildConcrete();
+
+            // First: Acquire a user token through the agent flow (with override)
+            // Leg 1
+            httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "t1-fmi");
+
+            await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithFmiPath(FmiPath)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Leg 2
+            httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(token: "t2-instance");
+
+            await app.AcquireTokenForClient(new[] { TokenExchangeScope })
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-fmi";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Leg 3: user token via agent
+            httpManager.AddMockHandler(CreateUserFicMockHandler(
+                uid: User1Uid, utid: User1Utid, displayName: User1Upn,
+                accessToken: "user1-via-agent", refreshToken: "user1-rt-agent",
+                scope: GraphScope));
+
+            var agentUserResult = await ((IByUserFederatedIdentityCredential)app)
+                .AcquireTokenByUserFederatedIdentityCredential(new[] { GraphScope }, User1Upn, "t2-instance")
+                .WithClientIdOverride(AgentAppId)
+                .OnBeforeTokenRequest(data =>
+                {
+                    data.BodyParameters["client_assertion"] = "t1-fmi";
+                    data.BodyParameters["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+                    return Task.CompletedTask;
+                })
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual("user1-via-agent", agentUserResult.AccessToken);
+
+            // Second: Acquire a user token directly as the blueprint app (no override)
+            // using the same scope and same user
+            httpManager.AddMockHandler(CreateUserFicMockHandler(
+                uid: User1Uid, utid: User1Utid, displayName: User1Upn,
+                accessToken: "user1-via-blueprint", refreshToken: "user1-rt-blueprint",
+                scope: GraphScope));
+
+            var blueprintUserResult = await ((IByUserFederatedIdentityCredential)app)
+                .AcquireTokenByUserFederatedIdentityCredential(new[] { GraphScope }, User1Upn, "some-blueprint-assertion")
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual("user1-via-blueprint", blueprintUserResult.AccessToken);
+
+            // === Verify no collision ===
+            var userAccessTokens = app.UserTokenCacheInternal.Accessor.GetAllAccessTokens();
+            Assert.HasCount(2, userAccessTokens,
+                "Should have 2 user tokens: one via agent, one via blueprint");
+
+            var agentToken = userAccessTokens.Single(t => t.ClientId == AgentAppId);
+            var blueprintToken = userAccessTokens.Single(t => t.ClientId == BlueprintClientId);
+
+            Assert.AreNotEqual(agentToken.CacheKey, blueprintToken.CacheKey,
+                "Agent and blueprint tokens for same user+scope should have different cache keys");
+
+            // Silent with override should return agent token
+            var silentAgent = await app
+                .AcquireTokenSilent(new[] { GraphScope }, agentUserResult.Account)
+                .WithClientIdOverride(AgentAppId)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual("user1-via-agent", silentAgent.AccessToken);
+
+            // Silent without override should return blueprint token
+            var silentBlueprint = await app
+                .AcquireTokenSilent(new[] { GraphScope }, blueprintUserResult.Account)
+                .ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual("user1-via-blueprint", silentBlueprint.AccessToken);
+        }
+
+        /// <summary>
+        /// Creates a mock HTTP handler that returns a user FIC token response with the given user identity.
+        /// </summary>
+        private static MockHttpMessageHandler CreateUserFicMockHandler(
+            string uid, string utid, string displayName,
+            string accessToken, string refreshToken, string scope)
+        {
+            string idToken = MockHelpers.CreateIdToken(uid, displayName, utid);
+            string clientInfo = MockHelpers.CreateClientInfo(uid, utid);
+
+            string responseBody =
+                "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"scope\":\"" + scope +
+                "\",\"access_token\":\"" + accessToken +
+                "\",\"refresh_token\":\"" + refreshToken +
+                "\",\"client_info\":\"" + clientInfo +
+                "\",\"id_token\":\"" + idToken +
+                "\",\"id_token_expires_in\":\"3600\"}";
+
+            return new MockHttpMessageHandler
+            {
+                ExpectedMethod = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessResponseMessage(responseBody)
+            };
+        }
+    }
+}


### PR DESCRIPTION
Not yet ready for review, just exploring potential alternatives to: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5883

Currently adds:
- `WithClientIdOverride`: a new request level parameter, to help test whether using the correct client ID in the cache key is enough to avoid the agent ID flow's cache collision risks
  - `AgentIdentityCacheIsolationTests`: new unit test class covering:
    - `TwoUsers_SameAgent_NoCacheCollision_Test`: Two different users through the same agent have distinct cache entries (different `HomeAccountId`), silent calls return the correct user's token
    - `TwoAgents_SameUser_NoCacheCollision_Test`: Same user through two different agents has distinct cache entries (different `ClientId` in key), silent calls return the correct agent's token
    - `AgentUserToken_DoesNotCollide_WithBlueprintUserToken_Test`: A user token acquired via agent (with override) doesn't collide with the same user+scope acquired directly by the blueprint (without override)
  - `Agentic`: Extra integration tests covering:
    - `SingleCca_AgentUserIdentity_WithCacheHit_Test`: Full 3-leg flow works end-to-end, all legs cache correctly, silent works, force-refresh works
    - `SingleCca_AgentUserIdentity_AppTokenCacheIsolation_Test`: Leg 1 and Leg 2 target the same scope but produce different tokens in different cache partitions