### PR TITLE
Detect dead KeyGuard keys and purge orphaned IMDSv2 mTLS certs on reboot

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/WindowsCngKeyOperations.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/WindowsCngKeyOperations.cs
@@ -458,6 +458,13 @@ namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
 
                     foreach (X509Certificate2 candidate in snapshot)
                     {
+                        if (candidate is null)
+                        {
+                            // Defensive: snapshot slot may be null if the store enumeration
+                            // yielded fewer items than Certificates.Count reported (TOCTOU).
+                            continue;
+                        }
+
                         try
                         {
                             inspected++;

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/WindowsCngKeyOperations.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/WindowsCngKeyOperations.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
 
@@ -28,6 +29,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
         private const string HardwareKeyName = "HardwareRSAKey";
         private const string KeyGuardVirtualIsoProperty = "Virtual Iso";
         private const string VbsNotAvailable = "VBS key isolation is not available";
+
+        // Issuer used by IMDSv2 mTLS PoP binding certificates. Matched as a case-insensitive
+        // substring against the certificate's Issuer DN, so any cert in CurrentUser\My issued
+        // by IMDSv2 can be wiped when we mint a fresh KeyGuard key (the previously persisted
+        // certs are bound to the now-replaced key by name and would fail the mTLS handshake).
+        internal const string ManagedIdentityIssuerCnFragment = "managedidentitysnissuer.login.microsoft.com";
 
         // KeyGuard + per-boot flags
         private const CngKeyCreationOptions NCryptUseVirtualIsolationFlag = (CngKeyCreationOptions)0x00020000;
@@ -66,16 +73,75 @@ namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
                 CngKey key;
                 try
                 {
+                    logger?.Info(() => $"[MI][WinKeyProvider] Attempting to open existing KeyGuard key. " +
+                                       $"Provider='{SoftwareKspName}', KeyName='{KeyGuardKeyName}', Scope=UserKey, Silent=true.");
+
                     key = CngKey.Open(
                         KeyGuardKeyName,
                         new CngProvider(SoftwareKspName),
                         CngKeyOpenOptions.UserKey | CngKeyOpenOptions.Silent);
+
+                    logger?.Info(() => $"[MI][WinKeyProvider] CngKey.Open succeeded for '{KeyGuardKeyName}'. " +
+                                       "Running liveness sign probe to detect stale per-boot key material " +
+                                       "(metadata file can survive a reboot while the VBS-isolated key material is destroyed).");
+
+                    // Liveness probe: per-boot KeyGuard keys (NCryptUsePerBootKeyFlag) leave a stale
+                    // metadata file on disk after reboot. CngKey.Open returns a handle, but the actual
+                    // VBS-protected key material is gone, so the first real sign operation fails.
+                    // Detect this here so we can recreate cleanly instead of failing later in the
+                    // mTLS handshake or signing path.
+                    if (!CanSign(key, logger))
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] KeyGuard liveness sign probe FAILED. " +
+                                           "Treating handle as stale (likely post-reboot per-boot key reaped). " +
+                                           "Disposing stale handle and recreating fresh KeyGuard key.");
+                        key.Dispose();
+                        key = CreateFresh(logger);
+
+                        if (key == null)
+                        {
+                            logger?.Info(() => "[MI][WinKeyProvider] CreateFresh returned null after failed liveness probe " +
+                                               "(VBS unavailable). KeyGuard path will be skipped.");
+                        }
+                        else
+                        {
+                            logger?.Info(() => "[MI][WinKeyProvider] Fresh KeyGuard key created successfully after stale handle replacement. " +
+                                               "Purging persisted IMDSv2 mTLS binding certificates that were bound to the replaced key.");
+
+                            // The new KeyGuard key reuses the container name 'KeyGuardRSAKey', but its
+                            // public/private pair is different from the one any persisted cert was issued
+                            // against. Wipe all certs in CurrentUser\My issued by IMDSv2 so the next request
+                            // mints fresh instead of failing the mTLS handshake.
+                            PurgeManagedIdentityCertificates(logger);
+                        }
+                    }
+                    else
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] KeyGuard liveness sign probe PASSED. Reusing existing handle.");
+                    }
                 }
-                catch (CryptographicException)
+                catch (CryptographicException openEx)
                 {
                     // Not found -> create fresh (helper may return null if VBS unavailable)
-                    logger?.Info(() => "[MI][WinKeyProvider] CredentialGuard key not found; creating fresh.");
+                    logger?.Info(() => $"[MI][WinKeyProvider] CngKey.Open threw CryptographicException for '{KeyGuardKeyName}'. " +
+                                       $"HR=0x{openEx.HResult:X8}, Message='{openEx.Message}'. " +
+                                       "Treating as 'key not found' and creating fresh.");
                     key = CreateFresh(logger);
+
+                    if (key == null)
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] CreateFresh returned null after Open failure (VBS unavailable).");
+                    }
+                    else
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] Fresh KeyGuard key created successfully after Open failure. " +
+                                           "Purging persisted IMDSv2 mTLS binding certificates that were bound to the replaced key.");
+
+                        // Same rationale as the probe-failed branch: any persisted IMDSv2 cert in
+                        // CurrentUser\My is bound to the previous KeyGuard key and will fail the mTLS
+                        // handshake. Wipe them so the next request mints fresh.
+                        PurgeManagedIdentityCertificates(logger);
+                    }
                 }
 
                 // If VBS is unavailable, CreateFresh() returns null. Bail out cleanly.
@@ -275,6 +341,171 @@ namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
 
             byte[] val = key.GetProperty(KeyGuardVirtualIsoProperty, CngPropertyOptions.None).GetValue();
             return val?.Length > 0 && val[0] != 0;
+        }
+
+        /// <summary>
+        /// Performs a small RSA sign operation against the supplied CNG key to verify the
+        /// underlying key material is actually usable.
+        /// </summary>
+        /// <param name="key">The CNG key handle returned from <see cref="CngKey.Open(string, CngProvider, CngKeyOpenOptions)"/>.</param>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        /// <returns>
+        /// <see langword="true"/> if the key signs successfully; otherwise <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// KeyGuard keys created with <c>NCryptUsePerBootKeyFlag</c> have their VBS-isolated
+        /// key material destroyed on every reboot, but the on-disk metadata file produced by the
+        /// Microsoft Software KSP often survives. As a result, <see cref="CngKey.Open(string, CngProvider, CngKeyOpenOptions)"/>
+        /// can return a handle that looks valid (correct algorithm, "Virtual Iso" property still set)
+        /// but whose first real cryptographic operation throws.
+        /// </para>
+        /// <para>
+        /// Probing with a one-byte sign here surfaces that condition cheaply (~1-3 ms for RSA-2048)
+        /// on the cold-start path. Subsequent calls reuse the cached key in
+        /// <c>WindowsManagedIdentityKeyProvider</c>, so the probe runs at most once per process.
+        /// </para>
+        /// </remarks>
+        private static bool CanSign(CngKey key, ILoggerAdapter logger)
+        {
+            try
+            {
+                logger?.Verbose(() => "[MI][WinKeyProvider] Liveness probe: attempting RSA-SHA256 sign of 1-byte payload.");
+
+                using (var rsa = new RSACng(key))
+                {
+                    _ = rsa.SignData(
+                        new byte[] { 0 },
+                        HashAlgorithmName.SHA256,
+                        RSASignaturePadding.Pkcs1);
+                }
+
+                logger?.Verbose(() => "[MI][WinKeyProvider] Liveness probe: sign succeeded; key material is live.");
+                return true;
+            }
+            catch (CryptographicException ex)
+            {
+                logger?.Info(() => $"[MI][WinKeyProvider] Liveness probe: sign threw CryptographicException. " +
+                                   $"HR=0x{ex.HResult:X8}, Message='{ex.Message}'. Key handle is stale.");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                logger?.Info(() => $"[MI][WinKeyProvider] Liveness probe: sign threw unexpected exception. " +
+                                   $"{ex.GetType().Name}: '{ex.Message}'. Treating as stale.");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes every certificate in the <c>CurrentUser\My</c> store whose issuer matches the
+        /// IMDSv2 mTLS PoP binding-certificate issuer.
+        /// </summary>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        /// <remarks>
+        /// <para>
+        /// IMDSv2 binding certificates are issued by
+        /// <c>CN=managedidentitysnissuer.login.microsoft.com</c> and stored in the user's personal
+        /// store. They reference the private key by KSP container name (<c>KeyGuardRSAKey</c>),
+        /// not by key material. When the KeyGuard key is re-minted (post-reboot, or after a failed
+        /// liveness probe), the new key reuses the same container name but with different
+        /// public/private parameters — leaving the persisted certs bound to a key that no longer
+        /// matches them, which then fails the mTLS handshake.
+        /// </para>
+        /// <para>
+        /// Purging the store at the moment we mint a fresh KeyGuard key eliminates the
+        /// failed-handshake + retry round trip that the SChannel-error catch in
+        /// <c>ImdsV2ManagedIdentitySource.AuthenticateAsync</c> would otherwise have to recover from.
+        /// </para>
+        /// <para>
+        /// All store I/O is best-effort and non-throwing.
+        /// </para>
+        /// </remarks>
+        internal static void PurgeManagedIdentityCertificates(ILoggerAdapter logger)
+        {
+            int removed = 0;
+            int inspected = 0;
+
+            try
+            {
+                logger?.Info(() =>
+                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: opening CurrentUser\\My to remove " +
+                    $"certs whose Issuer contains '{ManagedIdentityIssuerCnFragment}'.");
+
+                using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+                {
+                    store.Open(OpenFlags.ReadWrite);
+
+                    // Snapshot to avoid 'collection modified during enumeration' provider quirks.
+                    var snapshot = new X509Certificate2[store.Certificates.Count];
+                    try
+                    {
+                        store.Certificates.CopyTo(snapshot, 0);
+                    }
+                    catch (Exception copyEx)
+                    {
+                        logger?.Info(() =>
+                            $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: store snapshot via CopyTo failed " +
+                            $"({copyEx.GetType().Name}: {copyEx.Message}). Falling back to enumeration.");
+
+                        int i = 0;
+                        snapshot = new X509Certificate2[store.Certificates.Count];
+                        foreach (X509Certificate2 c in store.Certificates)
+                        {
+                            snapshot[i++] = c;
+                        }
+                    }
+
+                    foreach (X509Certificate2 candidate in snapshot)
+                    {
+                        try
+                        {
+                            inspected++;
+
+                            string issuer = candidate.Issuer ?? string.Empty;
+                            if (issuer.IndexOf(ManagedIdentityIssuerCnFragment, StringComparison.OrdinalIgnoreCase) < 0)
+                            {
+                                continue;
+                            }
+
+                            string thumb = candidate.Thumbprint;
+                            DateTime notAfter = candidate.NotAfter;
+
+                            try
+                            {
+                                store.Remove(candidate);
+                                removed++;
+                                logger?.Info(() =>
+                                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: removed cert. " +
+                                    $"Thumbprint={thumb}, NotAfter={notAfter:O}, Issuer='{issuer}'.");
+                            }
+                            catch (Exception removeEx)
+                            {
+                                logger?.Info(() =>
+                                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: failed to remove cert " +
+                                    $"Thumbprint={thumb}. {removeEx.GetType().Name}: '{removeEx.Message}'.");
+                            }
+                        }
+                        finally
+                        {
+                            candidate.Dispose();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.Info(() =>
+                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: store access failed. " +
+                    $"{ex.GetType().Name}: '{ex.Message}'. Removed={removed}, Inspected={inspected}.");
+                return;
+            }
+
+            int removedFinal = removed;
+            int inspectedFinal = inspected;
+            logger?.Info(() =>
+                $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: complete. " +
+                $"Removed={removedFinal}, Inspected={inspectedFinal}.");
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/MtlsCertificateCache.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/MtlsCertificateCache.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -183,6 +184,77 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             catch (Exception ex)
             {
                 logger?.Verbose(() => $"[PersistentCert] Error removing from persistent cache: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the cert's embedded public key does not match the
+        /// public key currently in the associated CNG container, indicating the container was
+        /// regenerated (e.g. by KeyGuard on reboot) while the cert on disk still references the
+        /// old key material.
+        /// </summary>
+        internal static bool IsCertKeyOrphaned(X509Certificate2 cert, ILoggerAdapter logger)
+        {
+            if (cert is null)
+                return true;
+
+            try
+            {
+                using var rsaKey = cert.GetRSAPrivateKey();
+                if (rsaKey is not RSACng rsaCng)
+                {
+                    // Non-CNG key (e.g. software CSP) — cannot perform KG container check; accept.
+                    return false;
+                }
+
+                return !PublicKeyMatchesCert(rsaCng, cert, logger);
+            }
+            catch (CryptographicException ex)
+            {
+                logger?.Verbose(() =>
+                    $"[PersistentCert] Cannot load private key for orphan check: {ex.Message}. Treating cert as unusable.");
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the public key exported from <paramref name="containerKey"/>
+        /// matches the public key embedded in <paramref name="cert"/>.
+        /// A mismatch means the container holds different key material than when the cert was issued.
+        /// </summary>
+        /// <remarks>
+        /// Check 3 from the original proposal — comparing the CNG container's
+        /// <c>NCRYPT_LAST_MODIFIED_PROPERTY</c> against the cert's <c>NotBefore</c> — is
+        /// intentionally omitted. Both Check 3 and this modulus comparison detect the same event:
+        /// KeyGuard regenerating the key in the container post-reboot. This check is definitive:
+        /// two independently generated RSA keys sharing a modulus is computationally infeasible,
+        /// so a mismatch conclusively means the container was regenerated. Check 3 is a heuristic
+        /// with a known false-negative window (a reboot occurring within one minute of cert
+        /// issuance), and adds no coverage that this check does not already provide.
+        /// </remarks>
+        internal static bool PublicKeyMatchesCert(RSACng containerKey, X509Certificate2 cert, ILoggerAdapter logger)
+        {
+            try
+            {
+                var containerParams = containerKey.ExportParameters(includePrivateParameters: false);
+                using var certPubKey = cert.GetRSAPublicKey();
+                if (certPubKey is null)
+                    return false;
+
+                var certParams = certPubKey.ExportParameters(includePrivateParameters: false);
+
+                return containerParams.Modulus is not null
+                    && certParams.Modulus is not null
+                    && containerParams.Modulus.AsSpan().SequenceEqual(certParams.Modulus)
+                    && containerParams.Exponent is not null
+                    && certParams.Exponent is not null
+                    && containerParams.Exponent.AsSpan().SequenceEqual(certParams.Exponent);
+            }
+            catch (CryptographicException ex)
+            {
+                logger?.Verbose(() =>
+                    $"[PersistentCert] Public key export failed during orphan check: {ex.Message}. Treating cert as orphaned.");
+                return false;
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/MtlsCertificateCache.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/MtlsCertificateCache.cs
@@ -201,9 +201,20 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             try
             {
                 using var rsaKey = cert.GetRSAPrivateKey();
+                if (rsaKey is null)
+                {
+                    // GetRSAPrivateKey() returns null for non-RSA certs (e.g. ECDSA) AND for RSA
+                    // certs where the private key is inaccessible. Distinguish the two cases:
+                    // if the cert has an RSA public key, the private key should be present but isn't
+                    // → the cert is unusable. If there is no RSA public key, it's a non-RSA cert
+                    // that we can't check → accept on faith.
+                    using var pubKey = cert.GetRSAPublicKey();
+                    return pubKey is not null; // RSA cert + inaccessible private key = orphaned
+                }
+
                 if (rsaKey is not RSACng rsaCng)
                 {
-                    // Non-CNG key (e.g. software CSP) — cannot perform KG container check; accept.
+                    // Non-CNG RSA key (e.g. software CSP) — cannot perform KG container check; accept.
                     return false;
                 }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
@@ -84,6 +84,14 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                             continue;
                         }
 
+                        // Skip certs whose CNG container key no longer matches the cert's public key.
+                        // This detects orphaned certs left on disk after a reboot regenerates the KG per-boot key.
+                        if (MtlsBindingCache.IsCertKeyOrphaned(candidate, logger))
+                        {
+                            logger.Verbose(() => "[PersistentCert] Candidate skipped: CNG container key does not match cert public key (orphaned post-reboot).");
+                            continue;
+                        }
+
                         if (candidate.NotAfter > bestNotAfter)
                         {
                             best?.Dispose();

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
@@ -34,15 +34,15 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
     {
         public bool Read(string alias, out CertificateCacheValue value, ILoggerAdapter logger)
         {
-            return Read(alias, out value, logger, MtlsBindingCache.IsCertKeyOrphaned);
+            return TryRead(alias, logger, MtlsBindingCache.IsCertKeyOrphaned, out value);
         }
 
-        // Internal overload for testability: accepts an injectable orphan-check delegate.
-        internal bool Read(
+        // Overload for testability: accepts an injectable orphan-check delegate.
+        public bool TryRead(
             string alias,
-            out CertificateCacheValue value,
             ILoggerAdapter logger,
-            Func<X509Certificate2, ILoggerAdapter, bool> isOrphaned)
+            Func<X509Certificate2, ILoggerAdapter, bool> isOrphaned,
+            out CertificateCacheValue value)
         {
             value = default;
 
@@ -52,17 +52,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                 store.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
 
                 // Snapshot first to avoid provider quirks ("collection modified" during enumeration).
-                X509Certificate2[] items;
-                try
-                {
-                    items = new X509Certificate2[store.Certificates.Count];
-                    store.Certificates.CopyTo(items, 0);
-                }
-                catch (Exception ex)
-                {
-                    logger.Verbose(() => "[PersistentCert] Store snapshot via CopyTo failed; falling back to enumeration. Details: " + ex.Message);
-                    items = store.Certificates.Cast<X509Certificate2>().ToArray();
-                }
+                var items = SnapshotCertificates(store, logger);
 
                 X509Certificate2 best = null;
                 string bestEndpoint = null;
@@ -162,46 +152,43 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
 
         private static void RemoveByThumbprints(string alias, List<string> thumbprints, ILoggerAdapter logger)
         {
-            try
-            {
-                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-                store.Open(OpenFlags.ReadWrite);
-
-                X509Certificate2[] items;
-                try
-                {
-                    items = new X509Certificate2[store.Certificates.Count];
-                    store.Certificates.CopyTo(items, 0);
-                }
-                catch (Exception ex)
-                {
-                    logger.Verbose(() => "[PersistentCert] Orphan-removal snapshot via CopyTo failed; falling back to enumeration. Details: " + ex.Message);
-                    items = store.Certificates.Cast<X509Certificate2>().ToArray();
-                }
-
-                int removed = 0;
-                foreach (var cert in items)
+            InterprocessLock.TryWithAliasLock(
+                alias,
+                timeout: TimeSpan.FromMilliseconds(300),
+                action: () =>
                 {
                     try
                     {
-                        if (thumbprints.Contains(cert.Thumbprint))
-                        {
-                            store.Remove(cert);
-                            removed++;
-                        }
-                    }
-                    finally
-                    {
-                        cert.Dispose();
-                    }
-                }
+                        using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                        store.Open(OpenFlags.ReadWrite);
 
-                logger.Verbose(() => $"[PersistentCert] Removed {removed} orphaned cert(s) for alias '{alias}'.");
-            }
-            catch (Exception ex)
-            {
-                logger.Verbose(() => "[PersistentCert] Orphan removal failed (best-effort): " + ex.Message);
-            }
+                        var items = SnapshotCertificates(store, logger);
+                        int removed = 0;
+
+                        foreach (var cert in items)
+                        {
+                            try
+                            {
+                                if (thumbprints.Contains(cert.Thumbprint))
+                                {
+                                    store.Remove(cert);
+                                    removed++;
+                                }
+                            }
+                            finally
+                            {
+                                cert.Dispose();
+                            }
+                        }
+
+                        logger.Verbose(() => $"[PersistentCert] Removed {removed} orphaned cert(s) for alias '{alias}'.");
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Verbose(() => "[PersistentCert] Orphan removal failed (best-effort): " + ex.Message);
+                    }
+                },
+                logVerbose: s => logger.Verbose(() => s));
         }
 
         public void Write(string alias, X509Certificate2 cert, string endpointBase, ILoggerAdapter logger)
@@ -241,17 +228,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                         // Skip write if a newer/equal, non-expired binding for this alias already exists.
                         DateTime newestForAliasUtc = DateTime.MinValue;
 
-                        X509Certificate2[] present;
-                        try
-                        {
-                            present = new X509Certificate2[store.Certificates.Count];
-                            store.Certificates.CopyTo(present, 0);
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.Verbose(() => "[PersistentCert] Store snapshot via CopyTo failed; falling back to enumeration. Details: " + ex.Message);
-                            present = store.Certificates.Cast<X509Certificate2>().ToArray();
-                        }
+                        var present = SnapshotCertificates(store, logger);
 
                         foreach (var existing in present)
                         {
@@ -356,18 +333,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                         using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
                         store.Open(OpenFlags.ReadWrite);
 
-                        X509Certificate2[] items;
-                        try
-                        {
-                            items = new X509Certificate2[store.Certificates.Count];
-                            store.Certificates.CopyTo(items, 0);
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.Verbose(() => "[PersistentCert] Store snapshot via CopyTo failed; falling back to enumeration. Details: " + ex.Message);
-                            items = store.Certificates.Cast<X509Certificate2>().ToArray();
-                        }
-
+                        var items = SnapshotCertificates(store, logger);
                         int removed = 0;
 
                         foreach (var existing in items)
@@ -399,6 +365,25 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
         }
 
         /// <summary>
+        /// Safely snapshots all certificates in <paramref name="store"/> into an array.
+        /// Falls back to LINQ enumeration if <c>CopyTo</c> throws (some providers don't support it).
+        /// </summary>
+        private static X509Certificate2[] SnapshotCertificates(X509Store store, ILoggerAdapter logger)
+        {
+            try
+            {
+                var items = new X509Certificate2[store.Certificates.Count];
+                store.Certificates.CopyTo(items, 0);
+                return items;
+            }
+            catch (Exception ex)
+            {
+                logger.Verbose(() => "[PersistentCert] Store snapshot via CopyTo failed; falling back to enumeration. Details: " + ex.Message);
+                return store.Certificates.Cast<X509Certificate2>().ToArray();
+            }
+        }
+
+        /// <summary>
         /// Deletes only certificates that are actually expired (NotAfter &lt; nowUtc),
         /// scoped to the given alias (cache key) via FriendlyName.
         /// </summary>
@@ -408,19 +393,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             DateTime nowUtc,
             ILoggerAdapter logger)
         {
-            X509Certificate2[] items;
-            try
-            {
-                items = new X509Certificate2[store.Certificates.Count];
-                // Safe snapshot for providers that throw if removing while iterating
-                store.Certificates.CopyTo(items, 0);
-            }
-            catch (Exception ex)
-            {
-                logger.Verbose(() => "[PersistentCert] Prune snapshot via CopyTo failed; falling back to enumeration. Details: " + ex.Message);
-                items = store.Certificates.Cast<X509Certificate2>().ToArray();
-            }
-
+            var items = SnapshotCertificates(store, logger);
             int removed = 0;
 
             foreach (var existing in items)

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
         {
             value = default;
 
+            if (isOrphaned is null)
+            {
+                throw new ArgumentNullException(nameof(isOrphaned));
+            }
+
             try
             {
                 using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
@@ -152,6 +157,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
 
         private static void RemoveByThumbprints(string alias, List<string> thumbprints, ILoggerAdapter logger)
         {
+            var thumbprintSet = new HashSet<string>(thumbprints, StringComparer.OrdinalIgnoreCase);
+
             InterprocessLock.TryWithAliasLock(
                 alias,
                 timeout: TimeSpan.FromMilliseconds(300),
@@ -169,7 +176,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                         {
                             try
                             {
-                                if (thumbprints.Contains(cert.Thumbprint))
+                                if (thumbprintSet.Contains(cert.Thumbprint))
                                 {
                                     store.Remove(cert);
                                     removed++;

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/WindowsPersistentCertificateCache.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Identity.Client.Core;
@@ -33,6 +34,16 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
     {
         public bool Read(string alias, out CertificateCacheValue value, ILoggerAdapter logger)
         {
+            return Read(alias, out value, logger, MtlsBindingCache.IsCertKeyOrphaned);
+        }
+
+        // Internal overload for testability: accepts an injectable orphan-check delegate.
+        internal bool Read(
+            string alias,
+            out CertificateCacheValue value,
+            ILoggerAdapter logger,
+            Func<X509Certificate2, ILoggerAdapter, bool> isOrphaned)
+        {
             value = default;
 
             try
@@ -56,6 +67,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                 X509Certificate2 best = null;
                 string bestEndpoint = null;
                 DateTime bestNotAfter = DateTime.MinValue;
+                List<string> orphanedThumbprints = null;
 
                 foreach (var candidate in items)
                 {
@@ -86,9 +98,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
 
                         // Skip certs whose CNG container key no longer matches the cert's public key.
                         // This detects orphaned certs left on disk after a reboot regenerates the KG per-boot key.
-                        if (MtlsBindingCache.IsCertKeyOrphaned(candidate, logger))
+                        // Collect thumbprints for post-loop removal so the store is only opened once for writes.
+                        if (isOrphaned(candidate, logger))
                         {
                             logger.Verbose(() => "[PersistentCert] Candidate skipped: CNG container key does not match cert public key (orphaned post-reboot).");
+                            orphanedThumbprints ??= new List<string>();
+                            orphanedThumbprints.Add(candidate.Thumbprint);
                             continue;
                         }
 
@@ -104,6 +119,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                     {
                         candidate.Dispose();
                     }
+                }
+
+                // Remove any orphaned certs discovered during the scan.
+                if (orphanedThumbprints is { Count: > 0 })
+                {
+                    RemoveByThumbprints(alias, orphanedThumbprints, logger);
                 }
 
                 if (best != null)
@@ -137,6 +158,50 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             }
 
             return false;
+        }
+
+        private static void RemoveByThumbprints(string alias, List<string> thumbprints, ILoggerAdapter logger)
+        {
+            try
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                store.Open(OpenFlags.ReadWrite);
+
+                X509Certificate2[] items;
+                try
+                {
+                    items = new X509Certificate2[store.Certificates.Count];
+                    store.Certificates.CopyTo(items, 0);
+                }
+                catch (Exception ex)
+                {
+                    logger.Verbose(() => "[PersistentCert] Orphan-removal snapshot via CopyTo failed; falling back to enumeration. Details: " + ex.Message);
+                    items = store.Certificates.Cast<X509Certificate2>().ToArray();
+                }
+
+                int removed = 0;
+                foreach (var cert in items)
+                {
+                    try
+                    {
+                        if (thumbprints.Contains(cert.Thumbprint))
+                        {
+                            store.Remove(cert);
+                            removed++;
+                        }
+                    }
+                    finally
+                    {
+                        cert.Dispose();
+                    }
+                }
+
+                logger.Verbose(() => $"[PersistentCert] Removed {removed} orphaned cert(s) for alias '{alias}'.");
+            }
+            catch (Exception ex)
+            {
+                logger.Verbose(() => "[PersistentCert] Orphan removal failed (best-effort): " + ex.Message);
+            }
         }
 
         public void Write(string alias, X509Certificate2 cert, string endpointBase, ILoggerAdapter logger)

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
@@ -880,9 +880,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             WindowsOnly();
 
             // Arrange - cert created with key1; pass key1 as the container key
-            using var key1 = RSA.Create(2048);
-            var rsaCng1 = key1 as RSACng;
-            Assert.IsNotNull(rsaCng1, "Expected RSACng on Windows.");
+            using var key1 = new RSACng(2048);
 
             var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
                 new X500DistinguishedName("CN=KeyMatchTest"),
@@ -892,7 +890,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddDays(14));
 
             // Act
-            bool result = MtlsBindingCache.PublicKeyMatchesCert(rsaCng1, cert, null);
+            bool result = MtlsBindingCache.PublicKeyMatchesCert(key1, cert, null);
 
             // Assert
             Assert.IsTrue(result, "The key used to create the cert should match the cert's embedded public key.");
@@ -905,10 +903,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
             // Arrange - cert created with key1, but we pass key2 as the container key
             // (simulates post-reboot KG regeneration: same container, new key material)
-            using var key1 = RSA.Create(2048);
-            using var key2 = RSA.Create(2048);
-            var rsaCng2 = key2 as RSACng;
-            Assert.IsNotNull(rsaCng2, "Expected RSACng on Windows.");
+            using var key1 = new RSACng(2048);
+            using var key2 = new RSACng(2048);
 
             var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
                 new X500DistinguishedName("CN=KeyMismatchTest"),
@@ -918,7 +914,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddDays(14));
 
             // Act
-            bool result = MtlsBindingCache.PublicKeyMatchesCert(rsaCng2, cert, null);
+            bool result = MtlsBindingCache.PublicKeyMatchesCert(key2, cert, null);
 
             // Assert
             Assert.IsFalse(result, "A different key than the one used to create the cert should produce a modulus mismatch.");

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
@@ -920,6 +920,38 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             Assert.IsFalse(result, "A different key than the one used to create the cert should produce a modulus mismatch.");
         }
 
+        [TestMethod]
+        public void Read_RemovesOrphanedCert_FromStore()
+        {
+            WindowsOnly();
+
+            // Arrange
+            var alias = "alias-orphan-remove-" + Guid.NewGuid().ToString("N");
+            var ep = "https://fake_mtls/orphan";
+            var guid = Guid.NewGuid().ToString("D");
+
+            try
+            {
+                using var cert = CreateSelfSignedWithKey("CN=" + guid, TimeSpan.FromDays(14));
+                _cache.Write(alias, cert, ep, Logger);
+
+                // Verify cert is in the store
+                Assert.AreEqual(1, CountAliasInStore(alias), "Cert should be in store after Write.");
+
+                // Act — use the injectable overload: treat every cert as orphaned
+                var concreteCache = (WindowsPersistentCertificateCache)_cache;
+                bool readResult = concreteCache.Read(alias, out _, Logger, (_, __) => true);
+
+                // Assert
+                Assert.IsFalse(readResult, "Read should return false when all candidates are orphaned.");
+                Assert.IsTrue(WaitForAliasCount(alias, 0), "Orphaned cert should have been removed from the store.");
+            }
+            finally
+            {
+                RemoveAliasFromStore(alias);
+            }
+        }
+
         #endregion
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
@@ -875,6 +875,27 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
+        public void IsCertKeyOrphaned_ReturnsTrue_For_RsaCert_WithNoPrivateKey()
+        {
+            // Arrange - public-only RSA cert (no private key associated)
+            using var rsa = RSA.Create(2048);
+            var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+                new X500DistinguishedName("CN=NoPrivKeyTest"),
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            // Create a cert without associating the private key (CopyWithPrivateKey not called)
+            using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddDays(14));
+            using var publicOnlyCert = new X509Certificate2(cert.Export(X509ContentType.Cert));
+
+            // Act — public-only RSA cert: GetRSAPrivateKey() returns null, GetRSAPublicKey() succeeds
+            bool result = MtlsBindingCache.IsCertKeyOrphaned(publicOnlyCert, null);
+
+            // Assert
+            Assert.IsTrue(result, "An RSA cert with no accessible private key should be treated as orphaned.");
+        }
+
+        [TestMethod]
         public void PublicKeyMatchesCert_ReturnsTrue_When_KeyMatchesCert()
         {
             WindowsOnly();

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
@@ -843,5 +843,87 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         #endregion
+
+        #region IsCertKeyOrphaned tests
+
+        [TestMethod]
+        public void IsCertKeyOrphaned_ReturnsTrue_For_NullCert()
+        {
+            // Arrange (no setup needed)
+
+            // Act
+            bool result = MtlsBindingCache.IsCertKeyOrphaned(null, null);
+
+            // Assert
+            Assert.IsTrue(result, "Null cert should be treated as orphaned.");
+        }
+
+        [TestMethod]
+        public void IsCertKeyOrphaned_ReturnsFalse_For_ValidCert()
+        {
+            WindowsOnly();
+
+            // Arrange - cert whose private key in the CNG container matches the cert's embedded public key
+            using var cert = CreateSelfSignedCert(TimeSpan.FromDays(14), "CN=ValidCertOrphanTest");
+            var logger = Substitute.For<ILoggerAdapter>();
+
+            // Act
+            bool result = MtlsBindingCache.IsCertKeyOrphaned(cert, logger);
+
+            // Assert
+            Assert.IsFalse(result, "A cert whose private key matches its embedded public key should not be considered orphaned.");
+        }
+
+        [TestMethod]
+        public void PublicKeyMatchesCert_ReturnsTrue_When_KeyMatchesCert()
+        {
+            WindowsOnly();
+
+            // Arrange - cert created with key1; pass key1 as the container key
+            using var key1 = RSA.Create(2048);
+            var rsaCng1 = key1 as RSACng;
+            Assert.IsNotNull(rsaCng1, "Expected RSACng on Windows.");
+
+            var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+                new X500DistinguishedName("CN=KeyMatchTest"),
+                key1,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddDays(14));
+
+            // Act
+            bool result = MtlsBindingCache.PublicKeyMatchesCert(rsaCng1, cert, null);
+
+            // Assert
+            Assert.IsTrue(result, "The key used to create the cert should match the cert's embedded public key.");
+        }
+
+        [TestMethod]
+        public void PublicKeyMatchesCert_ReturnsFalse_When_ModulusMismatch()
+        {
+            WindowsOnly();
+
+            // Arrange - cert created with key1, but we pass key2 as the container key
+            // (simulates post-reboot KG regeneration: same container, new key material)
+            using var key1 = RSA.Create(2048);
+            using var key2 = RSA.Create(2048);
+            var rsaCng2 = key2 as RSACng;
+            Assert.IsNotNull(rsaCng2, "Expected RSACng on Windows.");
+
+            var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+                new X500DistinguishedName("CN=KeyMismatchTest"),
+                key1,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddDays(14));
+
+            // Act
+            bool result = MtlsBindingCache.PublicKeyMatchesCert(rsaCng2, cert, null);
+
+            // Assert
+            Assert.IsFalse(result, "A different key than the one used to create the cert should produce a modulus mismatch.");
+        }
+
+        #endregion
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
@@ -961,7 +961,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 // Act — use the injectable overload: treat every cert as orphaned
                 var concreteCache = (WindowsPersistentCertificateCache)_cache;
-                bool readResult = concreteCache.Read(alias, out _, Logger, (_, __) => true);
+                bool readResult = concreteCache.TryRead(alias, Logger, (_, __) => true, out _);
 
                 // Assert
                 Assert.IsFalse(readResult, "Read should return false when all candidates are orphaned.");

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WindowsCngKeyOperationsPurgeUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WindowsCngKeyOperationsPurgeUnitTests.cs
@@ -1,0 +1,359 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.ManagedIdentity.KeyProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
+{
+    /// <summary>
+    /// Tests for <see cref="WindowsCngKeyOperations.PurgeManagedIdentityCertificates"/>.
+    /// The purge sweeps <c>CurrentUser\My</c> and removes every certificate whose issuer
+    /// contains <see cref="WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment"/>.
+    /// It runs after a fresh KeyGuard key is minted so that persisted IMDSv2 binding
+    /// certs (which are bound by container name to the now-replaced key) are not left
+    /// behind to fail the next mTLS handshake.
+    /// </summary>
+    [TestClass]
+    public class WindowsCngKeyOperationsPurgeUnitTests
+    {
+        // Discriminator we plant in each test cert's Subject so cleanup can find leftovers
+        // from a failed run without touching unrelated certs in the developer's store.
+        private const string TestSubjectDiscriminatorPrefix = "MSAL-Purge-Test-";
+
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private static ILoggerAdapter Logger => Substitute.For<ILoggerAdapter>();
+
+        [TestInitialize]
+        public void Init()
+        {
+            // Reuse the existing broad sweep so prior test runs don't leak state.
+            if (ImdsV2TestStoreCleaner.IsWindows)
+            {
+                ImdsV2TestStoreCleaner.RemoveAllTestArtifacts();
+            }
+
+            // Also remove any leftover purge-test certs from a previous failed run.
+            RemoveAllPurgeTestArtifacts();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            RemoveAllPurgeTestArtifacts();
+        }
+
+        private static void WindowsOnly()
+        {
+            if (!IsWindows)
+            {
+                Assert.Inconclusive("Windows-only");
+            }
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_RemovesCertWithMatchingIssuer()
+        {
+            WindowsOnly();
+
+            // Arrange
+            string discriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            string subject =
+                "CN=" + WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment +
+                ", OU=" + discriminator;
+
+            string plantedThumbprint;
+            using (var cert = CreateSelfSignedWithKey(subject, TimeSpan.FromDays(2)))
+            {
+                plantedThumbprint = cert.Thumbprint;
+                AddToCurrentUserMyStore(cert);
+            }
+
+            Assert.IsTrue(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Test setup precondition: planted cert must be present in CurrentUser\\My before purge.");
+
+            // Act
+            WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+            // Assert
+            Assert.IsFalse(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Purge should remove certs whose Issuer contains the managed identity issuer CN.");
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_LeavesCertWithNonMatchingIssuer()
+        {
+            WindowsOnly();
+
+            // Arrange
+            string discriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            // Subject/Issuer that does NOT contain the managed identity issuer fragment.
+            string subject = "CN=unrelated.example.test, OU=" + discriminator;
+
+            string plantedThumbprint;
+            using (var cert = CreateSelfSignedWithKey(subject, TimeSpan.FromDays(2)))
+            {
+                plantedThumbprint = cert.Thumbprint;
+                AddToCurrentUserMyStore(cert);
+            }
+
+            Assert.IsTrue(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Test setup precondition: planted cert must be present in CurrentUser\\My before purge.");
+
+            try
+            {
+                // Act
+                WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+                // Assert
+                Assert.IsTrue(
+                    IsInCurrentUserMyStore(plantedThumbprint),
+                    "Purge must not remove certs whose Issuer does not contain the managed identity issuer CN.");
+            }
+            finally
+            {
+                RemoveByThumbprintFromCurrentUserMyStore(plantedThumbprint);
+            }
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_MatchIsCaseInsensitive()
+        {
+            WindowsOnly();
+
+            // Arrange
+            string discriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            // Uppercase the issuer fragment to ensure the match is OrdinalIgnoreCase.
+            string subject =
+                "CN=" + WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment.ToUpperInvariant() +
+                ", OU=" + discriminator;
+
+            string plantedThumbprint;
+            using (var cert = CreateSelfSignedWithKey(subject, TimeSpan.FromDays(2)))
+            {
+                plantedThumbprint = cert.Thumbprint;
+                AddToCurrentUserMyStore(cert);
+            }
+
+            Assert.IsTrue(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Test setup precondition: planted cert must be present in CurrentUser\\My before purge.");
+
+            // Act
+            WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+            // Assert
+            Assert.IsFalse(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Purge issuer match should be case-insensitive.");
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_OnlyRemovesMatching_LeavesOtherCertsAlone()
+        {
+            WindowsOnly();
+
+            // Arrange: plant one matching and one non-matching cert
+            string matchDiscriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            string nonMatchDiscriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+
+            string matchingSubject =
+                "CN=" + WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment +
+                ", OU=" + matchDiscriminator;
+            string nonMatchingSubject = "CN=unrelated.example.test, OU=" + nonMatchDiscriminator;
+
+            string matchingThumb;
+            string nonMatchingThumb;
+
+            using (var matching = CreateSelfSignedWithKey(matchingSubject, TimeSpan.FromDays(2)))
+            using (var nonMatching = CreateSelfSignedWithKey(nonMatchingSubject, TimeSpan.FromDays(2)))
+            {
+                matchingThumb = matching.Thumbprint;
+                nonMatchingThumb = nonMatching.Thumbprint;
+
+                AddToCurrentUserMyStore(matching);
+                AddToCurrentUserMyStore(nonMatching);
+            }
+
+            Assert.IsTrue(IsInCurrentUserMyStore(matchingThumb), "Matching cert must be planted.");
+            Assert.IsTrue(IsInCurrentUserMyStore(nonMatchingThumb), "Non-matching cert must be planted.");
+
+            try
+            {
+                // Act
+                WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+                // Assert
+                Assert.IsFalse(IsInCurrentUserMyStore(matchingThumb), "Matching cert should be purged.");
+                Assert.IsTrue(IsInCurrentUserMyStore(nonMatchingThumb), "Non-matching cert should survive.");
+            }
+            finally
+            {
+                RemoveByThumbprintFromCurrentUserMyStore(nonMatchingThumb);
+            }
+        }
+
+        // ---------------- helpers ----------------
+
+        /// <summary>
+        /// Creates a self-signed RSA cert with a persistable private key.
+        /// Mirrors the pattern used by <c>PersistentCertificateStoreUnitTests.CreateSelfSignedWithKey</c>.
+        /// </summary>
+        private static X509Certificate2 CreateSelfSignedWithKey(string subject, TimeSpan lifetime)
+        {
+            using var rsa = RSA.Create(2048);
+
+            var req = new CertificateRequest(
+                new X500DistinguishedName(subject),
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddMinutes(-2);
+            DateTimeOffset notAfter = notBefore.Add(lifetime);
+
+            using var ephemeral = req.CreateSelfSigned(notBefore, notAfter);
+
+            // Re-import as PFX so the private key is persisted and the store will accept it.
+            var pfx = ephemeral.Export(X509ContentType.Pfx, "");
+            return new X509Certificate2(
+                pfx,
+                "",
+                X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+        }
+
+        private static void AddToCurrentUserMyStore(X509Certificate2 cert)
+        {
+            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadWrite);
+            store.Add(cert);
+        }
+
+        private static bool IsInCurrentUserMyStore(string thumbprint)
+        {
+            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+
+            foreach (X509Certificate2 c in store.Certificates)
+            {
+                try
+                {
+                    if (string.Equals(c.Thumbprint, thumbprint, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+                finally
+                {
+                    c.Dispose();
+                }
+            }
+
+            return false;
+        }
+
+        private static void RemoveByThumbprintFromCurrentUserMyStore(string thumbprint)
+        {
+            try
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                store.Open(OpenFlags.ReadWrite);
+
+                X509Certificate2[] snapshot;
+                try
+                {
+                    snapshot = new X509Certificate2[store.Certificates.Count];
+                    store.Certificates.CopyTo(snapshot, 0);
+                }
+                catch
+                {
+                    snapshot = store.Certificates.Cast<X509Certificate2>().ToArray();
+                }
+
+                foreach (var c in snapshot)
+                {
+                    try
+                    {
+                        if (string.Equals(c.Thumbprint, thumbprint, StringComparison.OrdinalIgnoreCase))
+                        {
+                            try
+                            { store.Remove(c); }
+                            catch { /* best-effort */ }
+                        }
+                    }
+                    finally
+                    {
+                        c.Dispose();
+                    }
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+
+        /// <summary>
+        /// Removes any leftover purge-test certificates from <c>CurrentUser\My</c>.
+        /// Matches our unique Subject OU discriminator to avoid touching unrelated certs.
+        /// Best-effort, no-throw.
+        /// </summary>
+        private static void RemoveAllPurgeTestArtifacts()
+        {
+            if (!IsWindows)
+            {
+                return;
+            }
+
+            try
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                store.Open(OpenFlags.ReadWrite);
+
+                X509Certificate2[] snapshot;
+                try
+                {
+                    snapshot = new X509Certificate2[store.Certificates.Count];
+                    store.Certificates.CopyTo(snapshot, 0);
+                }
+                catch
+                {
+                    snapshot = store.Certificates.Cast<X509Certificate2>().ToArray();
+                }
+
+                foreach (var c in snapshot)
+                {
+                    try
+                    {
+                        string subject = c.Subject ?? string.Empty;
+                        if (subject.IndexOf(TestSubjectDiscriminatorPrefix, StringComparison.Ordinal) >= 0)
+                        {
+                            try
+                            { store.Remove(c); }
+                            catch { /* best-effort */ }
+                        }
+                    }
+                    finally
+                    {
+                        c.Dispose();
+                    }
+                }
+            }
+            catch
+            {
+                // best-effort
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

After a VM or app restart, KeyGuard regenerates the per-boot private key in the same CNG container while old binding certs remain on disk under `CN=managedidentitysnissuer.login.microsoft.com`. The certs appear valid (time-wise, `HasPrivateKey=true`) but the key material has changed (or, in the zombie-VBS case, the container metadata survives but the private material is dead). MSAL loads such certs from the persistent store, attempts an mTLS handshake, and fails.

This PR addresses three distinct failure modes:

| Mode | Symptom | Root cause |
|------|---------|------------|
| 1. Container empty | `CngKey.Open` throws / `GetRSAPrivateKey()` returns null | VBS reaped per-boot key; `CreateFresh` hasn't run yet in this process |
| 2. Different key in container | Public key on cert doesn't match container | `CreateFresh` ran (with `OverwriteExistingKey`); cert references previous key material |
| 3. Zombie VBS | Public metadata matches cert but signing fails | Container metadata survives reboot; private material is dead |

## Fix — three complementary layers

### 1. Per-`Read` modulus comparison (`WindowsPersistentCertificateCache`)
Compare the cert's embedded public key (modulus + exponent) against the public key currently in the CNG container. A mismatch conclusively means the container was regenerated — the cert is orphaned. Runs inside `WindowsPersistentCertificateCache.Read` during candidate selection. Orphaned certs are **removed from the store** on detection so they don't accumulate and don't require the modulus check on every subsequent `Read`.

Covers: Mode 2 (and non-reboot drift scenarios).

### 2. `CanSign` liveness probe (`WindowsCngKeyOperations.TryGetOrCreateKeyGuard`)
A 1-byte RSA-SHA256 PKCS1 sign right after `CngKey.Open`. ~1–3 ms, runs once per process (the result is cached in `WindowsManagedIdentityKeyProvider._cachedKey`). If the probe fails, the container is treated as dead and `CreateFresh` is invoked.

Covers: Mode 3. Without this, `ExportParameters(false)` returns the old modulus from intact metadata, the per-`Read` modulus check passes, and the failure surfaces only at the mTLS handshake.

### 3. Issuer-CN sweep on fresh-key mint (`PurgeManagedIdentityCertificates`)
One-shot substring sweep of `CurrentUser\My` for `CN=managedidentitysnissuer.login.microsoft.com`, invoked at the moment a fresh KeyGuard key is minted (both the probe-failed path and the `Open`-threw path). Removes orphan binding certs at the cause site.

Covers: Modes 1 and 2 at the cause site — multi-identity hosts (SAMI + UAMIs sharing the KeyGuard container) are cleaned up uniformly, no per-`Read` discovery cost.

The reactive SChannel catch in `ImdsV2ManagedIdentitySource` is retained as a defensive backstop.

## Design notes

- Non-CNG keys (software CSP) are accepted on faith — KG regeneration does not apply
- `GetRSAPrivateKey()` returning null for an RSA cert is treated as orphaned (inaccessible = unusable); non-RSA certs (ECDSA, etc.) are accepted on faith
- `CryptographicException` during key load is treated as orphaned
- The CNG modified-time heuristic (Check 3 from Dragos's proposal) is intentionally omitted — the modulus comparison is definitive and covers the same case without the false-negative window
- The internal `TryRead` overload accepts an injectable `isOrphaned` delegate for testability; `IPersistentCertificateCache` interface is unchanged
- `RemoveByThumbprints` is wrapped in `InterprocessLock.TryWithAliasLock` (300 ms best-effort) — same pattern as `Write`/`Delete`/`DeleteAllForAlias`
- Cert-store snapshotting consolidated into a single `SnapshotCertificates` helper

## Testing

**Unit tests (Windows-only where RSACng is required):**

`PersistentCertificateStoreUnitTests.cs` — 6 tests:
- `IsCertKeyOrphaned_ReturnsTrue_For_NullCert`
- `IsCertKeyOrphaned_ReturnsFalse_For_ValidCert`
- `IsCertKeyOrphaned_ReturnsTrue_For_RsaCert_WithNoPrivateKey`
- `PublicKeyMatchesCert_ReturnsTrue_When_KeyMatchesCert`
- `PublicKeyMatchesCert_ReturnsFalse_When_ModulusMismatch` (different RSACng simulates post-reboot key replacement)
- `Read_RemovesOrphanedCert_FromStore` (verifies cert is deleted from store and `Read` returns false)

`WindowsCngKeyOperationsPurgeUnitTests.cs` — 4 tests for the purge filter:
- Matching issuer CN
- Non-matching issuer CN
- Case-insensitive matching
- Only removes matching certs

**Full unit suite:** 2068 passed, 0 failed, 19 skipped (net8.0).

**E2E validation** (Gladwin, Server 2022 KeyGuard VM, multiple reboots, mixed SAMI/UAMI):
- `CngKey.Open` threw `CryptographicException` HR=0x8009003A
- Fresh KeyGuard key created
- `PurgeManagedIdentityCertificates` removed orphan cert (Inspected=4)
- MAA attestation OK → `POST /issuecredential` → 200
- mTLS handshake → 200 on first try (no reactive catch invoked)
- Total ~2.8s on cold start

## Credits

Modulus-comparison layer authored by @Robbie-Microsoft. CanSign probe + issuer-CN sweep authored by @gladjohn (cherry-picked from #6037). Approach discussed with @bgavrilMS, @raghavendra-ms, @dragosav.

Companion to #6017 (token_not_after OID eviction — different failure mode). Refs #6031.
