### PR TITLE
Fix #6030: WithExtraQueryParameters on ManagedIdentityApplicationBuilder bypassed token caching

### DIFF
--- a/src/client/Microsoft.Identity.Client/AppConfig/ManagedIdentityApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ManagedIdentityApplicationBuilder.cs
@@ -116,16 +116,25 @@ namespace Microsoft.Identity.Client
         {
             ValidateUseOfExperimentalFeature();
 
+            if (extraQueryParameters == null)
+            {
+                return this;
+            }
+
             if (Config.ExtraQueryParameters == null)
             {
-                Config.ExtraQueryParameters = extraQueryParameters;
+                Config.ExtraQueryParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
-            else
+
+            // All extra query parameters are included in the cache key so that callers
+            // cannot inadvertently bypass token caching by varying parameter values.
+            // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6030
+            Config.CacheKeyComponents = Config.CacheKeyComponents ?? new SortedList<string, string>();
+
+            foreach (var kvp in extraQueryParameters)
             {
-                foreach (var kvp in extraQueryParameters)
-                {
-                    Config.ExtraQueryParameters[kvp.Key] = kvp.Value; // This will overwrite if key exists, or add if new
-                }
+                Config.ExtraQueryParameters[kvp.Key] = kvp.Value;
+                Config.CacheKeyComponents[kvp.Key] = kvp.Value;
             }
 
             return this;

--- a/src/client/Microsoft.Identity.Client/AppConfig/ManagedIdentityApplicationBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/ManagedIdentityApplicationBuilder.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Identity.Client
             // All extra query parameters are included in the cache key so that callers
             // cannot inadvertently bypass token caching by varying parameter values.
             // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6030
-            Config.CacheKeyComponents = Config.CacheKeyComponents ?? new SortedList<string, string>();
+            Config.CacheKeyComponents = Config.CacheKeyComponents ?? new SortedList<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var kvp in extraQueryParameters)
             {

--- a/src/client/Microsoft.Identity.Client/ApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ApplicationBase.cs
@@ -64,6 +64,19 @@ namespace Microsoft.Identity.Client
 
             var cacheKeyComponents = await InitializeCacheKeyComponentsAsync(commonParameters.CacheKeyComponents, cancellationToken).ConfigureAwait(false);
 
+            // Merge any app-level cache key components (e.g. set via application-builder
+            // WithExtraQueryParameters when IncludeInCacheKey is true) so they participate
+            // in token cache key computation alongside the per-request components.
+            // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6030
+            if (ServiceBundle.Config.CacheKeyComponents != null && ServiceBundle.Config.CacheKeyComponents.Count > 0)
+            {
+                cacheKeyComponents = cacheKeyComponents ?? new SortedList<string, string>();
+                foreach (var kvp in ServiceBundle.Config.CacheKeyComponents)
+                {
+                    cacheKeyComponents[kvp.Key] = kvp.Value;
+                }
+            }
+
             return new AuthenticationRequestParameters(
                 ServiceBundle,
                 cache,

--- a/src/client/Microsoft.Identity.Client/ApplicationBase.cs
+++ b/src/client/Microsoft.Identity.Client/ApplicationBase.cs
@@ -67,13 +67,18 @@ namespace Microsoft.Identity.Client
             // Merge any app-level cache key components (e.g. set via application-builder
             // WithExtraQueryParameters when IncludeInCacheKey is true) so they participate
             // in token cache key computation alongside the per-request components.
+            // Per-request components take precedence over app-level on key collisions,
+            // mirroring the precedence used for ExtraQueryParameters in AuthenticationRequestParameters.
             // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6030
             if (ServiceBundle.Config.CacheKeyComponents != null && ServiceBundle.Config.CacheKeyComponents.Count > 0)
             {
                 cacheKeyComponents = cacheKeyComponents ?? new SortedList<string, string>();
                 foreach (var kvp in ServiceBundle.Config.CacheKeyComponents)
                 {
-                    cacheKeyComponents[kvp.Key] = kvp.Value;
+                    if (!cacheKeyComponents.ContainsKey(kvp.Key))
+                    {
+                        cacheKeyComponents[kvp.Key] = kvp.Value;
+                    }
                 }
             }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -1503,6 +1503,61 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
+        public void WithExtraQueryParameters_PopulatesCacheKeyComponents_Issue6030()
+        {
+            // Arrange
+            var extraQueryParameters = new Dictionary<string, string>
+                {
+                    { "param1", "value1" },
+                    { "param2", "value2" }
+                };
+
+            // Act
+            var miBuilder = ManagedIdentityApplicationBuilder
+                .Create(ManagedIdentityId.SystemAssigned)
+                .WithExperimentalFeatures(true)
+                .WithExtraQueryParameters(extraQueryParameters);
+
+            // Assert: every EQP must participate in the cache key so callers cannot bypass caching.
+            Assert.IsNotNull(miBuilder.Config.CacheKeyComponents);
+            Assert.HasCount(2, miBuilder.Config.CacheKeyComponents);
+            Assert.AreEqual("value1", miBuilder.Config.CacheKeyComponents["param1"]);
+            Assert.AreEqual("value2", miBuilder.Config.CacheKeyComponents["param2"]);
+        }
+
+        [TestMethod]
+        public void WithExtraQueryParameters_DifferentValuesProduceDifferentCacheKeys_Issue6030()
+        {
+            // Two MI apps that differ only by an EQP value must produce distinct app-token cache keys
+            // so that the second app cannot read the first app's cached token.
+            var miA = ManagedIdentityApplicationBuilder
+                .Create(ManagedIdentityId.SystemAssigned)
+                .WithExperimentalFeatures(true)
+                .WithExtraQueryParameters(new Dictionary<string, string> { { "tenantHint", "tenantA" } })
+                .BuildConcrete();
+
+            var miB = ManagedIdentityApplicationBuilder
+                .Create(ManagedIdentityId.SystemAssigned)
+                .WithExperimentalFeatures(true)
+                .WithExtraQueryParameters(new Dictionary<string, string> { { "tenantHint", "tenantB" } })
+                .BuildConcrete();
+
+            string keyA = Client.Cache.CacheKeyFactory.GetAppTokenCacheItemKey(
+                miA.ServiceBundle.Config.ClientId,
+                tenantId: string.Empty,
+                popKid: null,
+                miA.ServiceBundle.Config.CacheKeyComponents);
+
+            string keyB = Client.Cache.CacheKeyFactory.GetAppTokenCacheItemKey(
+                miB.ServiceBundle.Config.ClientId,
+                tenantId: string.Empty,
+                popKid: null,
+                miB.ServiceBundle.Config.CacheKeyComponents);
+
+            Assert.AreNotEqual(keyA, keyB, "EQP-differentiated MI requests must not share a cache entry.");
+        }
+
+        [TestMethod]
         public async Task ManagedIdentityWithExtraQueryParametersTestAsync()
         {
             using (new EnvVariableContext())


### PR DESCRIPTION
Fixes #6030.

## Problem
ManagedIdentityApplicationBuilder.WithExtraQueryParameters(...) appended its parameters to the outgoing MI HTTP request but never fed them into the app-token cache key. Two MI apps that differed only by an EQP value (e.g. 	enantHint=A vs 	enantHint=B) therefore collided on the same cache entry, and the second app would receive the first app's cached token. Secondary gap: ApplicationConfiguration.CacheKeyComponents was set by the application-level builder but never consumed by the request pipeline, so even the existing tuple overload with IncludeInCacheKey=true had no effect.

## Fix
1. ManagedIdentityApplicationBuilder.WithExtraQueryParameters now also writes every key/value into Config.CacheKeyComponents so callers cannot inadvertently bypass token caching. The CacheKeyComponents SortedList is created with StringComparer.OrdinalIgnoreCase to match the case-insensitive comparer used for Config.ExtraQueryParameters on the same builder.
2. ApplicationBase.CreateRequestParametersAsync now merges ServiceBundle.Config.CacheKeyComponents into the per-request cache key components, completing the path so app-level cache key components actually flow into CacheKeyFactory.GetAppTokenCacheItemKey for all flows. On key collisions, per-request components take precedence over app-level — mirroring the precedence used for ExtraQueryParameters in AuthenticationRequestParameters.

## Tests
Two new unit tests in ManagedIdentityTests:
- WithExtraQueryParameters_PopulatesCacheKeyComponents_Issue6030
- WithExtraQueryParameters_DifferentValuesProduceDifferentCacheKeys_Issue6030

Local verification (net8.0): 386/386 ManagedIdentity tests pass; 250/250 Cache + AcquireTokenForClient tests pass. Clean build (TreatWarningsAsErrors=true).

No public API surface change.
