### PR TITLE
Promote MsalServiceException.SubError to public

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                     return null;
 #else
                     if (MsalError.InvalidGrantError.Equals(ex?.ErrorCode, StringComparison.OrdinalIgnoreCase) &&
-                        MsalError.ClientMismatch.Equals(ex?.SubError, StringComparison.OrdinalIgnoreCase))
+                        MsalError.ClientMismatch.Equals(ex?.SubErrorForLogging, StringComparison.OrdinalIgnoreCase))
                     {
                         logger.Error("[FOCI] FRT refresh failed - client mismatch. ");
                         return null;

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -205,10 +205,12 @@ namespace Microsoft.Identity.Client
 
         #endregion
 
-        /// <remarks>
-        /// The suberror should not be exposed for public consumption yet, as STS needs to do some work first.
-        /// </remarks>
-        internal string SubError { get; set; }
+        /// <summary>
+        /// Sub-error returned by the token service refining <see cref="MsalException.ErrorCode"/>
+        /// (for example <c>consent_required</c>, <c>bad_token</c>, <c>protection_policy_required</c>).
+        /// Diagnostic only — values are emitted by the service and may change without notice.
+        /// </summary>
+        public string SubError { get; set; }
 
         /// <summary>
         /// A list of STS-specific error codes that can help in diagnostics.

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -208,9 +208,9 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Sub-error returned by the token service refining <see cref="MsalException.ErrorCode"/>
         /// (for example <c>consent_required</c>, <c>bad_token</c>, <c>protection_policy_required</c>).
-        /// Diagnostic only — values are emitted by the service and may change without notice.
+        /// Values are emitted by the service and may change without notice.
         /// </summary>
-        public string SubError { get; set; }
+        public string SubError { get; internal set; }
 
         /// <summary>
         /// A list of STS-specific error codes that can help in diagnostics.

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -208,9 +208,10 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Sub-error returned by the token service refining <see cref="MsalException.ErrorCode"/>
         /// (for example <c>consent_required</c>, <c>bad_token</c>, <c>protection_policy_required</c>).
-        /// Values are emitted by the service and may change without notice.
+        /// Values are emitted by the service and may change without notice; intended for diagnostics
+        /// and logging — do not branch production behavior on this value.
         /// </summary>
-        public string SubError { get; internal set; }
+        public string SubErrorForLogging { get; internal set; }
 
         /// <summary>
         /// A list of STS-specific error codes that can help in diagnostics.
@@ -251,7 +252,7 @@ namespace Microsoft.Identity.Client
             jObject[ClaimsKey] = Claims;
             jObject[ResponseBodyKey] = ResponseBody;
             jObject[CorrelationIdKey] = CorrelationId;
-            jObject[SubErrorKey] = SubError;
+            jObject[SubErrorKey] = SubErrorForLogging;
         }
 
         internal override void PopulateObjectFromJson(JObject jObject)
@@ -261,7 +262,7 @@ namespace Microsoft.Identity.Client
             Claims = JsonHelper.GetExistingOrEmptyString(jObject, ClaimsKey);
             ResponseBody = JsonHelper.GetExistingOrEmptyString(jObject, ResponseBodyKey);
             CorrelationId = JsonHelper.GetExistingOrEmptyString(jObject, CorrelationIdKey);
-            SubError = JsonHelper.GetExistingOrEmptyString(jObject, SubErrorKey);
+            SubErrorForLogging = JsonHelper.GetExistingOrEmptyString(jObject, SubErrorKey);
         }
         #endregion
     }

--- a/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client
 
             ex.Claims = oAuth2Response?.Claims;
             ex.CorrelationId = oAuth2Response?.CorrelationId;
-            ex.SubError = oAuth2Response?.SubError;
+            ex.SubErrorForLogging = oAuth2Response?.SubError;
             ex.ErrorCodes = oAuth2Response?.ErrorCodes;
 
             return ex;
@@ -168,7 +168,7 @@ namespace Microsoft.Identity.Client
             SetHttpExceptionData(ex, brokerHttpResponse);
 
             ex.CorrelationId = correlationId;
-            ex.SubError = subErrorCode;
+            ex.SubErrorForLogging = subErrorCode;
 
             return ex;
         }

--- a/src/client/Microsoft.Identity.Client/MsalThrottledServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalThrottledServiceException.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Identity.Client
                 originalException.Message, 
                 originalException.InnerException)
         {
-            SubError = originalException.SubError;
+            SubErrorForLogging = originalException.SubErrorForLogging;
             StatusCode = originalException.StatusCode;
             Claims = originalException.Claims;
             CorrelationId = originalException.CorrelationId;

--- a/src/client/Microsoft.Identity.Client/MsalThrottledUiRequiredException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalThrottledUiRequiredException.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Identity.Client
                 originalException.InnerException, 
                 originalException.Classification)
         {
-            SubError = originalException.SubError;
+            SubErrorForLogging = originalException.SubErrorForLogging;
             StatusCode = originalException.StatusCode;
             Claims = originalException.Claims;
             CorrelationId = originalException.CorrelationId;

--- a/src/client/Microsoft.Identity.Client/MsalUiRequiredException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalUiRequiredException.cs
@@ -71,19 +71,19 @@ namespace Microsoft.Identity.Client
         {
             get
             {
-                if (string.Equals(base.SubError, MsalError.BasicAction, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(base.SubErrorForLogging, MsalError.BasicAction, StringComparison.OrdinalIgnoreCase))
                     return UiRequiredExceptionClassification.BasicAction;
 
-                if (string.Equals(base.SubError, MsalError.AdditionalAction, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(base.SubErrorForLogging, MsalError.AdditionalAction, StringComparison.OrdinalIgnoreCase))
                     return UiRequiredExceptionClassification.AdditionalAction;
 
-                if (string.Equals(base.SubError, MsalError.MessageOnly, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(base.SubErrorForLogging, MsalError.MessageOnly, StringComparison.OrdinalIgnoreCase))
                     return UiRequiredExceptionClassification.MessageOnly;
 
-                if (string.Equals(base.SubError, MsalError.ConsentRequired, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(base.SubErrorForLogging, MsalError.ConsentRequired, StringComparison.OrdinalIgnoreCase))
                     return UiRequiredExceptionClassification.ConsentRequired;
 
-                if (string.Equals(base.SubError, MsalError.UserPasswordExpired, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(base.SubErrorForLogging, MsalError.UserPasswordExpired, StringComparison.OrdinalIgnoreCase))
                     return UiRequiredExceptionClassification.UserPasswordExpired;
 
                 return _classification;

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
-Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
-Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
-Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
-Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
-Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
-Microsoft.Identity.Client.MsalServiceException.SubError.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-Microsoft.Identity.Client.MsalServiceException.SubError.get -> string
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance

--- a/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/BrokerTests/BrokerRequestTests.cs
@@ -890,7 +890,7 @@ namespace Microsoft.Identity.Test.Unit.BrokerTests
                 {
                     // Assert
                     Assert.AreEqual(BrokerResponseConst.AndroidUnauthorizedClient, ex.ErrorCode);
-                    Assert.AreEqual(BrokerResponseConst.AndroidProtectionPolicyRequired, ex.SubError);
+                    Assert.AreEqual(BrokerResponseConst.AndroidProtectionPolicyRequired, ex.SubErrorForLogging);
 
                     return;
                 }

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionSerializationTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
                 Claims = SomeClaims,
                 CorrelationId = SomeCorrelationId,
                 ResponseBody = SomeResponseBody,
-                SubError = SomeSubError
+                SubErrorForLogging = SomeSubError
             };
 
             SerializeDeserializeAndValidate(ex, typeof(MsalServiceException), true);
@@ -76,7 +76,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
                 Claims = SomeClaims,
                 CorrelationId = SomeCorrelationId,
                 ResponseBody = SomeResponseBody,
-                SubError = SomeSubError
+                SubErrorForLogging = SomeSubError
             };
 
             SerializeDeserializeAndValidate(ex, typeof(MsalUiRequiredException), true);
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
                 Assert.AreEqual(SomeClaims, serviceEx.Claims);
                 Assert.AreEqual(SomeResponseBody, serviceEx.ResponseBody);
                 Assert.AreEqual(SomeCorrelationId, serviceEx.CorrelationId);
-                Assert.AreEqual(SomeSubError, serviceEx.SubError);
+                Assert.AreEqual(SomeSubError, serviceEx.SubErrorForLogging);
             }
         }
     }

--- a/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ExceptionTests/MsalExceptionTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
             Assert.Contains(ExMessage, msalException.Message);
             Assert.AreEqual("some_claims", msalException.Claims);
             Assert.AreEqual("6347d33d-941a-4c35-9912-a9cf54fb1b3e", msalException.CorrelationId);
-            Assert.AreEqual(suberror ?? "", msalException.SubError);
+            Assert.AreEqual(suberror ?? "", msalException.SubErrorForLogging);
 
             if (expectUiRequiredException)
             {
@@ -194,7 +194,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
             Assert.AreEqual(ExMessage + " " + MsalErrorMessage.ClaimsChallenge, msalServiceException.Message);
             Assert.AreEqual("some_claims", msalServiceException.Claims);
             Assert.AreEqual("6347d33d-941a-4c35-9912-a9cf54fb1b3e", msalServiceException.CorrelationId);
-            Assert.AreEqual("some_suberror", msalServiceException.SubError);
+            Assert.AreEqual("some_suberror", msalServiceException.SubErrorForLogging);
 
             ValidateExceptionProductInformation(msalException);
         }      
@@ -265,7 +265,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
 
             Assert.AreEqual("some_claims", msalServiceException.Claims);
             Assert.AreEqual("6347d33d-941a-4c35-9912-a9cf54fb1b3e", msalServiceException.CorrelationId);
-            Assert.AreEqual("some_suberror", msalServiceException.SubError);
+            Assert.AreEqual("some_suberror", msalServiceException.SubErrorForLogging);
             ValidateExceptionProductInformation(msalException);
 
             // Act
@@ -343,7 +343,7 @@ namespace Microsoft.Identity.Test.Unit.ExceptionTests
             Assert.AreEqual(responseBody, msalServiceException.ResponseBody);
             Assert.AreEqual(ExMessage + " " + MsalErrorMessage.ClaimsChallenge, msalServiceException.Message);
             Assert.AreEqual((int)statusCode, msalServiceException.StatusCode);
-            Assert.AreEqual("some_suberror", msalServiceException.SubError);
+            Assert.AreEqual("some_suberror", msalServiceException.SubErrorForLogging);
 
             Assert.AreEqual(retryAfterSpan, msalServiceException.Headers.RetryAfter.Delta);
             ValidateExceptionProductInformation(msalException);


### PR DESCRIPTION
## Summary

Promotes `MsalServiceException.SubError` getter from `internal` to `public` so downstream layers can map richer error diagnostics through the outbound token-acquisition pipeline. Setter stays `internal` — only MSAL produces these values.

## What's proposed

- **`MsalServiceException.SubError`** — getter promoted from `internal` to `public` (net-new public surface on `MsalServiceException`; `MsalException` has no `SubError` member). Setter remains `internal` — only MSAL writes this value from the wire.

- **PublicAPI baseline files** updated per the project's analyzer.

## Why

`SubError` discriminates failure subtypes within a single `ErrorCode`. E.g. `invalid_grant` can be qualified by `consent_required` (caller should re-prompt), `bad_token` (drop the cached entry), or `protection_policy_required` (satisfy a CA challenge). Without public access, consumers building structured error surfaces (e.g. `TokenAcquisitionFailureDetails` in Microsoft.Identity.Abstractions) fall back to string-parsing `Message`.

## Compatibility

Widening a getter from `internal` to `public` is non-breaking on all three axes (binary, source, type-check). The setter is unchanged.

## References

- Abstractions PR: AzureAD/microsoft-identity-abstractions-for-dotnet#253
- IdWeb PR: AzureAD/microsoft-identity-web#3856
- MISE PR: [DevEx/MISE!24568](https://identitydivision.visualstudio.com/DefaultCollection/DevEx/_git/MISE/pullrequest/24568)
- Design doc: `MISE/docs/design proposal/surface_msal_authentication_result_metadata.md`
