### PR TITLE
Take home account from request, if not available elsewhere.

### DIFF
--- a/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
+++ b/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client
         public static string GetHomeAccountId(AuthenticationRequestParameters requestParams, MsalTokenResponse response, IdToken idToken)
         {
             ClientInfo clientInfo = response.ClientInfo != null ? ClientInfo.CreateFromJson(response.ClientInfo) : null;
-            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject ?? requestParams.Account.HomeAccountId.Identifier; // ADFS does not have client info, so we use subject
+            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject ?? requestParams.Account?.HomeAccountId?.Identifier; // ADFS does not have client info, so we use subject
 
             if (homeAccountId == null)
             {

--- a/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
+++ b/src/client/Microsoft.Identity.Client/TokenResponseHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Identity.Client
         public static string GetHomeAccountId(AuthenticationRequestParameters requestParams, MsalTokenResponse response, IdToken idToken)
         {
             ClientInfo clientInfo = response.ClientInfo != null ? ClientInfo.CreateFromJson(response.ClientInfo) : null;
-            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject; // ADFS does not have client info, so we use subject
+            string homeAccountId = clientInfo?.ToAccountIdentifier() ?? idToken?.Subject ?? requestParams.Account.HomeAccountId.Identifier; // ADFS does not have client info, so we use subject
 
             if (homeAccountId == null)
             {

--- a/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CacheTests/TokenCacheTests.cs
@@ -1087,6 +1087,38 @@ namespace Microsoft.Identity.Test.Unit.CacheTests
 
         [TestMethod]
         [TestCategory(TestCategories.TokenCacheTests)]
+        public async Task SaveAccessAndRefreshTokenWithNoClientInfoAsync()
+        {
+            var serviceBundle = TestCommon.CreateDefaultServiceBundle();
+            ITokenCacheInternal cache = new TokenCache(serviceBundle, false);
+            MsalTokenResponse response = TestConstants.CreateMsalTokenResponse();
+
+            var requestParams = TestCommon.CreateAuthenticationRequestParameters(serviceBundle);
+            requestParams.AuthorityManager = new AuthorityManager(
+                requestParams.RequestContext,
+                Authority.CreateAuthorityWithTenant(
+                    requestParams.AuthorityInfo,
+                    TestConstants.Utid));
+            AddHostToInstanceCache(serviceBundle, TestConstants.ProductionPrefNetworkEnvironment);
+
+            await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(false);
+
+            requestParams.Account = new Account(_homeAccountId, null, null);
+            response.IdToken = null;
+            response.ClientInfo = null;
+            response.AccessToken = "access-token-2";
+            response.RefreshToken = "refresh-token-2";
+
+            await cache.SaveTokenResponseAsync(requestParams, response).ConfigureAwait(false);
+
+            Assert.AreEqual(1, cache.Accessor.GetAllRefreshTokens().Count());
+            Assert.AreEqual(1, cache.Accessor.GetAllAccessTokens().Count());
+            Assert.AreEqual("refresh-token-2", (cache.Accessor.GetAllRefreshTokens()).First().Secret);
+            Assert.AreEqual("access-token-2", (cache.Accessor.GetAllAccessTokens()).First().Secret);
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategories.TokenCacheTests)]
         public void CacheAdfsTokenTest()
         {
             using (var harness = CreateTestHarness())


### PR DESCRIPTION
CI evaluation for fork PR #5657 (by @yowl). Fork PRs don't trigger CI pipelines, so re-creating here to validate.

Original PR: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5657
Fixes #5618

**Changes proposed in this request**
When refreshing a token, PingIdentity does not return the home account. This change takes the home account from the request if existing places do not supply it.

**Testing**
Added a test for the TokenCache for the PingIdentity scenario.