### PR TITLE
GA Microsoft.Identity.Client.KeyAttestation Package

### DIFF
--- a/src/client/Microsoft.Identity.Client.KeyAttestation/Microsoft.Identity.Client.KeyAttestation.csproj
+++ b/src/client/Microsoft.Identity.Client.KeyAttestation/Microsoft.Identity.Client.KeyAttestation.csproj
@@ -17,7 +17,7 @@
     <!--This should be passed from the VSTS build-->
     <MicrosoftIdentityClientVersion Condition="'$(MicrosoftIdentityClientVersion)' == ''">$(MsalInternalVersion)</MicrosoftIdentityClientVersion>
     <!--This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion-->
-    <Version>$(MicrosoftIdentityClientVersion)-preview</Version>
+    <Version>$(MicrosoftIdentityClientVersion)</Version>
     <!-- Copyright needs to be in the form of © not (c) to be compliant -->
     <Title>MSAL.NET extension for Credential Guard attestation support</Title>
     <Description>


### PR DESCRIPTION
This pull request makes a small but important change to the versioning of the `Microsoft.Identity.Client.KeyAttestation` project. The `-preview` suffix has been removed from the generated package version, so the version will now match `$(MicrosoftIdentityClientVersion)` exactly.

- Removed the `-preview` suffix from the `<Version>` property in `Microsoft.Identity.Client.KeyAttestation.csproj`, so the version now reflects only `$(MicrosoftIdentityClientVersion)` without any preview tag.