### PR TITLE
[CI] Opt-in nightly IdWeb-against-MSAL integration stage

### DIFF
--- a/build/pipeline-pullrequest.yaml
+++ b/build/pipeline-pullrequest.yaml
@@ -27,8 +27,8 @@ variables:
 #   zero agent time, zero impact on PR gating.
 # - On the separate ADO pipeline definition (.NET MSAL Nightly IdWeb
 #   Integration), the Variables UI sets RunIdWebIntegration='true' and
-#   IdWebRef='main' (or any branch/tag), and the Triggers UI attaches a
-#   scheduled trigger.
+#   IdWebRef='master' (IdWeb's default branch; or any branch/tag/SHA),
+#   and the Triggers UI attaches a scheduled trigger.
 
 #BUILD PHASE 
 

--- a/build/pipeline-pullrequest.yaml
+++ b/build/pipeline-pullrequest.yaml
@@ -15,7 +15,29 @@ variables:
   #intended for running all ui automation tests as one to reduce time
   ConsolidateAppCenterTests: true
 
+# Nightly IdWeb-against-MSAL integration.
+#
+# The IdWebAgainstMsal stage (see template-idweb-against-msal.yaml) is gated by
+# `eq(variables['RunIdWebIntegration'], 'true')`. We deliberately do NOT
+# declare RunIdWebIntegration or IdWebRef in this YAML's variables block --
+# root-level YAML variables override pipeline-definition Variables UI values
+# in ADO, which would defeat the per-definition override.
+#
+# - On PR pipeline 905 (.NET MSAL PR): variables are unset, stage is Skipped,
+#   zero agent time, zero impact on PR gating.
+# - On the separate ADO pipeline definition (.NET MSAL Nightly IdWeb
+#   Integration), the Variables UI sets RunIdWebIntegration='true' and
+#   IdWebRef='main' (or any branch/tag), and the Triggers UI attaches a
+#   scheduled trigger.
+
 #BUILD PHASE 
 
 stages:
 - template: template-build-and-run-all-tests.yaml
+
+# Nightly IdWeb integration -- runs only when RunIdWebIntegration='true'.
+# See template-idweb-against-msal.yaml for the stage definition + condition.
+- template: template-idweb-against-msal.yaml
+  parameters:
+    buildConfiguration: $(BuildConfiguration)
+    dependsOnStage: 'Build'

--- a/build/template-idweb-against-msal.yaml
+++ b/build/template-idweb-against-msal.yaml
@@ -23,6 +23,9 @@
 # RunIdWebIntegration='true' and IdWebRef in its Variables UI, and attaches
 # a scheduled trigger in its Triggers UI.
 #
+# IdWeb's default branch is 'master' (not 'main') -- this template's
+# PowerShell fallback defaults to 'master' if IdWebRef is unset.
+#
 # Scope: by design we restore/build/test ONLY the
 #   tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
 # csproj. Project references pull in the IdWeb libraries we care about
@@ -145,10 +148,11 @@ stages:
 
           # Resolve the ref. We deliberately do NOT declare $(IdWebRef) at
           # YAML root (UI-precedence issue), so it can be unset on this
-          # pipeline. Default to 'main' when undefined or unresolved.
+          # pipeline. Default to 'master' when undefined or unresolved
+          # (Microsoft.Identity.Web's default branch is 'master', not 'main').
           $ref = '$(IdWebRef)'
           if ([string]::IsNullOrWhiteSpace($ref) -or $ref -eq '$(IdWebRef)') {
-            $ref = 'main'
+            $ref = 'master'
           }
 
           # Allowlist: refs must look like branch/tag/sha names. Blocks

--- a/build/template-idweb-against-msal.yaml
+++ b/build/template-idweb-against-msal.yaml
@@ -232,7 +232,10 @@ stages:
           $ErrorActionPreference = 'Stop'
 
           # Check 1: global packages cache holds our version.
-          $globalPackages = (& dotnet nuget locals global-packages --list) -replace '.*: *',''
+          # Parse the path with a non-greedy, anchored regex. The naive
+          # '.*: *' is greedy and on Windows eats up to the drive-letter
+          # colon (e.g. "C:\Users\...\.nuget\packages\" -> "\Users\...\").
+          $globalPackages = (& dotnet nuget locals global-packages --list) -replace '^.*?global-packages:\s*',''
           $msalCachePath = Join-Path $globalPackages "microsoft.identity.client/$(MsalLocalVersion)"
           if (-not (Test-Path $msalCachePath)) {
             Write-Error "Restore did not pull Microsoft.Identity.Client $(MsalLocalVersion) from the local feed. Expected cache path: $msalCachePath"

--- a/build/template-idweb-against-msal.yaml
+++ b/build/template-idweb-against-msal.yaml
@@ -1,0 +1,313 @@
+# template-idweb-against-msal.yaml
+#
+# Conditional stage that builds Microsoft.Identity.Web (IdWeb) against the
+# current MSAL.NET source by packing MSAL locally and consuming it as a NuGet
+# package via IdWeb's existing $(MicrosoftIdentityClientVersion) override hook
+# in IdWeb's Directory.Build.props.
+#
+# This mirrors the DevEx unified-build pattern (definitionId=2749) that
+# already daisy-chains Abstractions -> Wilson -> IdWeb -> SAL -> MISE through
+# local NuGet feeds. We add MSAL as one more link upstream.
+#
+# Purpose: catch MSAL changes on 'main' that would break IdWeb consumers
+# before MSAL ships a release.
+#
+# Activation: this stage is gated by
+#   eq(variables['RunIdWebIntegration'], 'true')
+# The parent PR pipeline (build/pipeline-pullrequest.yaml) does NOT declare
+# RunIdWebIntegration at root -- root-level YAML variables override
+# pipeline-definition UI variables in ADO, which would defeat per-definition
+# override. So on PR runs the variable is undefined, the condition is false,
+# and the stage is Skipped (zero agent time). The separate ADO pipeline
+# definition (.NET MSAL Nightly IdWeb Integration) sets
+# RunIdWebIntegration='true' and IdWebRef in its Variables UI, and attaches
+# a scheduled trigger in its Triggers UI.
+#
+# Scope: by design we restore/build/test ONLY the
+#   tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj
+# csproj. Project references pull in the IdWeb libraries we care about
+# (Microsoft.Identity.Web, .TokenCache, .Certificateless) transitively.
+# Avoiding the full sln dodges unrelated projects (E2E, perf, DevApps,
+# Aspire, AOT TestApp, tooling) that produce false nightly failures from
+# workload/SDK drift.
+#
+# IMPORTANT: this template does NOT publish any NuGet package externally.
+# The .nupkg produced lives in $(LocalNugetFeed) on the agent only, with
+# version 99.0.0-nightly-* which is structurally impossible to confuse for
+# a real MSAL release and dominates any plausible transitive '>=' constraint.
+
+parameters:
+- name: buildConfiguration
+  displayName: 'Build configuration'
+  type: string
+  default: 'Release'
+- name: dependsOnStage
+  displayName: 'Stage to depend on (typically MSAL Build)'
+  type: string
+  default: 'Build'
+
+stages:
+- stage: IdWebAgainstMsal
+  displayName: 'IdWeb against MSAL src (nightly integration)'
+  dependsOn: ${{ parameters.dependsOnStage }}
+  condition: and(succeeded(), eq(variables['RunIdWebIntegration'], 'true'))
+  jobs:
+  - job: BuildAndTestIdWeb
+    displayName: 'Pack MSAL + build IdWeb against local feed + run unit tests'
+    pool:
+      vmImage: 'windows-2022'
+    timeoutInMinutes: 60
+    workspace:
+      clean: outputs
+    variables:
+      # Local-only MSAL version. 99.x dominates any plausible transitive '>='
+      # constraint that could otherwise silently fall back to a real release
+      # from nuget.org. Build.BuildId makes each run's version unique within
+      # the agent cache.
+      MsalLocalVersion: '99.0.0-nightly-$(Build.BuildId)'
+
+      # On-agent throwaway NuGet feed. Never published.
+      LocalNugetFeed:   '$(Build.ArtifactStagingDirectory)/nuget-local-3P'
+      IdWebRoot:        '$(Agent.BuildDirectory)/idweb'
+      BinlogDir:        '$(Build.ArtifactStagingDirectory)/binlogs'
+      TestResultsDir:   '$(Build.ArtifactStagingDirectory)/testresults'
+      IdWebTestCsproj:  '$(Agent.BuildDirectory)/idweb/tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj'
+
+    steps:
+    - checkout: self
+      displayName: 'Checkout MSAL.NET (self)'
+      clean: false
+      fetchDepth: 1
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 8 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '8.0.x'
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 9 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '9.0.x'
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 10 SDK (required by IdWeb global.json)'
+      inputs:
+        packageType: 'sdk'
+        version: '10.0.x'
+        includePreviewVersions: true
+
+    - task: PowerShell@2
+      displayName: 'Initialize local NuGet feed directory'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path '$(LocalNugetFeed)' | Out-Null
+          New-Item -ItemType Directory -Force -Path '$(BinlogDir)'      | Out-Null
+          New-Item -ItemType Directory -Force -Path '$(TestResultsDir)' | Out-Null
+          Write-Host "Local feed root: $(LocalNugetFeed)"
+          Write-Host "MSAL local version: $(MsalLocalVersion)"
+
+    - task: DotNetCoreCLI@2
+      displayName: 'Pack MSAL with local-only version'
+      inputs:
+        command: 'pack'
+        packagesToPack: '$(Build.SourcesDirectory)/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj'
+        packDirectory: '$(LocalNugetFeed)'
+        configuration: '${{ parameters.buildConfiguration }}'
+        buildProperties: 'Version=$(MsalLocalVersion);PackageVersion=$(MsalLocalVersion)'
+        verbosityPack: 'minimal'
+
+    - task: PowerShell@2
+      displayName: 'Verify MSAL pack produced expected nupkg'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $ErrorActionPreference = 'Stop'
+          $expected = "Microsoft.Identity.Client.$(MsalLocalVersion).nupkg"
+          $found = Get-ChildItem '$(LocalNugetFeed)' -Filter 'Microsoft.Identity.Client.*.nupkg' -ErrorAction SilentlyContinue
+          if (-not $found) { throw "No Microsoft.Identity.Client*.nupkg found in $(LocalNugetFeed)" }
+          $found | ForEach-Object { Write-Host ("  packed: {0} ({1:N1} KB)" -f $_.Name, ($_.Length / 1KB)) }
+          if (-not ($found.Name -contains $expected)) {
+            throw "Expected '$expected' not present in feed. Got: $($found.Name -join ', ')"
+          }
+          Write-Host "OK"
+
+    - task: PowerShell@2
+      displayName: 'Clone Microsoft.Identity.Web'
+      retryCountOnTaskFailure: 2
+      inputs:
+        targetType: 'inline'
+        script: |
+          $ErrorActionPreference = 'Stop'
+
+          # Resolve the ref. We deliberately do NOT declare $(IdWebRef) at
+          # YAML root (UI-precedence issue), so it can be unset on this
+          # pipeline. Default to 'main' when undefined or unresolved.
+          $ref = '$(IdWebRef)'
+          if ([string]::IsNullOrWhiteSpace($ref) -or $ref -eq '$(IdWebRef)') {
+            $ref = 'main'
+          }
+
+          # Allowlist: refs must look like branch/tag/sha names. Blocks
+          # argument-injection (refs starting with '-') and shell
+          # metacharacters. Allowed chars: alphanumerics, dot, underscore,
+          # forward slash, hyphen.
+          if ($ref -notmatch '^[A-Za-z0-9._/-]+$' -or $ref.StartsWith('-')) {
+            throw "IdWebRef '$ref' contains disallowed characters or starts with '-'"
+          }
+
+          $idwebDir = '$(IdWebRoot)'
+          if (Test-Path $idwebDir) {
+            Write-Host "Removing stale IdWeb clone at $idwebDir"
+            Remove-Item -Recurse -Force $idwebDir
+          }
+          $parent = Split-Path $idwebDir
+          if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
+
+          Write-Host "Cloning IdWeb @ '$ref'"
+          # Try a shallow clone first (works for branches + tags). If that
+          # fails, fall back to a full clone + checkout (handles arbitrary
+          # SHAs).
+          git clone --depth 1 --branch $ref https://github.com/AzureAD/microsoft-identity-web.git $idwebDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "Shallow branch clone failed; trying full clone + checkout (supports SHAs)"
+            if (Test-Path $idwebDir) { Remove-Item -Recurse -Force $idwebDir }
+            git clone https://github.com/AzureAD/microsoft-identity-web.git $idwebDir
+            if ($LASTEXITCODE -ne 0) { throw "git clone of IdWeb failed (exit $LASTEXITCODE)" }
+            git -C $idwebDir checkout $ref
+            if ($LASTEXITCODE -ne 0) { throw "git checkout '$ref' failed (exit $LASTEXITCODE)" }
+          }
+
+          Write-Host ""
+          Write-Host "IdWeb HEAD:"
+          git -C $idwebDir log -1 --oneline
+          Write-Host ""
+          Write-Host "MSAL HEAD (self) at $(Build.SourcesDirectory):"
+          git -C '$(Build.SourcesDirectory)' log -1 --oneline
+
+    - task: PowerShell@2
+      displayName: 'Wire local MSAL feed into IdWeb NuGet.Config'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $ErrorActionPreference = 'Stop'
+          $cfg = Join-Path '$(IdWebRoot)' 'NuGet.Config'
+          if (-not (Test-Path $cfg)) { throw "IdWeb NuGet.Config not found at $cfg" }
+          Write-Host "Adding source 'msal-nightly-3P' = $(LocalNugetFeed)"
+          dotnet nuget add source '$(LocalNugetFeed)' --name 'msal-nightly-3P' --configfile $cfg
+          if ($LASTEXITCODE -ne 0) { throw "dotnet nuget add source failed" }
+          Write-Host ""
+          Write-Host "Resulting NuGet.Config sources:"
+          dotnet nuget list source --configfile $cfg
+
+    - task: PowerShell@2
+      displayName: 'Restore IdWeb test project against local MSAL feed'
+      retryCountOnTaskFailure: 2
+      inputs:
+        targetType: 'inline'
+        workingDirectory: '$(IdWebRoot)'
+        script: |
+          $ErrorActionPreference = 'Stop'
+          # Project-scoped restore (not solution-wide -- see header comment).
+          # --configfile pins us to IdWeb's NuGet.Config (where we just added
+          # the local feed), bypassing any ADO task auto-feed-mgmt behavior.
+          dotnet restore '$(IdWebTestCsproj)' `
+            --configfile '$(IdWebRoot)/NuGet.Config' `
+            /p:MicrosoftIdentityClientVersion=$(MsalLocalVersion) `
+            /bl:'$(BinlogDir)/idweb-restore.binlog'
+          if ($LASTEXITCODE -ne 0) { throw "dotnet restore failed (exit $LASTEXITCODE)" }
+
+    - task: PowerShell@2
+      displayName: 'Sanity check: test csproj resolved MSAL from local feed'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $ErrorActionPreference = 'Stop'
+
+          # Check 1: global packages cache holds our version.
+          $globalPackages = (& dotnet nuget locals global-packages --list) -replace '.*: *',''
+          $msalCachePath = Join-Path $globalPackages "microsoft.identity.client/$(MsalLocalVersion)"
+          if (-not (Test-Path $msalCachePath)) {
+            Write-Error "Restore did not pull Microsoft.Identity.Client $(MsalLocalVersion) from the local feed. Expected cache path: $msalCachePath"
+            exit 1
+          }
+          Write-Host "OK: MSAL $(MsalLocalVersion) is in the global packages cache."
+
+          # Check 2: the test csproj's project.assets.json names our version.
+          # Catches the case where some other project pulled in our version
+          # (so check 1 passes) but the project under test resolved a real
+          # MSAL version transitively from nuget.org.
+          $assets = Join-Path (Split-Path '$(IdWebTestCsproj)') 'obj/project.assets.json'
+          if (-not (Test-Path $assets)) { throw "project.assets.json missing at $assets" }
+          $content = Get-Content $assets -Raw
+          if ($content -notmatch [regex]::Escape("Microsoft.Identity.Client/$(MsalLocalVersion)")) {
+            Write-Error "project.assets.json for the IdWeb test csproj does NOT name Microsoft.Identity.Client/$(MsalLocalVersion). A transitive '>=' constraint likely pulled a real MSAL. Inspect $assets."
+            exit 1
+          }
+          Write-Host "OK: test csproj resolves Microsoft.Identity.Client/$(MsalLocalVersion)."
+
+    - task: PowerShell@2
+      displayName: 'Build IdWeb test project against local MSAL'
+      inputs:
+        targetType: 'inline'
+        workingDirectory: '$(IdWebRoot)'
+        script: |
+          $ErrorActionPreference = 'Stop'
+          dotnet build '$(IdWebTestCsproj)' `
+            --no-restore `
+            --configuration ${{ parameters.buildConfiguration }} `
+            /p:MicrosoftIdentityClientVersion=$(MsalLocalVersion) `
+            /bl:'$(BinlogDir)/idweb-build.binlog'
+          if ($LASTEXITCODE -ne 0) { throw "dotnet build failed (exit $LASTEXITCODE)" }
+
+    - task: PowerShell@2
+      displayName: 'Run IdWeb unit tests'
+      inputs:
+        targetType: 'inline'
+        workingDirectory: '$(IdWebRoot)'
+        script: |
+          $ErrorActionPreference = 'Stop'
+          dotnet test '$(IdWebTestCsproj)' `
+            --no-build `
+            --configuration ${{ parameters.buildConfiguration }} `
+            --logger 'trx' `
+            --results-directory '$(TestResultsDir)' `
+            /p:MicrosoftIdentityClientVersion=$(MsalLocalVersion) `
+            /bl:'$(BinlogDir)/idweb-test.binlog'
+          # Don't throw on non-zero exit -- test failures are surfaced
+          # downstream by the PublishTestResults step with
+          # failTaskOnFailedTests=true. This keeps the failure attributed to
+          # tests in the ADO Tests tab rather than to a generic step failure.
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "##[warning]dotnet test exit code $LASTEXITCODE; test failures will be reported by PublishTestResults"
+          }
+
+    - task: PublishTestResults@2
+      displayName: 'Publish test results (.trx)'
+      condition: always()
+      inputs:
+        testResultsFormat: 'VSTest'
+        testResultsFiles: '**/*.trx'
+        searchFolder: '$(TestResultsDir)'
+        testRunTitle: 'IdWeb unit tests against MSAL $(MsalLocalVersion)'
+        failTaskOnFailedTests: true
+        mergeTestResults: true
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish MSBuild binlogs'
+      condition: always()
+      inputs:
+        PathtoPublish: '$(BinlogDir)'
+        ArtifactName: 'idweb-against-msal-binlogs'
+        publishLocation: 'Container'
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish .trx test results as build artifact'
+      condition: always()
+      inputs:
+        PathtoPublish: '$(TestResultsDir)'
+        ArtifactName: 'idweb-against-msal-testresults'
+        publishLocation: 'Container'


### PR DESCRIPTION
# [CI] Opt-in nightly IdWeb-against-MSAL integration stage

##  Fixes https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6013

## TL;DR

Adds a **conditional, opt-in stage** to `build/pipeline-pullrequest.yaml` that builds **Microsoft.Identity.Web (IdWeb)** against the current MSAL.NET source and runs IdWeb's unit tests. The stage is **Skipped on every PR run** — it only activates when a separate ADO pipeline definition flips a variable. **Zero impact on PR pipeline 905.**

---

## What this achieves

Today's MSAL → IdWeb breakage cycle:

1. MSAL.NET CI passes on `main`.
2. MSAL.NET ships a release to nuget.org.
3. IdWeb bumps `MicrosoftIdentityClientVersion` to the new MSAL release.
4. **A regression caused by the new MSAL surfaces in IdWeb consumers.**
5. MSAL ships a hotfix; IdWeb bumps again.

The feedback loop is **post-release**. This PR enables a **pre-release** loop: a nightly that builds and tests IdWeb against MSAL `main`. If the nightly fails, an MSAL change on `main` would have broken IdWeb if shipped today — and we learn before customers do.

---

## How it works

```
[ Stage: Build ]  (existing, unchanged)
       │
       │ dependsOn: Build
       ▼
[ Stage: IdWebAgainstMsal ]  (new, condition: RunIdWebIntegration == 'true')
   1. checkout: self                            ← MSAL.NET source
   2. dotnet pack Microsoft.Identity.Client.csproj
        /p:Version=99.0.0-nightly-$(Build.BuildId)
        → $(Build.ArtifactStagingDirectory)/nuget-local-3P    [throwaway feed]
   3. git clone https://github.com/AzureAD/microsoft-identity-web.git
        @ $(IdWebRef)                                         [default 'main']
   4. dotnet nuget add source <local-feed> --configfile <idweb>/NuGet.Config
   5. dotnet restore <idweb>/tests/Microsoft.Identity.Web.Test/...csproj
        /p:MicrosoftIdentityClientVersion=99.0.0-nightly-$(Build.BuildId)
   6. Sanity check: project.assets.json names exactly our version
        (catches transitive '>=' fallback to a real MSAL from nuget.org)
   7. dotnet build  (--no-restore)
   8. dotnet test   (--no-build, --logger trx)
   9. Publish binlogs + .trx as build artifacts
```

**Pattern alignment.** This mirrors the **DevEx unified build** (`identitydivision/DevEx`, definitionId `2749`) which already daisy-chains Abstractions → Wilson → IdWeb → SAL → MISE through local NuGet feeds in exactly this idiom. We just add MSAL upstream.

**Zero IdWeb-side changes required.** IdWeb's existing `<MicrosoftIdentityClientVersion>` property in its `Directory.Build.props` is the override hook the pipeline exploits.

**No external publishes.** The `.nupkg` lives only in the agent's `$(Build.ArtifactStagingDirectory)`. There is no `nuget push` anywhere.

---

## Why no YAML root variables for `RunIdWebIntegration` / `IdWebRef`

ADO variable precedence: **root-level YAML variables override pipeline-definition Variables UI values**. If we declared `RunIdWebIntegration: 'false'` in this YAML, the nightly pipeline definition's `RunIdWebIntegration=true` override in its Variables tab would be **ignored** and the stage would never run.

So we deliberately do not declare these in YAML root. They come from the nightly pipeline definition's Variables UI (with a PowerShell fallback to `main` inside the clone step if `$(IdWebRef)` is unresolved).

---

## Zero impact on PR pipeline 905

| Aspect | Behavior on PR pipeline 905 (`.NET MSAL PR (YAML)`) |
|---|---|
| `RunIdWebIntegration` variable | Undefined |
| Stage condition `eq(variables['RunIdWebIntegration'], 'true')` | False |
| Stage result | **Skipped** (zero agent time, zero gate impact) |
| Visible change to PR reviewers | One extra "Skipped" tile in the pipeline graph |
| Existing stages (Build, MacBuild, UnitTests*, IntegrationTests*, etc.) | Unchanged |

---

## Local validation

Ran the full pipeline shape against IdWeb on `main` from a Windows host with .NET 8/9/10 SDKs installed (matches `windows-2022` agent + `UseDotNet@2` steps):

| Step | Result |
|---|---|
| `dotnet pack` Microsoft.Identity.Client with `Version=99.0.0-nightly-test-2` | ✅ 2.0 MB nupkg + .snupkg |
| Add local feed to IdWeb's `NuGet.Config` | ✅ source registered, listed |
| `dotnet restore` IdWeb test csproj with `/p:MicrosoftIdentityClientVersion=` | ✅ |
| Sanity check 1: `~/.nuget/packages/microsoft.identity.client/99.0.0-nightly-test-2` exists | ✅ |
| Sanity check 2: test csproj's `project.assets.json` names exactly `Microsoft.Identity.Client/99.0.0-nightly-test-2` | ✅ (no transitive fallback) |
| `dotnet build --no-restore` across net462 / net472 / net8.0 / net9.0 / net10.0 | ✅ 0 errors, 0 warnings |
| `dotnet test --no-build` | ✅ **2,726 passed, 0 failed, 19 skipped** across 5 TFMs |

---

## Setup instructions — registering the nightly pipeline definition

This PR **wires up the YAML** but does not register the second ADO pipeline definition that actually queues the nightly. After merge, an ADO admin needs to:

### 1. Create a new pipeline definition pointing at the same YAML

In the MSAL ADO project (the same project that owns pipeline 905):

- **New pipeline → Azure Repos Git → microsoft-authentication-library-for-dotnet → Existing Azure Pipelines YAML file**
- Path: `/build/pipeline-pullrequest.yaml`
- Save (do **not** run yet).

Rename the definition to something like:

> `.NET MSAL Nightly IdWeb Integration (YAML)`

Place it next to definition 905 in the folder structure (`\CI\DotNet\MSAL YAML\` or wherever 905 lives).

### 2. Configure Variables (Edit → Variables tab)

Add two pipeline-level variables (**not** queue-time settable, unless you want ad-hoc overrides):

| Name | Value | Notes |
|---|---|---|
| `RunIdWebIntegration` | `true` | Activates the conditional stage. |
| `IdWebRef` | `master` | Branch / tag / SHA of `microsoft-identity-web` to integrate against. IdWeb's default branch is `master`, not `main`. (Optional — template's fallback defaults to `master` if this variable is unset.) |

### 3. Configure Triggers (Edit → Triggers tab)

- **YAML PR trigger:** override and **disable**. (The YAML declares `pr: branches: include: [main]` for pipeline 905's sake; we don't want this nightly definition to fire on every PR.)
- **YAML CI trigger:** the YAML declares `trigger: none`, nothing to override.
- **Add a scheduled trigger:**
  - Time: a low-traffic window (e.g., `08:00 UTC`)
  - Branch filter: `main` (include)
  - "Always run" / "Only if source has changed since last successful": your choice. Recommended **always run** initially, so we get a daily signal even on slow code-change days.

### 4. (Recommended) Configure notifications

In the new pipeline definition's settings, add an email/Teams notification for **failed runs**. Without this, nightly breakages can sit silently.

### 5. Smoke-test before letting it run unattended

- From the new pipeline definition, **Queue → Run pipeline → branch `main`**.
- First run will exercise the full path: pack MSAL → clone IdWeb → restore/build/test.
- Expected duration: ~25–40 minutes on a Microsoft-hosted `windows-2022` agent (pack ~3 min, IdWeb restore + build ~10 min, tests ~10 min).
- Inspect the **Tests** tab for the test report and download **idweb-against-msal-binlogs** + **idweb-against-msal-testresults** artifacts to confirm everything published.

### 6. Verify PR pipeline 905 is unaffected

After this PR merges, **open or re-queue a PR** to confirm pipeline 905 still passes and the new `IdWebAgainstMsal` stage shows as **Skipped** (not failed). It should look like a greyed-out tile in the pipeline graph.

---

## Operational notes (for the on-call rotation)

**When the nightly fails:** the failure means an MSAL change on `main` is incompatible with IdWeb at `main`. Likely causes:

1. **MSAL public API change** — IdWeb's source-level usage of MSAL types/methods no longer compiles. Look at `idweb-build.binlog` first.
2. **MSAL behavioral change** — IdWeb compiles but a unit test fails. Look at the failed test in the Tests tab, then `idweb-test.binlog`.
3. **NuGet resolution issue** — the "Sanity check" step fails because `project.assets.json` doesn't name our `99.0.0-nightly-*` version. Means a transitive `>=` constraint somewhere in IdWeb's graph won out and pulled a real MSAL version from nuget.org. Look at the assets file in the binlog.
4. **Infrastructure** — git clone or NuGet restore network blip. The clone + restore steps have `retryCountOnTaskFailure: 2`; if all retries are exhausted, it's a real outage.

**To reproduce locally:**
```pwsh
$ver = '99.0.0-nightly-local'
$feed = 'C:\temp\msal-local-feed'
mkdir $feed -Force | Out-Null

# 1. Pack MSAL
cd <msal-dotnet>
dotnet pack src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj `
  /p:Version=$ver --output $feed --configuration Release

# 2. Wire feed into IdWeb's NuGet.Config (back it up first!)
cd <idweb>
dotnet nuget add source $feed --name msal-local --configfile NuGet.Config

# 3. Restore, build, test the IdWeb test csproj
dotnet restore tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj `
  /p:MicrosoftIdentityClientVersion=$ver
dotnet build  tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj `
  --no-restore /p:MicrosoftIdentityClientVersion=$ver
dotnet test   tests/Microsoft.Identity.Web.Test/Microsoft.Identity.Web.Test.csproj `
  --no-build  /p:MicrosoftIdentityClientVersion=$ver
```

**Triggering an ad-hoc run for a non-`main` IdWeb branch:** in the nightly pipeline definition, **Run pipeline** with `IdWebRef` overridden at queue time to the branch/tag/SHA you want to test against.

---

## What's NOT in this PR (deliberate scope cuts; consider for v2)

- **Integration tests** — only `Microsoft.Identity.Web.Test` (unit) is run. Integration tests need lab credentials / KeyVault and were left out for v1 to keep blast radius small.
- **Matrix against MSAL `release/*` branches** — only `main` is built by definition (it's the IDef's checkout). To run nightly against `release/4.x`, queue an ad-hoc run from that branch.
- **Matrix against IdWeb `release/*` branches** — possible by adjusting `IdWebRef`, but no automated matrix loop.
- **Cross-repo coupling via `resources.repositories`** — we use a raw `git clone` to public GitHub. Cleaner long-term (better credentials + artifact tracking) would be a `resources.repositories` declaration with an ADO service connection, like DevEx 2749 uses. Defensible for v1 because IdWeb is fully public.
- **Auto-PR on MSAL.NET when nightly fails** — currently the signal is email-only via pipeline notifications.

---

## Security / safety review

| Concern | Status |
|---|---|
| External NuGet publish? | ❌ None. Local-only feed. |
| Secrets / KeyVault access? | ❌ None. No `AzureKeyVault@2`, no `SecretsFilter`. |
| Untrusted code execution from `IdWebRef`? | Mitigated: ref validated against allowlist regex `^[A-Za-z0-9._/-]+$`, rejects `-` prefix (argument injection). Anyone with permission to set `IdWebRef` already has MSAL.NET write access. |
| SDL / signing? | Out of scope — this is a CI integration check, not a shipping pipeline. |
| Agent pool | `vmImage: 'windows-2022'` (Microsoft-hosted, matches MSAL's existing template). |

---

## Reviewer checklist

- [ ] Confirm the conditional stage approach is the preferred opt-in mechanism (vs. a separate YAML file)
- [ ] Confirm `99.0.0-nightly-*` version scheme is acceptable (deliberately dominates transitive `>=` MSAL constraints in IdWeb)
- [ ] Confirm raw `git clone` to public GitHub is OK for v1 (vs. `resources.repositories` + service connection)
- [ ] Confirm `Microsoft.Identity.Web.Test` is the right test scope for v1
- [ ] Confirm the post-merge admin steps in **Setup instructions** can be completed by the on-call rotation

---

**Co-authored by Copilot** as part of a session implementing this nightly integration end-to-end (design, dry-run, rubber-duck review, fixes, validation).
