### PR TITLE
Spike #6042: delegate IMDSv2 token leg to internal TokenClient exchange

### DIFF
--- a/docs/imdsv2_cca_delegation_spike.md
+++ b/docs/imdsv2_cca_delegation_spike.md
@@ -188,3 +188,72 @@ keep MI caching, and add the `invalid_client` remint wrapper. This is the minima
 that lets the future MSIv2 NSP claims (#5982) ride MSAL's existing
 claims→body / CP1-merge / claims-cache-key machinery instead of being re-ported into the
 managed-identity path. Reassess option B once the IMDS NSP wire contract lands.
+
+## 9. PoC results (Phase 2 — completed)
+
+A throwaway PoC was implemented on branch `rginsburg/imdsv2-cca-delegation-spike`,
+gated behind `ImdsV2ManagedIdentitySource.s_delegateTokenLegToInternalExchange`
+(default **off**, so all existing behavior/tests are unaffected).
+
+Changes:
+- `ImdsV2ManagedIdentitySource`: extracted the cert-mint flow into
+  `AcquireMtlsBindingAsync()` (behavior-neutral refactor) and added a mint-only
+  delegation entrypoint `AcquireMtlsBindingForDelegationAsync(...)` (sets the
+  attestation provider / PoP flag and supports `invalid_client` re-mint eviction).
+- `ManagedIdentityClient`: added `AcquireImdsV2MtlsBindingAsync(...)` (mints without
+  sending the bespoke token POST).
+- `ManagedIdentityAuthRequest`: added a flag-gated delegation branch plus
+  `SendDelegatedImdsV2TokenRequestAsync` / `DelegateImdsV2TokenLegAsync`, which inject
+  the minted cert, apply `MtlsPopAuthenticationOperation`, and call
+  `new TokenClient(reqParams).SendTokenRequestAsync(body, scopeOverride, tokenEndpointOverride)`,
+  wrapped in an `invalid_client` re-mint-and-retry-once.
+
+**Feasibility: confirmed.** Option A works with **no change to `TokenClient`**:
+- `tokenEndpointOverride` targets the IMDS-provided ESTS-R endpoint with zero instance
+  discovery.
+- The canonical mint client_id is supplied via `additionalBodyParameters` and overrides
+  `AppConfig.ClientId` (`OAuth2Client.AddBodyParameter` overwrites by key).
+- The minted cert flows as the mTLS transport cert via `requestParams.MtlsCertificate`.
+- MI token caching is preserved: the cache lookup runs upstream in
+  `ManagedIdentityAuthRequest.ExecuteAsync`, so the delegated branch only executes on a
+  cache miss; the cert is re-primed for the scheme via `SetRuntimeMtlsBindingCertificate`.
+
+**Validation:** new test `mTLSPop_DelegatedTokenLeg_HappyPath_Spike6042` (SAMI, KeyGuard +
+attestation) passes — the delegated request hits
+`{mtls_endpoint}/{tenant}/oauth2/v2.0/token`, posts `client_credentials` +
+canonical `client_id` + `token_type=mtls_pop`, returns a cert-bound token
+(`TokenSource.IdentityProvider`), and the second acquire is served from cache
+(`TokenSource.Cache`). All **83** `ImdsV2Tests` pass with the flag default-off.
+
+### Measurement (issue ask: lines removed vs. lines added)
+
+`git diff --numstat origin/main` (production token-leg files only):
+
+| File | +added | −removed |
+|------|-------:|---------:|
+| `ManagedIdentityAuthRequest.cs` | 80 | 0 |
+| `ManagedIdentityClient.cs` | 17 | 0 |
+| `ImdsV2ManagedIdentitySource.cs` | 66 | 24 |
+| **Total** | **163** | **24** |
+
+Decomposition (the raw numbers overstate "new" code because the spike kept the bespoke
+path intact behind a flag and only *extracted* the mint block):
+
+- **Behavior-neutral refactor (moved, not new):** ~50 lines — the mint block relocated
+  from `CreateRequestAsync` into `AcquireMtlsBindingAsync`.
+- **Net-new delegation glue:** ~95 lines — delegation branch + 2 helpers (~70 in
+  `ManagedIdentityAuthRequest`), the mint accessor (17 in `ManagedIdentityClient`), and the
+  flag + delegation entrypoint (~25 in `ImdsV2ManagedIdentitySource`).
+- **Bespoke token-path code the delegation bypasses (would be removed in a non-flagged
+  migration):** ~26 lines in `CreateRequestAsync` (lines 417–442: `ManagedIdentityRequest`
+  construction, headers, body params, `RequestType`/`MtlsCertificate`) **plus** reliance on
+  the MI-specific HTTP send and `ManagedIdentityResponse` parsing that `TokenClient` and
+  `MsalTokenResponse` replace.
+
+**Key finding (the real driver):** for the *happy path* the line count is roughly
+net-neutral. The decisive benefit is qualitative: delegation means claims→body, CP1
+capability merge, claims-in-cache-key, and ESTS error handling are inherited from
+`TokenClient`/`ClientCredentialRequest` instead of being **re-ported and maintained** in
+the MSI v2 path. The bespoke path would have to *grow* to add NSP (#5982); the delegated
+path gets it for free. Recommendation: adopt option A as the basis for MSIv2 NSP once the
+IMDS `/issuecredential` wire contract is finalized.

--- a/docs/imdsv2_cca_delegation_spike.md
+++ b/docs/imdsv2_cca_delegation_spike.md
@@ -1,0 +1,190 @@
+# Spike: IMDSv2 — delegate the post-mint token leg to MSAL's internal exchange path
+
+> Tracking issue: **#6042** — *[Engineering task] Spike - IMDSv2: delegate token leg to internal ConfidentialClientApplication*
+> Related: **#5982** (`docs/nsp_claims_design.md`, NSP / `WithClaimsFromClient` design)
+
+## 1. Background
+
+MSI v2 (IMDS v2) acquires an mTLS **binding certificate** from IMDS via
+`/getplatformmetadata` (CSR metadata) and `/issuecredential` (cert mint), then makes a
+`client_credentials` POST **directly** to the ESTS-R mTLS token endpoint
+(`{mtlsAuthenticationEndpoint}/{tenant}/oauth2/v2.0/token`).
+
+That post-mint token request is **hand-rolled** in
+`ImdsV2ManagedIdentitySource.CreateRequestAsync` and sent through the managed-identity
+pipeline. It re-implements behavior that already exists in MSAL's confidential-client
+exchange (`ClientCredentialRequest` / `TokenClient`):
+
+- claims → request body
+- client-capability (CP1) merge into claims
+- claims-as-cache-key
+- token-type / auth-scheme validation
+- telemetry around the token endpoint
+
+The real driver (per #6042 comments and #5982) is **claims / NSP support**. Adding
+NSP / CP1 / client claims to the bespoke MSI v2 path means re-porting all of the above
+plus a remint loop. The agreed direction (Bogdan + Robbie on #6042) is to **delegate
+the token leg to MSAL's internal exchange path** — *not* to instantiate a public
+`ConfidentialClientApplication`.
+
+## 2. Goal & non-goals
+
+**Goal:** Replace only the post-mint HTTP token request with a call into MSAL's
+internal `ClientCredentialRequest` / `TokenClient`, so the IMDS-minted cert rides the
+same code path that already handles claims, capabilities, caching, and telemetry.
+
+**Non-goals:**
+- Do **not** change the cert-mint code (`/getplatformmetadata` + `/issuecredential`).
+- Do **not** create or call a public `ConfidentialClientApplication`. Reuse the
+  internal `ClientCredentialRequest` / `TokenClient` plumbing only.
+- Do **not** finalize the MSIv2 NSP wire contract — #5982 marks MSIv2 as
+  "design pending (IMDS team)". This spike delivers the delegation **seam** that the
+  NSP claims will later ride on; it does not ship NSP for MSIv2.
+
+## 3. Current state (verified, with citations)
+
+### 3.1 Cert-mint (keep as-is)
+`src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs`
+- Endpoint constants: lines 36–38 (`CsrMetadataPath`, `CertificateRequestPath`,
+  `AcquireEntraTokenPath = "/oauth2/v2.0/token"`).
+- `GetCsrMetadataAsync` (42–93) → GET `/getplatformmetadata`.
+- `ExecuteCertificateRequestAsync` (~245–333) → POST `/issuecredential`.
+- KeyGuard validation + CSR generation + cert assembly inside `CreateRequestAsync`
+  (343–411). The mint result yields `MtlsBindingInfo { Certificate, Endpoint, ClientId }`.
+
+### 3.2 Post-mint token request (to be replaced)
+`ImdsV2ManagedIdentitySource.CreateRequestAsync` (335–442):
+- Builds a `ManagedIdentityRequest` POST to `endpointBaseForToken + "/oauth2/v2.0/token"`
+  (417–419).
+- Body: `client_id` (434), `grant_type=client_credentials` (435),
+  `scope={resource}/.default` (436), `token_type` bearer/mtls_pop (432, 437).
+- Sets `request.MtlsCertificate = bindingCertificate` (440), `RequestType = STS` (439).
+
+`src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs`:
+- `SendTokenRequestForManagedIdentityAsync` (214–253): resolves authority, forwards
+  `ClientClaims` (225–228), calls
+  `_managedIdentityClient.SendTokenRequestForManagedIdentityAsync(...)` (230–233),
+  applies the `MtlsPopAuthenticationOperation` scheme **before** caching (235–247),
+  then `CacheTokenResponseAndCreateAuthenticationResultAsync` (252).
+
+### 3.3 Delegation target (internal exchange)
+`src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs`:
+- `ExecuteAsync` (36–129): scope validation (38–43); cache-skip for ForceRefresh / claims
+  (60–76); cache hit + proactive refresh (78–116); `GetAccessTokenAsync` on miss (125).
+- `GetBodyParameters` (487–497): `grant_type=client_credentials`, `client_info=2`, scope.
+
+`src/client/Microsoft.Identity.Client/OAuth2/TokenClient.cs`:
+- ctor (34–43): builds `OAuth2Client` with `requestParams.MtlsCertificate` → mTLS cert
+  flows from the request params, **no extra wiring needed**.
+- `SendTokenRequestAsync` (45–116): **accepts `tokenEndpointOverride` (48)**; when set it
+  is used verbatim (55–59) and **instance/endpoint discovery is skipped**. This is the
+  key enabler — we pass the IMDS-provided ESTS-R endpoint directly.
+- `AddBodyParamsAndHeadersAsync` (133–197): `client_id` (139), credential material via
+  `CredentialMaterialResolver` (142–163), `scope` (166), `claims` from
+  `_requestParams.ClaimsAndClientCapabilities` (168), auth-scheme params (175–178).
+
+### 3.4 Claims / capability merge (free once delegated)
+- `AuthenticationRequestParameters.ClaimsAndClientCapabilities` (76–82, 114) merges
+  `Claims` + `ClientClaims` with capabilities via
+  `ClaimsHelper.GetMergedClaimsAndClientCapabilities` (57–70).
+
+### 3.5 Instance discovery already disabled for MI
+- `ManagedIdentityApplicationBuilder.DefaultConfiguration()` sets
+  `IsInstanceDiscoveryEnabled = false` (160–167). Combined with `tokenEndpointOverride`,
+  the delegated request makes **zero** discovery calls.
+
+### 3.6 No remint loop today
+- No `invalid_client` handling exists under `ManagedIdentity/`. The only retry hook is
+  the generic `OnMsalServiceFailure` callback in `ClientCredentialRequest` (164–189,
+  253–287). The remint-on-`invalid_client` behavior must be **added** around the
+  delegated call.
+
+## 4. Proposed delegation
+
+### 4.1 Sequence
+```
+ManagedIdentityAuthRequest (MSI v2, mTLS PoP)
+  └─ mint cert  (UNCHANGED: /getplatformmetadata + /issuecredential)
+       → MtlsBindingInfo { cert, estsrEndpoint, clientIdGuid }
+  └─ DELEGATE token leg:
+       build internal AuthenticationRequestParameters for the exchange:
+         • Authority         = ESTS-R mTLS authority from MtlsBindingInfo.Endpoint
+         • ClientId          = MtlsBindingInfo.ClientId
+         • Scope             = {resource}/.default
+         • MtlsCertificate   = MtlsBindingInfo.Certificate
+         • AuthenticationScheme = MtlsPopAuthenticationOperation(cert)  (PoP) / Bearer
+         • Claims / ClientClaims / capabilities  ← from the MI request params
+       new TokenClient(requestParams)
+         .SendTokenRequestAsync(
+             GetBodyParameters(),
+             tokenEndpointOverride: MtlsBindingInfo.Endpoint + "/oauth2/v2.0/token")
+       wrap in invalid_client → remint cert → retry-once
+  └─ cache + build AuthenticationResult (existing MI cache path)
+```
+
+### 4.2 Two viable integration depths
+- **(A) Delegate to `TokenClient` only (recommended for the spike).** Keep the MI cache /
+  result-shaping path in `ManagedIdentityAuthRequest`; replace just the bespoke POST with
+  `new TokenClient(reqParams).SendTokenRequestAsync(body, tokenEndpointOverride: estsr)`.
+  Smallest, lowest-risk change; cert flows via `reqParams.MtlsCertificate`; claims via
+  `ClaimsAndClientCapabilities`. Endpoint override avoids touching `Authority`/discovery.
+- **(B) Delegate to the full `ClientCredentialRequest`.** Gets cache + claims-cache-key +
+  proactive refresh "for free", but requires constructing a parallel
+  `AuthenticationRequestParameters` + `AcquireTokenForClientParameters` + token cache and
+  reconciling it with the MI app cache. Higher fidelity to "share CCA's path", higher
+  blast radius. Recommend prototyping (A) first, then assessing (B).
+
+### 4.3 The `invalid_client` remint wrapper (new)
+Catch `MsalServiceException` with `invalid_client` (cert rejected/expired) around the
+delegated call; on first occurrence invalidate the cert cache entry
+(`s_mtlsCertificateCache` / `GetMtlsCertCacheKey`), re-run mint, and retry **once**.
+Surface the second failure unchanged. Bound to a single retry to avoid loops.
+
+## 5. Open feasibility questions → answers from this read
+
+| # | Question | Finding |
+|---|----------|---------|
+| 1 | Endpoint without discovery? | **Yes** — `TokenClient.SendTokenRequestAsync(tokenEndpointOverride)` (48, 55–59) bypasses discovery; MI already disables instance discovery. |
+| 2 | mTLS cert injection? | **Yes** — `TokenClient` ctor reads `requestParams.MtlsCertificate` (39–42); set it on the delegated request params. |
+| 3 | ClientId/tenant source? | From the mint result (`MtlsBindingInfo.ClientId`, ESTS-R endpoint embeds tenant). |
+| 4 | Claims/CP1 wiring? | **Free** — `ClaimsAndClientCapabilities` (ARP 76–82) + `ClaimsHelper` (57–70); `TokenClient` reads it at 168. |
+| 5 | invalid_client remint? | **Must add** — no existing handler; wrap the delegated call (see 4.3). |
+| 6 | Telemetry parity? | `TokenClient` sets `ApiEvent.TokenEndpoint` (61–63) and clears telemetry on send (219–258); confirm MI-source tags still emitted in the PoC. |
+| 7 | ServiceBundle/params? | `TokenClient(AuthenticationRequestParameters)` needs only ARP, which carries `RequestContext`→`ServiceBundle`; MI request already has these. |
+
+## 6. Risks & considerations
+- **Token-cache coherence (option B):** the MI app cache vs. a CCA-style cache must not
+  diverge; option A sidesteps this by keeping MI caching.
+- **Auth-scheme/token-type validation:** `TokenClient` validates `token_type` against
+  `AuthenticationScheme.AccessTokenType` (102–112) — the PoP scheme must be set on the
+  delegated params before send, mirroring `ManagedIdentityAuthRequest` (235–247).
+- **Throttling key:** `TokenClient` participates in `ThrottlingManager` keyed on the
+  request params (74–76, 86); verify MSI v2 requests throttle sensibly under the new path.
+- **Warnings-as-errors:** repo builds with `TreatWarningsAsErrors=true`
+  (`Directory.Build.props`); keep the PoC clean even though throwaway.
+- **No reflection** in product code/tests (repo guideline).
+
+## 7. PoC plan & measurement methodology
+
+PoC (throwaway branch `rginsburg/imdsv2-cca-delegation-spike`):
+1. Behind a flag, replace the bespoke POST construction in `CreateRequestAsync` /
+   `SendTokenRequestForManagedIdentityAsync` with delegation per **option A**.
+2. Add the `invalid_client` remint-and-retry-once wrapper.
+3. Run existing MSI v2 + mTLS PoP unit/integration tests; adjust as needed.
+
+Measurement (the issue's explicit ask — *lines removed vs. lines added*):
+- **Removed:** bespoke body/endpoint/header construction in `ImdsV2ManagedIdentitySource`
+  (the `client_credentials` POST assembly, ~ lines 417–442) and any MI-only send glue
+  made redundant by delegation.
+- **Added:** the delegation glue (params construction, `TokenClient` call,
+  endpoint-override plumbing) + the remint wrapper.
+- Report as `git diff --stat` net for the token-leg files, plus a short table of
+  removed-vs-added with a qualitative duplication-eliminated note (claims/CP1/cache-key
+  no longer needing a bespoke MSI v2 port).
+
+## 8. Recommendation (to validate in PoC)
+Proceed with **option A** (delegate the send to `TokenClient` with `tokenEndpointOverride`),
+keep MI caching, and add the `invalid_client` remint wrapper. This is the minimal seam
+that lets the future MSIv2 NSP claims (#5982) ride MSAL's existing
+claims→body / CP1-merge / claims-cache-key machinery instead of being re-ported into the
+managed-identity path. Reassess option B once the IMDS NSP wire contract lands.

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -10,6 +11,7 @@ using Microsoft.Identity.Client.AuthScheme.PoP;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.ManagedIdentity;
+using Microsoft.Identity.Client.ManagedIdentity.V2;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 using Microsoft.Identity.Client.Utils;
@@ -227,6 +229,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 _managedIdentityParameters.ClientClaims = AuthenticationRequestParameters.ClientClaims;
             }
 
+            // Spike #6042 (throwaway PoC): delegate the post-mint token leg to MSAL's internal
+            // TokenClient exchange path instead of the bespoke MI token POST. Default off.
+            if (ImdsV2ManagedIdentitySource.s_delegateTokenLegToInternalExchange &&
+                AuthenticationRequestParameters.IsMtlsPopRequested)
+            {
+                return await SendDelegatedImdsV2TokenRequestAsync(logger, cancellationToken).ConfigureAwait(false);
+            }
+
             ManagedIdentityResponse managedIdentityResponse =
                 await _managedIdentityClient
                 .SendTokenRequestForManagedIdentityAsync(AuthenticationRequestParameters.RequestContext, _managedIdentityParameters, cancellationToken)
@@ -250,6 +260,76 @@ namespace Microsoft.Identity.Client.Internal.Requests
             msalTokenResponse.Scope = AuthenticationRequestParameters.Scope.AsSingleString();
 
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Spike #6042 (throwaway PoC): mint the IMDSv2 binding cert, then delegate the token
+        // request to MSAL's internal TokenClient (the same exchange path CCA uses). Wraps an
+        // invalid_client re-mint-and-retry-once. The minted cert is injected as the mTLS
+        // transport cert and the mtls_pop scheme is applied so the result is cert-bound.
+        private async Task<AuthenticationResult> SendDelegatedImdsV2TokenRequestAsync(
+            ILoggerAdapter logger,
+            CancellationToken cancellationToken)
+        {
+            logger.Info("[ManagedIdentityRequest][Spike6042] Delegating IMDSv2 token leg to internal TokenClient exchange path.");
+
+            string resource = _managedIdentityParameters.Resource;
+            MsalTokenResponse msalTokenResponse;
+
+            try
+            {
+                msalTokenResponse = await DelegateImdsV2TokenLegAsync(resource, forceRemint: false, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (MsalServiceException ex) when (
+                string.Equals(ex.ErrorCode, "invalid_client", StringComparison.OrdinalIgnoreCase))
+            {
+                logger.Info("[ManagedIdentityRequest][Spike6042] ESTS-R returned invalid_client; re-minting binding certificate and retrying once.");
+                msalTokenResponse = await DelegateImdsV2TokenLegAsync(resource, forceRemint: true, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<MsalTokenResponse> DelegateImdsV2TokenLegAsync(
+            string resource,
+            bool forceRemint,
+            CancellationToken cancellationToken)
+        {
+            MtlsBindingInfo binding = await _managedIdentityClient
+                .AcquireImdsV2MtlsBindingAsync(
+                    AuthenticationRequestParameters.RequestContext,
+                    _managedIdentityParameters,
+                    forceRemint,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            // Inject the IMDS-minted cert as the request mTLS transport cert and apply the
+            // mtls_pop scheme so TokenClient emits token_type=mtls_pop and the result is bound.
+            AuthenticationRequestParameters.MtlsCertificate = binding.Certificate;
+            AuthenticationRequestParameters.AuthenticationScheme =
+                new MtlsPopAuthenticationOperation(binding.Certificate);
+
+            // Parity with the bespoke path: remember the cert for subsequent cache lookups.
+            _managedIdentityClient.SetRuntimeMtlsBindingCertificate(binding.Certificate);
+
+            var bodyParameters = new Dictionary<string, string>
+            {
+                [OAuth2Parameter.GrantType] = OAuth2GrantType.ClientCredentials,
+                [OAuth2Parameter.ClientId] = binding.ClientId
+            };
+
+            string tokenEndpoint = binding.Endpoint.TrimEnd('/') + ImdsV2ManagedIdentitySource.AcquireEntraTokenPath;
+            string scopeOverride = resource.TrimEnd('/') + "/.default";
+
+            var tokenClient = new TokenClient(AuthenticationRequestParameters);
+
+            return await tokenClient.SendTokenRequestAsync(
+                bodyParameters,
+                scopeOverride: scopeOverride,
+                tokenEndpointOverride: tokenEndpoint,
+                cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
         }
 
         private async Task<MsalAccessTokenCacheItem> GetCachedAccessTokenAsync()

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -55,6 +55,23 @@ namespace Microsoft.Identity.Client.ManagedIdentity
             return await msi.AuthenticateAsync(parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Spike #6042 (throwaway PoC): mints (or reuses) the IMDSv2 mTLS binding without sending
+        /// the bespoke token request, so the caller can delegate the token leg to MSAL's internal
+        /// exchange path. mTLS PoP always routes to the IMDSv2 source.
+        /// </summary>
+        internal async Task<MtlsBindingInfo> AcquireImdsV2MtlsBindingAsync(
+            RequestContext requestContext,
+            AcquireTokenForManagedIdentityParameters parameters,
+            bool forceRemint,
+            CancellationToken cancellationToken)
+        {
+            var source = (ImdsV2ManagedIdentitySource)ImdsV2ManagedIdentitySource.Create(requestContext);
+            return await source
+                .AcquireMtlsBindingForDelegationAsync(parameters, forceRemint, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         // This method selects the managed identity source for token acquisition.
         // It does NOT probe IMDS. It uses the cached explicit discovery result if available,
         // otherwise checks environment variables, and defaults to IMDS without probing.

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
         // Central, process-local cache for mTLS binding (cert + endpoint + canonical client_id).
         internal static readonly ICertificateCache s_mtlsCertificateCache = new InMemoryCertificateCache();
 
+        // Spike #6042 (throwaway PoC): when true, the post-mint token leg is delegated to
+        // MSAL's internal TokenClient exchange path instead of the bespoke MI token POST.
+        // Default off so existing behavior/tests are unaffected.
+        internal static bool s_delegateTokenLegToInternalExchange;
+
         private readonly IMtlsCertificateCache _mtlsCache;
         private Func<string, SafeHandle, string, string, ILoggerAdapter, CancellationToken, Task<string>> _attestationTokenProvider;
 
@@ -334,6 +339,48 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
 
         protected override async Task<ManagedIdentityRequest> CreateRequestAsync(string resource)
         {
+            MtlsBindingInfo mtlsBinding = await AcquireMtlsBindingAsync().ConfigureAwait(false);
+
+            X509Certificate2 bindingCertificate = mtlsBinding.Certificate;
+            string endpointBaseForToken = mtlsBinding.Endpoint;
+            string clientIdForToken = mtlsBinding.ClientId;
+
+            ManagedIdentityRequest request = new ManagedIdentityRequest(
+                HttpMethod.Post,
+                new Uri(endpointBaseForToken + AcquireEntraTokenPath));
+
+            Dictionary<string, string> idParams = MsalIdHelper.GetMsalIdParameters(_requestContext.Logger);
+
+            foreach (KeyValuePair<string, string> idParam in idParams)
+            {
+                request.Headers[idParam.Key] = idParam.Value;
+            }
+
+            request.Headers.Add(OAuth2Header.XMsCorrelationId, _requestContext.CorrelationId.ToString());
+            request.Headers.Add(ThrottleCommon.ThrottleRetryAfterHeaderName, ThrottleCommon.ThrottleRetryAfterHeaderValue);
+            request.Headers.Add(OAuth2Header.RequestCorrelationIdInResponse, "true");
+
+            var tokenType = _isMtlsPopRequested ? Constants.MtlsPoPTokenType : Constants.BearerTokenType;
+
+            request.BodyParameters.Add("client_id", clientIdForToken);
+            request.BodyParameters.Add("grant_type", OAuth2GrantType.ClientCredentials);
+            request.BodyParameters.Add("scope", resource.TrimEnd('/') + "/.default");
+            request.BodyParameters.Add("token_type", tokenType);
+
+            request.RequestType = RequestType.STS;
+            request.MtlsCertificate = bindingCertificate;
+
+            return request;
+        }
+
+        /// <summary>
+        /// Performs the cert-mint flow (/getplatformmetadata + /issuecredential) and returns the
+        /// resulting mTLS binding (cert + ESTS-R endpoint + canonical client_id). Extracted from
+        /// <see cref="CreateRequestAsync"/> so the binding can be reused by the internal-exchange
+        /// delegation path (spike #6042) without building the bespoke token request.
+        /// </summary>
+        private async Task<MtlsBindingInfo> AcquireMtlsBindingAsync()
+        {
             CsrMetadata csrMetadata = await GetCsrMetadataAsync(_requestContext).ConfigureAwait(false);
 
             // Early validation: Fail-fast if mTLS PoP was requested but KeyGuard is unavailable.
@@ -410,36 +457,31 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
                 _requestContext.Logger)
                 .ConfigureAwait(false);
 
-            X509Certificate2 bindingCertificate = mtlsBinding.Certificate;
-            string endpointBaseForToken = mtlsBinding.Endpoint;
-            string clientIdForToken = mtlsBinding.ClientId;
+            return mtlsBinding;
+        }
 
-            ManagedIdentityRequest request = new ManagedIdentityRequest(
-                HttpMethod.Post,
-                new Uri(endpointBaseForToken + AcquireEntraTokenPath));
+        /// <summary>
+        /// Spike #6042 (throwaway PoC): mint-only entrypoint used by the internal-exchange
+        /// delegation path. Sets the attestation provider and mTLS-PoP flag from the request
+        /// parameters, optionally evicts a rejected cert (invalid_client re-mint), and returns
+        /// the mTLS binding. Does NOT send the token request.
+        /// </summary>
+        internal async Task<MtlsBindingInfo> AcquireMtlsBindingForDelegationAsync(
+            ApiConfig.Parameters.AcquireTokenForManagedIdentityParameters parameters,
+            bool forceRemint,
+            CancellationToken cancellationToken)
+        {
+            _attestationTokenProvider = parameters.AttestationTokenProvider;
+            _isMtlsPopRequested = true;
 
-            Dictionary<string, string> idParams = MsalIdHelper.GetMsalIdParameters(_requestContext.Logger);
-
-            foreach (KeyValuePair<string, string> idParam in idParams)
+            if (forceRemint && _mtlsCache is MtlsBindingCache bindingCache)
             {
-                request.Headers[idParam.Key] = idParam.Value;
+                bindingCache.RemoveBadCert(GetMtlsCertCacheKey(), _requestContext.Logger);
             }
 
-            request.Headers.Add(OAuth2Header.XMsCorrelationId, _requestContext.CorrelationId.ToString());
-            request.Headers.Add(ThrottleCommon.ThrottleRetryAfterHeaderName, ThrottleCommon.ThrottleRetryAfterHeaderValue);
-            request.Headers.Add(OAuth2Header.RequestCorrelationIdInResponse, "true");
+            cancellationToken.ThrowIfCancellationRequested();
 
-            var tokenType = _isMtlsPopRequested ? Constants.MtlsPoPTokenType : Constants.BearerTokenType;
-
-            request.BodyParameters.Add("client_id", clientIdForToken);
-            request.BodyParameters.Add("grant_type", OAuth2GrantType.ClientCredentials);
-            request.BodyParameters.Add("scope", resource.TrimEnd('/') + "/.default");
-            request.BodyParameters.Add("token_type", tokenType);
-
-            request.RequestType = RequestType.STS;
-            request.MtlsCertificate = bindingCertificate;
-
-            return request;
+            return await AcquireMtlsBindingAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -225,6 +227,83 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
             }
+        }
+
+        // Spike #6042 (throwaway PoC): proves the IMDSv2 post-mint token leg can be delegated to
+        // MSAL's internal TokenClient exchange path. The cert-mint flow (/getplatformmetadata +
+        // /issuecredential) is unchanged; only the token request is delegated. Validates that the
+        // delegated request hits the ESTS-R mtls endpoint, posts the canonical client_id +
+        // token_type=mtls_pop, returns a cert-bound token, and is cached (second call = Cache).
+        [TestMethod]
+        public async Task mTLSPop_DelegatedTokenLeg_HappyPath_Spike6042()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+                ImdsV2ManagedIdentitySource.s_delegateTokenLegToInternalExchange = true;
+
+                try
+                {
+                    var managedIdentityApp = await CreateManagedIdentityAsync(
+                        httpManager,
+                        managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                    // Cert-mint mocks (unchanged path) + delegated ESTS-R token mock.
+                    httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                    httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse());
+                    httpManager.AddMockHandler(CreateDelegatedEntraTokenMock());
+
+                    // Act
+                    var result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithMtlsProofOfPossession()
+                        .WithAttestationSupport()
+                        .ExecuteAsync().ConfigureAwait(false);
+
+                    // Assert - token acquired from the delegated exchange path and cert-bound.
+                    Assert.IsNotNull(result);
+                    Assert.IsNotNull(result.AccessToken);
+                    Assert.AreEqual(MTLSPoP, result.TokenType);
+                    Assert.IsNotNull(result.BindingCertificate);
+                    Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                    // Act - second acquire should hit the MSAL cache (no further HTTP needed).
+                    result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithMtlsProofOfPossession()
+                        .WithAttestationSupport()
+                        .ExecuteAsync().ConfigureAwait(false);
+
+                    // Assert
+                    Assert.IsNotNull(result.AccessToken);
+                    Assert.AreEqual(MTLSPoP, result.TokenType);
+                    Assert.IsNotNull(result.BindingCertificate);
+                    Assert.AreEqual(TokenSource.Cache, result.AuthenticationResultMetadata.TokenSource);
+                }
+                finally
+                {
+                    ImdsV2ManagedIdentitySource.s_delegateTokenLegToInternalExchange = false;
+                }
+            }
+        }
+
+        // ESTS-R mtls token mock for the delegated path. Unlike the bespoke MI token mock, the
+        // delegated path goes through TokenClient, which parses a standard ESTS token response
+        // (expires_in). Asserts the canonical client_id, client_credentials grant, and mtls_pop.
+        private static MockHttpMessageHandler CreateDelegatedEntraTokenMock()
+        {
+            return new MockHttpMessageHandler()
+            {
+                ExpectedUrl = $"{TestConstants.MtlsAuthenticationEndpoint}/{TestConstants.TenantId}{ImdsV2ManagedIdentitySource.AcquireEntraTokenPath}",
+                ExpectedMethod = HttpMethod.Post,
+                ExpectedPostData = new Dictionary<string, string>
+                {
+                    { "token_type", "mtls_pop" },
+                    { "client_id", TestConstants.ClientId },
+                    { "grant_type", "client_credentials" }
+                },
+                ResponseMessage = MockHelpers.CreateSuccessfulClientCredentialTokenResponseMessage(tokenType: MTLSPoP)
+            };
         }
 
         [TestMethod]


### PR DESCRIPTION
## Spike #6042 — IMDSv2: delegate the token leg to MSAL's internal exchange path

This is a **throwaway spike** PR for #6042. All production behavior is gated behind a **default-off** flag (`s_delegateTokenLegToInternalExchange`); it is not intended to merge as-is.

### What & why
Per the discussion on #6042, this validates replacing IMDSv2's hand-rolled post-mint token POST with delegation to the internal `TokenClient` exchange. The driver is unblocking MSIv2 claims/NSP support (#5982), so claims→body, CP1 merge, claims-in-cache-key, and ESTS error handling are inherited rather than re-ported.

### Deliverables
- **Design doc**: `docs/imdsv2_cca_delegation_spike.md` (current-state map, the delegation seam, two integration depths — recommends option A, feasibility Q&A, risks, measurement).
- **PoC** (behind default-off flag):
  - Extracted cert-mint into `AcquireMtlsBindingAsync` (behavior-neutral); added a mint-only delegation entrypoint + `invalid_client` cert eviction.
  - `ManagedIdentityClient.AcquireImdsV2MtlsBindingAsync` mints without the bespoke POST.
  - `ManagedIdentityAuthRequest` delegation branch → `new TokenClient(reqParams).SendTokenRequestAsync(body, scopeOverride, tokenEndpointOverride)` with the minted cert + `mtls_pop` scheme, wrapped in `invalid_client` re-mint-and-retry-once.

### Feasibility: confirmed — no `TokenClient` change needed
`tokenEndpointOverride` hits ESTS-R with zero instance discovery; canonical `client_id` overrides `AppConfig.ClientId` via body params; the minted cert flows as the mTLS transport cert; MI caching is preserved (lookup runs upstream, branch only fires on cache miss).

### Validation
- New test `mTLSPop_DelegatedTokenLeg_HappyPath_Spike6042` passes (IdP then Cache, cert-bound).
- Core lib builds 0-warning (warnings-as-errors). All 424 ManagedIdentity unit tests pass.

### Measurement (the issue''s ask)
+163/−24 across 3 prod files: ~50 moved (refactor), ~95 net-new glue, vs ~26 bespoke token-path lines bypassed. Happy-path line count is ~net-neutral, but the qualitative win is inheriting the shared exchange machinery for MSIv2 NSP (#5982).

Spike only — tracking issue: #6042.
