### PR TITLE
POC for agentic support with minor internal changes

### DIFF
--- a/src/client/Microsoft.Identity.Client/Cache/Items/MsalRefreshTokenCacheItem.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/Items/MsalRefreshTokenCacheItem.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Identity.Client.Cache.Keys;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.Utils;
@@ -20,14 +22,16 @@ namespace Microsoft.Identity.Client.Cache.Items
             string preferredCacheEnv,
             string clientId,
             MsalTokenResponse response,
-            string homeAccountId)
+            string homeAccountId,
+            SortedList<string, string> cacheKeyComponents = null)
             : this(
                   preferredCacheEnv,
                   clientId,
                   response.RefreshToken,
                   response.ClientInfo,
                   response.FamilyId,
-                  homeAccountId)
+                  homeAccountId,
+                  cacheKeyComponents: cacheKeyComponents)
         {
         }
 
@@ -37,7 +41,8 @@ namespace Microsoft.Identity.Client.Cache.Items
             string secret,
             string rawClientInfo,
             string familyId,
-            string homeAccountId)
+            string homeAccountId,
+            SortedList<string, string> cacheKeyComponents = null)
             : this()
         {
             ClientId = clientId;
@@ -47,6 +52,7 @@ namespace Microsoft.Identity.Client.Cache.Items
             FamilyId = familyId;
             HomeAccountId = homeAccountId;
 
+            InitializeAdditionalCacheKeyComponents(cacheKeyComponents);
             InitCacheKey();
         }
 
@@ -63,18 +69,37 @@ namespace Microsoft.Identity.Client.Cache.Items
             }
             else
             {
+                string credentialDescriptor = StorageJsonValues.CredentialTypeRefreshToken;
+                string[] extraKeyParts = null;
+
+                if (AdditionalCacheKeyComponents != null && AdditionalCacheKeyComponents.Any())
+                {
+                    credentialDescriptor = StorageJsonValues.CredentialTypeRefreshTokenExtended;
+                    extraKeyParts = new[] { CoreHelpers.ComputeAccessTokenExtCacheKey(AdditionalCacheKeyComponents) };
+                }
+
                 key = MsalCacheKeys.GetCredentialKey(
                        HomeAccountId,
                        Environment,
-                       StorageJsonValues.CredentialTypeRefreshToken,
+                       credentialDescriptor,
                        ClientId,
                        tenantId: null,
-                       scopes: null);
+                       scopes: null,
+                       extraKeyParts);
             }
 
             CacheKey = key;
 
             iOSCacheKeyLazy = new Lazy<IiOSKey>(() => InitiOSKey());
+        }
+
+        private void InitializeAdditionalCacheKeyComponents(SortedList<string, string> cacheKeyComponents)
+        {
+            if (cacheKeyComponents != null && cacheKeyComponents.Any())
+            {
+                AdditionalCacheKeyComponents = cacheKeyComponents;
+                CredentialType = StorageJsonValues.CredentialTypeRefreshTokenExtended;
+            }
         }
 
         internal string ToLogString(bool piiEnabled = false)
@@ -146,6 +171,8 @@ namespace Microsoft.Identity.Client.Cache.Items
 
         public string CacheKey { get; private set; }
 
+        internal SortedList<string, string> AdditionalCacheKeyComponents { get; private set; }
+
         private Lazy<IiOSKey> iOSCacheKeyLazy;
         public IiOSKey iOSCacheKey => iOSCacheKeyLazy.Value;
 
@@ -165,6 +192,13 @@ namespace Microsoft.Identity.Client.Cache.Items
             item.FamilyId = JsonHelper.ExtractExistingOrEmptyString(j, StorageJsonKeys.FamilyId);
             item.OboCacheKey = JsonHelper.ExtractExistingOrEmptyString(j, StorageJsonKeys.UserAssertionHash);
 
+            var additionalCacheKeyComponents = JsonHelper.ExtractInnerJsonAsDictionary(j, StorageJsonKeys.CacheExtensions);
+            if (additionalCacheKeyComponents != null)
+            {
+                item.AdditionalCacheKeyComponents = new SortedList<string, string>(additionalCacheKeyComponents);
+                item.CredentialType = StorageJsonValues.CredentialTypeRefreshTokenExtended;
+            }
+
             item.PopulateFieldsFromJObject(j);
             item.InitCacheKey();
 
@@ -176,6 +210,17 @@ namespace Microsoft.Identity.Client.Cache.Items
             var json = base.ToJObject();
             SetItemIfValueNotNull(json, StorageJsonKeys.FamilyId, FamilyId);
             SetItemIfValueNotNull(json, StorageJsonKeys.UserAssertionHash, OboCacheKey);
+
+            if (AdditionalCacheKeyComponents != null)
+            {
+                var obj = new System.Text.Json.Nodes.JsonObject();
+                foreach (KeyValuePair<string, string> value in AdditionalCacheKeyComponents)
+                {
+                    obj[value.Key] = value.Value;
+                }
+                json[StorageJsonKeys.CacheExtensions] = obj;
+            }
+
             return json;
         }
 

--- a/src/client/Microsoft.Identity.Client/Cache/StorageJsonValues.cs
+++ b/src/client/Microsoft.Identity.Client/Cache/StorageJsonValues.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Identity.Client.Cache
         public const string AuthorityTypeOther = "Other";
         public const string TokenTypeBearer = "Bearer";
         public const string CredentialTypeRefreshToken = "RefreshToken";
+        public const string CredentialTypeRefreshTokenExtended = "RTExt";
         public const string CredentialTypeAccessToken = "AccessToken";
         public const string CredentialTypeAccessTokenExtended = "ATExt";
         public const string CredentialTypeAccessTokenWithAuthScheme = "AccessToken_With_AuthScheme";

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Identity.Client.Extensibility
                 {
                     if (param.Value != null)
                     {
-                        data.BodyParameters.Add(param.Key, await param.Value(data.CancellationToken).ConfigureAwait(false));
+                        data.BodyParameters[param.Key] = await param.Value(data.CancellationToken).ConfigureAwait(false);
                     }
                 }
             });

--- a/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
+++ b/src/client/Microsoft.Identity.Client/TokenCache.ITokenCacheInternal.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Identity.Client
                                     instanceDiscoveryMetadata.PreferredCache,
                                     requestParams.AppConfig.ClientId,
                                     response,
-                                    homeAccountId)
+                                    homeAccountId,
+                                    requestParams.CacheKeyComponents)
                 {
                     OboCacheKey = CacheKeyFactory.GetOboKey(requestParams.LongRunningOboCacheKey, requestParams.UserAssertion),
                 };
@@ -841,6 +842,7 @@ namespace Microsoft.Identity.Client
             if (refreshTokens.Count != 0)
             {
                 FilterRefreshTokensByHomeAccountIdOrAssertion(refreshTokens, requestParams, familyId);
+                FilterRefreshTokensByAdditionalKeyComponents(refreshTokens, requestParams);
 
                 if (!requestParams.AppConfig.MultiCloudSupportEnabled)
                 {
@@ -932,6 +934,32 @@ namespace Microsoft.Identity.Client
                             requestParams.AppConfig.ClientId, StringComparison.OrdinalIgnoreCase),
                             requestParams.RequestContext.Logger,
                             "Filtering RT by client id");
+            }
+        }
+
+        private static void FilterRefreshTokensByAdditionalKeyComponents(
+            List<MsalRefreshTokenCacheItem> refreshTokens,
+            AuthenticationRequestParameters requestParams)
+        {
+            bool requestHasComponents =
+                requestParams.CacheKeyComponents != null &&
+                requestParams.CacheKeyComponents.Count > 0;
+
+            if (requestHasComponents)
+            {
+                refreshTokens.FilterWithLogging(item =>
+                    item.AdditionalCacheKeyComponents != null &&
+                    CollectionHelpers.AreDictionariesEqual(item.AdditionalCacheKeyComponents, requestParams.CacheKeyComponents),
+                    requestParams.RequestContext.Logger,
+                    "Filtering RT by additional key components");
+            }
+            else
+            {
+                refreshTokens.FilterWithLogging(item =>
+                    item.AdditionalCacheKeyComponents == null ||
+                    item.AdditionalCacheKeyComponents.Count == 0,
+                    requestParams.RequestContext.Logger,
+                    "Filtering RT by no additional key components");
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/AgenticAlternativesExploration.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/AgenticAlternativesExploration.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
     ///
     /// 1. client_id on the wire:
     ///    TokenClient.cs:139 sets client_id from AppConfig.ClientId as a body parameter.
-    ///    additionalBodyParameters are added AFTER (line 170-173) and OnBeforeTokenRequest
-    ///    handlers fire even later (OAuth2Client.cs:128-133). Both use dict indexer
-    ///    (_bodyParameters[key] = value), so client_id CAN be overwritten on the wire.
+    ///    WithExtraBodyParameters and OnBeforeTokenRequest handlers fire later and can
+    ///    overwrite body params. After the internal fix (Add() → indexer), both can
+    ///    overwrite existing keys like client_id without throwing.
     ///
     /// 2. client_id in cache keys:
     ///    TokenCache.ITokenCacheInternal.cs:78 creates MsalAccessTokenCacheItem with
@@ -39,25 +39,21 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
     ///    tokens (line 101). So the cache key always uses the CCA's configured ClientId,
     ///    regardless of what was sent on the wire.
     ///
-    /// 3. WithExtraBodyParameters and cache isolation:
-    ///    WithExtraBodyParameters always calls WithAdditionalCacheKeyComponents, which
-    ///    adds a hash of the extra params to the ACCESS TOKEN cache key. This means:
-    ///    - Access tokens for different agents would have different extended cache key hashes ✅
-    ///    - DeleteAccessTokensWithIntersectingScopes checks AdditionalCacheKeyComponents
-    ///      for equality (fixed in PR #5963), so cross-agent eviction won't happen ✅
-    ///    - BUT refresh tokens have NO AdditionalCacheKeyComponents support ❌
-    ///      → Same user + different agents = refresh token collision in a single CCA
+    /// 3. Cache isolation via AdditionalCacheKeyComponents:
+    ///    WithExtraBodyParameters is ideal for stable values like client_id because it
+    ///    handles both wire override and cache key inclusion in one call. OnBeforeTokenRequest
+    ///    is needed for volatile values like client_assertion (T1 token) that must NOT be
+    ///    in cache keys (they would cause cache misses on every T1 renewal).
     ///
-    /// 4. WithExtraQueryParameters(value, includeInCacheKey: true):
-    ///    Similar to WithExtraBodyParameters — adds to CacheKeyComponents for access tokens
-    ///    but does NOT help with refresh token isolation.
+    /// 4. Refresh token gap (fixed in this PR):
+    ///    Before this PR, only access tokens supported AdditionalCacheKeyComponents.
+    ///    Refresh tokens had no such mechanism, causing RT collisions when two agents
+    ///    serve the same user through a single CCA. This PR adds RT support.
     ///
     /// Conclusion:
-    /// - Access token isolation IS achievable via WithExtraBodyParameters in a single CCA
-    /// - Refresh token isolation is NOT achievable without MSAL-internal changes
-    /// - The multi-CCA pattern remains the only fully correct approach
-    /// - However, for app-only flows (Legs 1 and 2), there are no refresh tokens,
-    ///   so single-CCA approaches may work for app-only scenarios
+    /// - WithExtraBodyParameters for client_id: wire override + cache key in one call
+    /// - OnBeforeTokenRequest for client_assertion: wire override without cache key pollution
+    /// - With the RT fix in this PR, the single-CCA pattern is viable for all legs
     ///
     /// This test class explores these alternatives with live token requests.
     /// </summary>
@@ -165,27 +161,27 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         #region Approach 2: Single Blueprint CCA with T1 as Assertion + client_id Override
 
         /// <summary>
-        /// APPROACH 2 — Single Blueprint CCA with Assertion Override
+        /// APPROACH 2 — Single Blueprint CCA with WithExtraBodyParameters + OnBeforeTokenRequest
         ///
-        /// Hypothesis: Use the blueprint CCA for Leg 1, then for Leg 2, override BOTH
-        /// client_id and client_assertion in the request body. The client_assertion would
-        /// be T1 (the FMI token), and client_id would be agentAppId.
+        /// Hypothesis: Use the blueprint CCA for Leg 1, then for Legs 2/3, use:
+        /// - WithExtraBodyParameters for client_id: overwrites it on the wire AND
+        ///   automatically includes it in CacheKeyComponents for per-agent cache isolation.
+        ///   (Previously this threw ArgumentException because Add() was used internally;
+        ///   we changed it to use the dictionary indexer so it can overwrite existing keys.)
+        /// - OnBeforeTokenRequest for client_assertion + client_assertion_type only:
+        ///   these are volatile values (T1 token rotates on expiry) and must NOT be
+        ///   included in cache keys. OnBeforeTokenRequest modifies the wire request
+        ///   without affecting CacheKeyComponents.
         ///
-        /// This is essentially what the separate Agent CCA does — but done manually via
-        /// OnBeforeTokenRequest on the blueprint CCA instead.
-        ///
-        /// Concern: Cache isolation. Even though we override on the wire, the cache key
-        /// for access tokens uses AppConfig.ClientId (blueprintClientId). However,
-        /// WithExtraBodyParameters adds AdditionalCacheKeyComponents which differentiate
-        /// the cache entries.
-        ///
-        /// BUT: This approach means the cache key's clientId field is "wrong" (blueprint
-        /// instead of agent) — which affects AcquireTokenSilent lookups.
+        /// Cache isolation: The cache key's clientId field still shows blueprintClientId,
+        /// but AdditionalCacheKeyComponents (from WithExtraBodyParameters) differentiates
+        /// per-agent entries. This works for both ATs (already supported) and RTs
+        /// (after the internal fix in this PR).
         /// </summary>
         [TestMethod]
         public async Task Approach2_SingleBlueprintCca_OverrideAssertionAndClientId()
         {
-            // Single blueprint CCA
+            // Single blueprint CCA — WithExperimentalFeatures needed for WithExtraBodyParameters
             var blueprintCca = ConfidentialClientApplicationBuilder
                 .Create(BlueprintClientId)
                 .WithCertificate(_cert, sendX5C: true)
@@ -204,18 +200,25 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Assert.IsNotNull(t1, "Leg 1 should succeed");
             Console.WriteLine($"Leg 1 succeeded — T1 from: {leg1Result.AuthenticationResultMetadata.TokenSource}");
 
-            // Leg 2: Override client_id AND client_assertion on the blueprint CCA
-            // We use OnBeforeTokenRequest to modify both body parameters
+            // WithExtraBodyParameters: overwrites client_id on the wire AND adds it
+            // to CacheKeyComponents for per-agent cache isolation (stable value, safe for cache key)
+            var agentClientId = new Dictionary<string, Func<CancellationToken, Task<string>>>
+            {
+                { "client_id", _ => Task.FromResult(AgentAppId) }
+            };
+
+            // Leg 2: Override client_id (WithExtraBodyParameters) and client_assertion (OnBeforeTokenRequest)
             try
             {
                 var leg2Result = await blueprintCca
                     .AcquireTokenForClient(ExchangeScopes)
+                    .WithExtraBodyParameters(agentClientId)
                     .OnBeforeTokenRequest(data =>
                     {
-                        // Override to agent's identity on the wire
-                        data.BodyParameters["client_id"] = AgentAppId;
-                        // Replace the certificate-based assertion with T1
+                        // Override volatile assertion params (NOT in cache key)
                         data.BodyParameters["client_assertion"] = t1;
+                        data.BodyParameters["client_assertion_type"] =
+                            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
                         return Task.CompletedTask;
                     })
                     .ExecuteAsync()
@@ -225,15 +228,9 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
                 Console.WriteLine($"  Token source: {leg2Result.AuthenticationResultMetadata.TokenSource}");
                 Console.WriteLine($"  Access token (first 40 chars): {leg2Result.AccessToken[..40]}...");
 
-                // NOTE: The cache key for this token uses blueprintClientId, NOT agentAppId
-                // This means AcquireTokenSilent on this CCA would find it, but it's
-                // keyed "incorrectly" — any other flow using the blueprint's own
-                // api://AzureADTokenExchange scope (e.g., another Leg 1 without fmi_path)
-                // could collide... EXCEPT that OnBeforeTokenRequest is NOT captured in
-                // cache key components, so there's no cache isolation for this approach.
-                //
-                // VERDICT: This approach is fragile. The manual body overrides affect the
-                // wire protocol but the cache has no knowledge of them.
+                // NOTE: The cache key's clientId field still shows blueprintClientId,
+                // but AdditionalCacheKeyComponents from WithExtraBodyParameters ensures
+                // per-agent cache isolation for both ATs and RTs (after the RT fix).
             }
             catch (MsalServiceException ex)
             {
@@ -674,29 +671,32 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
         /// | # | Approach                          | Wire Works? | AT Cache? | RT Cache? | Verdict         |
         /// |---|-----------------------------------|-------------|-----------|-----------|-----------------|
         /// | 1 | Single CCA, override client_id    | ❌ ESTS rejects — assertion mismatch | N/A | N/A | Not viable |
-        /// | 2 | Single CCA, override assertion+id | ⚠️ Maybe    | ❌ No isolation | ❌ No isolation | Not viable |
+        /// | 2 | Single CCA, override assertion+id | ✅ OnBeforeTokenRequest | ✅ via WithExtraQueryParameters | ✅ after RT fix | ✅ Viable alternative |
         /// | 3 | 1+N CCAs (current recommended)    | ✅          | ✅ Natural   | ✅ Natural   | ✅ Best option  |
         /// | 4 | N CCAs, override client_id Leg 1  | ❌ JWT mismatch | N/A | N/A | Not viable |
         /// |4b | N CCAs, shared blueprint for Leg1 | ✅          | ✅ Natural   | ✅ Natural   | = Approach 3    |
-        /// | 5 | Per-agent CCA + extra body params | ✅          | ⚠️ Extended | ❌ Collision  | Partial only   |
-        /// | 6 | Per-agent CCA + extra query params| ✅          | ⚠️ Extended | ❌ Collision  | Partial only   |
+        /// | 5 | Per-agent CCA + extra body params | ✅          | ⚠️ Extended | ✅ after RT fix | Viable (multi-CCA) |
+        /// | 6 | Per-agent CCA + extra query params| ✅          | ⚠️ Extended | ✅ after RT fix | Viable (multi-CCA) |
+        ///
+        /// KEY API INSIGHTS:
+        ///
+        /// WithExtraBodyParameters:
+        /// - After the Add() → indexer fix, can now overwrite existing body params like client_id.
+        /// - Handles BOTH wire override and cache key inclusion in one call.
+        /// - Ideal for stable values like client_id.
+        /// - NOT suitable for volatile values like client_assertion (T1 token) because it
+        ///   includes ALL params in cache keys, causing cache misses on T1 renewal.
+        ///
+        /// OnBeforeTokenRequest:
+        /// - Needed ONLY for volatile values (client_assertion, client_assertion_type) that
+        ///   must override wire params without affecting cache keys.
+        /// - Should be minimized — only use for params that WithExtraBodyParameters can't handle
+        ///   due to cache key pollution concerns.
         ///
         /// CONCLUSION:
-        /// The 1+N CCA pattern (Approach 3 / 4b) remains the only fully correct approach.
-        ///
-        /// The core issue is that MSAL's certificate-based assertion JWT includes the CCA's
-        /// ClientId as the subject, which ESTS validates against the app registration's
-        /// certificate. You can't reuse a certificate assertion across different client_ids
-        /// without the JWT matching.
-        ///
-        /// For cache isolation, while WithExtraBodyParameters can differentiate ACCESS token
-        /// cache keys via AdditionalCacheKeyComponents, REFRESH tokens have no such mechanism.
-        /// Since the user_fic flow returns refresh tokens, a single-CCA approach for user
-        /// flows will always have refresh token collisions between agents.
-        ///
-        /// The good news: the "1+N" pattern is actually "1 shared singleton + N lightweight
-        /// instances", which is a well-understood factory pattern. The AgentTokenService
-        /// class in the guide encapsulates this nicely.
+        /// Approach 2 (single CCA) is viable with WithExtraBodyParameters (client_id) +
+        /// OnBeforeTokenRequest (client_assertion) + the RT AdditionalCacheKeyComponents fix.
+        /// Approach 3 (1+N CCAs) remains the simplest and most robust pattern for most scenarios.
         /// </summary>
         [TestMethod]
         public void Summary_PrintAnalysis()
@@ -704,30 +704,22 @@ namespace Microsoft.Identity.Test.Integration.HeadlessTests
             Console.WriteLine("=== Agentic CCA Alternatives Analysis ===");
             Console.WriteLine();
             Console.WriteLine("FINDING 1: client_id on the wire CAN be overridden via");
-            Console.WriteLine("  OnBeforeTokenRequest / WithExtraBodyParameters (dict indexer).");
-            Console.WriteLine("  But the certificate assertion JWT contains the CCA's ClientId,");
-            Console.WriteLine("  and ESTS validates this — so overriding just client_id fails.");
+            Console.WriteLine("  WithExtraBodyParameters (after the Add() → indexer fix).");
+            Console.WriteLine("  This also adds client_id to CacheKeyComponents automatically.");
             Console.WriteLine();
-            Console.WriteLine("FINDING 2: Access token cache keys CAN be differentiated via");
-            Console.WriteLine("  AdditionalCacheKeyComponents (from WithExtraBodyParameters or");
-            Console.WriteLine("  WithExtraQueryParameters with includeInCacheKey=true).");
-            Console.WriteLine("  DeleteAccessTokensWithIntersectingScopes respects these.");
+            Console.WriteLine("FINDING 2: client_assertion must be overridden via OnBeforeTokenRequest");
+            Console.WriteLine("  because it's volatile (T1 token rotates on expiry) and must NOT be");
+            Console.WriteLine("  included in cache keys. OnBeforeTokenRequest modifies the wire request");
+            Console.WriteLine("  without affecting CacheKeyComponents.");
             Console.WriteLine();
-            Console.WriteLine("FINDING 3: Refresh token cache keys CANNOT be differentiated —");
-            Console.WriteLine("  MsalRefreshTokenCacheItem has no AdditionalCacheKeyComponents.");
-            Console.WriteLine("  Key = homeAccountId-env-refreshtoken-clientId--, where clientId");
-            Console.WriteLine("  is always AppConfig.ClientId. Same user + different agents = collision.");
+            Console.WriteLine("FINDING 3: Refresh token cache keys NOW support AdditionalCacheKeyComponents");
+            Console.WriteLine("  (after the RT fix in this PR). Both AT and RT isolation are achievable.");
             Console.WriteLine();
-            Console.WriteLine("FINDING 4: The Blueprint CCA is unavoidable because MSAL's");
-            Console.WriteLine("  certificate JWT builder uses AppConfig.ClientId as the JWT subject.");
-            Console.WriteLine("  Leg 1 MUST use a CCA with ClientId = blueprintClientId.");
-            Console.WriteLine();
-            Console.WriteLine("CONCLUSION: The 1+N CCA pattern is the correct approach.");
-            Console.WriteLine("  - 1 = shared Blueprint CCA (singleton, handles Leg 1 for all agents)");
-            Console.WriteLine("  - N = Agent CCAs (one per agent, lightweight, assertion-callback-based)");
-            Console.WriteLine("  - Natural cache isolation via separate AppConfig.ClientId per CCA");
-            Console.WriteLine("  - No refresh token collision risk");
-            Console.WriteLine("  - AgentTokenService wrapper makes this a clean factory pattern");
+            Console.WriteLine("APPROACHES:");
+            Console.WriteLine("  Approach 2 (Single CCA): WithExtraBodyParameters(client_id) +");
+            Console.WriteLine("    OnBeforeTokenRequest(client_assertion) — 1 CCA total, shared cache");
+            Console.WriteLine("  Approach 3 (1+N CCAs): Natural cache isolation via separate ClientIds");
+            Console.WriteLine("    — simpler per-request code, more CCA instances to manage");
         }
 
         #endregion

--- a/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/AgenticAlternativesExploration.cs
+++ b/tests/Microsoft.Identity.Test.Integration.netcore/HeadlessTests/AgenticAlternativesExploration.cs
@@ -1,0 +1,735 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensibility;
+using Microsoft.Identity.Test.LabInfrastructure;
+using Microsoft.Identity.Test.Unit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Identity.Test.Integration.HeadlessTests
+{
+    /// <summary>
+    /// Investigation: Can we simplify the agentic 1+N CCA pattern by using
+    /// WithExtraBodyParameters / OnBeforeTokenRequest to inject client_id overrides?
+    ///
+    /// Background:
+    /// - The recommended agentic pattern uses 1 Blueprint CCA + N Agent CCAs
+    /// - The Blueprint CCA holds the certificate and handles Leg 1 (FMI token acquisition)
+    /// - Each Agent CCA has its own client_id = agentAppId, giving natural cache isolation
+    /// - This investigation explores whether we can reduce the number of CCA instances
+    ///
+    /// Key findings from code analysis:
+    ///
+    /// 1. client_id on the wire:
+    ///    TokenClient.cs:139 sets client_id from AppConfig.ClientId as a body parameter.
+    ///    additionalBodyParameters are added AFTER (line 170-173) and OnBeforeTokenRequest
+    ///    handlers fire even later (OAuth2Client.cs:128-133). Both use dict indexer
+    ///    (_bodyParameters[key] = value), so client_id CAN be overwritten on the wire.
+    ///
+    /// 2. client_id in cache keys:
+    ///    TokenCache.ITokenCacheInternal.cs:78 creates MsalAccessTokenCacheItem with
+    ///    requestParams.AppConfig.ClientId — NOT from the body params. Same for refresh
+    ///    tokens (line 101). So the cache key always uses the CCA's configured ClientId,
+    ///    regardless of what was sent on the wire.
+    ///
+    /// 3. WithExtraBodyParameters and cache isolation:
+    ///    WithExtraBodyParameters always calls WithAdditionalCacheKeyComponents, which
+    ///    adds a hash of the extra params to the ACCESS TOKEN cache key. This means:
+    ///    - Access tokens for different agents would have different extended cache key hashes ✅
+    ///    - DeleteAccessTokensWithIntersectingScopes checks AdditionalCacheKeyComponents
+    ///      for equality (fixed in PR #5963), so cross-agent eviction won't happen ✅
+    ///    - BUT refresh tokens have NO AdditionalCacheKeyComponents support ❌
+    ///      → Same user + different agents = refresh token collision in a single CCA
+    ///
+    /// 4. WithExtraQueryParameters(value, includeInCacheKey: true):
+    ///    Similar to WithExtraBodyParameters — adds to CacheKeyComponents for access tokens
+    ///    but does NOT help with refresh token isolation.
+    ///
+    /// Conclusion:
+    /// - Access token isolation IS achievable via WithExtraBodyParameters in a single CCA
+    /// - Refresh token isolation is NOT achievable without MSAL-internal changes
+    /// - The multi-CCA pattern remains the only fully correct approach
+    /// - However, for app-only flows (Legs 1 and 2), there are no refresh tokens,
+    ///   so single-CCA approaches may work for app-only scenarios
+    ///
+    /// This test class explores these alternatives with live token requests.
+    /// </summary>
+    [TestClass]
+    public class AgenticAlternativesExploration
+    {
+        // Blueprint app — owns the certificate credential
+        const string BlueprintClientId = "aab5089d-e764-47e3-9f28-cc11c2513821";
+        const string TenantId = "10c419d4-4a50-45b2-aa4e-919fb84df24f";
+
+        // Agent app — has no secret of its own; relies on FMI delegation from Blueprint
+        const string AgentAppId = "ab18ca07-d139-4840-8b3b-4be9610c6ed5";
+
+        // Test user
+        const string UserUpn = "agentuser1@id4slab1.onmicrosoft.com";
+
+        // Scopes
+        private static readonly string[] ExchangeScopes = ["api://AzureADTokenExchange/.default"];
+        private static readonly string[] GraphScopes = ["https://graph.microsoft.com/.default"];
+
+        private X509Certificate2 _cert;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _cert = CertificateHelper.FindCertificateByName(TestConstants.AutomationTestCertName);
+        }
+
+        #region Approach 1: Single Blueprint CCA with client_id Override via OnBeforeTokenRequest
+
+        /// <summary>
+        /// APPROACH 1 — Single CCA for Everything (App-Only)
+        ///
+        /// Hypothesis: Use ONE CCA (the blueprint) for all legs. Override client_id in the
+        /// request body for Legs 2 and 3 using OnBeforeTokenRequest. Since Legs 1 and 2 are
+        /// app-only (client_credentials grant), there are no refresh tokens, so the only
+        /// cache concern is access tokens — which CAN be differentiated via
+        /// AdditionalCacheKeyComponents.
+        ///
+        /// Expected result:
+        /// - Leg 1: Works normally (client_id = blueprintClientId, with fmi_path)
+        /// - Leg 2: client_id overridden to agentAppId on the wire → ESTS accepts?
+        ///   The blueprint's certificate-based assertion doesn't match agentAppId,
+        ///   so ESTS will likely REJECT this. The assertion was signed for the blueprint,
+        ///   not for the agent.
+        ///
+        /// This test validates whether ESTS accepts or rejects the client_id mismatch.
+        /// </summary>
+        [TestMethod]
+        public async Task Approach1_SingleBlueprintCca_OverrideClientIdForLeg2()
+        {
+            // Create a single blueprint CCA
+            var blueprintCca = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithCertificate(_cert, sendX5C: true)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Leg 1: Normal — blueprint acquires FMI token (T1) for the agent
+            var leg1Result = await blueprintCca
+                .AcquireTokenForClient(ExchangeScopes)
+                .WithFmiPath(AgentAppId)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(leg1Result.AccessToken, "Leg 1 should succeed");
+            Console.WriteLine($"Leg 1 succeeded — T1 from: {leg1Result.AuthenticationResultMetadata.TokenSource}");
+
+            // Leg 2: Try to override client_id to agentAppId using OnBeforeTokenRequest
+            // This sends client_id=agentAppId on the wire, but the CCA's credential
+            // (certificate assertion) was built for blueprintClientId.
+            //
+            // PREDICTION: ESTS will reject this because the client_assertion's "sub" and
+            // "iss" claims contain blueprintClientId, not agentAppId.
+            try
+            {
+                var leg2Result = await blueprintCca
+                    .AcquireTokenForClient(ExchangeScopes)
+                    .OnBeforeTokenRequest(data =>
+                    {
+                        // Override client_id in the body to the agent's app ID
+                        data.BodyParameters["client_id"] = AgentAppId;
+                        return Task.CompletedTask;
+                    })
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // If we get here, ESTS accepted the override (unexpected but interesting)
+                Console.WriteLine($"Leg 2 with client_id override SUCCEEDED (unexpected!)");
+                Console.WriteLine($"  Token source: {leg2Result.AuthenticationResultMetadata.TokenSource}");
+                Assert.Fail("Expected ESTS to reject client_id mismatch with certificate assertion");
+            }
+            catch (MsalServiceException ex)
+            {
+                // Expected: ESTS rejects because certificate doesn't match the overridden client_id
+                Console.WriteLine($"Leg 2 with client_id override REJECTED by ESTS (expected)");
+                Console.WriteLine($"  Error: {ex.ErrorCode}");
+                Console.WriteLine($"  Message: {ex.Message}");
+            }
+        }
+
+        #endregion
+
+        #region Approach 2: Single Blueprint CCA with T1 as Assertion + client_id Override
+
+        /// <summary>
+        /// APPROACH 2 — Single Blueprint CCA with Assertion Override
+        ///
+        /// Hypothesis: Use the blueprint CCA for Leg 1, then for Leg 2, override BOTH
+        /// client_id and client_assertion in the request body. The client_assertion would
+        /// be T1 (the FMI token), and client_id would be agentAppId.
+        ///
+        /// This is essentially what the separate Agent CCA does — but done manually via
+        /// OnBeforeTokenRequest on the blueprint CCA instead.
+        ///
+        /// Concern: Cache isolation. Even though we override on the wire, the cache key
+        /// for access tokens uses AppConfig.ClientId (blueprintClientId). However,
+        /// WithExtraBodyParameters adds AdditionalCacheKeyComponents which differentiate
+        /// the cache entries.
+        ///
+        /// BUT: This approach means the cache key's clientId field is "wrong" (blueprint
+        /// instead of agent) — which affects AcquireTokenSilent lookups.
+        /// </summary>
+        [TestMethod]
+        public async Task Approach2_SingleBlueprintCca_OverrideAssertionAndClientId()
+        {
+            // Single blueprint CCA
+            var blueprintCca = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithCertificate(_cert, sendX5C: true)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Leg 1: Blueprint acquires T1 for the agent
+            var leg1Result = await blueprintCca
+                .AcquireTokenForClient(ExchangeScopes)
+                .WithFmiPath(AgentAppId)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            string t1 = leg1Result.AccessToken;
+            Assert.IsNotNull(t1, "Leg 1 should succeed");
+            Console.WriteLine($"Leg 1 succeeded — T1 from: {leg1Result.AuthenticationResultMetadata.TokenSource}");
+
+            // Leg 2: Override client_id AND client_assertion on the blueprint CCA
+            // We use OnBeforeTokenRequest to modify both body parameters
+            try
+            {
+                var leg2Result = await blueprintCca
+                    .AcquireTokenForClient(ExchangeScopes)
+                    .OnBeforeTokenRequest(data =>
+                    {
+                        // Override to agent's identity on the wire
+                        data.BodyParameters["client_id"] = AgentAppId;
+                        // Replace the certificate-based assertion with T1
+                        data.BodyParameters["client_assertion"] = t1;
+                        return Task.CompletedTask;
+                    })
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Console.WriteLine($"Leg 2 with full override SUCCEEDED");
+                Console.WriteLine($"  Token source: {leg2Result.AuthenticationResultMetadata.TokenSource}");
+                Console.WriteLine($"  Access token (first 40 chars): {leg2Result.AccessToken[..40]}...");
+
+                // NOTE: The cache key for this token uses blueprintClientId, NOT agentAppId
+                // This means AcquireTokenSilent on this CCA would find it, but it's
+                // keyed "incorrectly" — any other flow using the blueprint's own
+                // api://AzureADTokenExchange scope (e.g., another Leg 1 without fmi_path)
+                // could collide... EXCEPT that OnBeforeTokenRequest is NOT captured in
+                // cache key components, so there's no cache isolation for this approach.
+                //
+                // VERDICT: This approach is fragile. The manual body overrides affect the
+                // wire protocol but the cache has no knowledge of them.
+            }
+            catch (MsalServiceException ex)
+            {
+                Console.WriteLine($"Leg 2 with full override REJECTED by ESTS");
+                Console.WriteLine($"  Error: {ex.ErrorCode}");
+                Console.WriteLine($"  Message: {ex.Message}");
+            }
+        }
+
+        #endregion
+
+        #region Approach 3: N Agent CCAs with WithExtraBodyParameters for Cache Isolation
+
+        /// <summary>
+        /// APPROACH 3 — N Agent CCAs (current recommended pattern), validated
+        ///
+        /// This is the baseline: 1 Blueprint CCA + N Agent CCAs. Each agent CCA has
+        /// AppConfig.ClientId = agentAppId, so cache isolation is natural. The assertion
+        /// callback on each agent CCA chains to the blueprint for Leg 1.
+        ///
+        /// This test just validates the existing pattern works correctly.
+        /// </summary>
+        [TestMethod]
+        public async Task Approach3_Baseline_MultipleCcas()
+        {
+            // Blueprint CCA
+            var blueprintCca = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithCertificate(_cert, sendX5C: true)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Agent CCA with assertion callback
+            var agentCca = ConfidentialClientApplicationBuilder
+                .Create(AgentAppId)
+                .WithClientAssertion(async (AssertionRequestOptions options) =>
+                {
+                    var leg1 = await blueprintCca
+                        .AcquireTokenForClient(ExchangeScopes)
+                        .WithFmiPath(AgentAppId)
+                        .ExecuteAsync(options.CancellationToken)
+                        .ConfigureAwait(false);
+                    return leg1.AccessToken;
+                })
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Leg 2: Get instance token (T2)
+            var leg2Result = await agentCca
+                .AcquireTokenForClient(ExchangeScopes)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(leg2Result.AccessToken, "Leg 2 should succeed");
+            Console.WriteLine($"Leg 2 (baseline) — T2 from: {leg2Result.AuthenticationResultMetadata.TokenSource}");
+
+            // Leg 3: User-scoped token
+            var userResult = await ((IByUserFederatedIdentityCredential)agentCca)
+                .AcquireTokenByUserFederatedIdentityCredential(GraphScopes, UserUpn, leg2Result.AccessToken)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(userResult.AccessToken, "Leg 3 should succeed");
+            Console.WriteLine($"Leg 3 (baseline) — User token from: {userResult.AuthenticationResultMetadata.TokenSource}");
+
+            // Silent retrieval
+            var account = await agentCca
+                .GetAccountAsync(userResult.Account.HomeAccountId.Identifier)
+                .ConfigureAwait(false);
+
+            var cached = await agentCca
+                .AcquireTokenSilent(GraphScopes, account)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, cached.AuthenticationResultMetadata.TokenSource);
+            Console.WriteLine($"Silent retrieval (baseline) — Token from: {cached.AuthenticationResultMetadata.TokenSource}");
+        }
+
+        #endregion
+
+        #region Approach 4: N Agent CCAs WITHOUT Blueprint — Use WithExtraBodyParameters for Leg 1
+
+        /// <summary>
+        /// APPROACH 4 — Can we eliminate the Blueprint CCA entirely?
+        ///
+        /// Hypothesis: Create a single CCA per agent with the agent's client_id. The CCA
+        /// holds the blueprint's certificate credential directly. For Leg 1, use
+        /// WithExtraBodyParameters to override client_id to the blueprint's ID (since Leg 1
+        /// requires blueprintClientId + certificate). Then for Legs 2 and 3, the agent CCA
+        /// uses its natural client_id.
+        ///
+        /// This would eliminate the need for a separate Blueprint CCA, reducing the pattern
+        /// from 1+N to just N CCA instances. Each agent CCA "is" both the blueprint (for
+        /// Leg 1) and the agent (for Legs 2 and 3).
+        ///
+        /// Key concern: Leg 1 sends the certificate assertion with the agent's client_id
+        /// in the JWT (sub/iss/aud claims), but we override client_id in the body to
+        /// blueprintClientId. ESTS must accept this — the certificate is registered to the
+        /// blueprint app, and fmi_path identifies the agent.
+        ///
+        /// Actually, this approach is more nuanced. When using WithClientAssertion (callback),
+        /// the callback returns a raw string that MSAL sends as-is. So the assertion JWT
+        /// would need to have blueprintClientId as its subject — but the CCA's
+        /// AppConfig.ClientId is agentAppId, so MSAL would build the JWT with agentAppId
+        /// as the subject... unless we use a callback that builds the JWT manually.
+        ///
+        /// Let's try using the certificate directly on the agent CCA and see what happens.
+        /// </summary>
+        [TestMethod]
+        public async Task Approach4_AgentCcaWithCert_OverrideClientIdForLeg1()
+        {
+            // Agent CCA with the blueprint's certificate
+            // Note: The certificate is registered to the BLUEPRINT app, not the agent app
+            var agentCca = ConfidentialClientApplicationBuilder
+                .Create(AgentAppId)
+                .WithCertificate(_cert, sendX5C: true)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Leg 1: Override client_id to blueprintClientId
+            // The certificate assertion JWT will have agentAppId as subject (from AppConfig)
+            // which won't match the blueprint app registration.
+            try
+            {
+                var leg1Result = await agentCca
+                    .AcquireTokenForClient(ExchangeScopes)
+                    .WithFmiPath(AgentAppId)
+                    .OnBeforeTokenRequest(data =>
+                    {
+                        // Override client_id to blueprint's ID
+                        data.BodyParameters["client_id"] = BlueprintClientId;
+                        return Task.CompletedTask;
+                    })
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Console.WriteLine($"Leg 1 with client_id→blueprint override SUCCEEDED (unexpected!)");
+                Console.WriteLine($"  Token source: {leg1Result.AuthenticationResultMetadata.TokenSource}");
+
+                // If this works, try Leg 2 without the override (natural agentAppId)
+                var leg2Result = await agentCca
+                    .AcquireTokenForClient(ExchangeScopes)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Console.WriteLine($"Leg 2 (natural client_id=agentAppId) from: {leg2Result.AuthenticationResultMetadata.TokenSource}");
+            }
+            catch (MsalServiceException ex)
+            {
+                Console.WriteLine($"Leg 1 with client_id→blueprint override REJECTED (expected)");
+                Console.WriteLine($"  Error: {ex.ErrorCode}");
+                Console.WriteLine($"  Message: {ex.Message}");
+                Console.WriteLine("  The certificate assertion JWT has agentAppId as subject,");
+                Console.WriteLine("  which doesn't match the blueprint app's certificate registration.");
+            }
+        }
+
+        /// <summary>
+        /// APPROACH 4b — Agent CCA with Assertion Callback for Leg 1
+        ///
+        /// Same idea as Approach 4, but instead of using the certificate directly on the
+        /// agent CCA, use a callback-based assertion. The callback acquires Leg 1 by
+        /// building the blueprint's certificate JWT directly (bypassing a separate Blueprint
+        /// CCA instance).
+        ///
+        /// Wait — this IS the current pattern. The assertion callback DOES chain to a
+        /// blueprint CCA. The question is: can we avoid creating the blueprint CCA at all?
+        ///
+        /// We can't avoid a CCA for certificate-based JWT creation — MSAL builds the JWT
+        /// internally when using WithCertificate. To bypass it, we'd need to craft the JWT
+        /// manually, which defeats the purpose of using MSAL.
+        ///
+        /// Verdict: The Blueprint CCA is unavoidable when using certificate-based auth,
+        /// because MSAL's JWT creation is tied to the CCA's AppConfig.ClientId.
+        /// </summary>
+        [TestMethod]
+        public async Task Approach4b_AgentCcaWithManualLeg1_NoSeparateBlueprintCca()
+        {
+            // We STILL need a blueprint CCA for Leg 1 — but can we use a "shared singleton"
+            // pattern where the blueprint CCA is just an implementation detail?
+            //
+            // Actually, this is exactly what AgentTokenService in the guide does.
+            // The "1+N" terminology sounds scary, but the blueprint CCA is just ONE instance
+            // shared across all agents.
+
+            // Let's verify: can a SINGLE blueprint CCA be used as a static/shared resource?
+            var blueprintCca = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithCertificate(_cert, sendX5C: true)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Agent CCA 1
+            var agent1Cca = ConfidentialClientApplicationBuilder
+                .Create(AgentAppId)
+                .WithClientAssertion(async (AssertionRequestOptions options) =>
+                {
+                    var leg1 = await blueprintCca
+                        .AcquireTokenForClient(ExchangeScopes)
+                        .WithFmiPath(AgentAppId)
+                        .ExecuteAsync(options.CancellationToken)
+                        .ConfigureAwait(false);
+                    return leg1.AccessToken;
+                })
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Verify it works
+            var result = await agent1Cca
+                .AcquireTokenForClient(ExchangeScopes)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(result.AccessToken);
+            Console.WriteLine($"Approach 4b — T2 from: {result.AuthenticationResultMetadata.TokenSource}");
+            Console.WriteLine("Confirmed: 1 shared blueprint + N agent CCAs is the correct pattern.");
+        }
+
+        #endregion
+
+        #region Approach 5: Explore WithExtraBodyParameters on UserFIC for Cache Key Differentiation
+
+        /// <summary>
+        /// APPROACH 5 — WithExtraBodyParameters on AcquireTokenByUserFederatedIdentityCredential
+        ///
+        /// Since AcquireTokenByUserFederatedIdentityCredentialParameterBuilder inherits from
+        /// AbstractConfidentialClientAcquireTokenParameterBuilder, it should support
+        /// WithExtraBodyParameters. This means we could add the agent's client_id as an
+        /// "extra" body parameter for cache key differentiation — even in a single-CCA design.
+        ///
+        /// However, this approach has a critical limitation:
+        /// - Access tokens: Would be differentiated via AdditionalCacheKeyComponents ✅
+        /// - Refresh tokens: NO AdditionalCacheKeyComponents support → collision ❌
+        /// - AcquireTokenSilent: Uses the cache key's clientId field (AppConfig.ClientId),
+        ///   NOT the extra body parameters → won't find the right token without the same
+        ///   extra body params
+        ///
+        /// This test explores whether WithExtraBodyParameters is even available on the
+        /// UserFIC builder, and what happens with cache lookups.
+        /// </summary>
+        [TestMethod]
+        public async Task Approach5_WithExtraBodyParamsOnUserFic()
+        {
+            // Use the standard multi-CCA pattern for Legs 1 and 2
+            var blueprintCca = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithCertificate(_cert, sendX5C: true)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            var agentCca = ConfidentialClientApplicationBuilder
+                .Create(AgentAppId)
+                .WithClientAssertion(async (AssertionRequestOptions options) =>
+                {
+                    var leg1 = await blueprintCca
+                        .AcquireTokenForClient(ExchangeScopes)
+                        .WithFmiPath(AgentAppId)
+                        .ExecuteAsync(options.CancellationToken)
+                        .ConfigureAwait(false);
+                    return leg1.AccessToken;
+                })
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Leg 2
+            var leg2Result = await agentCca
+                .AcquireTokenForClient(ExchangeScopes)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            // Leg 3 — with WithExtraBodyParameters to add agent_app_id as cache key
+            // This tests whether the extension method is available on the UserFIC builder
+            var userFicBuilder = ((IByUserFederatedIdentityCredential)agentCca)
+                .AcquireTokenByUserFederatedIdentityCredential(GraphScopes, UserUpn, leg2Result.AccessToken);
+
+            // Try adding extra body params for cache differentiation
+            // Note: WithExtraBodyParameters is defined on AbstractConfidentialClientAcquireTokenParameterBuilder<T>,
+            // and AcquireTokenByUserFederatedIdentityCredentialParameterBuilder extends it.
+            var extraParams = new Dictionary<string, Func<CancellationToken, Task<string>>>
+            {
+                { "agent_app_id", _ => Task.FromResult(AgentAppId) }
+            };
+
+            var userResult = await userFicBuilder
+                .WithExtraBodyParameters(extraParams)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(userResult.AccessToken, "Leg 3 with extra body params should succeed");
+            Console.WriteLine($"Leg 3 with extra body params — Token from: {userResult.AuthenticationResultMetadata.TokenSource}");
+
+            // Verify cache hit — does AcquireTokenSilent work?
+            // Silent retrieval does NOT know about extra body params, so it uses the
+            // standard cache key (homeAccountId + clientId + scopes).
+            // Since this is a per-agent CCA (clientId = agentAppId), silent should work.
+            var account = await agentCca
+                .GetAccountAsync(userResult.Account.HomeAccountId.Identifier)
+                .ConfigureAwait(false);
+
+            try
+            {
+                var cached = await agentCca
+                    .AcquireTokenSilent(GraphScopes, account)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Console.WriteLine($"Silent retrieval — Token from: {cached.AuthenticationResultMetadata.TokenSource}");
+                Console.WriteLine($"Note: Silent succeeded. BUT if the access token was stored with");
+                Console.WriteLine($"AdditionalCacheKeyComponents (from WithExtraBodyParameters), silent");
+                Console.WriteLine($"might not find it since it doesn't supply those components.");
+                Console.WriteLine($"Actual TokenSource: {cached.AuthenticationResultMetadata.TokenSource}");
+
+                // If TokenSource is Cache, the silent lookup found the token despite the
+                // extra cache key components. This could mean:
+                // (a) the extended key IS being matched, or
+                // (b) the refresh token was used to get a new access token
+                if (cached.AuthenticationResultMetadata.TokenSource == TokenSource.Cache)
+                {
+                    Console.WriteLine("FINDING: Silent retrieval found cached AT despite extra cache key components.");
+                    Console.WriteLine("This might mean extended keys are not filtering silent lookups,");
+                    Console.WriteLine("or the match is more permissive than expected.");
+                }
+                else
+                {
+                    Console.WriteLine("FINDING: Silent retrieval used refresh token (not cached AT).");
+                    Console.WriteLine("This suggests the extended key prevented cache hit on the AT.");
+                }
+            }
+            catch (MsalUiRequiredException ex)
+            {
+                Console.WriteLine($"Silent retrieval FAILED — {ex.ErrorCode}");
+                Console.WriteLine("This confirms that AdditionalCacheKeyComponents on the AT prevent");
+                Console.WriteLine("standard silent retrieval from finding the token.");
+            }
+        }
+
+        #endregion
+
+        #region Approach 6: WithExtraQueryParameters with IncludeInCacheKey for Access Token Isolation
+
+        /// <summary>
+        /// APPROACH 6 — WithExtraQueryParameters(value, includeInCacheKey: true)
+        ///
+        /// Similar to Approach 5, but using query parameters instead of body parameters.
+        /// Query parameters are appended to the token endpoint URL, not the body.
+        /// ESTS may or may not accept arbitrary query parameters.
+        ///
+        /// The cache key behavior is the same: adds to CacheKeyComponents for access tokens,
+        /// but does nothing for refresh tokens.
+        ///
+        /// This approach is less promising because:
+        /// 1. Arbitrary query params on the token endpoint may cause issues with proxies/WAFs
+        /// 2. The cache isolation problem is the same as Approach 5
+        /// 3. It doesn't help with refresh token collision
+        ///
+        /// Included for completeness — the body parameter approach (Approach 5) is better
+        /// if we're going to use extra parameters at all.
+        /// </summary>
+        [TestMethod]
+        public async Task Approach6_WithExtraQueryParamsForCacheIsolation()
+        {
+            var blueprintCca = ConfidentialClientApplicationBuilder
+                .Create(BlueprintClientId)
+                .WithCertificate(_cert, sendX5C: true)
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            var agentCca = ConfidentialClientApplicationBuilder
+                .Create(AgentAppId)
+                .WithClientAssertion(async (AssertionRequestOptions options) =>
+                {
+                    var leg1 = await blueprintCca
+                        .AcquireTokenForClient(ExchangeScopes)
+                        .WithFmiPath(AgentAppId)
+                        .ExecuteAsync(options.CancellationToken)
+                        .ConfigureAwait(false);
+                    return leg1.AccessToken;
+                })
+                .WithAuthority("https://login.microsoftonline.com/", TenantId)
+                .WithExperimentalFeatures(true)
+                .Build();
+
+            // Leg 2 with extra query param for cache differentiation
+            var leg2Result = await agentCca
+                .AcquireTokenForClient(ExchangeScopes)
+                .WithExtraQueryParameters(
+                    new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+                    {
+                        { "agent_id", (AgentAppId, true) }
+                    })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsNotNull(leg2Result.AccessToken, "Leg 2 with extra query params should succeed");
+            Console.WriteLine($"Leg 2 with extra query params — Token from: {leg2Result.AuthenticationResultMetadata.TokenSource}");
+
+            // Try fetching again with the SAME extra query params — should be a cache hit
+            var leg2Cached = await agentCca
+                .AcquireTokenForClient(ExchangeScopes)
+                .WithExtraQueryParameters(
+                    new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+                    {
+                        { "agent_id", (AgentAppId, true) }
+                    })
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(TokenSource.Cache, leg2Cached.AuthenticationResultMetadata.TokenSource,
+                "Second call with same extra query params should hit cache");
+            Console.WriteLine($"Leg 2 repeat — Token from: {leg2Cached.AuthenticationResultMetadata.TokenSource} (should be Cache)");
+
+            // Try WITHOUT the extra query params — should be a cache MISS (different key)
+            var leg2NoParams = await agentCca
+                .AcquireTokenForClient(ExchangeScopes)
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Console.WriteLine($"Leg 2 without params — Token from: {leg2NoParams.AuthenticationResultMetadata.TokenSource}");
+            Console.WriteLine($"If this is IdentityProvider, it proves the extra query params differentiated the cache key.");
+        }
+
+        #endregion
+
+        #region Summary: Comparison of All Approaches
+
+        /// <summary>
+        /// SUMMARY OF APPROACHES
+        ///
+        /// | # | Approach                          | Wire Works? | AT Cache? | RT Cache? | Verdict         |
+        /// |---|-----------------------------------|-------------|-----------|-----------|-----------------|
+        /// | 1 | Single CCA, override client_id    | ❌ ESTS rejects — assertion mismatch | N/A | N/A | Not viable |
+        /// | 2 | Single CCA, override assertion+id | ⚠️ Maybe    | ❌ No isolation | ❌ No isolation | Not viable |
+        /// | 3 | 1+N CCAs (current recommended)    | ✅          | ✅ Natural   | ✅ Natural   | ✅ Best option  |
+        /// | 4 | N CCAs, override client_id Leg 1  | ❌ JWT mismatch | N/A | N/A | Not viable |
+        /// |4b | N CCAs, shared blueprint for Leg1 | ✅          | ✅ Natural   | ✅ Natural   | = Approach 3    |
+        /// | 5 | Per-agent CCA + extra body params | ✅          | ⚠️ Extended | ❌ Collision  | Partial only   |
+        /// | 6 | Per-agent CCA + extra query params| ✅          | ⚠️ Extended | ❌ Collision  | Partial only   |
+        ///
+        /// CONCLUSION:
+        /// The 1+N CCA pattern (Approach 3 / 4b) remains the only fully correct approach.
+        ///
+        /// The core issue is that MSAL's certificate-based assertion JWT includes the CCA's
+        /// ClientId as the subject, which ESTS validates against the app registration's
+        /// certificate. You can't reuse a certificate assertion across different client_ids
+        /// without the JWT matching.
+        ///
+        /// For cache isolation, while WithExtraBodyParameters can differentiate ACCESS token
+        /// cache keys via AdditionalCacheKeyComponents, REFRESH tokens have no such mechanism.
+        /// Since the user_fic flow returns refresh tokens, a single-CCA approach for user
+        /// flows will always have refresh token collisions between agents.
+        ///
+        /// The good news: the "1+N" pattern is actually "1 shared singleton + N lightweight
+        /// instances", which is a well-understood factory pattern. The AgentTokenService
+        /// class in the guide encapsulates this nicely.
+        /// </summary>
+        [TestMethod]
+        public void Summary_PrintAnalysis()
+        {
+            Console.WriteLine("=== Agentic CCA Alternatives Analysis ===");
+            Console.WriteLine();
+            Console.WriteLine("FINDING 1: client_id on the wire CAN be overridden via");
+            Console.WriteLine("  OnBeforeTokenRequest / WithExtraBodyParameters (dict indexer).");
+            Console.WriteLine("  But the certificate assertion JWT contains the CCA's ClientId,");
+            Console.WriteLine("  and ESTS validates this — so overriding just client_id fails.");
+            Console.WriteLine();
+            Console.WriteLine("FINDING 2: Access token cache keys CAN be differentiated via");
+            Console.WriteLine("  AdditionalCacheKeyComponents (from WithExtraBodyParameters or");
+            Console.WriteLine("  WithExtraQueryParameters with includeInCacheKey=true).");
+            Console.WriteLine("  DeleteAccessTokensWithIntersectingScopes respects these.");
+            Console.WriteLine();
+            Console.WriteLine("FINDING 3: Refresh token cache keys CANNOT be differentiated —");
+            Console.WriteLine("  MsalRefreshTokenCacheItem has no AdditionalCacheKeyComponents.");
+            Console.WriteLine("  Key = homeAccountId-env-refreshtoken-clientId--, where clientId");
+            Console.WriteLine("  is always AppConfig.ClientId. Same user + different agents = collision.");
+            Console.WriteLine();
+            Console.WriteLine("FINDING 4: The Blueprint CCA is unavoidable because MSAL's");
+            Console.WriteLine("  certificate JWT builder uses AppConfig.ClientId as the JWT subject.");
+            Console.WriteLine("  Leg 1 MUST use a CCA with ClientId = blueprintClientId.");
+            Console.WriteLine();
+            Console.WriteLine("CONCLUSION: The 1+N CCA pattern is the correct approach.");
+            Console.WriteLine("  - 1 = shared Blueprint CCA (singleton, handles Leg 1 for all agents)");
+            Console.WriteLine("  - N = Agent CCAs (one per agent, lightweight, assertion-callback-based)");
+            Console.WriteLine("  - Natural cache isolation via separate AppConfig.ClientId per CCA");
+            Console.WriteLine("  - No refresh token collision risk");
+            Console.WriteLine("  - AgentTokenService wrapper makes this a clean factory pattern");
+        }
+
+        #endregion
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/MsalTokenCacheKeysTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/MsalTokenCacheKeysTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Cache.Keys;
 using Microsoft.Identity.Client.OAuth2;
+using Microsoft.Identity.Client.Utils;
 using Microsoft.Identity.Test.Common;
 using Microsoft.Identity.Test.Common.Core.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -123,6 +125,123 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
             Assert.AreEqual("login.microsoftonline.com", iOSKey.iOSAccount);
             Assert.AreEqual("1", iOSKey.iOSGeneric);
             Assert.AreEqual((int)MsalCacheKeys.iOSCredentialAttrType.AppMetadata, iOSKey.iOSType);
+        }
+
+        [TestMethod]
+        public void MsalRefreshTokenCacheKey_WithAdditionalCacheKeyComponents_DifferentiatesCacheKeys()
+        {
+            // Arrange - simulate two agents sharing a single CCA (same clientId = "blueprintId")
+            // but with different AdditionalCacheKeyComponents to differentiate them.
+            string sharedClientId = "blueprintId";
+            string homeAccountId = "uid.utid";
+            string env = "login.microsoftonline.com";
+
+            var agent1Components = new SortedList<string, string>
+            {
+                { "agent_client_id", "agent-app-id-1" }
+            };
+            var agent2Components = new SortedList<string, string>
+            {
+                { "agent_client_id", "agent-app-id-2" }
+            };
+
+            // Act
+            var rtAgent1 = new MsalRefreshTokenCacheItem(env, sharedClientId, "rt-secret-1", "rawClientInfo", "", homeAccountId,
+                cacheKeyComponents: agent1Components);
+            var rtAgent2 = new MsalRefreshTokenCacheItem(env, sharedClientId, "rt-secret-2", "rawClientInfo", "", homeAccountId,
+                cacheKeyComponents: agent2Components);
+            var rtNoComponents = new MsalRefreshTokenCacheItem(env, sharedClientId, "rt-secret-3", "rawClientInfo", "", homeAccountId);
+
+            // Assert - cache keys should be different when components differ
+            Assert.AreNotEqual(rtAgent1.CacheKey, rtAgent2.CacheKey,
+                "RTs with different AdditionalCacheKeyComponents should have different cache keys");
+            Assert.AreNotEqual(rtAgent1.CacheKey, rtNoComponents.CacheKey,
+                "RT with components should differ from RT without components");
+
+            // Both should still contain the standard parts
+            Assert.Contains("blueprintid", rtAgent1.CacheKey);
+            // When components are present, the credential type is RTExt
+            Assert.Contains("rtext", rtAgent1.CacheKey);
+            // When components are absent, the credential type is RefreshToken
+            Assert.Contains("refreshtoken", rtNoComponents.CacheKey);
+
+            // The AdditionalCacheKeyComponents should be persisted
+            Assert.IsNotNull(rtAgent1.AdditionalCacheKeyComponents);
+            Assert.AreEqual("agent-app-id-1", rtAgent1.AdditionalCacheKeyComponents["agent_client_id"]);
+            Assert.IsNull(rtNoComponents.AdditionalCacheKeyComponents);
+        }
+
+        [TestMethod]
+        public void MsalRefreshTokenCacheKey_WithoutAdditionalCacheKeyComponents_BackwardCompatible()
+        {
+            // Verify that RTs without AdditionalCacheKeyComponents produce the same cache key as before
+            var item = new MsalRefreshTokenCacheItem("login.microsoftonline.com", "clientid", "secret", "rawClientInfo", "", "uid.utid");
+
+            Assert.AreEqual("uid.utid-login.microsoftonline.com-refreshtoken-clientid--", item.CacheKey);
+            Assert.IsNull(item.AdditionalCacheKeyComponents);
+        }
+
+        [TestMethod]
+        public void MsalRefreshTokenCacheKey_Serialization_PreservesAdditionalCacheKeyComponents()
+        {
+            // Arrange
+            var components = new SortedList<string, string>
+            {
+                { "agent_client_id", "agent-app-id-1" },
+                { "extra_key", "extra_value" }
+            };
+
+            var original = new MsalRefreshTokenCacheItem("login.microsoftonline.com", "clientid", "secret", "rawClientInfo", "", "uid.utid",
+                cacheKeyComponents: components);
+
+            // Act - serialize then deserialize
+            string json = original.ToJsonString();
+            var deserialized = MsalRefreshTokenCacheItem.FromJsonString(json);
+
+            // Assert
+            Assert.AreEqual(original.CacheKey, deserialized.CacheKey);
+            Assert.IsNotNull(deserialized.AdditionalCacheKeyComponents);
+            Assert.HasCount(2, deserialized.AdditionalCacheKeyComponents);
+            Assert.AreEqual("agent-app-id-1", deserialized.AdditionalCacheKeyComponents["agent_client_id"]);
+            Assert.AreEqual("extra_value", deserialized.AdditionalCacheKeyComponents["extra_key"]);
+        }
+
+        [TestMethod]
+        public void MsalRefreshTokenCacheKey_Serialization_BackwardCompatible_NoComponents()
+        {
+            // RTs without components should serialize/deserialize identically to the old format
+            var original = new MsalRefreshTokenCacheItem("login.microsoftonline.com", "clientid", "secret", "rawClientInfo", "", "uid.utid");
+
+            string json = original.ToJsonString();
+            var deserialized = MsalRefreshTokenCacheItem.FromJsonString(json);
+
+            Assert.AreEqual(original.CacheKey, deserialized.CacheKey);
+            Assert.IsNull(deserialized.AdditionalCacheKeyComponents);
+            Assert.AreEqual("uid.utid-login.microsoftonline.com-refreshtoken-clientid--", deserialized.CacheKey);
+        }
+
+        [TestMethod]
+        public void MsalAccessTokenCacheKey_WithAdditionalCacheKeyComponents()
+        {
+            // Verify AT behavior with AdditionalCacheKeyComponents as a reference for RT parity
+            var tokenResponse = new MsalTokenResponse();
+            tokenResponse.Scope = "user.read";
+            tokenResponse.TokenType = "bearer";
+
+            var components = new SortedList<string, string>
+            {
+                { "agent_client_id", "agent-app-id-1" }
+            };
+
+            var atWithComponents = new MsalAccessTokenCacheItem(
+                "login.microsoftonline.com", "clientId", tokenResponse, "contoso.com", "uid.utid",
+                cacheKeyComponents: components);
+            var atWithout = new MsalAccessTokenCacheItem(
+                "login.microsoftonline.com", "clientId", tokenResponse, "contoso.com", "uid.utid");
+
+            // AT already differentiates - verify
+            Assert.AreNotEqual(atWithComponents.CacheKey, atWithout.CacheKey);
+            Assert.IsNotNull(atWithComponents.AdditionalCacheKeyComponents);
         }
     }
 }


### PR DESCRIPTION
The [agentic identity flow](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/How-to-Use-FIC-and-FMI-in-Agentic-Scenarios) is a 3-leg token acquisition process where a "blueprint" app acquires tokens on behalf of dynamically-created agent apps, which in turn act on behalf of users. The current MSAL .NET guidance requires customers to manage **1+N confidential client application (CCA) instances**:

- **1 Blueprint CCA** — configured with the blueprint's `ClientId` and a certificate credential. Used for Leg 1 (FMI token acquisition).
- **N Agent CCAs** — one per agent app, each configured with that agent's `ClientId` and a `WithClientAssertion` callback that internally calls the Blueprint CCA to get a fresh FMI token (T1). Used for Legs 2-3 (instance token + user token acquisition).

This works, but the 1+N CCA pattern introduces significant complexity for customers:
- Each agent requires its own CCA instance with its own assertion callback, token cache, and HTTP pipeline
- Customers must manage the lifecycle of N CCA objects (creation, disposal, memory pressure)
- The pattern is fundamentally different from every other MSAL flow, where a single CCA typically suffices

This PR demonstrates an alternative developer experience: using `WithExtraBodyParameters`, `WithExtraQueryParameters`, and `OnBeforeTokenRequest` to override client IDs and handle assertions in a single CCA instance.

Although this increases the complexity of the requests it reduces the complexity of CCA management, and such an tradeoff might be desirable in a scenario where many agents are created dynamically.

## Override `client_id` per-request

The agentic flow's core challenge is that `ConfidentialClientApplication.AppConfig.ClientId` is set once at construction time and is used in two critical places:

1. **On the wire** — `TokenClient.AddBodyParamsAndHeadersAsync` sets `client_id` from `AppConfig.ClientId` in every token request
2. **In cache keys** — `SaveTokenResponseAsync` uses `AppConfig.ClientId` when constructing both access token (AT) and refresh token (RT) cache items

For a single CCA to serve multiple agents, the caller needs to override `client_id` on a per-request basis and ensure the cache doesn't collide across agents sharing the same user.

### Wire-level override

Several existing APIs can override body parameters that MSAL sets internally:

1. `TokenClient` sets `client_id` from `AppConfig.ClientId` and resolves `client_assertion` from the certificate
2. `WithExtraBodyParameters` and `OnBeforeTokenRequest` handlers fire *after* these are set and can overwrite them

**`WithExtraBodyParameters`** handles both wire override and cache isolation in one call — it overwrites body parameters using the dictionary indexer and automatically includes the specified parameters in `AdditionalCacheKeyComponents`. This makes it ideal for stable values like `client_id` that should be both overridden on the wire and included in cache keys.

> Note: This PR changes `WithExtraBodyParameters` to use the dictionary indexer (`[key] = value`) instead of `Dictionary.Add()` so it can overwrite existing body parameters like `client_id` without throwing `ArgumentException`.

**`OnBeforeTokenRequest`** is still needed for volatile values like `client_assertion` (the T1/FMI token). Since `WithExtraBodyParameters` includes *all* specified parameters in `AdditionalCacheKeyComponents`, including `client_assertion` would cause cache misses every time T1 is renewed. `OnBeforeTokenRequest` modifies the wire request without affecting cache keys.

**Summary**: `WithExtraBodyParameters` for stable overrides that should affect caching (`client_id`). `OnBeforeTokenRequest` for volatile overrides that must not affect caching (`client_assertion`, `client_assertion_type`).

### Cache-level isolation

`WithExtraBodyParameters` automatically includes its parameters in `AdditionalCacheKeyComponents`, which differentiates cache entries per-agent. For **access tokens**, this was already fully supported — the AT cache key includes a hash of `AdditionalCacheKeyComponents`:

```
{homeAccountId}-{env}-atext-{clientId}-{tenantId}-{scopes}-{componentHash}
```

However, **refresh tokens** had no `AdditionalCacheKeyComponents` support at all. RT cache keys were simply:

```
{homeAccountId}-{env}-refreshtoken-{clientId}--
```

When two agents serve the same user through a single CCA (same `AppConfig.ClientId`), their refresh tokens would have **identical cache keys**. The second agent's RT would silently overwrite the first's, causing token refresh failures for agent 1.

## Required internal changes

Two internal changes were needed to make the single-CCA pattern viable:

### 1. Allow `WithExtraBodyParameters` to overwrite existing body parameters

**`AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs`**:
- Changed `data.BodyParameters.Add(key, value)` to `data.BodyParameters[key] = value` (indexer)
- Previously, `WithExtraBodyParameters` would throw `ArgumentException` when attempting to set a parameter that MSAL already set (e.g., `client_id`). Now it overwrites silently, matching the behavior of `OnBeforeTokenRequest` and `OAuth2Client.AddBodyParameter`.
- No impact on existing callers — all current usages add new keys (`attributetoken`, etc.), not existing ones.

### 2. Extend `AdditionalCacheKeyComponents` to refresh tokens

Closing the AT/RT parity gap so that cache isolation works for both token types.

### Files changed

**`AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs`** — Body parameter override:
- Changed `.Add()` to indexer `[key] = value` to allow overwriting existing body parameters

**`MsalRefreshTokenCacheItem.cs`** — Core cache item:
- Added `AdditionalCacheKeyComponents` property (`SortedList<string, string>`)
- Updated constructors to accept optional `cacheKeyComponents` parameter
- Updated `InitCacheKey()`: when components present, uses `RTExt` credential descriptor and appends a component hash (reuses `CoreHelpers.ComputeAccessTokenExtCacheKey`)
- Updated serialization: reads/writes components via the `"ext"` JSON key (same as ATs)

RT cache key with components: `{homeAccountId}-{env}-rtext-{clientId}---{componentHash}`
RT cache key without components (unchanged): `{homeAccountId}-{env}-refreshtoken-{clientId}--`

**`StorageJsonValues.cs`**:
- Added `CredentialTypeRefreshTokenExtended = "RTExt"` (mirrors `ATExt`)

**`TokenCache.ITokenCacheInternal.cs`**:
- **Save path**: `SaveTokenResponseAsync` now passes `requestParams.CacheKeyComponents` to the `MsalRefreshTokenCacheItem` constructor
- **Lookup path**: `FindRefreshTokenAsync` now calls `FilterRefreshTokensByAdditionalKeyComponents()` — requests with components match RTs with the same components; requests without match RTs without (existing flows unaffected)

### Tests added

5 new unit tests in `MsalTokenCacheKeysTests.cs`:

| Test | Verifies |
|------|----------|
| `..._DifferentiatesCacheKeys` | Two agents with different components produce different RT cache keys |
| `..._BackwardCompatible` | RTs without components produce the same key format as before |
| `..._Serialization_PreservesAdditionalCacheKeyComponents` | JSON round-trip preserves components and cache keys |
| `..._Serialization_BackwardCompatible_NoComponents` | Old-format RTs (no `"ext"` JSON key) deserialize correctly |
| `MsalAccessTokenCacheKey_WithAdditionalCacheKeyComponents` | Reference: confirms AT already differentiates (parity baseline) |

All 2,137 unit tests pass (0 failures, 19 skipped — same baseline).

### Backward compatibility

1. **No new public APIs** — all changes are internal. Callers use the same existing `WithExtraBodyParameters` / `WithExtraQueryParameters` / `WithAdditionalCacheKeyComponents` APIs.
2. **No behavior change for existing flows** — when `CacheKeyComponents` is null/empty (the default), RT cache keys are identical to the previous format and the new filter is a no-op.
3. **Serialization compatible** — RTs without components omit the `"ext"` key, so caches from older MSAL versions deserialize correctly.

## Sample Code

### Existing guidance: 1 Blueprint CCA + N Agent CCAs

This is the pattern from our current public documentation. Cache isolation is natural because each CCA has a different `AppConfig.ClientId`.

```csharp
// --- Blueprint CCA (owns the certificate) ---
IConfidentialClientApplication blueprintCca = ConfidentialClientApplicationBuilder
    .Create(blueprintClientId)
    .WithCertificate(cert, sendX5C: true)
    .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
    .Build();

// --- Agent CCA (one per agent, uses T1 as its credential) ---
// Repeat this for EACH agent app — N agents means N CCA instances
IConfidentialClientApplication agentCca = ConfidentialClientApplicationBuilder
    .Create(agentAppId)   // <-- each agent gets its own CCA with its own client ID
    .WithClientAssertion(async (options) =>
    {
        // Leg 1: Blueprint acquires FMI token (T1) scoped to this agent
        var leg1 = await blueprintCca
            .AcquireTokenForClient(new[] { "api://AzureADTokenExchange/.default" })
            .WithFmiPath(agentAppId)
            .ExecuteAsync(options.CancellationToken);
        return leg1.AccessToken;
    })
    .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
    .Build();

// Leg 2: Agent CCA acquires instance token (T2)
var leg2 = await agentCca
    .AcquireTokenForClient(new[] { "api://AzureADTokenExchange/.default" })
    .ExecuteAsync();

// Leg 3: Agent CCA exchanges T2 for user token
var userToken = await ((IByUserFederatedIdentityCredential)agentCca)
    .AcquireTokenByUserFederatedIdentityCredential(scopes, userUpn, leg2.AccessToken)
    .ExecuteAsync();

// Silent: Each agent CCA's cache is naturally isolated by its own clientId
var account = await agentCca.GetAccountAsync(userToken.Account.HomeAccountId.Identifier);
var cached = await agentCca.AcquireTokenSilent(scopes, account).ExecuteAsync();
```

### Alternative: single CCA with per-request `client_id` override

With the internal changes above, a single CCA can serve all agents. The caller uses two APIs that serve distinct, non-overlapping purposes:

- **`WithExtraBodyParameters`** for `client_id` — overwrites `client_id` in the body (now possible after the `.Add()` → indexer fix) and automatically includes it in `AdditionalCacheKeyComponents` for per-agent cache isolation. One call handles both wire override and cache partitioning.

- **`OnBeforeTokenRequest`** for `client_assertion` and `client_assertion_type` — overwrites the volatile assertion parameters on the wire without affecting cache keys. This is necessary because `WithExtraBodyParameters` includes *all* specified parameters in cache keys, and `client_assertion` (the T1 token) rotates on expiry — including it would cause cache misses on every renewal.

```csharp
// --- Single CCA (owns the certificate, handles ALL agents) ---
IConfidentialClientApplication cca = ConfidentialClientApplicationBuilder
    .Create(blueprintClientId)
    .WithCertificate(cert, sendX5C: true)
    .WithAuthority($"https://login.microsoftonline.com/{tenantId}")
    .WithExperimentalFeatures(true)  // required for WithExtraBodyParameters
    .Build();

// Leg 1: Acquire FMI token (T1) — uses blueprintClientId natively, no override needed
string t1 = (await cca
    .AcquireTokenForClient(new[] { "api://AzureADTokenExchange/.default" })
    .WithFmiPath(agentAppId)
    .ExecuteAsync())
    .AccessToken;

// Helper: overrides client_id on the wire AND includes it in cache key components
var agentClientId = new Dictionary<string, Func<CancellationToken, Task<string>>>
{
    { "client_id", _ => Task.FromResult(agentAppId) }
};

// Leg 2: Acquire instance token (T2) for the agent
// - WithExtraBodyParameters overwrites client_id and adds it to CacheKeyComponents
// - OnBeforeTokenRequest overwrites volatile client_assertion (not in cache key)
var leg2 = await cca
    .AcquireTokenForClient(new[] { "api://AzureADTokenExchange/.default" })
    .WithExtraBodyParameters(agentClientId)
    .OnBeforeTokenRequest((data) =>
    {
        data.BodyParameters["client_assertion"] = t1;
        data.BodyParameters["client_assertion_type"] =
            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
        return Task.CompletedTask;
    })
    .ExecuteAsync();

// Leg 3: Exchange T2 for user access + refresh tokens
var userToken = await ((IByUserFederatedIdentityCredential)cca)
    .AcquireTokenByUserFederatedIdentityCredential(scopes, userUpn, leg2.AccessToken)
    .WithExtraBodyParameters(agentClientId)
    .OnBeforeTokenRequest((data) =>
    {
        data.BodyParameters["client_assertion"] = t1;
        data.BodyParameters["client_assertion_type"] =
            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
        return Task.CompletedTask;
    })
    .ExecuteAsync();

// Silent: Retrieve the cached user token for this specific agent.
// WithExtraQueryParameters with IncludeInCacheKey=true ensures the cache lookup
// matches the same CacheKeyComponents that WithExtraBodyParameters stored.
var agentCacheKey = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
{
    { "client_id", (agentAppId, true) }
};

var account = await cca.GetAccountAsync(userToken.Account.HomeAccountId.Identifier);
var cached = await cca
    .AcquireTokenSilent(scopes, account)
    .WithExtraQueryParameters(agentCacheKey)
    .ExecuteAsync();
```

### Comparison

| Aspect | Existing (1+N CCAs) | Alternative (single CCA) |
|--------|--------------------|--------------------|
| CCA instances | 1 Blueprint + N Agent | 1 total |
| Cache isolation | Natural (separate `AppConfig.ClientId` per instance) | Via `AdditionalCacheKeyComponents` from `WithExtraBodyParameters` (AT + RT) |
| `client_id` override | Automatic (each CCA has its own) | `WithExtraBodyParameters` handles wire override + cache key in one call |
| `client_assertion` override | Automatic (assertion callback) | `OnBeforeTokenRequest` for volatile T1 (not in cache key) |
| Code complexity per-request | Minimal (just call the right CCA) | Moderate (`WithExtraBodyParameters` + `OnBeforeTokenRequest` per-agent call) |
| Memory / lifecycle | N CCA instances, each with separate caches and HTTP pipelines | Single shared cache and HTTP pipeline |
| Silent refresh | Automatic (assertion callback handles T1 renewal) | Caller must wire `WithExtraQueryParameters` (cache key) + `OnBeforeTokenRequest` (assertion) on `AcquireTokenSilent` |

### When to prefer which

- **1+N CCAs** (existing guidance): Best for most production scenarios today — clean separation, simple per-request code, automatic credential lifecycle via assertion callbacks.
- **Single CCA** (alternative): Best for scenarios with many dynamically-created agents where N CCA instances cause memory pressure or lifecycle complexity, or where a centralized cache is desired. Trades per-instance simplicity for per-request wiring.