### PR TITLE
Fix IMDSv2 attestation: pass non-null clientPayload to AttestKeyGuardImportKey

### DIFF
--- a/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/AttestationClient.cs
+++ b/src/client/Microsoft.Identity.Client.KeyAttestation/Attestation/AttestationClient.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client.KeyAttestation.Attestation
                 keyHandle.DangerousAddRef(ref addRef);
 
                 int rc = AttestationClientLib.AttestKeyGuardImportKey(
-                    endpoint, null, null, keyHandle, out buf, clientId);
+                    endpoint, null, "{}", keyHandle, out buf, clientId);
 
                 if (rc != 0)
                     return new(AttestationStatus.NativeError, null, null, rc, null);


### PR DESCRIPTION
## Problem

All 4 ManagedIdentityImdsV2Tests (mTLS PoP with attestation) have been failing since May 20 with:

AADSTS1000901: certificate 'token_not_after' extension has expired

## Root Cause

The native AttestationClientLib.dll now requires the clientPayload parameter to be a valid JSON string (at minimum "{}"). Passing null causes error code -8 (ERRORINVALIDINPUTPARAMETER) with native log: "Error parsing the client payload Json"

Confirmed by direct P/Invoke testing on the MSIV2 VM:
- null -> rc=-8, attestation fails
- "{}" -> rc=0, valid JWT returned (24h lifetime, exp in the future)

## Fix

Pass "{}" instead of null for the clientPayload parameter in AttestationClient.Attest().

## Testing

Verified on MSIV2 VM as dcadmin (same user as ADO agent) - attestation succeeds and returns a valid token with correct timestamps.
