### PR TITLE
Make IMDSv2 persistent cert cache opt-in (default to in-memory)

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/PersistentCertificateCacheFactory.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/PersistentCertificateCacheFactory.cs
@@ -9,23 +9,46 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
 {
     internal static class PersistentCertificateCacheFactory
     {
-        private const string DisableEnvVar = "MSAL_MI_DISABLE_PERSISTENT_CERT_CACHE";
+        private const string EnableEnvVar = "MSAL_MI_ENABLE_PERSISTENT_CERT_CACHE";
 
         public static IPersistentCertificateCache Create(ILoggerAdapter logger)
         {
-            var disable = Environment.GetEnvironmentVariable(DisableEnvVar);
-            if (!string.IsNullOrEmpty(disable) &&
-                (disable.Equals("1", StringComparison.OrdinalIgnoreCase) ||
-                 disable.Equals("true", StringComparison.OrdinalIgnoreCase)))
+            string raw;
+            try
             {
-                logger.Info(() => "[PersistentCert] No-op persistent cache enabled via " + DisableEnvVar + ".");
+                raw = Environment.GetEnvironmentVariable(EnableEnvVar);
+            }
+            catch (System.Security.SecurityException)
+            {
+                // Persistence must never block authentication; if we cannot read the
+                // environment we silently default to in-memory (NoOp) behavior.
                 return new NoOpPersistentCertificateCache();
             }
 
-            // We persist only on Windows because FriendlyName tagging is required.
-            return DesktopOsHelper.IsWindows()
-                ? new WindowsPersistentCertificateCache()
-                : new NoOpPersistentCertificateCache();
+            string value = raw?.Trim();
+            if (string.IsNullOrEmpty(value))
+            {
+                return new NoOpPersistentCertificateCache();
+            }
+
+            bool optedIn =
+                value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                value.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+            if (!optedIn)
+            {
+                logger.Info(() => "[PersistentCert] " + EnableEnvVar + " is set to an unrecognized value (expected '1' or 'true'). Persistent cache will not be enabled.");
+                return new NoOpPersistentCertificateCache();
+            }
+
+            if (DesktopOsHelper.IsWindows())
+            {
+                logger.Info(() => "[PersistentCert] Windows persistent cache enabled via " + EnableEnvVar + ".");
+                return new WindowsPersistentCertificateCache();
+            }
+
+            logger.Info(() => "[PersistentCert] " + EnableEnvVar + " is set but persistent cache is only supported on Windows. Falling back to no-op.");
+            return new NoOpPersistentCertificateCache();
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateCacheFactoryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateCacheFactoryTests.cs
@@ -14,32 +14,20 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
     [TestClass]
     public class PersistentCertificateCacheFactoryTests
     {
-        private const string DisableEnvVar = "MSAL_MI_DISABLE_PERSISTENT_CERT_CACHE";
+        private const string EnableEnvVar = "MSAL_MI_ENABLE_PERSISTENT_CERT_CACHE";
 
         [TestMethod]
         [DataRow("true")]
         [DataRow("TRUE")]
+        [DataRow("TruE")]
         [DataRow("1")]
-        public void Factory_Disabled_ByEnvVar(string environmentVariableValue)
+        [DataRow(" true ")]
+        [DataRow("\t1\t")]
+        public void Factory_Enabled_ByEnvVar(string environmentVariableValue)
         {
             using (new EnvVariableContext())
             {
-                Environment.SetEnvironmentVariable(DisableEnvVar, environmentVariableValue);
-
-                var logger = Substitute.For<ILoggerAdapter>();
-                var cache = PersistentCertificateCacheFactory.Create(logger);
-
-                Assert.IsInstanceOfType(cache, typeof(NoOpPersistentCertificateCache));
-            }
-        }
-
-        [TestMethod]
-        public void Factory_Defaults_To_Platform_When_EnvVar_Unset()
-        {
-            using (new EnvVariableContext())
-            {
-                // Ensure unset
-                Environment.SetEnvironmentVariable(DisableEnvVar, null);
+                Environment.SetEnvironmentVariable(EnableEnvVar, environmentVariableValue);
 
                 var logger = Substitute.For<ILoggerAdapter>();
                 var cache = PersistentCertificateCacheFactory.Create(logger);
@@ -52,6 +40,48 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 {
                     Assert.IsInstanceOfType(cache, typeof(NoOpPersistentCertificateCache));
                 }
+            }
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow(" ")]
+        [DataRow("\t")]
+        public void Factory_Defaults_To_NoOp_When_EnvVar_Unset(string environmentVariableValue)
+        {
+            using (new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable(EnableEnvVar, environmentVariableValue);
+
+                var logger = Substitute.For<ILoggerAdapter>();
+                var cache = PersistentCertificateCacheFactory.Create(logger);
+
+                Assert.IsInstanceOfType(cache, typeof(NoOpPersistentCertificateCache));
+            }
+        }
+
+        [TestMethod]
+        [DataRow("0")]
+        [DataRow("false")]
+        [DataRow("False")]
+        [DataRow("FALSE")]
+        [DataRow("yes")]
+        [DataRow("no")]
+        [DataRow("on")]
+        [DataRow("off")]
+        [DataRow("enabled")]
+        [DataRow("ture")]
+        public void Factory_Ignores_Unrecognized_Values(string environmentVariableValue)
+        {
+            using (new EnvVariableContext())
+            {
+                Environment.SetEnvironmentVariable(EnableEnvVar, environmentVariableValue);
+
+                var logger = Substitute.For<ILoggerAdapter>();
+                var cache = PersistentCertificateCacheFactory.Create(logger);
+
+                Assert.IsInstanceOfType(cache, typeof(NoOpPersistentCertificateCache));
             }
         }
     }


### PR DESCRIPTION
Fixes #6011

## Summary
Flip the IMDSv2 persistent certificate cache so the **in-memory NoOp** implementation is the default on every platform. Cross-process certificate persistence is now **opt-in** via a single env var:

```
MSAL_MI_ENABLE_PERSISTENT_CERT_CACHE = 1 | true
```

## Behavior

| Env var state                   | Windows                              | Linux / macOS                |
|---------------------------------|--------------------------------------|------------------------------|
| Unset / empty / whitespace      | NoOpPersistentCertificateCache     | NoOpPersistentCertificateCache |
| `1` / `true` (case- & ws-tolerant) | WindowsPersistentCertificateCache  | NoOpPersistentCertificateCache + Info log |
| Any other value (e.g. `0`, `false`, `yes`) | NoOpPersistentCertificateCache + Info log | NoOpPersistentCertificateCache + Info log |
| `SecurityException` reading env var | NoOpPersistentCertificateCache (silent) | NoOpPersistentCertificateCache (silent) |

Persistence must never block authentication, so every failure mode falls back to the in-memory NoOp.

## Tests
- `PersistentCertificateCacheFactoryTests` rewritten with three methods covering Enabled / Defaults-to-NoOp / Ignores-Unrecognized (20 DataRows total). Stock `NSubstitute` logger.
- Persistent-cache internals (Read / Write / Delete / DeleteAllForAlias / mutex / lifetime / boundary) continue to be covered by `PersistentCertificateStoreUnitTests`.
- Full `Microsoft.Identity.Test.Unit` suite on net8.0: **2067 passed / 0 failed / 19 skipped** (pre-existing macOS-keychain skips).

## Files
- `src/client/Microsoft.Identity.Client/ManagedIdentity/V2/PersistentCertificateCacheFactory.cs`
- `tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateCacheFactoryTests.cs`
