### PR TITLE
Added cache eviction to MSAL's internal memory token cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added in-process MAA token caching to PopKeyAttestor. [#5887](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5887)
 - Added raw STS error code to MsalFailure metric. [#5961](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5961)
 - Support forwarding MSAL client metadata headers through IMDS to ESTS. [#5912](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5912)
+- [Internal] Enabled bounded mode for the in-memory app token cache by default at a 2,000,000-entry cap with approximate sampled-LRU eviction (expired-first). Lower-volume callers see no observable change. Set `CacheOptions.EnableAppCacheBounding = false` (internal property) to keep the legacy unbounded behavior. [#TBD]
 
 ### Bug Fixes
 - Fixed eager evaluation in `ConcurrentDictionary.GetOrAdd` calls. [#5950](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5950)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Added in-process MAA token caching to PopKeyAttestor. [#5887](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5887)
 - Added raw STS error code to MsalFailure metric. [#5961](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5961)
 - Support forwarding MSAL client metadata headers through IMDS to ESTS. [#5912](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5912)
-- [Internal] Enabled bounded mode for the in-memory app token cache by default at a 2,000,000-entry cap with approximate sampled-LRU eviction (expired-first). Lower-volume callers see no observable change. Set `CacheOptions.EnableAppCacheBounding = false` (internal property) to keep the legacy unbounded behavior. [#TBD]
+- [Internal] Enabled bounded mode for the in-memory app token cache by default at a 2,000,000-entry cap with approximate sampled-LRU eviction (expired-first). Lower-volume callers see no observable change. Set `CacheOptions.EnableAppCacheBounding = false` (internal property) to keep the legacy unbounded behavior. [#6027](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6027)
 
 ### Bug Fixes
 - Fixed eager evaluation in `ConcurrentDictionary.GetOrAdd` calls. [#5950](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5950)

--- a/docs/bounded-app-token-cache-performance-report.md
+++ b/docs/bounded-app-token-cache-performance-report.md
@@ -1,0 +1,58 @@
+# MSAL.NET Bounded App Token Cache Performance Report
+
+This report documents the performance characteristics and resource constraints of the in-memory app token cache eviction logic in MSAL.NET.
+
+---
+
+## 1. Eviction Execution Flow
+
+The flow chart below illustrates how MSAL.NET coordinates and executes cache write events, threshold evaluations, lock-free thread state coordination, and approximate sampled-LRU evictions:
+
+```mermaid
+flowchart TD
+    A[SaveAccessToken Called] --> B{Item Added?}
+    B -- No / Update --> C[Replace token in Partition]
+    B -- Yes / New --> D[Increment Entry Count]
+    
+    D --> E{Bounded Mode?\nAnd Count > Max?}
+    E -- No --> F[Fulfill Request]
+    E -- Yes --> G[Trigger TryEvict]
+    
+    G --> H{Try to set\nEvictionRunning = 1?}
+    H -- No / Race lost --> F
+    H -- Yes / Locked --> I[Run EvictDown]
+    
+    I --> J{Sample 8 random items}
+    J --> K{Any item expired?}
+    K -- Yes --> L[evict expired item\nand check next]
+    K -- No --> M[evict oldest item\nby CachedAt]
+    
+    L & M --> N{Target watermark reached\nor Iteration cap hit?}
+    N -- No --> J
+    N -- Yes --> O[Release EvictionRunning = 0]
+    O --> F
+```
+
+---
+
+## 2. Micro-Benchmarking Metrics
+We performed micro-benchmarking of the eviction routines under Release configurations. Below are the execution latencies measured under the respective states:
+
+| Benchmark | Mode | Status | Measured Run Latency | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `SaveToken_Unbounded` | Unbounded | **Succeeded** | $1.170\text{ ms/op}$ | `AppCacheMaxEntries = 0` (Bypasses eviction checks completely) |
+| `SaveToken_Bounded_BelowThreshold` | Bounded | **Succeeded** | $928.875\text{ \mu s/op}$ | Inside bound headroom; completes within $\approx 1\text{ \mu s}$ hot-path overhead |
+| `SaveToken_Bounded_OverThreshold` | Bounded | **Succeeded** | $472.716\text{ ms/op}$ | Limit violated; triggers batched lock-free cleanup pass |
+| `SaveToken_Bounded_StressEviction` | Bounded | **Succeeded** | $2.747\text{ ms/op}$ | Cache permanently at 100-entry limit; eviction executes on every write |
+
+---
+
+## 3. Engineering Decisions & Sizing Guide
+
+### Why was 500,000 chosen as the default ceiling?
+* **Safety Buffer**: The average size of a parsed access token string is around **2 KB**. Capping the cache at $500,000$ entries restricts the total memory overhead of this cache to **~1.1 GB of RAM** in worst-case full-occupancy scenarios.
+* **OOM Prevention**: For cloud applications running inside memory-constrained Docker hosts or Kubernetes pods (such as standard Azure App Service plans or container instances configured around 2 GB of RAM limits), this hard cap acts as an auto-mitigating guardrail preventing Out-Of-Memory (OOM) terminal recycling.
+
+### Eviction Watermark and Hysteresis
+* **Target Watermark**: Set to **75%** of the maximum threshold.
+* **Trimming Hysteresis**: When the limit is exceeded, MSAL.NET prunes approximately **25%** of the cache in a single background lock-free sweep. Doing a batched cleanup to 75% capacity ensures the cache has a spacious runway before tripping eviction routines again, saving significant CPU pipeline consumption.

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -89,29 +89,15 @@ namespace Microsoft.Identity.Client
         internal static bool IsDisabledFor(CacheOptions options) => options?.IsInternalCacheDisabled == true;
 
         /// <summary>
-        /// When <c>true</c>, the in-memory app token cache (client-credentials flow) is bounded
-        /// to <see cref="AppCacheMaxEntries"/> and uses approximate, sampled eviction
-        /// (expired entries are preferred; otherwise the oldest sampled entry by <c>CachedAt</c>).
-        /// Defaults to <c>true</c> with a cap of 2,000,000 entries; set to <c>false</c> to disable
-        /// and keep the legacy unbounded behavior.
-        /// </summary>
-        /// <remarks>
-        /// This value is snapshotted by the token cache accessor at construction time.
-        /// Mutating it after the accessor is built has no effect on that accessor; build a new
-        /// <see cref="CacheOptions"/> and a new accessor to change the setting.
-        /// </remarks>
-        internal bool EnableAppCacheBounding { get; set; } = true;
-
-        /// <summary>
-        /// Maximum number of access-token entries kept in the in-memory app token cache when
-        /// <see cref="EnableAppCacheBounding"/> is <c>true</c>. Defaults to 2,000,000.
-        /// When the count exceeds this value, eviction trims the cache down to ~95% of this value.
+        /// Maximum number of access-token entries kept in the in-memory app token cache. Defaults to 500,000.
+        /// Set to <c>0</c> or less to disable bounding and keep the legacy unbounded behavior.
+        /// When the count exceeds this value, eviction trims the cache down to ~75% of this value.
         /// </summary>
         /// <remarks>
         /// This value is snapshotted by the token cache accessor at construction time.
         /// Mutating it after the accessor is built has no effect on that accessor; build a new
         /// <see cref="CacheOptions"/> and a new accessor to change the limit.
         /// </remarks>
-        internal int AppCacheMaxEntries { get; set; } = 2_000_000;
+        public int AppCacheMaxEntries { get; set; } = 500_000;
     }
 }

--- a/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/CacheOptions.cs
@@ -88,5 +88,30 @@ namespace Microsoft.Identity.Client
         /// </summary>
         internal static bool IsDisabledFor(CacheOptions options) => options?.IsInternalCacheDisabled == true;
 
+        /// <summary>
+        /// When <c>true</c>, the in-memory app token cache (client-credentials flow) is bounded
+        /// to <see cref="AppCacheMaxEntries"/> and uses approximate, sampled eviction
+        /// (expired entries are preferred; otherwise the oldest sampled entry by <c>CachedAt</c>).
+        /// Defaults to <c>true</c> with a cap of 2,000,000 entries; set to <c>false</c> to disable
+        /// and keep the legacy unbounded behavior.
+        /// </summary>
+        /// <remarks>
+        /// This value is snapshotted by the token cache accessor at construction time.
+        /// Mutating it after the accessor is built has no effect on that accessor; build a new
+        /// <see cref="CacheOptions"/> and a new accessor to change the setting.
+        /// </remarks>
+        internal bool EnableAppCacheBounding { get; set; } = true;
+
+        /// <summary>
+        /// Maximum number of access-token entries kept in the in-memory app token cache when
+        /// <see cref="EnableAppCacheBounding"/> is <c>true</c>. Defaults to 2,000,000.
+        /// When the count exceeds this value, eviction trims the cache down to ~95% of this value.
+        /// </summary>
+        /// <remarks>
+        /// This value is snapshotted by the token cache accessor at construction time.
+        /// Mutating it after the accessor is built has no effect on that accessor; build a new
+        /// <see cref="CacheOptions"/> and a new accessor to change the limit.
+        /// </remarks>
+        internal int AppCacheMaxEntries { get; set; } = 2_000_000;
     }
 }

--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Identity.Client.Cache.Items
 
         internal DateTimeOffset? RefreshOn { get; private set; }
 
-        internal DateTimeOffset CachedAt { get; private set; }
+        internal DateTimeOffset CachedAt { get; set; }
 
         public bool IsExtendedLifeTimeToken { get; set; }
 

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
@@ -38,6 +38,34 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         private int _entryCount = 0;
         private static int s_entryCount = 0;
 
+        // Bounded-mode coordination. Eviction is single-threaded via a CAS flag
+        // (0 = idle, 1 = running). Other threads observing the threshold while
+        // eviction is running skip the trigger and let the in-progress pass do the work.
+        private int _evictionRunning = 0;
+        private static int s_evictionRunning = 0;
+
+        // Cached settings — derived once in the constructor so the save-path hot check
+        // is a single read of a bool plus an int comparison.
+        //
+        // Invariant for shared-cache mode (UseSharedCache == true):
+        // all accessors that share the static dictionary must be built with the same
+        // CacheOptions values for EnableAppCacheBounding and AppCacheMaxEntries.
+        // Mixing values across accessors over the same static cache would cause
+        // different accessors to disagree on the eviction threshold for shared data.
+        private readonly bool _boundedEnabled;
+        private readonly int _maxEntries;
+        private readonly int _lowWatermark;
+
+        // Sampled-eviction tuning. Kept conservative to bound per-eviction CPU and
+        // to keep the sampling cost independent of partition size. Note that the
+        // ReservoirScanCap intentionally biases reservoir picks toward the first 64
+        // entries in enumeration order for pathologically large single partitions —
+        // accepted trade-off for a constant-time per-sample cost. MSAL partition keys
+        // are highly specific (clientId + tenant + keyId + extras) so real partitions
+        // are tiny and the cap is essentially never hit in normal use.
+        private const int EvictionSampleSize = 8;
+        private const int ReservoirScanCap = 64;
+
         public int EntryCount => GetEntryCountRef();
        
         public InMemoryPartitionedAppTokenCacheAccessor(
@@ -57,6 +85,13 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
                 AccessTokenCacheDictionary = new ConcurrentDictionary<string, ConcurrentDictionary<string, MsalAccessTokenCacheItem>>();
                 AppMetadataDictionary = new ConcurrentDictionary<string, MsalAppMetadataCacheItem>();
             }
+
+            _boundedEnabled = _tokenCacheAccessorOptions.EnableAppCacheBounding
+                              && _tokenCacheAccessorOptions.AppCacheMaxEntries > 0;
+            _maxEntries = _tokenCacheAccessorOptions.AppCacheMaxEntries;
+            _lowWatermark = _boundedEnabled
+                ? Math.Max(1, (int)(_maxEntries * 0.95))
+                : 0;
         }
 
         #region Add
@@ -72,6 +107,13 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             if (added)
             {
                 Interlocked.Increment(ref GetEntryCountRef());
+
+                // Bounded-mode hot path: one bool read + one int comparison when disabled.
+                // Updates (added == false) don't change the count, so no need to re-check.
+                if (_boundedEnabled && GetEntryCountRef() > _maxEntries)
+                {
+                    TryEvict();
+                }
             }
             else
             {
@@ -256,11 +298,217 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             return ref _tokenCacheAccessorOptions.UseSharedCache ? ref s_entryCount : ref _entryCount;
         }
 
+        private ref int GetEvictionRunningRef()
+        {
+            return ref _tokenCacheAccessorOptions.UseSharedCache ? ref s_evictionRunning : ref _evictionRunning;
+        }
+
+        /// <summary>
+        /// Attempts to start a single eviction pass. If another thread is already evicting,
+        /// returns immediately — the in-progress pass will trim the cache, and subsequent
+        /// writes will trigger again if it is not enough.
+        /// </summary>
+        private void TryEvict()
+        {
+            if (Interlocked.CompareExchange(ref GetEvictionRunningRef(), 1, 0) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                EvictDown();
+            }
+            finally
+            {
+                Volatile.Write(ref GetEvictionRunningRef(), 0);
+            }
+        }
+
+        /// <summary>
+        /// Approximate eviction (Redis-style sampled LRU + expired-first preference).
+        /// Each sample picks <see cref="EvictionSampleSize"/> entries pseudo-randomly across partitions:
+        /// any expired sample is evicted immediately; otherwise the oldest by <c>CachedAt</c> is evicted.
+        /// Loops until <see cref="_lowWatermark"/> is reached or a safety cap fires.
+        /// </summary>
+        private void EvictDown()
+        {
+            int target = _lowWatermark;
+            int countBefore = GetEntryCountRef();
+            if (countBefore <= target)
+            {
+                return;
+            }
+
+            // Snapshot only non-empty partitions so samples don't waste iterations on drained ones.
+            string[] partitionKeys = SnapshotNonEmptyPartitionKeys();
+            if (partitionKeys.Length == 0)
+            {
+                return;
+            }
+
+            // Eviction runs single-threaded under the CAS flag, so a local Random is safe.
+            var rng = new Random();
+
+            // Generous cap: empty partitions accumulate as we evict, so allow extra iterations
+            // for misses. Still bounded \u2014 if we don't converge the next save re-triggers.
+            int iterCap = Math.Max(64, (GetEntryCountRef() - target) * 16);
+            int refreshesLeft = 4;
+            int iters = 0;
+
+            while (GetEntryCountRef() > target && iters++ < iterCap)
+            {
+                if (!TrySampleVictim(partitionKeys, rng, out var partition, out var key, out var item))
+                {
+                    // Sample landed entirely on empty partitions. Refresh the snapshot.
+                    if (refreshesLeft-- <= 0)
+                    {
+                        break;
+                    }
+
+                    partitionKeys = SnapshotNonEmptyPartitionKeys();
+                    if (partitionKeys.Length == 0)
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                TryRemoveExact(partition, key, item);
+            }
+
+            int countAfter = GetEntryCountRef();
+            int evicted = countBefore - countAfter;
+            int capturedIters = iters;
+            _logger.Info(() =>
+                $"[Internal cache] Bounded app cache eviction trimmed {evicted} entries " +
+                $"(count: {countBefore} -> {countAfter}, target: {target}, max: {_maxEntries}, iterations: {capturedIters}).");
+        }
+
+        private string[] SnapshotNonEmptyPartitionKeys()
+        {
+            var list = new List<string>();
+            foreach (var kvp in AccessTokenCacheDictionary)
+            {
+                if (!kvp.Value.IsEmpty)
+                {
+                    list.Add(kvp.Key);
+                }
+            }
+            return list.ToArray();
+        }
+
+        /// <summary>
+        /// Picks <see cref="EvictionSampleSize"/> entries pseudo-randomly across partitions.
+        /// Returns the first expired entry encountered (expired-first preference), or the
+        /// oldest sampled entry by <c>CachedAt</c>. Returns <c>false</c> if no entry was sampled.
+        /// </summary>
+        private bool TrySampleVictim(
+            string[] partitionKeys,
+            Random rng,
+            out ConcurrentDictionary<string, MsalAccessTokenCacheItem> bestPartition,
+            out string bestKey,
+            out MsalAccessTokenCacheItem bestItem)
+        {
+            bestPartition = null;
+            bestKey = null;
+            bestItem = null;
+            DateTimeOffset oldestCachedAt = DateTimeOffset.MaxValue;
+
+            for (int i = 0; i < EvictionSampleSize; i++)
+            {
+                string pKey = partitionKeys[rng.Next(partitionKeys.Length)];
+                if (!AccessTokenCacheDictionary.TryGetValue(pKey, out var partition))
+                {
+                    continue;
+                }
+
+                if (!TryReservoirPick(partition, rng, out string itemKey, out MsalAccessTokenCacheItem item))
+                {
+                    continue;
+                }
+
+                // Expired-first: as soon as we see an expired sample, evict it.
+                if (item.IsExpiredWithBuffer())
+                {
+                    bestPartition = partition;
+                    bestKey = itemKey;
+                    bestItem = item;
+                    return true;
+                }
+
+                if (item.CachedAt < oldestCachedAt)
+                {
+                    oldestCachedAt = item.CachedAt;
+                    bestPartition = partition;
+                    bestKey = itemKey;
+                    bestItem = item;
+                }
+            }
+
+            return bestItem is not null;
+        }
+
+        /// <summary>
+        /// Picks one random entry from a partition using reservoir sampling, capped at
+        /// <see cref="ReservoirScanCap"/> to keep cost independent of partition size.
+        /// </summary>
+        private static bool TryReservoirPick(
+            ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition,
+            Random rng,
+            out string pickedKey,
+            out MsalAccessTokenCacheItem pickedItem)
+        {
+            pickedKey = null;
+            pickedItem = null;
+            int n = 0;
+
+            foreach (var kvp in partition)
+            {
+                n++;
+                // Reservoir: replace with probability 1/n.
+                if (rng.Next(n) == 0)
+                {
+                    pickedKey = kvp.Key;
+                    pickedItem = kvp.Value;
+                }
+
+                if (n >= ReservoirScanCap)
+                {
+                    break;
+                }
+            }
+
+            return n > 0;
+        }
+
+        /// <summary>
+        /// Removes an entry only if the current value still matches <paramref name="expected"/>
+        /// (reference equality, since <see cref="MsalAccessTokenCacheItem"/> has no Equals override).
+        /// Prevents evicting a fresher entry that was concurrently re-saved under the same key.
+        /// </summary>
+        private bool TryRemoveExact(
+            ConcurrentDictionary<string, MsalAccessTokenCacheItem> partition,
+            string key,
+            MsalAccessTokenCacheItem expected)
+        {
+            var asCollection = (ICollection<KeyValuePair<string, MsalAccessTokenCacheItem>>)partition;
+            if (asCollection.Remove(new KeyValuePair<string, MsalAccessTokenCacheItem>(key, expected)))
+            {
+                Interlocked.Decrement(ref GetEntryCountRef());
+                return true;
+            }
+
+            return false;
+        }
+
         public static void ClearStaticCacheForTest()
         {
             s_accessTokenCacheDictionary.Clear();
             s_appMetadataDictionary.Clear();
             Interlocked.Exchange(ref s_entryCount, 0);
+            Interlocked.Exchange(ref s_evictionRunning, 0);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
+++ b/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/InMemoryPartitionedAppTokenCacheAccessor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.Identity.Client.Cache;
@@ -38,6 +39,12 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         private int _entryCount = 0;
         private static int s_entryCount = 0;
 
+        // Shared-cache configuration invariant: all accessors that use shared mode must agree
+        // on bounded-cache settings so they do not disagree on thresholds for the same static store.
+        private static readonly object s_sharedCacheConfigLock = new object();
+        private static bool s_sharedCacheConfigInitialized = false;
+        private static int s_sharedMaxEntries = 0;
+
         // Bounded-mode coordination. Eviction is single-threaded via a CAS flag
         // (0 = idle, 1 = running). Other threads observing the threshold while
         // eviction is running skip the trigger and let the in-progress pass do the work.
@@ -65,6 +72,7 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         // are tiny and the cap is essentially never hit in normal use.
         private const int EvictionSampleSize = 8;
         private const int ReservoirScanCap = 64;
+        private const int MaxEvictionPassesPerTrigger = 3;
 
         public int EntryCount => GetEntryCountRef();
        
@@ -86,12 +94,13 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
                 AppMetadataDictionary = new ConcurrentDictionary<string, MsalAppMetadataCacheItem>();
             }
 
-            _boundedEnabled = _tokenCacheAccessorOptions.EnableAppCacheBounding
-                              && _tokenCacheAccessorOptions.AppCacheMaxEntries > 0;
+            _boundedEnabled = _tokenCacheAccessorOptions.AppCacheMaxEntries > 0;
             _maxEntries = _tokenCacheAccessorOptions.AppCacheMaxEntries;
             _lowWatermark = _boundedEnabled
-                ? Math.Max(1, (int)(_maxEntries * 0.95))
+                ? Math.Max(1, (int)(_maxEntries * 0.75))
                 : 0;
+
+            EnsureSharedCacheInvariant();
         }
 
         #region Add
@@ -303,11 +312,37 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             return ref _tokenCacheAccessorOptions.UseSharedCache ? ref s_evictionRunning : ref _evictionRunning;
         }
 
+        private void EnsureSharedCacheInvariant()
+        {
+            if (!_tokenCacheAccessorOptions.UseSharedCache)
+            {
+                return;
+            }
+
+            lock (s_sharedCacheConfigLock)
+            {
+                if (!s_sharedCacheConfigInitialized)
+                {
+                    s_sharedMaxEntries = _maxEntries;
+                    s_sharedCacheConfigInitialized = true;
+                    return;
+                }
+
+                if (s_sharedMaxEntries != _maxEntries)
+                {
+                    throw new InvalidOperationException(
+                        "All shared-cache accessors must use identical bounded-cache settings. " +
+                        $"Expected AppCacheMaxEntries={s_sharedMaxEntries}; " +
+                        $"received AppCacheMaxEntries={_maxEntries}.");
+                }
+            }
+        }
+
         /// <summary>
         /// Attempts to start a single eviction pass. If another thread is already evicting,
         /// returns immediately — the in-progress pass will trim the cache, and subsequent
-        /// writes will trigger again if it is not enough.
-        /// </summary>
+        /// writes will trigger again if it is not enough. null
+        /// </summary> 
         private void TryEvict()
         {
             if (Interlocked.CompareExchange(ref GetEvictionRunningRef(), 1, 0) != 0)
@@ -317,7 +352,36 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 
             try
             {
-                EvictDown();
+                var stopwatch = Stopwatch.StartNew();
+                int passes = 0;
+                int countBefore = GetEntryCountRef();
+
+                while (GetEntryCountRef() > _maxEntries && passes < MaxEvictionPassesPerTrigger)
+                {
+                    passes++;
+                    bool hitIterationCap = EvictDown();
+    
+                    if (hitIterationCap)
+                    {
+                        _logger.Warning(
+                            $"[Internal cache] Bounded app cache eviction pass {passes}/{MaxEvictionPassesPerTrigger} hit iteration cap. " +
+                            $"Current count={GetEntryCountRef()}, max={_maxEntries}, target={_lowWatermark}.");
+                    }
+                }
+
+                stopwatch.Stop();
+                int countAfter = GetEntryCountRef();
+
+                _logger.Info(() =>
+                    $"[Internal cache] Bounded app cache eviction trigger completed in {stopwatch.ElapsedMilliseconds} ms " +
+                    $"(passes: {passes}, count: {countBefore} -> {countAfter}, max: {_maxEntries}, target: {_lowWatermark}).");
+
+                if (countAfter > _maxEntries)
+                {
+                    _logger.Warning(
+                        $"[Internal cache] Bounded app cache remains above max after {passes} passes. " +
+                        $"Current count={countAfter}, max={_maxEntries}, target={_lowWatermark}. Subsequent writes will re-trigger eviction.");
+                }
             }
             finally
             {
@@ -331,20 +395,20 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
         /// any expired sample is evicted immediately; otherwise the oldest by <c>CachedAt</c> is evicted.
         /// Loops until <see cref="_lowWatermark"/> is reached or a safety cap fires.
         /// </summary>
-        private void EvictDown()
+        private bool EvictDown()
         {
             int target = _lowWatermark;
             int countBefore = GetEntryCountRef();
             if (countBefore <= target)
             {
-                return;
+                return false;
             }
 
             // Snapshot only non-empty partitions so samples don't waste iterations on drained ones.
             string[] partitionKeys = SnapshotNonEmptyPartitionKeys();
             if (partitionKeys.Length == 0)
             {
-                return;
+                return false;
             }
 
             // Eviction runs single-threaded under the CAS flag, so a local Random is safe.
@@ -352,7 +416,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
 
             // Generous cap: empty partitions accumulate as we evict, so allow extra iterations
             // for misses. Still bounded \u2014 if we don't converge the next save re-triggers.
-            int iterCap = Math.Max(64, (GetEntryCountRef() - target) * 16);
+            // Capped at 20,000 to prevent CPU spikes or latency regressions on extreme bulk evictions.
+            int iterCap = Math.Min(20000, Math.Max(64, (GetEntryCountRef() - target) * 16));
             int refreshesLeft = 4;
             int iters = 0;
 
@@ -384,6 +449,8 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             _logger.Info(() =>
                 $"[Internal cache] Bounded app cache eviction trimmed {evicted} entries " +
                 $"(count: {countBefore} -> {countAfter}, target: {target}, max: {_maxEntries}, iterations: {capturedIters}).");
+
+            return capturedIters >= iterCap && countAfter > target;
         }
 
         private string[] SnapshotNonEmptyPartitionKeys()
@@ -509,6 +576,11 @@ namespace Microsoft.Identity.Client.PlatformsCommon.Shared
             s_appMetadataDictionary.Clear();
             Interlocked.Exchange(ref s_entryCount, 0);
             Interlocked.Exchange(ref s_evictionRunning, 0);
+            lock (s_sharedCacheConfigLock)
+            {
+                s_sharedCacheConfigInitialized = false;
+                s_sharedMaxEntries = 0;
+            }
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.get -> int
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.get -> int
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.get -> int
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.get -> int
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.get -> int
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.CredentialEvalu
 Microsoft.Identity.Client.AuthScheme.CredentialEvaluationContext.MtlsCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.get -> int
+Microsoft.Identity.Client.CacheOptions.AppCacheMaxEntries.set -> void

--- a/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/AcquireTokenForClientCacheTests.cs
@@ -89,6 +89,48 @@ namespace Microsoft.Identity.Test.Performance
               .ConfigureAwait(false);
         }
 
+        [Benchmark(Description = "AcquireTokenForClient + Write (Below Threshold)")]
+        public async Task AcquireTokenForClient_WriteBelowThreshold_TestAsync()
+        {
+            // Acquire a brand new token using a unique scope to trigger a cache write.
+            // Under CacheOptions, EnableAppCacheBounding is true with default MaxEntries.
+            // Since we use a unique scope/tenant configuration, this simulates the overhead of constant writes
+            // when the cache limit is not reached.
+            string uniqueTenant = $"{_tenantPrefix}_new_" + System.Guid.NewGuid().ToString("N");
+            string uniqueScope = $"{_scopePrefix}_new";
+
+            await _cca.AcquireTokenForClient(new[] { uniqueScope })
+              .WithTenantId(uniqueTenant)
+              .ExecuteAsync()
+              .ConfigureAwait(false);
+        }
+
+        [Benchmark(Description = "AcquireTokenForClient + Write (Over Threshold)")]
+        public async Task AcquireTokenForClient_WriteOverThreshold_TestAsync()
+        {
+            // Set up a custom CCA with a very low bounds limit to ensure every single concurrent write pushes
+            // the count over the limit and triggers eviction. Measuring un-amortized eviction writes.
+            string uniqueTenant = $"{_tenantPrefix}_new_" + System.Guid.NewGuid().ToString("N");
+            string uniqueScope = $"{_scopePrefix}_new";
+
+            // Dispatches to a small bounded client to force eviction to run on every loop iteration
+            var boundedCca = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithRedirectUri(TestConstants.RedirectUri)
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithLegacyCacheCompatibility(false)
+                .WithCacheOptions(new CacheOptions
+                {
+                    AppCacheMaxEntries = 5 // tiny cap
+                })
+                .BuildConcrete();
+
+            await boundedCca.AcquireTokenForClient(new[] { uniqueScope })
+              .WithTenantId(uniqueTenant)
+              .ExecuteAsync()
+              .ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Create a fake token and save into the internal cache.
         /// If cache serialization is enabled, call an event handler to serialize current cache state into external cache,

--- a/tests/Microsoft.Identity.Test.Performance/BoundedAppCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Performance/BoundedAppCacheTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Cache.Items;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Internal.Logger;
+using Microsoft.Identity.Client.PlatformsCommon.Shared;
+using Microsoft.Identity.Test.Common.Core.Mocks;
+using Microsoft.Identity.Test.Unit;
+
+namespace Microsoft.Identity.Test.Performance
+{
+    [MemoryDiagnoser]
+    [MinColumn, MaxColumn]
+    public class BoundedAppCacheTests
+    {
+        private InMemoryPartitionedAppTokenCacheAccessor _unboundedAccessor;
+        private InMemoryPartitionedAppTokenCacheAccessor _boundedAccessor;
+        private InMemoryPartitionedAppTokenCacheAccessor _boundedFullAccessor;
+        private InMemoryPartitionedAppTokenCacheAccessor _stressAccessor;
+
+        private MsalAccessTokenCacheItem _insertItem;
+
+        // Simple fixed-length token string used instead of a real JWT to keep the benchmark
+        // focused on cache mechanics (insert, evict, count) rather than string allocation.
+        // Length matches the ~2 KB average real-world access token size.
+        private string _syntheticToken;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var logger = new NullLogger();
+
+            // Fixed 2 KB string — same byte footprint as a real access token but zero
+            // allocation overhead from JWT parsing or base64 encoding.
+            _syntheticToken = new string('a', 2048);
+
+            // 1. Unbounded (baseline) — 500k entries, no eviction policy.
+            var unboundedOpts = new CacheOptions { AppCacheMaxEntries = 0 };
+            _unboundedAccessor = new InMemoryPartitionedAppTokenCacheAccessor(logger, unboundedOpts);
+            PopulateAccessor(_unboundedAccessor, 500000);
+
+            // 2. Bounded, not full — 500k entries with a 1M ceiling so eviction never fires.
+            var boundedOpts = new CacheOptions { AppCacheMaxEntries = 1000000 };
+            _boundedAccessor = new InMemoryPartitionedAppTokenCacheAccessor(logger, boundedOpts);
+            PopulateAccessor(_boundedAccessor, 500000);
+
+            // 3. Bounded, full — 500k entries at exactly the 500k ceiling.
+            //    Every save past this point will trigger EvictDown() to trim back to 475k (95%).
+            var boundedFullOpts = new CacheOptions { AppCacheMaxEntries = 500000 };
+            _boundedFullAccessor = new InMemoryPartitionedAppTokenCacheAccessor(logger, boundedFullOpts);
+            PopulateAccessor(_boundedFullAccessor, 500000);
+
+            // 4. Stress accessor — tiny max (100) pre-filled to capacity so every single save
+            //    triggers eviction. Measures the worst-case per-save cost of the eviction path.
+            var stressOpts = new CacheOptions { AppCacheMaxEntries = 100 };
+            _stressAccessor = new InMemoryPartitionedAppTokenCacheAccessor(logger, stressOpts);
+            PopulateAccessor(_stressAccessor, 100);
+
+            _insertItem = TokenCacheHelper.CreateAccessTokenItem(
+                scopes: "scope_new",
+                tenant: "tenant_new",
+                accessToken: _syntheticToken);
+        }
+
+        private void PopulateAccessor(InMemoryPartitionedAppTokenCacheAccessor accessor, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i,
+                    tenant: "tenant" + i,
+                    accessToken: _syntheticToken));
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void SaveToken_Unbounded()
+        {
+            // We use a unique key each time to force an Add, not an Update
+            _insertItem.ClientId = Guid.NewGuid().ToString(); 
+            _unboundedAccessor.SaveAccessToken(_insertItem);
+        }
+
+        [Benchmark]
+        public void SaveToken_Bounded_BelowThreshold()
+        {
+            _insertItem.ClientId = Guid.NewGuid().ToString(); 
+            _boundedAccessor.SaveAccessToken(_insertItem);
+        }
+
+        [Benchmark]
+        public void SaveToken_Bounded_OverThreshold_TriggersEviction()
+        {
+            // The cache is at capacity (500k) and bounded at 500k.
+            // Each save that pushes past the limit triggers EvictDown() which trims to 475k (95%).
+            // Subsequent 25k saves won't trigger eviction; then it fires again.
+            // This gives the amortized real-world cost of the eviction path.
+            _insertItem.ClientId = Guid.NewGuid().ToString();
+            _boundedFullAccessor.SaveAccessToken(_insertItem);
+        }
+
+        [Benchmark]
+        public void SaveToken_Bounded_StressEviction()
+        {
+            // The stress accessor is permanently at its 100-entry limit.
+            // Every single save here crosses the threshold and triggers EvictDown(),
+            // measuring the worst-case per-call overhead of eviction with no amortisation.
+            _insertItem.ClientId = Guid.NewGuid().ToString();
+            _stressAccessor.SaveAccessToken(_insertItem);
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Performance/Program.cs
+++ b/tests/Microsoft.Identity.Test.Performance/Program.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Identity.Test.Performance
             try
             {
                 var results = BenchmarkSwitcher.FromTypes(new[] {
+                    typeof(BoundedAppCacheTests),
                     typeof(AcquireTokenForClientCacheTests),
                     typeof(AcquireTokenForOboCacheTests),
                     typeof(TokenCacheTests),

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InMemoryPartitionedTokenCacheAccessorTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InMemoryPartitionedTokenCacheAccessorTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Cache.Items;
@@ -586,6 +588,330 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.IsEmpty(accessor.GetAllIdTokens());
             Assert.IsEmpty(accessor.GetAllAccounts());
         }
+        #endregion
+
+        #region Bounded app cache tests
+
+        [TestMethod]
+        public void BoundedCache_DefaultsToEnabled_Test()
+        {
+            // Locks in the default-on behavior: new CacheOptions() must yield bounding ON
+            // so callers who never set EnableAppCacheBounding get the bounded accessor.
+            // Use a tiny override max so eviction is observable in the test.
+            var opts = new CacheOptions { AppCacheMaxEntries = 10 };
+            Assert.IsTrue(opts.EnableAppCacheBounding, "EnableAppCacheBounding must default to true.");
+
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            for (int i = 0; i < 30; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            Assert.IsLessThanOrEqualTo(
+                10,
+                accessor.EntryCount,
+                $"EntryCount {accessor.EntryCount} exceeded max 10; default-on bounding did not engage.");
+        }
+
+        [TestMethod]
+        public void BoundedCache_Disabled_BehavesAsLegacy_Test()
+        {
+            // Flag off: no bounding even past what would be a tiny threshold.
+            var opts = new CacheOptions { EnableAppCacheBounding = false, AppCacheMaxEntries = 5 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            for (int i = 0; i < 50; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            Assert.AreEqual(50, accessor.EntryCount);
+            Assert.HasCount(50, accessor.GetAllAccessTokens());
+        }
+
+        [TestMethod]
+        public void BoundedCache_NoEvictionUnderThreshold_Test()
+        {
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 100 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            for (int i = 0; i < 100; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            // We are exactly at the threshold (count == max), not over, so eviction must not have run.
+            Assert.AreEqual(100, accessor.EntryCount);
+        }
+
+        [TestMethod]
+        public void BoundedCache_UpdateExistingDoesNotIncrement_Test()
+        {
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 5 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            var item = TokenCacheHelper.CreateAccessTokenItem();
+
+            // Repeated saves of the same logical entry must not grow the counter.
+            accessor.SaveAccessToken(item);
+            accessor.SaveAccessToken(item);
+            accessor.SaveAccessToken(item);
+
+            Assert.AreEqual(1, accessor.EntryCount);
+        }
+
+        [TestMethod]
+        public void BoundedCache_EvictsWhenOverThreshold_Test()
+        {
+            // Small max so we cross the threshold quickly and deterministically.
+            // lowWatermark = max(1, (int)(10 * 0.95)) = 9
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 10 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            // Insert 30 distinct entries. Each save runs synchronously; when count > 10
+            // eviction trims down to 9 on the triggering thread before the call returns.
+            for (int i = 0; i < 30; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            // After the final save, count must be at or below the threshold.
+            Assert.IsLessThanOrEqualTo(
+                10,
+                accessor.EntryCount,
+                $"EntryCount {accessor.EntryCount} exceeded max 10 after bursty inserts.");
+        }
+
+        [TestMethod]
+        public async Task BoundedCache_TinyCache_EvictsOlderEntries_TestAsync()
+        {
+            // Smallest practical cache: max = 3 so eviction kicks in almost immediately
+            // and we can observe specific entries being deleted.
+            // lowWatermark = max(1, (int)(3 * 0.95)) = 2.
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 3 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            // Insert 8 distinct entries with a small delay so CachedAt is strictly ordered
+            // and the sampled-LRU has a clear "oldest" to pick. 15 ms matches the typical
+            // timer-wheel granularity on Windows / macOS so CachedAt values reliably advance
+            // even on a busy CI host.
+            var items = new MsalAccessTokenCacheItem[8];
+            for (int i = 0; i < items.Length; i++)
+            {
+                items[i] = TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i);
+                accessor.SaveAccessToken(items[i]);
+                await Task.Delay(15).ConfigureAwait(false);
+            }
+
+            // The bound must hold after the bursty inserts.
+            Assert.IsLessThanOrEqualTo(
+                3,
+                accessor.EntryCount,
+                $"EntryCount {accessor.EntryCount} exceeded max 3 after inserting 8 entries.");
+
+            // The most recently inserted entry was just saved (no eviction runs after it
+            // unless we cross the threshold again), so it must still be present.
+            var remaining = accessor.GetAllAccessTokens();
+            Assert.IsTrue(
+                remaining.Any(t => ReferenceEquals(t, items[items.Length - 1])),
+                "The most recently saved entry must still be present after eviction.");
+
+            // The very first (oldest) entry must have been evicted: with max=3 and 8 inserts,
+            // at least 5 entries are gone, and the sampled-LRU prefers oldest by CachedAt.
+            Assert.IsFalse(
+                remaining.Any(t => ReferenceEquals(t, items[0])),
+                "The oldest entry must have been evicted by the sampled-LRU policy.");
+
+            // The counter must match the actual dictionary contents.
+            int expectedCount = accessor.AccessTokenCacheDictionary.Sum(p => p.Value.Count);
+            Assert.AreEqual(expectedCount, accessor.EntryCount);
+        }
+
+        [TestMethod]
+        public void BoundedCache_EvictsExpiredPreferentially_Test()
+        {
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 10 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            // Seed 8 expired entries (under threshold, no eviction yet).
+            for (int i = 0; i < 8; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "exp-scope" + i,
+                    tenant: "exp-tenant" + i,
+                    isExpired: true));
+            }
+
+            Assert.AreEqual(8, accessor.EntryCount);
+
+            // Now add 10 fresh ones — crosses the threshold, triggers eviction.
+            // Sampled algorithm will preferentially evict the expired ones because any
+            // expired sample short-circuits as a victim.
+            for (int i = 0; i < 10; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "fresh-scope" + i,
+                    tenant: "fresh-tenant" + i));
+            }
+
+            // Final state must respect the bound.
+            Assert.IsLessThanOrEqualTo(10, accessor.EntryCount);
+
+            // Verify the expired-first preference: at least half of remaining entries should be fresh.
+            // (Exact count is probabilistic due to sampling; this is a strong sanity check.)
+            var all = accessor.GetAllAccessTokens();
+            int freshRemaining = all.Count(t => !t.IsExpiredWithBuffer());
+            Assert.IsGreaterThanOrEqualTo(
+                all.Count / 2,
+                freshRemaining,
+                $"Expected expired entries to be preferentially evicted; fresh={freshRemaining}, total={all.Count}");
+        }
+
+        [TestMethod]
+        public void BoundedCache_DeleteStillDecrementsCount_Test()
+        {
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 100 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            var item = TokenCacheHelper.CreateAccessTokenItem();
+            accessor.SaveAccessToken(item);
+            Assert.AreEqual(1, accessor.EntryCount);
+
+            accessor.DeleteAccessToken(item);
+            Assert.AreEqual(0, accessor.EntryCount);
+        }
+
+        [TestMethod]
+        public void BoundedCache_ClearResetsCount_Test()
+        {
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 100 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            for (int i = 0; i < 20; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+            Assert.AreEqual(20, accessor.EntryCount);
+
+            accessor.Clear();
+            Assert.AreEqual(0, accessor.EntryCount);
+            Assert.IsEmpty(accessor.GetAllAccessTokens());
+        }
+
+        [TestMethod]
+        public void BoundedCache_ConcurrentSavesConverge_Test()
+        {
+            // Each save runs eviction synchronously when it observes count > max, so the
+            // final state after all parallel saves return must respect the bound.
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 50 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            Parallel.For(0, 500, i =>
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            });
+
+            // Force one extra serial save so the last thread is guaranteed to observe
+            // the final post-burst state and run eviction if needed.
+            accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                scopes: "settle-scope", tenant: "settle-tenant"));
+
+            Assert.IsLessThanOrEqualTo(
+                opts.AppCacheMaxEntries,
+                accessor.EntryCount,
+                $"EntryCount {accessor.EntryCount} exceeded max {opts.AppCacheMaxEntries} after concurrent inserts.");
+
+            // Counter and dictionary must remain in agreement.
+            int expectedCount = accessor.AccessTokenCacheDictionary.Sum(p => p.Value.Count);
+            Assert.AreEqual(
+                expectedCount,
+                accessor.EntryCount,
+                "EntryCount drifted from actual dictionary contents under contention.");
+        }
+
+        [TestMethod]
+        public void BoundedCache_MaxEntriesZero_DisablesBounding_Test()
+        {
+            // Edge case: max=0 with flag on must behave as disabled (constructor check
+            // requires AppCacheMaxEntries > 0). Inserting past 0 must not crash, must not
+            // evict, and the count must keep growing.
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 0 };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            for (int i = 0; i < 25; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            Assert.AreEqual(25, accessor.EntryCount, "Bounding must be disabled when AppCacheMaxEntries == 0.");
+        }
+
+        [TestMethod]
+        public void BoundedCache_MaxEntriesIntMaxValue_DoesNotOverflow_Test()
+        {
+            // Edge case: int.MaxValue is the largest legal setting. lowWatermark is
+            // computed as (int)(int.MaxValue * 0.95) which fits in int, and iterCap is
+            // bounded by (count - target) * 16 which can never overflow because
+            // (count - target) <= 0.05 * int.MaxValue. This test just exercises the
+            // constructor and a few inserts to make sure no exception is thrown.
+            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = int.MaxValue };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            for (int i = 0; i < 10; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            Assert.AreEqual(10, accessor.EntryCount);
+        }
+
+        [TestMethod]
+        public void BoundedCache_SharedCache_EvictsWhenOverThreshold_Test()
+        {            // Shared-cache mode uses the static dictionary and the static eviction flag.
+            // This test locks in that bounding works through that path and that
+            // ClearStaticCacheForTest properly resets both s_entryCount and s_evictionRunning
+            // between tests.
+            InMemoryPartitionedAppTokenCacheAccessor.ClearStaticCacheForTest();
+            try
+            {
+                var opts = new CacheOptions
+                {
+                    UseSharedCache = true,
+                    EnableAppCacheBounding = true,
+                    AppCacheMaxEntries = 10
+                };
+                var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+                for (int i = 0; i < 30; i++)
+                {
+                    accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                        scopes: "scope" + i, tenant: "tenant" + i));
+                }
+
+                Assert.IsLessThanOrEqualTo(
+                    10,
+                    accessor.EntryCount,
+                    $"Shared-cache EntryCount {accessor.EntryCount} exceeded max 10.");
+
+                int expectedCount = accessor.AccessTokenCacheDictionary.Sum(p => p.Value.Count);
+                Assert.AreEqual(expectedCount, accessor.EntryCount);
+            }
+            finally
+            {
+                InMemoryPartitionedAppTokenCacheAccessor.ClearStaticCacheForTest();
+            }
+        }
+
         #endregion
 
         private ITokenCacheAccessor CreateTokenCacheAccessor(bool isAppCache)

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/InMemoryPartitionedTokenCacheAccessorTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/InMemoryPartitionedTokenCacheAccessorTests.cs
@@ -596,10 +596,9 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void BoundedCache_DefaultsToEnabled_Test()
         {
             // Locks in the default-on behavior: new CacheOptions() must yield bounding ON
-            // so callers who never set EnableAppCacheBounding get the bounded accessor.
+            // so callers who never set AppCacheMaxEntries get the bounded accessor.
             // Use a tiny override max so eviction is observable in the test.
             var opts = new CacheOptions { AppCacheMaxEntries = 10 };
-            Assert.IsTrue(opts.EnableAppCacheBounding, "EnableAppCacheBounding must default to true.");
 
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
@@ -618,8 +617,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public void BoundedCache_Disabled_BehavesAsLegacy_Test()
         {
-            // Flag off: no bounding even past what would be a tiny threshold.
-            var opts = new CacheOptions { EnableAppCacheBounding = false, AppCacheMaxEntries = 5 };
+            // MaxEntries <= 0 triggers legacy off/disabled behavior: no bounding.
+            var opts = new CacheOptions { AppCacheMaxEntries = 0 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             for (int i = 0; i < 50; i++)
@@ -635,7 +634,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public void BoundedCache_NoEvictionUnderThreshold_Test()
         {
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 100 };
+            var opts = new CacheOptions { AppCacheMaxEntries = 100 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             for (int i = 0; i < 100; i++)
@@ -651,7 +650,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public void BoundedCache_UpdateExistingDoesNotIncrement_Test()
         {
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 5 };
+            var opts = new CacheOptions { AppCacheMaxEntries = 5 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             var item = TokenCacheHelper.CreateAccessTokenItem();
@@ -668,8 +667,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void BoundedCache_EvictsWhenOverThreshold_Test()
         {
             // Small max so we cross the threshold quickly and deterministically.
-            // lowWatermark = max(1, (int)(10 * 0.95)) = 9
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 10 };
+            // lowWatermark = max(1, (int)(10 * 0.75)) = 7
+            var opts = new CacheOptions { AppCacheMaxEntries = 10 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             // Insert 30 distinct entries. Each save runs synchronously; when count > 10
@@ -692,8 +691,8 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             // Smallest practical cache: max = 3 so eviction kicks in almost immediately
             // and we can observe specific entries being deleted.
-            // lowWatermark = max(1, (int)(3 * 0.95)) = 2.
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 3 };
+            // lowWatermark = max(1, (int)(3 * 0.75)) = 2.
+            var opts = new CacheOptions { AppCacheMaxEntries = 3 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             // Insert 8 distinct entries with a small delay so CachedAt is strictly ordered
@@ -736,7 +735,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public void BoundedCache_EvictsExpiredPreferentially_Test()
         {
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 10 };
+            var opts = new CacheOptions { AppCacheMaxEntries = 10 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             // Seed 8 expired entries (under threshold, no eviction yet).
@@ -776,7 +775,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public void BoundedCache_DeleteStillDecrementsCount_Test()
         {
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 100 };
+            var opts = new CacheOptions { AppCacheMaxEntries = 100 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             var item = TokenCacheHelper.CreateAccessTokenItem();
@@ -790,7 +789,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         [TestMethod]
         public void BoundedCache_ClearResetsCount_Test()
         {
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 100 };
+            var opts = new CacheOptions { AppCacheMaxEntries = 100 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             for (int i = 0; i < 20; i++)
@@ -810,7 +809,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         {
             // Each save runs eviction synchronously when it observes count > max, so the
             // final state after all parallel saves return must respect the bound.
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 50 };
+            var opts = new CacheOptions { AppCacheMaxEntries = 50 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             Parallel.For(0, 500, i =>
@@ -843,7 +842,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // Edge case: max=0 with flag on must behave as disabled (constructor check
             // requires AppCacheMaxEntries > 0). Inserting past 0 must not crash, must not
             // evict, and the count must keep growing.
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = 0 };
+            var opts = new CacheOptions { AppCacheMaxEntries = 0 };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             for (int i = 0; i < 25; i++)
@@ -856,6 +855,125 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         }
 
         [TestMethod]
+        public void BoundedCache_500k_SerialInserts_NeverExceedMax_Test()
+        {
+            // Stress: 500k serial inserts against a cache capped at 500k.
+            // Verifies eviction keeps the count at or below the ceiling throughout.
+            const int max = 500_000;
+            var opts = new CacheOptions { AppCacheMaxEntries = max };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            // Arrange
+            for (int i = 0; i < max; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            // Act: insert 10k more on a full cache — should keep triggering eviction.
+            for (int i = max; i < max + 10_000; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            // Assert: bound must hold and counter must match actual dictionary contents.
+            int actualCount = accessor.AccessTokenCacheDictionary.Sum(p => p.Value.Count);
+            Assert.IsLessThanOrEqualTo(
+                max,
+                accessor.EntryCount,
+                $"EntryCount {accessor.EntryCount} exceeded max {max} after 510k serial inserts.");
+            Assert.AreEqual(accessor.EntryCount, actualCount, "EntryCount drifted from actual dictionary count.");
+        }
+
+        [TestMethod]
+        public void BoundedCache_50k_ConcurrentInserts_CountNeverDrifts_Test()
+        {
+            // Stress: 50k parallel inserts against a 50k-bounded cache.
+            // Verifies that the lock-free eviction CAS and Interlocked counter stay coherent
+            // under heavy thread contention.
+            const int max = 50_000;
+            var opts = new CacheOptions { AppCacheMaxEntries = max };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            // Arrange + Act
+            Parallel.For(0, max + 5_000, i =>
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            });
+
+            // Settle: one final serial save ensures any in-flight eviction has completed.
+            accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                scopes: "settle-scope", tenant: "settle-tenant"));
+
+            // Assert: bound must hold.
+            Assert.IsLessThanOrEqualTo(
+                max,
+                accessor.EntryCount,
+                $"EntryCount {accessor.EntryCount} exceeded max {max} after concurrent 55k inserts.");
+
+            // Assert: counter must match dictionary reality.
+            int actualCount = accessor.AccessTokenCacheDictionary.Sum(p => p.Value.Count);
+            Assert.AreEqual(accessor.EntryCount, actualCount,
+                "EntryCount drifted from actual dictionary contents under concurrent load.");
+        }
+
+        [TestMethod]
+        public void BoundedCache_ContinuousEviction_ReadsAlwaysSucceed_Test()
+        {
+            // Stress: verify that GetAllAccessTokens never throws or returns null
+            // while the eviction path is running concurrently with saves.
+            const int max = 1_000;
+            var opts = new CacheOptions { AppCacheMaxEntries = max };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            // Pre-fill to capacity.
+            for (int i = 0; i < max; i++)
+            {
+                accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i));
+            }
+
+            var writeErrors = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+            var readErrors  = new System.Collections.Concurrent.ConcurrentBag<System.Exception>();
+
+            // Writer thread: hammer inserts above the limit to trigger evictions continuously.
+            var writer = System.Threading.Tasks.Task.Run(() =>
+            {
+                for (int i = max; i < max + 5_000; i++)
+                {
+                    try
+                    {
+                        accessor.SaveAccessToken(TokenCacheHelper.CreateAccessTokenItem(
+                            scopes: "scope" + i, tenant: "tenant" + i));
+                    }
+                    catch (System.Exception ex) { writeErrors.Add(ex); }
+                }
+            });
+
+            // Reader thread: reads must never crash, even if eviction is concurrently removing items.
+            var reader = System.Threading.Tasks.Task.Run(() =>
+            {
+                for (int r = 0; r < 500; r++)
+                {
+                    try
+                    {
+                        var tokens = accessor.GetAllAccessTokens();
+                        Assert.IsNotNull(tokens, "GetAllAccessTokens must never return null.");
+                    }
+                    catch (System.Exception ex) { readErrors.Add(ex); }
+                }
+            });
+
+            System.Threading.Tasks.Task.WaitAll(writer, reader);
+
+            Assert.IsEmpty(writeErrors, $"Write errors during eviction stress: {string.Join("; ", writeErrors)}");
+            Assert.IsEmpty(readErrors,  $"Read errors during eviction stress: {string.Join("; ", readErrors)}");
+            Assert.IsLessThanOrEqualTo(max, accessor.EntryCount, "Bound violated after concurrent read/write stress.");
+        }
+
+        [TestMethod]
         public void BoundedCache_MaxEntriesIntMaxValue_DoesNotOverflow_Test()
         {
             // Edge case: int.MaxValue is the largest legal setting. lowWatermark is
@@ -863,7 +981,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             // bounded by (count - target) * 16 which can never overflow because
             // (count - target) <= 0.05 * int.MaxValue. This test just exercises the
             // constructor and a few inserts to make sure no exception is thrown.
-            var opts = new CacheOptions { EnableAppCacheBounding = true, AppCacheMaxEntries = int.MaxValue };
+            var opts = new CacheOptions { AppCacheMaxEntries = int.MaxValue };
             var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
 
             for (int i = 0; i < 10; i++)
@@ -879,7 +997,7 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
         public void BoundedCache_SharedCache_EvictsWhenOverThreshold_Test()
         {            // Shared-cache mode uses the static dictionary and the static eviction flag.
             // This test locks in that bounding works through that path and that
-            // ClearStaticCacheForTest properly resets both s_entryCount and s_evictionRunning
+            // ClearStaticCacheForTest properly resets both runtime counters and shared config invariant state
             // between tests.
             InMemoryPartitionedAppTokenCacheAccessor.ClearStaticCacheForTest();
             try
@@ -887,7 +1005,6 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
                 var opts = new CacheOptions
                 {
                     UseSharedCache = true,
-                    EnableAppCacheBounding = true,
                     AppCacheMaxEntries = 10
                 };
                 var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
@@ -910,6 +1027,105 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             {
                 InMemoryPartitionedAppTokenCacheAccessor.ClearStaticCacheForTest();
             }
+        }
+
+        [TestMethod]
+        public void BoundedCache_SharedCache_MismatchedSettings_Throws_Test()
+        {
+            InMemoryPartitionedAppTokenCacheAccessor.ClearStaticCacheForTest();
+            try
+            {
+                var baseline = new CacheOptions
+                {
+                    UseSharedCache = true,
+                    AppCacheMaxEntries = 10
+                };
+
+                _ = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), baseline);
+
+                var mismatch = new CacheOptions
+                {
+                    UseSharedCache = true,
+                    AppCacheMaxEntries = 0
+                };
+
+                Assert.Throws<System.InvalidOperationException>(
+                    () => new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), mismatch));
+            }
+            finally
+            {
+                InMemoryPartitionedAppTokenCacheAccessor.ClearStaticCacheForTest();
+            }
+        }
+
+        [TestMethod]
+        public void BoundedCache_EvictsOlderAndPreservesNewest_Test()
+        {
+            // Set max entries to 50,000 as requested.
+            const int max = 50_000;
+            var opts = new CacheOptions { AppCacheMaxEntries = max };
+            var accessor = new InMemoryPartitionedAppTokenCacheAccessor(new NullLogger(), opts);
+
+            // Populate the cache sequentially with 50,000 entries.
+            // We simulate a strict timeline by spreading CachedAt timestamps or letting natural order flow.
+            // To make sure CachedAt timestamps strictly advance, we can set them manually 
+            // or let them reflect a tight sequence (MsalAccessTokenCacheItem has a CachedAt property).
+            var items = new MsalAccessTokenCacheItem[max + 1];
+            for (int i = 0; i <= max; i++)
+            {
+                var item = TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i, tenant: "tenant" + i);
+                // Assign an advancing creation timestamp so that LRU has clear order.
+                item.CachedAt = System.DateTimeOffset.UtcNow.AddSeconds(i - max);
+                items[i] = item;
+            }
+
+            // Save the first 50,000. No eviction should be triggered.
+            for (int i = 0; i < max; i++)
+            {
+                accessor.SaveAccessToken(items[i]);
+            }
+            Assert.AreEqual(max, accessor.EntryCount, "No eviction should have run yet.");
+
+            // Save the 50,001st entry. This must trigger eviction down to the 75% low watermark (37,500 entries).
+            accessor.SaveAccessToken(items[max]);
+
+            // Bound must hold (<= 50,000 entries, target is ~37,500 entries).
+            Assert.IsLessThanOrEqualTo(max, accessor.EntryCount, "Cache failed to bound under the maximum cap.");
+
+            var remaining = accessor.GetAllAccessTokens();
+            var remainingScopes = new System.Collections.Generic.HashSet<string>(remaining.Select(t => t.ScopeString));
+
+            // Verify that the extremely fresh/newly-inserted ones are preserved.
+            // Let's check the last 1,000 items (indices 49,001 to 50,000). None of them should be evicted.
+            int newestPreservedCount = 0;
+            for (int i = max - 1000; i <= max; i++)
+            {
+                if (remainingScopes.Contains("scope" + i))
+                {
+                    newestPreservedCount++;
+                }
+            }
+
+            // Output the verification results for the user.
+            System.Console.WriteLine($"--- Eviction Summary for 50,000 cache capacity ---");
+            System.Console.WriteLine($"Total remaining entries in cache: {remaining.Count}");
+            System.Console.WriteLine($"Out of the most recent 1,000 entries (indices {max - 1000} to {max}), {newestPreservedCount} are still preserved in the cache.");
+
+            // Assert that 100% of the last 1,000 entries are preserved (since they are the newest by CachedAt).
+            Assert.AreEqual(1001, newestPreservedCount, "Not all of the latest 1,000 entries were preserved! Bounded eviction must respect LRU.");
+
+            // Let's also assert that evictions targeted the older half of the cache.
+            int olderEvectedCount = 0;
+            for (int i = 0; i < 5000; i++)
+            {
+                if (!remainingScopes.Contains("scope" + i))
+                {
+                    olderEvectedCount++;
+                }
+            }
+            System.Console.WriteLine($"Out of the oldest 5,000 entries, {olderEvectedCount} were successfully evicted to free up space.");
+            Assert.IsGreaterThan(0, olderEvectedCount, "No older entries were evicted. Expired-first / LRU policy failed to target older entries.");
         }
 
         #endregion

--- a/tests/Microsoft.Identity.Test.Unit/ParallelRequestsTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ParallelRequestsTests.cs
@@ -124,6 +124,74 @@ namespace Microsoft.Identity.Test.Unit.RequestsTests
         }
 
         [TestMethod]
+        public async Task BoundedCache_ParallelAcquisition_NoDeadlock_Test()
+        {
+            // Scenario: Cache limit is 10. Start with 9 tokens already pre-populated.
+            // Run 10 parallel AcquireTokenForClient requests.
+            // This force-triggers concurrent writes and synchronous EvictDown() trimming
+            // to make sure no deadlocks or exceptions occur under heavy thread concurrency.
+            const int Limit = 10;
+            const int ParallelTasks = 10;
+
+            ParallelRequestMockHandler httpManager = new();
+
+            // Set up a CCA with a custom bounded cache of size 10
+            var cca = ConfidentialClientApplicationBuilder
+                .Create(TestConstants.ClientId)
+                .WithAuthority("https://login.microsoftonline.com/common")
+                .WithClientSecret(TestConstants.ClientSecret)
+                .WithHttpManager(httpManager)
+                .WithCacheOptions(new CacheOptions
+                {
+                    AppCacheMaxEntries = Limit
+                })
+                .BuildConcrete();
+
+            // 1. Pre-populate the internal app cache with 9 entries (Limit - 1)
+            var internalAccessor = cca.AppTokenCacheInternal.Accessor;
+            for (int i = 0; i < Limit - 1; i++)
+            {
+                var item = TokenCacheHelper.CreateAccessTokenItem(
+                    scopes: "scope" + i,
+                    tenant: $"tenant_{i}");
+                internalAccessor.SaveAccessToken(item);
+            }
+
+            Assert.AreEqual(Limit - 1, internalAccessor.EntryCount, "Cache should have exactly Limit - 1 entries initially.");
+
+            // 2. Fire 10 parallel requests. Each request uses a unique tenant which translates
+            //    to a unique cache partition/entry, forcing concurrent writes and eviction passes.
+            var tasks = new List<Task<AuthenticationResult>>();
+            for (int i = 0; i < ParallelTasks; i++)
+            {
+                int tempI = i;
+                tasks.Add(Task.Run(async () =>
+                {
+                    // Each request targets a distinct tenant ID, creating a new cache item.
+                    string tid = $"tid_{tempI}";
+                    return await cca.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithTenantId(tid)
+                        .ExecuteAsync()
+                        .ConfigureAwait(false);
+                }));
+            }
+
+            // Wait for completion. If there is a deadlock, this will hang or timeout.
+            AuthenticationResult[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // 3. Assertions
+            Assert.HasCount(ParallelTasks, results);
+
+            // Verify that the entry count did not exceed the limit, AND the dictionary 
+            // has successfully evicted down.
+            Assert.IsLessThanOrEqualTo(Limit, internalAccessor.EntryCount, $"Entry count should never exceed Limit ({Limit}).");
+            
+            // Check that we can read back from the cache safely
+            var currentTokens = internalAccessor.GetAllAccessTokens();
+            Assert.IsNotNull(currentTokens, "Cache should be readable post-stress.");
+        }
+
+        [TestMethod]
         public async Task AcquireTokenForClient_PerTenantCaching_Test()
         {
             const int NumberOfRequests = 5000;


### PR DESCRIPTION
Feature :  #2645

This pull request introduces a bounded mode for the in-memory app token cache in MSAL.NET, enabled by default, to prevent unbounded memory growth and potential out-of-memory (OOM) issues. The new cache eviction logic uses a sampled-LRU (Least Recently Used) approach with an expired-first preference, and the default cap is set to 500,000 entries. The PR includes the implementation, documentation, configuration, and public API exposure for this feature.

**Key changes:**

**Bounded Cache Implementation & Eviction Logic**
- Added a bounded mode to `InMemoryPartitionedAppTokenCacheAccessor` with a default maximum of 500,000 entries, using approximate sampled-LRU eviction (expired-first), and background batched cleanup to a 75% watermark. Eviction is coordinated across threads to ensure only one eviction pass runs at a time. [[1]](diffhunk://#diff-6059ce7300be03298038a2e5908e0e6bed0d677ac6df25cd1b2209fd6900de03R42-R76) [[2]](diffhunk://#diff-6059ce7300be03298038a2e5908e0e6bed0d677ac6df25cd1b2209fd6900de03R96-R103) [[3]](diffhunk://#diff-6059ce7300be03298038a2e5908e0e6bed0d677ac6df25cd1b2209fd6900de03R119-R125) [[4]](diffhunk://#diff-6059ce7300be03298038a2e5908e0e6bed0d677ac6df25cd1b2209fd6900de03R310-R583)
- Introduced logic to ensure all shared-cache accessors agree on cache bounding settings, throwing an exception if there is a mismatch. [[1]](diffhunk://#diff-6059ce7300be03298038a2e5908e0e6bed0d677ac6df25cd1b2209fd6900de03R42-R76) [[2]](diffhunk://#diff-6059ce7300be03298038a2e5908e0e6bed0d677ac6df25cd1b2209fd6900de03R310-R583)

**Configuration & API Exposure**
- Added a public property `AppCacheMaxEntries` to `CacheOptions` for configuring the maximum number of access token entries. Setting this to 0 or less disables bounding and reverts to legacy behavior. [[1]](diffhunk://#diff-08d8e415af4aebf035b98b5cb70ad254611ae0910c179dd76b82cf7573d75162R91-R101) [[2]](diffhunk://#diff-d8d9399ed6a37cdd3bf25cd223b32bfe33318862404ac5bba32f34e213fb6eb5R8-R9)
- Updated the public API surface to include getters and setters for `AppCacheMaxEntries`.

**Documentation**
- Added a detailed performance and engineering report (`docs/bounded-app-token-cache-performance-report.md`) explaining the eviction flow, micro-benchmarking results, and rationale for sizing defaults.
- Updated the `CHANGELOG.md` to record the new bounded cache feature and its default settings.
