### PR TITLE
[ManagedIdentity] Detect dead KeyGuard keys and purge orphan IMDSv2 mTLS certs on reboot

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/WindowsCngKeyOperations.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/WindowsCngKeyOperations.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
 
@@ -28,6 +29,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
         private const string HardwareKeyName = "HardwareRSAKey";
         private const string KeyGuardVirtualIsoProperty = "Virtual Iso";
         private const string VbsNotAvailable = "VBS key isolation is not available";
+
+        // Issuer used by IMDSv2 mTLS PoP binding certificates. Matched as a case-insensitive
+        // substring against the certificate's Issuer DN, so any cert in CurrentUser\My issued
+        // by IMDSv2 can be wiped when we mint a fresh KeyGuard key (the previously persisted
+        // certs are bound to the now-replaced key by name and would fail the mTLS handshake).
+        internal const string ManagedIdentityIssuerCnFragment = "managedidentitysnissuer.login.microsoft.com";
 
         // KeyGuard + per-boot flags
         private const CngKeyCreationOptions NCryptUseVirtualIsolationFlag = (CngKeyCreationOptions)0x00020000;
@@ -66,16 +73,75 @@ namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
                 CngKey key;
                 try
                 {
+                    logger?.Info(() => $"[MI][WinKeyProvider] Attempting to open existing KeyGuard key. " +
+                                       $"Provider='{SoftwareKspName}', KeyName='{KeyGuardKeyName}', Scope=UserKey, Silent=true.");
+
                     key = CngKey.Open(
                         KeyGuardKeyName,
                         new CngProvider(SoftwareKspName),
                         CngKeyOpenOptions.UserKey | CngKeyOpenOptions.Silent);
+
+                    logger?.Info(() => $"[MI][WinKeyProvider] CngKey.Open succeeded for '{KeyGuardKeyName}'. " +
+                                       "Running liveness sign probe to detect stale per-boot key material " +
+                                       "(metadata file can survive a reboot while the VBS-isolated key material is destroyed).");
+
+                    // Liveness probe: per-boot KeyGuard keys (NCryptUsePerBootKeyFlag) leave a stale
+                    // metadata file on disk after reboot. CngKey.Open returns a handle, but the actual
+                    // VBS-protected key material is gone, so the first real sign operation fails.
+                    // Detect this here so we can recreate cleanly instead of failing later in the
+                    // mTLS handshake or signing path.
+                    if (!CanSign(key, logger))
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] KeyGuard liveness sign probe FAILED. " +
+                                           "Treating handle as stale (likely post-reboot per-boot key reaped). " +
+                                           "Disposing stale handle and recreating fresh KeyGuard key.");
+                        key.Dispose();
+                        key = CreateFresh(logger);
+
+                        if (key == null)
+                        {
+                            logger?.Info(() => "[MI][WinKeyProvider] CreateFresh returned null after failed liveness probe " +
+                                               "(VBS unavailable). KeyGuard path will be skipped.");
+                        }
+                        else
+                        {
+                            logger?.Info(() => "[MI][WinKeyProvider] Fresh KeyGuard key created successfully after stale handle replacement. " +
+                                               "Purging persisted IMDSv2 mTLS binding certificates that were bound to the replaced key.");
+
+                            // The new KeyGuard key reuses the container name 'KeyGuardRSAKey', but its
+                            // public/private pair is different from the one any persisted cert was issued
+                            // against. Wipe all certs in CurrentUser\My issued by IMDSv2 so the next request
+                            // mints fresh instead of failing the mTLS handshake.
+                            PurgeManagedIdentityCertificates(logger);
+                        }
+                    }
+                    else
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] KeyGuard liveness sign probe PASSED. Reusing existing handle.");
+                    }
                 }
-                catch (CryptographicException)
+                catch (CryptographicException openEx)
                 {
                     // Not found -> create fresh (helper may return null if VBS unavailable)
-                    logger?.Info(() => "[MI][WinKeyProvider] CredentialGuard key not found; creating fresh.");
+                    logger?.Info(() => $"[MI][WinKeyProvider] CngKey.Open threw CryptographicException for '{KeyGuardKeyName}'. " +
+                                       $"HR=0x{openEx.HResult:X8}, Message='{openEx.Message}'. " +
+                                       "Treating as 'key not found' and creating fresh.");
                     key = CreateFresh(logger);
+
+                    if (key == null)
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] CreateFresh returned null after Open failure (VBS unavailable).");
+                    }
+                    else
+                    {
+                        logger?.Info(() => "[MI][WinKeyProvider] Fresh KeyGuard key created successfully after Open failure. " +
+                                           "Purging persisted IMDSv2 mTLS binding certificates that were bound to the replaced key.");
+
+                        // Same rationale as the probe-failed branch: any persisted IMDSv2 cert in
+                        // CurrentUser\My is bound to the previous KeyGuard key and will fail the mTLS
+                        // handshake. Wipe them so the next request mints fresh.
+                        PurgeManagedIdentityCertificates(logger);
+                    }
                 }
 
                 // If VBS is unavailable, CreateFresh() returns null. Bail out cleanly.
@@ -275,6 +341,171 @@ namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
 
             byte[] val = key.GetProperty(KeyGuardVirtualIsoProperty, CngPropertyOptions.None).GetValue();
             return val?.Length > 0 && val[0] != 0;
+        }
+
+        /// <summary>
+        /// Performs a small RSA sign operation against the supplied CNG key to verify the
+        /// underlying key material is actually usable.
+        /// </summary>
+        /// <param name="key">The CNG key handle returned from <see cref="CngKey.Open(string, CngProvider, CngKeyOpenOptions)"/>.</param>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        /// <returns>
+        /// <see langword="true"/> if the key signs successfully; otherwise <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// KeyGuard keys created with <c>NCryptUsePerBootKeyFlag</c> have their VBS-isolated
+        /// key material destroyed on every reboot, but the on-disk metadata file produced by the
+        /// Microsoft Software KSP often survives. As a result, <see cref="CngKey.Open(string, CngProvider, CngKeyOpenOptions)"/>
+        /// can return a handle that looks valid (correct algorithm, "Virtual Iso" property still set)
+        /// but whose first real cryptographic operation throws.
+        /// </para>
+        /// <para>
+        /// Probing with a one-byte sign here surfaces that condition cheaply (~1-3 ms for RSA-2048)
+        /// on the cold-start path. Subsequent calls reuse the cached key in
+        /// <c>WindowsManagedIdentityKeyProvider</c>, so the probe runs at most once per process.
+        /// </para>
+        /// </remarks>
+        private static bool CanSign(CngKey key, ILoggerAdapter logger)
+        {
+            try
+            {
+                logger?.Verbose(() => "[MI][WinKeyProvider] Liveness probe: attempting RSA-SHA256 sign of 1-byte payload.");
+
+                using (var rsa = new RSACng(key))
+                {
+                    _ = rsa.SignData(
+                        new byte[] { 0 },
+                        HashAlgorithmName.SHA256,
+                        RSASignaturePadding.Pkcs1);
+                }
+
+                logger?.Verbose(() => "[MI][WinKeyProvider] Liveness probe: sign succeeded; key material is live.");
+                return true;
+            }
+            catch (CryptographicException ex)
+            {
+                logger?.Info(() => $"[MI][WinKeyProvider] Liveness probe: sign threw CryptographicException. " +
+                                   $"HR=0x{ex.HResult:X8}, Message='{ex.Message}'. Key handle is stale.");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                logger?.Info(() => $"[MI][WinKeyProvider] Liveness probe: sign threw unexpected exception. " +
+                                   $"{ex.GetType().Name}: '{ex.Message}'. Treating as stale.");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes every certificate in the <c>CurrentUser\My</c> store whose issuer matches the
+        /// IMDSv2 mTLS PoP binding-certificate issuer.
+        /// </summary>
+        /// <param name="logger">Logger for diagnostic output.</param>
+        /// <remarks>
+        /// <para>
+        /// IMDSv2 binding certificates are issued by
+        /// <c>CN=managedidentitysnissuer.login.microsoft.com</c> and stored in the user's personal
+        /// store. They reference the private key by KSP container name (<c>KeyGuardRSAKey</c>),
+        /// not by key material. When the KeyGuard key is re-minted (post-reboot, or after a failed
+        /// liveness probe), the new key reuses the same container name but with different
+        /// public/private parameters — leaving the persisted certs bound to a key that no longer
+        /// matches them, which then fails the mTLS handshake.
+        /// </para>
+        /// <para>
+        /// Purging the store at the moment we mint a fresh KeyGuard key eliminates the
+        /// failed-handshake + retry round trip that the SChannel-error catch in
+        /// <c>ImdsV2ManagedIdentitySource.AuthenticateAsync</c> would otherwise have to recover from.
+        /// </para>
+        /// <para>
+        /// All store I/O is best-effort and non-throwing.
+        /// </para>
+        /// </remarks>
+        internal static void PurgeManagedIdentityCertificates(ILoggerAdapter logger)
+        {
+            int removed = 0;
+            int inspected = 0;
+
+            try
+            {
+                logger?.Info(() =>
+                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: opening CurrentUser\\My to remove " +
+                    $"certs whose Issuer contains '{ManagedIdentityIssuerCnFragment}'.");
+
+                using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+                {
+                    store.Open(OpenFlags.ReadWrite);
+
+                    // Snapshot to avoid 'collection modified during enumeration' provider quirks.
+                    var snapshot = new X509Certificate2[store.Certificates.Count];
+                    try
+                    {
+                        store.Certificates.CopyTo(snapshot, 0);
+                    }
+                    catch (Exception copyEx)
+                    {
+                        logger?.Info(() =>
+                            $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: store snapshot via CopyTo failed " +
+                            $"({copyEx.GetType().Name}: {copyEx.Message}). Falling back to enumeration.");
+
+                        int i = 0;
+                        snapshot = new X509Certificate2[store.Certificates.Count];
+                        foreach (X509Certificate2 c in store.Certificates)
+                        {
+                            snapshot[i++] = c;
+                        }
+                    }
+
+                    foreach (X509Certificate2 candidate in snapshot)
+                    {
+                        try
+                        {
+                            inspected++;
+
+                            string issuer = candidate.Issuer ?? string.Empty;
+                            if (issuer.IndexOf(ManagedIdentityIssuerCnFragment, StringComparison.OrdinalIgnoreCase) < 0)
+                            {
+                                continue;
+                            }
+
+                            string thumb = candidate.Thumbprint;
+                            DateTime notAfter = candidate.NotAfter;
+
+                            try
+                            {
+                                store.Remove(candidate);
+                                removed++;
+                                logger?.Info(() =>
+                                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: removed cert. " +
+                                    $"Thumbprint={thumb}, NotAfter={notAfter:O}, Issuer='{issuer}'.");
+                            }
+                            catch (Exception removeEx)
+                            {
+                                logger?.Info(() =>
+                                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: failed to remove cert " +
+                                    $"Thumbprint={thumb}. {removeEx.GetType().Name}: '{removeEx.Message}'.");
+                            }
+                        }
+                        finally
+                        {
+                            candidate.Dispose();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.Info(() =>
+                    $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: store access failed. " +
+                    $"{ex.GetType().Name}: '{ex.Message}'. Removed={removed}, Inspected={inspected}.");
+                return;
+            }
+
+            int removedFinal = removed;
+            int inspectedFinal = inspected;
+            logger?.Info(() =>
+                $"[MI][WinKeyProvider] PurgeManagedIdentityCertificates: complete. " +
+                $"Removed={removedFinal}, Inspected={inspectedFinal}.");
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WindowsCngKeyOperationsPurgeUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/WindowsCngKeyOperationsPurgeUnitTests.cs
@@ -1,0 +1,359 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.ManagedIdentity.KeyProviders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
+{
+    /// <summary>
+    /// Tests for <see cref="WindowsCngKeyOperations.PurgeManagedIdentityCertificates"/>.
+    /// The purge sweeps <c>CurrentUser\My</c> and removes every certificate whose issuer
+    /// contains <see cref="WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment"/>.
+    /// It runs after a fresh KeyGuard key is minted so that persisted IMDSv2 binding
+    /// certs (which are bound by container name to the now-replaced key) are not left
+    /// behind to fail the next mTLS handshake.
+    /// </summary>
+    [TestClass]
+    public class WindowsCngKeyOperationsPurgeUnitTests
+    {
+        // Discriminator we plant in each test cert's Subject so cleanup can find leftovers
+        // from a failed run without touching unrelated certs in the developer's store.
+        private const string TestSubjectDiscriminatorPrefix = "MSAL-Purge-Test-";
+
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private static ILoggerAdapter Logger => Substitute.For<ILoggerAdapter>();
+
+        [TestInitialize]
+        public void Init()
+        {
+            // Reuse the existing broad sweep so prior test runs don't leak state.
+            if (ImdsV2TestStoreCleaner.IsWindows)
+            {
+                ImdsV2TestStoreCleaner.RemoveAllTestArtifacts();
+            }
+
+            // Also remove any leftover purge-test certs from a previous failed run.
+            RemoveAllPurgeTestArtifacts();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            RemoveAllPurgeTestArtifacts();
+        }
+
+        private static void WindowsOnly()
+        {
+            if (!IsWindows)
+            {
+                Assert.Inconclusive("Windows-only");
+            }
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_RemovesCertWithMatchingIssuer()
+        {
+            WindowsOnly();
+
+            // Arrange
+            string discriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            string subject =
+                "CN=" + WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment +
+                ", OU=" + discriminator;
+
+            string plantedThumbprint;
+            using (var cert = CreateSelfSignedWithKey(subject, TimeSpan.FromDays(2)))
+            {
+                plantedThumbprint = cert.Thumbprint;
+                AddToCurrentUserMyStore(cert);
+            }
+
+            Assert.IsTrue(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Test setup precondition: planted cert must be present in CurrentUser\\My before purge.");
+
+            // Act
+            WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+            // Assert
+            Assert.IsFalse(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Purge should remove certs whose Issuer contains the managed identity issuer CN.");
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_LeavesCertWithNonMatchingIssuer()
+        {
+            WindowsOnly();
+
+            // Arrange
+            string discriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            // Subject/Issuer that does NOT contain the managed identity issuer fragment.
+            string subject = "CN=unrelated.example.test, OU=" + discriminator;
+
+            string plantedThumbprint;
+            using (var cert = CreateSelfSignedWithKey(subject, TimeSpan.FromDays(2)))
+            {
+                plantedThumbprint = cert.Thumbprint;
+                AddToCurrentUserMyStore(cert);
+            }
+
+            Assert.IsTrue(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Test setup precondition: planted cert must be present in CurrentUser\\My before purge.");
+
+            try
+            {
+                // Act
+                WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+                // Assert
+                Assert.IsTrue(
+                    IsInCurrentUserMyStore(plantedThumbprint),
+                    "Purge must not remove certs whose Issuer does not contain the managed identity issuer CN.");
+            }
+            finally
+            {
+                RemoveByThumbprintFromCurrentUserMyStore(plantedThumbprint);
+            }
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_MatchIsCaseInsensitive()
+        {
+            WindowsOnly();
+
+            // Arrange
+            string discriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            // Uppercase the issuer fragment to ensure the match is OrdinalIgnoreCase.
+            string subject =
+                "CN=" + WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment.ToUpperInvariant() +
+                ", OU=" + discriminator;
+
+            string plantedThumbprint;
+            using (var cert = CreateSelfSignedWithKey(subject, TimeSpan.FromDays(2)))
+            {
+                plantedThumbprint = cert.Thumbprint;
+                AddToCurrentUserMyStore(cert);
+            }
+
+            Assert.IsTrue(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Test setup precondition: planted cert must be present in CurrentUser\\My before purge.");
+
+            // Act
+            WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+            // Assert
+            Assert.IsFalse(
+                IsInCurrentUserMyStore(plantedThumbprint),
+                "Purge issuer match should be case-insensitive.");
+        }
+
+        [TestMethod]
+        public void PurgeManagedIdentityCertificates_OnlyRemovesMatching_LeavesOtherCertsAlone()
+        {
+            WindowsOnly();
+
+            // Arrange: plant one matching and one non-matching cert
+            string matchDiscriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+            string nonMatchDiscriminator = TestSubjectDiscriminatorPrefix + Guid.NewGuid().ToString("N");
+
+            string matchingSubject =
+                "CN=" + WindowsCngKeyOperations.ManagedIdentityIssuerCnFragment +
+                ", OU=" + matchDiscriminator;
+            string nonMatchingSubject = "CN=unrelated.example.test, OU=" + nonMatchDiscriminator;
+
+            string matchingThumb;
+            string nonMatchingThumb;
+
+            using (var matching = CreateSelfSignedWithKey(matchingSubject, TimeSpan.FromDays(2)))
+            using (var nonMatching = CreateSelfSignedWithKey(nonMatchingSubject, TimeSpan.FromDays(2)))
+            {
+                matchingThumb = matching.Thumbprint;
+                nonMatchingThumb = nonMatching.Thumbprint;
+
+                AddToCurrentUserMyStore(matching);
+                AddToCurrentUserMyStore(nonMatching);
+            }
+
+            Assert.IsTrue(IsInCurrentUserMyStore(matchingThumb), "Matching cert must be planted.");
+            Assert.IsTrue(IsInCurrentUserMyStore(nonMatchingThumb), "Non-matching cert must be planted.");
+
+            try
+            {
+                // Act
+                WindowsCngKeyOperations.PurgeManagedIdentityCertificates(Logger);
+
+                // Assert
+                Assert.IsFalse(IsInCurrentUserMyStore(matchingThumb), "Matching cert should be purged.");
+                Assert.IsTrue(IsInCurrentUserMyStore(nonMatchingThumb), "Non-matching cert should survive.");
+            }
+            finally
+            {
+                RemoveByThumbprintFromCurrentUserMyStore(nonMatchingThumb);
+            }
+        }
+
+        // ---------------- helpers ----------------
+
+        /// <summary>
+        /// Creates a self-signed RSA cert with a persistable private key.
+        /// Mirrors the pattern used by <c>PersistentCertificateStoreUnitTests.CreateSelfSignedWithKey</c>.
+        /// </summary>
+        private static X509Certificate2 CreateSelfSignedWithKey(string subject, TimeSpan lifetime)
+        {
+            using var rsa = RSA.Create(2048);
+
+            var req = new CertificateRequest(
+                new X500DistinguishedName(subject),
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddMinutes(-2);
+            DateTimeOffset notAfter = notBefore.Add(lifetime);
+
+            using var ephemeral = req.CreateSelfSigned(notBefore, notAfter);
+
+            // Re-import as PFX so the private key is persisted and the store will accept it.
+            var pfx = ephemeral.Export(X509ContentType.Pfx, "");
+            return new X509Certificate2(
+                pfx,
+                "",
+                X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+        }
+
+        private static void AddToCurrentUserMyStore(X509Certificate2 cert)
+        {
+            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadWrite);
+            store.Add(cert);
+        }
+
+        private static bool IsInCurrentUserMyStore(string thumbprint)
+        {
+            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+
+            foreach (X509Certificate2 c in store.Certificates)
+            {
+                try
+                {
+                    if (string.Equals(c.Thumbprint, thumbprint, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+                finally
+                {
+                    c.Dispose();
+                }
+            }
+
+            return false;
+        }
+
+        private static void RemoveByThumbprintFromCurrentUserMyStore(string thumbprint)
+        {
+            try
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                store.Open(OpenFlags.ReadWrite);
+
+                X509Certificate2[] snapshot;
+                try
+                {
+                    snapshot = new X509Certificate2[store.Certificates.Count];
+                    store.Certificates.CopyTo(snapshot, 0);
+                }
+                catch
+                {
+                    snapshot = store.Certificates.Cast<X509Certificate2>().ToArray();
+                }
+
+                foreach (var c in snapshot)
+                {
+                    try
+                    {
+                        if (string.Equals(c.Thumbprint, thumbprint, StringComparison.OrdinalIgnoreCase))
+                        {
+                            try
+                            { store.Remove(c); }
+                            catch { /* best-effort */ }
+                        }
+                    }
+                    finally
+                    {
+                        c.Dispose();
+                    }
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+
+        /// <summary>
+        /// Removes any leftover purge-test certificates from <c>CurrentUser\My</c>.
+        /// Matches our unique Subject OU discriminator to avoid touching unrelated certs.
+        /// Best-effort, no-throw.
+        /// </summary>
+        private static void RemoveAllPurgeTestArtifacts()
+        {
+            if (!IsWindows)
+            {
+                return;
+            }
+
+            try
+            {
+                using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                store.Open(OpenFlags.ReadWrite);
+
+                X509Certificate2[] snapshot;
+                try
+                {
+                    snapshot = new X509Certificate2[store.Certificates.Count];
+                    store.Certificates.CopyTo(snapshot, 0);
+                }
+                catch
+                {
+                    snapshot = store.Certificates.Cast<X509Certificate2>().ToArray();
+                }
+
+                foreach (var c in snapshot)
+                {
+                    try
+                    {
+                        string subject = c.Subject ?? string.Empty;
+                        if (subject.IndexOf(TestSubjectDiscriminatorPrefix, StringComparison.Ordinal) >= 0)
+                        {
+                            try
+                            { store.Remove(c); }
+                            catch { /* best-effort */ }
+                        }
+                    }
+                    finally
+                    {
+                        c.Dispose();
+                    }
+                }
+            }
+            catch
+            {
+                // best-effort
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the post-reboot recovery path for IMDSv2 mTLS PoP token acquisition on Azure VMs with KeyGuard.

On VM restart the per-boot KeyGuard key (`NCryptUsePerBootKeyFlag`) is reaped by VBS, but the persisted binding cert under `CN=managedidentitysnissuer.login.microsoft.com` in `CurrentUser\My` still references the old public key. Two failure modes today:

1. **`CngKey.Open` throws `HR=0x8009003A`** (`Cannot decrypt a VBS-isolated key.`) — handled by minting fresh, but the orphaned cert was left behind, so a subsequent cold path could still surface it before the reactive `IsSchanelFailure` catch in `ImdsV2ManagedIdentitySource` kicks in.
2. **Zombie-VBS handle** — `CngKey.Open` succeeds, the container's public-key metadata survived a reboot, but the private material is dead. `ExportParameters(false)` still returns the old modulus that matches the persisted cert, so any cert-side modulus comparison can't detect this case. SChannel handshake then fails and we fall through to the reactive catch.

## Changes

### `WindowsCngKeyOperations.cs`

- **`CanSign` liveness probe** right after `CngKey.Open` succeeds. 1-byte RSA-SHA256 PKCS1 sign; ~1–3 ms; runs once per process (the result is cached in `WindowsManagedIdentityKeyProvider._cachedKey` behind a `SemaphoreSlim`). Catches the zombie-handle variant cleanly.
- **`PurgeManagedIdentityCertificates`** — one-shot, issuer-CN substring sweep (`managedidentitysnissuer.login.microsoft.com`, case-insensitive) of `CurrentUser\My`, invoked at the moment a fresh KeyGuard key is minted (both probe-failed and `Open`-threw branches).

### `WindowsCngKeyOperationsPurgeUnitTests.cs`

Four Windows-only unit tests for the purge filter behavior:
- `RemovesCertWithMatchingIssuer`
- `LeavesCertWithNonMatchingIssuer`
- `MatchIsCaseInsensitive`
- `OnlyRemovesMatching_LeavesOtherCertsAlone`

Tests use `CertificateRequest`-based self-signed PFX with a discriminating Subject OU (`MSAL-Purge-Test-<Guid>`) and `ImdsV2TestStoreCleaner.RemoveAllTestArtifacts()` in `[TestInitialize]`.

### Retained

The reactive SChannel catch in `ImdsV2ManagedIdentitySource.AuthenticateAsync` is kept as a defensive backstop.

## Why purge at the mint site

When the container was just regenerated we know **every** cert under that issuer is orphaned by definition — no need to inspect them individually.

- **No per-`Read` discovery cost** on cold cache after reboot.
- **Multi-identity hosts** (SAMI + multiple UAMIs sharing the same KeyGuard container) are cleaned up uniformly in a single store-open.
- **Lower first-call latency** post-reboot — the first request after restart hits a clean store and a single `/issuecredential` POST.

## Validation

Validated E2E on a Server 2022 KeyGuard VM across multiple reboots and mixed SAMI/UAMI cases. Canonical post-reboot first call:

```
CngKey.Open threw CryptographicException HR=0x8009003A
Fresh KeyGuard key created
PurgeManagedIdentityCertificates: removed cert. Thumbprint=D3AE2783… (Inspected=4, Removed=1)
MAA attestation OK
POST /issuecredential -> 200
mTLS handshake -> 200 on first try (no reactive catch invoked)
Total ~2.8s on cold start
x5t#S256: 11Iz2a_ZOO0rhl2NzCBOVW75ul5Bg1M24rFKY8q1kEA
```

Full unit suite green on `net8.0`: **2069 passed, 0 failed, 19 skipped**.

## Refs

- Fixes #6031
- Complementary to #6020 (cert-side modulus comparison). PR #6020 addresses orphan detection at the persistent-cert cache layer; this PR addresses it at the key-acquisition layer with a liveness probe + broad sweep at the cause site. The two approaches cover different failure modes and aren't mutually exclusive — both could ship together if desired.

## Draft status

Opening as **draft** to gather feedback alongside #6020 before deciding the final shape. Happy to:
- merge first and have #6020 layer the per-`Read` modulus check on top, or
- close this and fold the `CanSign` probe + issuer-CN sweep into #6020, or
- ship both as the PRs stand.
