### PR TITLE
Add IsMtlsPopSupportedByHost to ManagedIdentitySourceResult

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ComputeMetadataResponse.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ComputeMetadataResponse.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client.Platforms.net;
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    /// <summary>
+    /// Represents compute metadata retrieved from the Azure Instance Metadata Service (IMDS).
+    /// </summary>
+    [JsonObject]
+    [Preserve(AllMembers = true)]
+    internal class ComputeMetadataResponse
+    {
+        /// <summary>Operating system type (e.g., Windows, Linux).</summary>
+        [JsonProperty("osType")]
+        public string OsType { get; set; }
+
+        /// <summary>
+        /// Security profile indicating platform security posture. May be null when IMDS
+        /// does not return security profile information for the current VM.
+        /// </summary>
+        [JsonProperty("securityProfile")]
+        public ComputeSecurityProfile SecurityProfile { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the security profile of an Azure VM from IMDS compute metadata.
+    /// </summary>
+    [JsonObject]
+    [Preserve(AllMembers = true)]
+    internal class ComputeSecurityProfile
+    {
+        /// <summary>Security type of the VM (e.g., TrustedLaunch, ConfidentialVM).</summary>
+        [JsonProperty("securityType")]
+        public string SecurityType { get; set; }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsComputeMetadataManager.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ImdsComputeMetadataManager.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Http.Retry;
+using Microsoft.Identity.Client.Utils;
+
+namespace Microsoft.Identity.Client.ManagedIdentity
+{
+    /// <summary>
+    /// Fetches compute metadata from the Azure Instance Metadata Service (IMDS)
+    /// to determine VM characteristics such as OS type and security profile.
+    /// </summary>
+    internal static class ImdsComputeMetadataManager
+    {
+        internal const string ImdsComputePath = "/metadata/instance/compute";
+        internal const string ImdsComputeApiVersion = "2021-02-01";
+
+        internal static async Task<ComputeMetadataResponse> GetComputeMetadataAsync(
+            IHttpManager httpManager,
+            ILoggerAdapter logger,
+            CancellationToken cancellationToken)
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { "Metadata", "true" }
+            };
+
+            try
+            {
+                string queryParams =
+                    $"{ImdsManagedIdentitySource.ApiVersionQueryParam}={ImdsComputeApiVersion}";
+
+                Uri endpoint = ImdsManagedIdentitySource.GetValidatedEndpoint(
+                    logger,
+                    ImdsComputePath,
+                    queryParams);
+
+                HttpResponse response = await httpManager.SendRequestAsync(
+                    endpoint,
+                    headers,
+                    body: null,
+                    method: HttpMethod.Get,
+                    logger: logger,
+                    doNotThrow: true,
+                    mtlsCertificate: null,
+                    validateServerCertificate: null,
+                    cancellationToken: cancellationToken,
+                    retryPolicy: new ImdsRetryPolicy())
+                    .ConfigureAwait(false);
+
+                if (response is null || response.StatusCode != HttpStatusCode.OK)
+                {
+                    logger.Info($"[Managed Identity] IMDS compute metadata request failed. " +
+                        $"StatusCode: {response?.StatusCode}");
+                    return null;
+                }
+
+                return JsonHelper.TryToDeserializeFromJson<ComputeMetadataResponse>(response.Body);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.Info($"[Managed Identity] IMDS compute metadata request failed with exception: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the host VM supports mTLS PoP based on compute metadata.
+        /// mTLS PoP is supported when the VM runs Windows and is a TVM (TrustedLaunch) or CVM (ConfidentialVM).
+        /// </summary>
+        internal static bool IsMtlsPopSupported(ComputeMetadataResponse metadata)
+        {
+            if (metadata is null)
+            {
+                return false;
+            }
+
+            bool isWindows = string.Equals(metadata.OsType, "Windows", StringComparison.OrdinalIgnoreCase);
+
+            string securityType = metadata.SecurityProfile?.SecurityType;
+            bool isTvmOrCvm = string.Equals(securityType, "TrustedLaunch", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(securityType, "ConfidentialVM", StringComparison.OrdinalIgnoreCase);
+
+            return isWindows && isTvmOrCvm;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -156,7 +156,19 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             if (imdsV1Success)
             {
                 requestContext.Logger.Info("[Managed Identity] IMDS detected via v1 probe.");
-                return CacheDiscoveryResult(new ManagedIdentitySourceResult(ManagedIdentitySource.Imds));
+
+                var result = new ManagedIdentitySourceResult(ManagedIdentitySource.Imds);
+
+                // Fetch compute metadata to determine mTLS PoP support
+                var computeMetadata = await ImdsComputeMetadataManager.GetComputeMetadataAsync(
+                    requestContext.ServiceBundle.HttpManager,
+                    requestContext.Logger,
+                    cancellationToken).ConfigureAwait(false);
+
+                result.IsMtlsPopSupportedByHost = ImdsComputeMetadataManager.IsMtlsPopSupported(computeMetadata);
+                requestContext.Logger.Info($"[Managed Identity] mTLS PoP supported by host: {result.IsMtlsPopSupportedByHost}");
+
+                return CacheDiscoveryResult(result);
             }
 
             requestContext.Logger.Info($"[Managed Identity] {MsalErrorMessage.ManagedIdentityAllSourcesUnavailable}");

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -159,7 +159,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
                 var result = new ManagedIdentitySourceResult(ManagedIdentitySource.Imds);
 
-                // Fetch compute metadata to determine mTLS PoP support
+#if !NET462
+                // Fetch compute metadata to determine mTLS PoP support (not available on .NET Framework 4.6.2)
                 var computeMetadata = await ImdsComputeMetadataManager.GetComputeMetadataAsync(
                     requestContext.ServiceBundle.HttpManager,
                     requestContext.Logger,
@@ -167,6 +168,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
                 result.IsMtlsPopSupportedByHost = ImdsComputeMetadataManager.IsMtlsPopSupported(computeMetadata);
                 requestContext.Logger.Info($"[Managed Identity] mTLS PoP supported by host: {result.IsMtlsPopSupportedByHost}");
+#endif
 
                 return CacheDiscoveryResult(result);
             }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySourceResult.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentitySourceResult.cs
@@ -32,6 +32,17 @@ namespace Microsoft.Identity.Client.ManagedIdentity
         public string ImdsFailureReason { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether the host VM supports mTLS Proof-of-Possession (PoP) tokens.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the VM runs Windows and has a security profile indicating a Trusted VM (TVM)
+        /// or Confidential VM (CVM); <c>false</c> if the compute metadata could not be retrieved,
+        /// the VM is not Windows, or the VM does not have a TVM/CVM security profile.
+        /// This property is only meaningful when <see cref="Source"/> is <see cref="ManagedIdentitySource.Imds"/>.
+        /// </value>
+        public bool IsMtlsPopSupportedByHost { get; internal set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ManagedIdentitySourceResult"/> class.
         /// </summary>
         /// <param name="source">The detected managed identity source.</param>

--- a/src/client/Microsoft.Identity.Client/Platforms/net/MsalJsonSerializerContext.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/net/MsalJsonSerializerContext.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Identity.Client.Platforms.net
     [JsonSerializable(typeof(CuidInfo))]
     [JsonSerializable(typeof(CertificateRequestBody))]
     [JsonSerializable(typeof(CertificateRequestResponse))]
+    [JsonSerializable(typeof(ComputeMetadataResponse))]
+    [JsonSerializable(typeof(ComputeSecurityProfile))]
     [JsonSerializable(typeof(Dictionary<string, object>))]
     [JsonSourceGenerationOptions]
     internal partial class MsalJsonSerializerContext : JsonSerializerContext

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsFailur
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV1FailureReason.set -> void
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.get -> string
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.IsMtlsPopSupportedByHost.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsFailur
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV1FailureReason.set -> void
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.get -> string
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.IsMtlsPopSupportedByHost.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsFailur
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV1FailureReason.set -> void
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.get -> string
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.IsMtlsPopSupportedByHost.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsFailur
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV1FailureReason.set -> void
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.get -> string
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.IsMtlsPopSupportedByHost.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsFailur
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV1FailureReason.set -> void
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.get -> string
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.IsMtlsPopSupportedByHost.get -> bool

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsFailur
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV1FailureReason.set -> void
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.get -> string
 *REMOVED*Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.ImdsV2FailureReason.set -> void
+Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySourceResult.IsMtlsPopSupportedByHost.get -> bool

--- a/src/client/Microsoft.Identity.Lab.Api/Http/MockHelpers.cs
+++ b/src/client/Microsoft.Identity.Lab.Api/Http/MockHelpers.cs
@@ -949,6 +949,50 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
         }
 
         /// <summary>
+        /// Creates a mock IMDS compute metadata response handler.
+        /// </summary>
+        /// <param name="osType">The OS type to return (e.g., "Windows", "Linux").</param>
+        /// <param name="securityType">The security profile type (e.g., "TrustedLaunch", "ConfidentialVM"), or null.</param>
+        /// <returns>A configured <see cref="MockHttpMessageHandler"/>.</returns>
+        internal static MockHttpMessageHandler MockImdsComputeMetadata(
+            string osType = "Windows",
+            string securityType = "TrustedLaunch")
+        {
+            string securityProfileJson = securityType != null
+                ? $", \"securityProfile\": {{ \"securityType\": \"{securityType}\" }}"
+                : "";
+
+            string body = $"{{ \"osType\": \"{osType}\"{securityProfileJson} }}";
+
+            return new MockHttpMessageHandler()
+            {
+                ExpectedUrl = $"{ImdsManagedIdentitySource.DefaultImdsBaseEndpoint}{ImdsComputeMetadataManager.ImdsComputePath}",
+                ExpectedMethod = HttpMethod.Get,
+                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body),
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates a mock IMDS compute metadata 404 (not found) response handler.
+        /// </summary>
+        /// <returns>A configured <see cref="MockHttpMessageHandler"/>.</returns>
+        internal static MockHttpMessageHandler MockImdsComputeMetadataNotFound()
+        {
+            return new MockHttpMessageHandler()
+            {
+                ExpectedUrl = $"{ImdsManagedIdentitySource.DefaultImdsBaseEndpoint}{ImdsComputeMetadataManager.ImdsComputePath}",
+                ExpectedMethod = HttpMethod.Get,
+                ResponseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent(""),
+                }
+            };
+        }
+
+        /// <summary>
         /// Creates a mock CSR metadata response handler for IMDS v2 flows.
         /// </summary>
         /// <param name="statusCode">The HTTP status code to return.</param>

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             {
                 // Discovery probes V1 (succeeds) → Imds cached
                 httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1, userAssignedIdentityId, userAssignedId));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata());
 
                 if (addSourceCheck)
                 {
@@ -142,6 +143,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             {
                 // Discovery probes V1 (succeeds) → Imds cached; mTLS PoP requests are routed to IMDSv2 automatically
                 httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1, userAssignedIdentityId, userAssignedId));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata());
             }
 
             if (addSourceCheck)
@@ -377,10 +379,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 // Regression test for issue #6024:
                 // Azure SDK calls GetManagedIdentitySourceAsync first, which probes IMDSv1 and caches "Imds".
                 httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1, userAssignedIdentityId, userAssignedId));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata());
                 var sourceResult = await (managedIdentityApp as ManagedIdentityApplication)
                     .GetManagedIdentitySourceAsync(ManagedIdentityTests.ImdsProbesCancellationToken)
                     .ConfigureAwait(false);
                 Assert.AreEqual(ManagedIdentitySource.Imds, sourceResult.Source);
+                Assert.IsTrue(sourceResult.IsMtlsPopSupportedByHost);
 
                 // Now an mTLS PoP request should route to IMDSv2 despite v1 being cached.
                 AddMocksToGetEntraToken(httpManager, userAssignedIdentityId, userAssignedId);
@@ -461,8 +465,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             {
                 SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
 
-                // Discovery probes V1 (succeeds)
+                // Discovery probes V1 (succeeds), then fetches compute metadata
                 httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata());
 
                 await CreateManagedIdentityAsync(httpManager, addProbeMock: false).ConfigureAwait(false);
             }
@@ -514,6 +519,113 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             }
         }
         #endregion Probe Tests
+
+        #region IsMtlsPopSupportedByHost Tests
+        [TestMethod]
+        public async Task IsMtlsPopSupportedByHost_WindowsTvm_ReturnsTrue()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata(osType: "Windows", securityType: "TrustedLaunch"));
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(httpManager, addProbeMock: false, addSourceCheck: false).ConfigureAwait(false);
+
+                var result = await (managedIdentityApp as ManagedIdentityApplication)
+                    .GetManagedIdentitySourceAsync(ManagedIdentityTests.ImdsProbesCancellationToken).ConfigureAwait(false);
+
+                Assert.AreEqual(ManagedIdentitySource.Imds, result.Source);
+                Assert.IsTrue(result.IsMtlsPopSupportedByHost);
+            }
+        }
+
+        [TestMethod]
+        public async Task IsMtlsPopSupportedByHost_WindowsCvm_ReturnsTrue()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata(osType: "Windows", securityType: "ConfidentialVM"));
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(httpManager, addProbeMock: false, addSourceCheck: false).ConfigureAwait(false);
+
+                var result = await (managedIdentityApp as ManagedIdentityApplication)
+                    .GetManagedIdentitySourceAsync(ManagedIdentityTests.ImdsProbesCancellationToken).ConfigureAwait(false);
+
+                Assert.AreEqual(ManagedIdentitySource.Imds, result.Source);
+                Assert.IsTrue(result.IsMtlsPopSupportedByHost);
+            }
+        }
+
+        [TestMethod]
+        public async Task IsMtlsPopSupportedByHost_Linux_ReturnsFalse()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata(osType: "Linux", securityType: "TrustedLaunch"));
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(httpManager, addProbeMock: false, addSourceCheck: false).ConfigureAwait(false);
+
+                var result = await (managedIdentityApp as ManagedIdentityApplication)
+                    .GetManagedIdentitySourceAsync(ManagedIdentityTests.ImdsProbesCancellationToken).ConfigureAwait(false);
+
+                Assert.AreEqual(ManagedIdentitySource.Imds, result.Source);
+                Assert.IsFalse(result.IsMtlsPopSupportedByHost);
+            }
+        }
+
+        [TestMethod]
+        public async Task IsMtlsPopSupportedByHost_WindowsNoSecurityProfile_ReturnsFalse()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata(osType: "Windows", securityType: null));
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(httpManager, addProbeMock: false, addSourceCheck: false).ConfigureAwait(false);
+
+                var result = await (managedIdentityApp as ManagedIdentityApplication)
+                    .GetManagedIdentitySourceAsync(ManagedIdentityTests.ImdsProbesCancellationToken).ConfigureAwait(false);
+
+                Assert.AreEqual(ManagedIdentitySource.Imds, result.Source);
+                Assert.IsFalse(result.IsMtlsPopSupportedByHost);
+            }
+        }
+
+        [TestMethod]
+        public async Task IsMtlsPopSupportedByHost_ComputeMetadata404_ReturnsFalse()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1));
+                httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadataNotFound());
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(httpManager, addProbeMock: false, addSourceCheck: false).ConfigureAwait(false);
+
+                var result = await (managedIdentityApp as ManagedIdentityApplication)
+                    .GetManagedIdentitySourceAsync(ManagedIdentityTests.ImdsProbesCancellationToken).ConfigureAwait(false);
+
+                Assert.AreEqual(ManagedIdentitySource.Imds, result.Source);
+                Assert.IsFalse(result.IsMtlsPopSupportedByHost);
+            }
+        }
+        #endregion IsMtlsPopSupportedByHost Tests
 
         #region Fallback Behavior Tests
         // Verifies non-mTLS request after IMDS detection uses IMDSv1 (Bearer),

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -69,8 +69,9 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 if (managedIdentitySource == ManagedIdentitySource.Imds)
                 {
-                    // Discovery probes V1 only
+                    // Discovery probes V1 only, then fetches compute metadata
                     httpManager.AddMockHandler(MockHelpers.MockImdsProbe(ImdsVersion.V1));
+                    httpManager.AddMockHandler(MockHelpers.MockImdsComputeMetadata());
                 }
 
                 var miSourceResult = await mi.GetManagedIdentitySourceAsync(ImdsProbesCancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
﻿## Summary

During IMDS discovery (GetManagedIdentitySourceAsync), after the v1 probe succeeds, fetch compute metadata from /metadata/instance/compute to determine if the host VM supports mTLS PoP.

## New public API

IsMtlsPopSupportedByHost is true when:
- The VM runs Windows (osType == "Windows")
- AND the VM has a TVM (TrustedLaunch) or CVM (ConfidentialVM) security profile

Returns false when:
- Compute metadata endpoint returns 404 or is unreachable
- The VM is Linux
- The VM has no TVM/CVM security profile
- Running on net462 (skipped entirely)

## Implementation

- ComputeMetadataResponse (internal) - minimal model for IMDS compute metadata
- ImdsComputeMetadataManager (internal) - fetches /metadata/instance/compute and evaluates mTLS PoP support
- Compute metadata is fetched only after a successful v1 probe, and only on non-net462 TFMs

## Tests (5 new)

- Windows + TrustedLaunch -> true
- Windows + ConfidentialVM -> true
- Linux + TrustedLaunch -> false
- Windows + no security profile -> false
- Compute metadata 404 -> false

All 388 ManagedIdentity tests pass.
