### PR TITLE
Add CacheKey to AppTokenProviderResult for cache partitioning

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/AppTokenProviderResult.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AppTokenProviderResult.cs
@@ -28,5 +28,13 @@ namespace Microsoft.Identity.Client.Extensibility
         /// </summary>
         /// <remarks>If not set, MSAL will set it to half of the expiry time if that time is longer than 2 hours.</remarks>
         public long? RefreshInSeconds { get; set; }
+
+        /// <summary>
+        /// An optional cache key that is added to the access token cache key, allowing the app token provider
+        /// to partition the cache. When provided, this value is stored in the request's
+        /// <c>CacheKeyComponents</c> under the key <c>"appTokenProviderKey"</c> and contributes to the
+        /// computed access token cache key.
+        /// </summary>
+        public string CacheKey { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Constants.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Constants.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Identity.Client.Internal
         public const int CodeVerifierLength = 128;
         public const int CodeVerifierByteSize = 96;
 
+        public const string AppTokenProviderCacheKey = "appTokenProviderKey";
+
         public const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
         public const string NativeClientRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
         public const string LocalHostRedirectUri = "http://localhost";

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public IEnumerable<string> PersistedCacheParameters => _commonParameters.AdditionalCacheParameters;
 
-        public SortedList<string, string> CacheKeyComponents {get; private set; }
+        public SortedList<string, string> CacheKeyComponents {get; internal set; }
         public bool? SendOfflineAccessScope { get; private set; }
 
         #region TODO REMOVE FROM HERE AND USE FROM SPECIFIC REQUEST PARAMETERS

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -347,6 +347,16 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             AppTokenProviderResult externalToken = await ServiceBundle.Config.AppTokenProvider(appTokenProviderParameters).ConfigureAwait(false);
 
+            if (!string.IsNullOrEmpty(externalToken?.CacheKey))
+            {
+                if (AuthenticationRequestParameters.CacheKeyComponents == null)
+                {
+                    AuthenticationRequestParameters.CacheKeyComponents = new SortedList<string, string>();
+                }
+
+                AuthenticationRequestParameters.CacheKeyComponents[Constants.AppTokenProviderCacheKey] = externalToken.CacheKey;
+            }
+
             var tokenResponse = MsalTokenResponse.CreateFromAppProviderResponse(externalToken);
             tokenResponse.Scope = appTokenProviderParameters.Scopes.AsSingleString();
             tokenResponse.CorrelationId = appTokenProviderParameters.CorrelationId;

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.get -> string
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.get -> string
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.get -> string
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.get -> string
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.get -> string
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.get -> string
+Microsoft.Identity.Client.Extensibility.AppTokenProviderResult.CacheKey.set -> void

--- a/tests/Microsoft.Identity.Test.Unit/AppTokenProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/AppTokenProviderTests.cs
@@ -159,6 +159,111 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        [TestMethod]
+        public async Task AppTokenProvider_CacheKey_PartitionsCacheAsync()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                string currentCacheKey = "tenantA";
+                int callbackInvoked = 0;
+
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithAppTokenProvider((AppTokenProviderParameters _) =>
+                                                              {
+                                                                  Interlocked.Increment(ref callbackInvoked);
+                                                                  return Task.FromResult(new AppTokenProviderResult
+                                                                  {
+                                                                      AccessToken = TestConstants.DefaultAccessToken + "_" + currentCacheKey,
+                                                                      ExpiresInSeconds = 3600,
+                                                                      RefreshInSeconds = 1000,
+                                                                      CacheKey = currentCacheKey,
+                                                                  });
+                                                              })
+                                                              .WithHttpManager(harness.HttpManager)
+                                                              .BuildConcrete();
+
+                // Arrange & Act - First call with provider-supplied CacheKey "tenantA".
+                AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                       .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+
+                // Assert - Token came from IdP.
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(TestConstants.DefaultAccessToken + "_tenantA", result.AccessToken);
+                Assert.AreEqual(1, callbackInvoked);
+
+                // Act - Second call with different provider-supplied CacheKey "tenantB".
+                currentCacheKey = "tenantB";
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                  .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+
+                // Assert - Token came from IdP again (provider supplies its own key), distinct partition created.
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(TestConstants.DefaultAccessToken + "_tenantB", result.AccessToken);
+                Assert.AreEqual(2, callbackInvoked);
+
+                // Assert - Two distinct cache entries exist, each carrying the "appTokenProviderKey" component
+                // with the value provided by the AppTokenProviderResult.CacheKey.
+                var allTokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
+                Assert.HasCount(2, allTokens);
+
+                foreach (var t in allTokens)
+                {
+                    Assert.IsNotNull(t.AdditionalCacheKeyComponents,
+                        "Cached AT is missing AdditionalCacheKeyComponents.");
+                    Assert.IsTrue(
+                        t.AdditionalCacheKeyComponents.TryGetValue("appTokenProviderKey", out string _),
+                        "Cached AT does not contain the 'appTokenProviderKey' cache component.");
+                }
+
+                var keysSeen = allTokens
+                    .Select(t => t.AdditionalCacheKeyComponents["appTokenProviderKey"])
+                    .ToList();
+
+                CollectionAssert.AreEquivalent(new[] { "tenantA", "tenantB" }, keysSeen);
+            }
+        }
+
+        [TestMethod]
+        public async Task AppTokenProvider_NoCacheKey_DoesNotAddCacheKeyComponentAsync()
+        {
+            using (var harness = CreateTestHarness())
+            {
+                harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithAppTokenProvider((AppTokenProviderParameters _) =>
+                                                                  Task.FromResult(new AppTokenProviderResult
+                                                                  {
+                                                                      AccessToken = TestConstants.DefaultAccessToken,
+                                                                      ExpiresInSeconds = 3600,
+                                                                      RefreshInSeconds = 1000,
+                                                                  }))
+                                                              .WithHttpManager(harness.HttpManager)
+                                                              .BuildConcrete();
+
+                AuthenticationResult result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                                       .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                var allTokens = app.AppTokenCacheInternal.Accessor.GetAllAccessTokens();
+                Assert.HasCount(1, allTokens);
+
+                var token = allTokens.Single();
+                bool hasProviderKey = token.AdditionalCacheKeyComponents != null &&
+                                      token.AdditionalCacheKeyComponents.ContainsKey("appTokenProviderKey");
+                Assert.IsFalse(hasProviderKey,
+                    "When AppTokenProviderResult.CacheKey is not set, the 'appTokenProviderKey' component must not be added.");
+
+                // Second call should hit cache, since no extra partition key was added.
+                result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                                  .ExecuteAsync(new CancellationToken()).ConfigureAwait(false);
+                Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+            }
+        }
+
         private AppTokenProviderResult GetAppTokenProviderResult(string differentScopesForAt = "", long? refreshIn = 1000)
         {
             var token = new AppTokenProviderResult();


### PR DESCRIPTION
This pull request introduces support for partitioning the access token cache in MSAL by allowing an `AppTokenProvider` to specify a custom cache key via the new `CacheKey` property in `AppTokenProviderResult`. This enables scenarios where tokens should be cached separately based on provider-specific criteria. The changes also include updates to the public API, internal logic for cache key handling, and comprehensive unit tests to verify the new behavior.

**App Token Provider Cache Partitioning:**

- Added a new `CacheKey` property to `AppTokenProviderResult`, allowing the app token provider to partition the access token cache. This value is included in the cache key components under `"appTokenProviderKey"`, ensuring tokens with different cache keys are stored separately.
- Updated the public API surface to include the new `CacheKey` property in all relevant `PublicAPI.Unshipped.txt` files.
- Introduced the constant `AppTokenProviderCacheKey` in `Constants.cs` to standardize the cache key component name.
- Modified the token acquisition flow in `ClientCredentialRequest` to add the `CacheKey` to `AuthenticationRequestParameters.CacheKeyComponents` if provided by the app token provider.
- Changed the setter for `CacheKeyComponents` in `AuthenticationRequestParameters` to `internal` to allow internal updates.

**Testing:**

- Added unit tests to verify that tokens are cached in separate partitions when different cache keys are provided, and that no extra cache key is added when `CacheKey` is not set.Fixes #
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
<!-- Concisely list the changes. -->
<!-- If helpful, describe how and why the bug was fixed. -->
<!-- If needed, describe how to review (ex. which files have the primary changes, which are nit changes, etc.) -->

**Testing**
<!-- Have unit, integration, etc. tests been added? Describe any relevant testing that has been done. -->
<!-- Mention if any and what extra manual testing is needed during the release. -->

**Performance impact**
<!-- Describe any applicable performance impact or performance testing done. -->

**Documentation**
- [ ] All relevant documentation is updated.
