### PR TITLE
Add MSAL.NET telemetry enrichment

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -52,6 +52,14 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         /// and a mutable list of tags to which additional dimensions can be appended.
         /// Set via <c>WithOtelTagsEnricher</c>.
         /// </summary>
+        /// <remarks>
+        /// The tags returned by the enricher are applied to every metric MSAL records for the request, so keep
+        /// both their value cardinality and their number low. High-cardinality tag values (for example correlation
+        /// ids, timestamps, or user identifiers) are the dominant cost: each distinct value multiplies the number
+        /// of metric time series the downstream backend must store and aggregate. A large number of tags is a
+        /// secondary cost that adds per-record overhead on MSAL's metric-recording path. Prefer a small set of
+        /// low-cardinality dimensions; avoid using request-unique values as tags.
+        /// </remarks> 
         public Action<ExecutionResult, IList<KeyValuePair<string, object>>> OtelTagsEnricher { get; set; }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/AcquireTokenCommonParameters.cs
@@ -47,6 +47,14 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
         public string ExtraClientAssertionClaims { get; internal set; }
 
         /// <summary>
+        /// Optional caller-supplied delegate that adds extra tags to the OpenTelemetry metrics MSAL records
+        /// for this request. It receives the <see cref="ExecutionResult"/> of the acquisition (success or failure)
+        /// and a mutable list of tags to which additional dimensions can be appended.
+        /// Set via <c>WithOtelTagsEnricher</c>.
+        /// </summary>
+        public Action<ExecutionResult, IList<KeyValuePair<string, object>>> OtelTagsEnricher { get; set; }
+
+        /// <summary>
         /// Optional delegate for obtaining attestation JWT for Credential Guard keys.
         /// Set by the KeyAttestation package via .WithAttestationSupport().
         /// Returns null for non-attested flows.

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -412,8 +412,10 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <returns>The builder to chain the .With methods.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="tagsEnricher"/> is null.</exception>
         /// <remarks>
-        /// Keep the cardinality of added tag values low. High-cardinality values (such as correlation ids or
-        /// user identifiers) can cause an unbounded number of metric time series in the downstream telemetry backend.
+        /// Keep both the number of added tags and — more importantly — their value cardinality low. High-cardinality
+        /// tag values (such as correlation ids, timestamps, or user identifiers) can cause an unbounded number of
+        /// metric time series in the downstream telemetry backend. The tags are applied to every metric MSAL records
+        /// for the request, so a large number of tags also adds overhead on the metric-recording path.
         /// </remarks>
         public static AbstractAcquireTokenParameterBuilder<T> WithOtelTagsEnricher<T>(
             this AbstractAcquireTokenParameterBuilder<T> builder,

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -408,6 +408,7 @@ namespace Microsoft.Identity.Client.Extensibility
         /// <param name="tagsEnricher">
         /// A delegate that receives the <see cref="ExecutionResult"/> and a mutable list of tags to enrich.
         /// The delegate runs on MSAL's metric-recording path, so it should be fast, non-blocking and must not throw.
+        /// The supplied tag list must be populated synchronously; do not retain or mutate it after the delegate returns.
         /// </param>
         /// <returns>The builder to chain the .With methods.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="tagsEnricher"/> is null.</exception>

--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractConfidentialClientAcquireTokenParameterBuilderExtension.cs
@@ -395,5 +395,39 @@ namespace Microsoft.Identity.Client.Extensibility
 
             return builder;
         }
-    }   
+
+        /// <summary>
+        /// Registers a delegate that adds additional tags (dimensions) to the OpenTelemetry metrics MSAL emits
+        /// for this token acquisition. The delegate is invoked while MSAL records its metrics and receives the
+        /// <see cref="ExecutionResult"/> of the acquisition (indicating success or failure, with the result or
+        /// exception) together with a mutable list of tags. Tags appended to that list are attached to every metric
+        /// recorded for the request.
+        /// </summary>
+        /// <typeparam name="T">The concrete builder type.</typeparam>
+        /// <param name="builder">The builder to chain options to.</param>
+        /// <param name="tagsEnricher">
+        /// A delegate that receives the <see cref="ExecutionResult"/> and a mutable list of tags to enrich.
+        /// The delegate runs on MSAL's metric-recording path, so it should be fast, non-blocking and must not throw.
+        /// </param>
+        /// <returns>The builder to chain the .With methods.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="tagsEnricher"/> is null.</exception>
+        /// <remarks>
+        /// Keep the cardinality of added tag values low. High-cardinality values (such as correlation ids or
+        /// user identifiers) can cause an unbounded number of metric time series in the downstream telemetry backend.
+        /// </remarks>
+        public static AbstractAcquireTokenParameterBuilder<T> WithOtelTagsEnricher<T>(
+            this AbstractAcquireTokenParameterBuilder<T> builder,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher)
+            where T : AbstractAcquireTokenParameterBuilder<T>
+        {
+            if (tagsEnricher == null)
+            {
+                throw new ArgumentNullException(nameof(tagsEnricher));
+            }
+
+            builder.CommonParameters.OtelTagsEnricher = tagsEnricher;
+
+            return builder;
+        }
+    }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -218,6 +218,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public string ExtraClientAssertionClaims => _commonParameters.ExtraClientAssertionClaims;
 
+        /// <summary>
+        /// Optional caller-supplied delegate that adds extra tags to the OpenTelemetry metrics MSAL records
+        /// for this request. Configured via <c>WithOtelTagsEnricher</c>.
+        /// </summary>
+        public Action<ExecutionResult, IList<KeyValuePair<string, object>>> OtelTagsEnricher => _commonParameters.OtelTagsEnricher;
+
         public void LogParameters()
         {
             var logger = RequestContext.Logger;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -105,8 +105,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                             using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                             return await GetAccessTokenAsync(tokenSource.Token, logger).ConfigureAwait(false);
                         }, logger, ServiceBundle, AuthenticationRequestParameters.RequestContext.ApiEvent,
-                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkApiId, 
-                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion);
+                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkApiId,
+                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion,
+                        AuthenticationRequestParameters.OtelTagsEnricher);
                     }
                 }
                 catch (MsalServiceException e)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -133,7 +133,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                                 return await GetAccessTokenAsync(tokenSource.Token, logger).ConfigureAwait(false);
                             }, logger, ServiceBundle, AuthenticationRequestParameters.RequestContext.ApiEvent,
                         AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkApiId,
-                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion);
+                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion,
+                        AuthenticationRequestParameters.OtelTagsEnricher);
                     }
                 }
                 catch (MsalServiceException e)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -165,7 +165,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                             return await RefreshRtOrFetchNewAccessTokenAsync(tokenSource.Token).ConfigureAwait(false);
                         }, logger, ServiceBundle, AuthenticationRequestParameters.RequestContext.ApiEvent,
                         AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkApiId,
-                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion);
+                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion,
+                        AuthenticationRequestParameters.OtelTagsEnricher);
                     }
                 }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -140,17 +140,17 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             CacheLevel cacheLevel = GetCacheLevel(authenticationResult);
 
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = AuthenticationRequestParameters.OtelTagsEnricher;
-
-            // Only materialize an ExecutionResult when an enricher is configured to consume it.
-            ExecutionResult executionResult = tagsEnricher == null
-                ? null
-                : new ExecutionResult
+            // Invoke the caller-supplied enricher once per acquisition and merge the resulting fixed set of
+            // extra tags into every instrument below, so the delegate is not re-run per metric.
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = OtelEnrichmentHelper.MaterializeExtraTags(
+                AuthenticationRequestParameters.OtelTagsEnricher,
+                () => new ExecutionResult
                 {
                     Successful = true,
                     Result = authenticationResult,
                     ClientCertificate = AuthenticationRequestParameters.ResolvedCertificate
-                };
+                },
+                AuthenticationRequestParameters.RequestContext.Logger);
 
             // Log metrics
             ServiceBundle.PlatformProxy.OtelInstrumentation.LogSuccessMetrics(
@@ -163,23 +163,22 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         authenticationResult.AuthenticationResultMetadata,
                         AuthenticationRequestParameters.RequestContext.Logger,
                         authenticationResult.ExpiresOn,
-                        executionResult,
-                        tagsEnricher);
+                        extraTags);
         }
 
         private void LogFailureTelemetryToOtel(string errorCodeToLog, ApiEvent apiEvent, CacheRefreshReason cacheRefreshReason, int httpStatusCode, long totalDurationInMs, MsalException exception = null, string rawStsErrorCode = null)
         {
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = AuthenticationRequestParameters.OtelTagsEnricher;
-
-            // Only materialize an ExecutionResult when an enricher is configured to consume it.
-            ExecutionResult executionResult = tagsEnricher == null
-                ? null
-                : new ExecutionResult
+            // Invoke the caller-supplied enricher once per acquisition and merge the resulting fixed set of
+            // extra tags into every instrument below, so the delegate is not re-run per metric.
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = OtelEnrichmentHelper.MaterializeExtraTags(
+                AuthenticationRequestParameters.OtelTagsEnricher,
+                () => new ExecutionResult
                 {
                     Successful = false,
                     Exception = exception,
                     ClientCertificate = AuthenticationRequestParameters.ResolvedCertificate
-                };
+                },
+                AuthenticationRequestParameters.RequestContext.Logger);
 
             ServiceBundle.PlatformProxy.OtelInstrumentation.LogFailureMetrics(
                         ServiceBundle.PlatformProxy.GetProductName(),
@@ -193,8 +192,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         totalDurationInMs,
                         rawStsErrorCode,
                         AuthenticationRequestParameters.RequestContext.Logger,
-                        executionResult,
-                        tagsEnricher);
+                        extraTags);
         }
 
         private Tuple<string, string> ParseScopesForTelemetry()

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -24,6 +24,7 @@ using Microsoft.Identity.Client.TelemetryCore.OpenTelemetry;
 using Microsoft.Identity.Client.Internal.Broker;
 using System.Runtime.ConstrainedExecution;
 using Microsoft.Identity.Client.AuthScheme;
+using Microsoft.Identity.Client.Extensibility;
 
 namespace Microsoft.Identity.Client.Internal.Requests
 {
@@ -121,7 +122,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     apiEvent.CacheInfo,
                     httpStatusCode,
                     requestStopwatch.ElapsedMilliseconds + measureTelemetryDurationResult.Milliseconds,
-                    (ex as MsalServiceException)?.ErrorCodes?.FirstOrDefault());
+                    exception: ex,
+                    rawStsErrorCode: (ex as MsalServiceException)?.ErrorCodes?.FirstOrDefault());
                 throw;
             }
             catch (Exception ex)
@@ -138,6 +140,18 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             CacheLevel cacheLevel = GetCacheLevel(authenticationResult);
 
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = AuthenticationRequestParameters.OtelTagsEnricher;
+
+            // Only materialize an ExecutionResult when an enricher is configured to consume it.
+            ExecutionResult executionResult = tagsEnricher == null
+                ? null
+                : new ExecutionResult
+                {
+                    Successful = true,
+                    Result = authenticationResult,
+                    ClientCertificate = AuthenticationRequestParameters.ResolvedCertificate
+                };
+
             // Log metrics
             ServiceBundle.PlatformProxy.OtelInstrumentation.LogSuccessMetrics(
                         ServiceBundle.PlatformProxy.GetProductName(),
@@ -148,11 +162,25 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         durationInUs,
                         authenticationResult.AuthenticationResultMetadata,
                         AuthenticationRequestParameters.RequestContext.Logger,
-                        authenticationResult.ExpiresOn);
+                        authenticationResult.ExpiresOn,
+                        executionResult,
+                        tagsEnricher);
         }
 
-        private void LogFailureTelemetryToOtel(string errorCodeToLog, ApiEvent apiEvent, CacheRefreshReason cacheRefreshReason, int httpStatusCode, long totalDurationInMs, string rawStsErrorCode = null)
+        private void LogFailureTelemetryToOtel(string errorCodeToLog, ApiEvent apiEvent, CacheRefreshReason cacheRefreshReason, int httpStatusCode, long totalDurationInMs, MsalException exception = null, string rawStsErrorCode = null)
         {
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = AuthenticationRequestParameters.OtelTagsEnricher;
+
+            // Only materialize an ExecutionResult when an enricher is configured to consume it.
+            ExecutionResult executionResult = tagsEnricher == null
+                ? null
+                : new ExecutionResult
+                {
+                    Successful = false,
+                    Exception = exception,
+                    ClientCertificate = AuthenticationRequestParameters.ResolvedCertificate
+                };
+
             ServiceBundle.PlatformProxy.OtelInstrumentation.LogFailureMetrics(
                         ServiceBundle.PlatformProxy.GetProductName(),
                         errorCodeToLog,
@@ -163,7 +191,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
                         apiEvent.TokenType,
                         httpStatusCode,
                         totalDurationInMs,
-                        rawStsErrorCode);
+                        rawStsErrorCode,
+                        AuthenticationRequestParameters.RequestContext.Logger,
+                        executionResult,
+                        tagsEnricher);
         }
 
         private Tuple<string, string> ParseScopesForTelemetry()

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/Silent/CacheSilentStrategy.cs
@@ -116,7 +116,8 @@ namespace Microsoft.Identity.Client.Internal.Requests.Silent
                             return await RefreshRtOrFailAsync(tokenSource.Token).ConfigureAwait(false);
                         }, logger, ServiceBundle, AuthenticationRequestParameters.RequestContext.ApiEvent,
                         AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkApiId,
-                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion);
+                        AuthenticationRequestParameters.RequestContext.ApiEvent.CallerSdkVersion,
+                        AuthenticationRequestParameters.OtelTagsEnricher);
                     }
                 }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -12,6 +12,7 @@ using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
+using Microsoft.Identity.Client.TelemetryCore.OpenTelemetry;
 #if iOS
 using Microsoft.Identity.Client.Platforms.iOS;
 #endif
@@ -98,10 +99,12 @@ namespace Microsoft.Identity.Client.Internal
                 {
                     var authResult = await fetchAction().ConfigureAwait(false);
 
-                    // Only materialize an ExecutionResult when an enricher is configured to consume it.
-                    ExecutionResult executionResult = tagsEnricher == null
-                        ? null
-                        : new ExecutionResult { Successful = true, Result = authResult };
+                    // Invoke the enricher once for this background refresh and reuse the materialized
+                    // tags across every instrument below.
+                    IReadOnlyList<KeyValuePair<string, object>> extraTags = OtelEnrichmentHelper.MaterializeExtraTags(
+                        tagsEnricher,
+                        () => new ExecutionResult { Successful = true, Result = authResult },
+                        logger);
 
                     serviceBundle.PlatformProxy.OtelInstrumentation.IncrementSuccessCounter(
                         serviceBundle.PlatformProxy.GetProductName(),
@@ -113,8 +116,7 @@ namespace Microsoft.Identity.Client.Internal
                         Cache.CacheLevel.None,
                         logger,
                         apiEvent.TokenType,
-                        executionResult,
-                        tagsEnricher);
+                        extraTags);
 
                     serviceBundle.PlatformProxy.OtelInstrumentation.LogRemainingTokenLifetime(
                         serviceBundle.PlatformProxy.GetProductName(),
@@ -125,16 +127,14 @@ namespace Microsoft.Identity.Client.Internal
                         apiEvent.TokenType,
                         authResult.ExpiresOn,
                         logger,
-                        executionResult,
-                        tagsEnricher);
+                        extraTags);
 
                     serviceBundle.PlatformProxy.OtelInstrumentation.LogSuccessHttpDuration(
                         serviceBundle.PlatformProxy.GetProductName(),
                         apiEvent.ApiId,
                         authResult.AuthenticationResultMetadata,
                         logger,
-                        executionResult,
-                        tagsEnricher);
+                        extraTags);
                 }
                 catch (MsalServiceException ex)
                 {
@@ -185,18 +185,20 @@ namespace Microsoft.Identity.Client.Internal
             var otel = serviceBundle.PlatformProxy.OtelInstrumentation;
             var platform = serviceBundle.PlatformProxy.GetProductName();
 
-            // Only materialize an ExecutionResult when an enricher is configured to consume it.
-            ExecutionResult executionResult = tagsEnricher == null
-                ? null
-                : new ExecutionResult { Successful = false, Exception = exception };
+            // Invoke the enricher once for this background failure and reuse the materialized tags
+            // across both instruments below.
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = OtelEnrichmentHelper.MaterializeExtraTags(
+                tagsEnricher,
+                () => new ExecutionResult { Successful = false, Exception = exception },
+                logger);
 
             otel.IncrementFailureCounter(
                 platform, errorCode, apiEvent.ApiId, callerSdkId, callerSdkVersion,
                 CacheRefreshReason.ProactivelyRefreshed, apiEvent.TokenType, rawStsErrorCode,
-                logger, executionResult, tagsEnricher);
+                logger, extraTags);
 
             otel.LogFailureHttpDuration(
-                platform, apiEvent, httpStatusCode, logger, executionResult, tagsEnricher);
+                platform, apiEvent, httpStatusCode, logger, extraTags);
         }
 
         private static Random s_random = new Random();

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Cache.Items;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
@@ -84,17 +85,24 @@ namespace Microsoft.Identity.Client.Internal
         internal static void ProcessFetchInBackground(
             MsalAccessTokenCacheItem oldAccessToken,
             Func<Task<AuthenticationResult>> fetchAction,
-            ILoggerAdapter logger, 
-            IServiceBundle serviceBundle, 
-            ApiEvent apiEvent, 
-            string callerSdkId, 
-            string callerSdkVersion)
+            ILoggerAdapter logger,
+            IServiceBundle serviceBundle,
+            ApiEvent apiEvent,
+            string callerSdkId,
+            string callerSdkVersion,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             _ = Task.Run(async () =>
             {
                 try
                 {
                     var authResult = await fetchAction().ConfigureAwait(false);
+
+                    // Only materialize an ExecutionResult when an enricher is configured to consume it.
+                    ExecutionResult executionResult = tagsEnricher == null
+                        ? null
+                        : new ExecutionResult { Successful = true, Result = authResult };
+
                     serviceBundle.PlatformProxy.OtelInstrumentation.IncrementSuccessCounter(
                         serviceBundle.PlatformProxy.GetProductName(),
                         apiEvent.ApiId,
@@ -104,7 +112,9 @@ namespace Microsoft.Identity.Client.Internal
                         CacheRefreshReason.ProactivelyRefreshed,
                         Cache.CacheLevel.None,
                         logger,
-                        apiEvent.TokenType);
+                        apiEvent.TokenType,
+                        executionResult,
+                        tagsEnricher);
 
                     serviceBundle.PlatformProxy.OtelInstrumentation.LogRemainingTokenLifetime(
                         serviceBundle.PlatformProxy.GetProductName(),
@@ -113,12 +123,18 @@ namespace Microsoft.Identity.Client.Internal
                         Cache.CacheLevel.None,
                         CacheRefreshReason.ProactivelyRefreshed,
                         apiEvent.TokenType,
-                        authResult.ExpiresOn);
+                        authResult.ExpiresOn,
+                        logger,
+                        executionResult,
+                        tagsEnricher);
 
                     serviceBundle.PlatformProxy.OtelInstrumentation.LogSuccessHttpDuration(
                         serviceBundle.PlatformProxy.GetProductName(),
                         apiEvent.ApiId,
-                        authResult.AuthenticationResultMetadata);
+                        authResult.AuthenticationResultMetadata,
+                        logger,
+                        executionResult,
+                        tagsEnricher);
                 }
                 catch (MsalServiceException ex)
                 {
@@ -133,19 +149,19 @@ namespace Microsoft.Identity.Client.Internal
                     }
 
                     LogBackgroundFailureTelemetry(serviceBundle, apiEvent, callerSdkId, callerSdkVersion,
-                        ex.ErrorCode, ex.StatusCode, ex.ErrorCodes?.FirstOrDefault());
+                        ex.ErrorCode, ex.StatusCode, ex.ErrorCodes?.FirstOrDefault(), ex, tagsEnricher, logger);
                 }
                 catch (OperationCanceledException ex)
                 {
                     logger.WarningPiiWithPrefix(ex, ProactiveRefreshCancellationError);
                     LogBackgroundFailureTelemetry(serviceBundle, apiEvent, callerSdkId, callerSdkVersion,
-                        ex.GetType().Name, httpStatusCode: 0);
+                        ex.GetType().Name, httpStatusCode: 0, tagsEnricher: tagsEnricher, logger: logger);
                 }
                 catch (Exception ex)
                 {
                     logger.ErrorPiiWithPrefix(ex, ProactiveRefreshGeneralError);
                     LogBackgroundFailureTelemetry(serviceBundle, apiEvent, callerSdkId, callerSdkVersion,
-                        ex.GetType().Name, httpStatusCode: 0);
+                        ex.GetType().Name, httpStatusCode: 0, tagsEnricher: tagsEnricher, logger: logger);
                 }
             });
         }
@@ -161,17 +177,26 @@ namespace Microsoft.Identity.Client.Internal
             string callerSdkVersion,
             string errorCode,
             int httpStatusCode,
-            string rawStsErrorCode = null)
+            string rawStsErrorCode = null,
+            MsalException exception = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null,
+            ILoggerAdapter logger = null)
         {
             var otel = serviceBundle.PlatformProxy.OtelInstrumentation;
             var platform = serviceBundle.PlatformProxy.GetProductName();
 
+            // Only materialize an ExecutionResult when an enricher is configured to consume it.
+            ExecutionResult executionResult = tagsEnricher == null
+                ? null
+                : new ExecutionResult { Successful = false, Exception = exception };
+
             otel.IncrementFailureCounter(
                 platform, errorCode, apiEvent.ApiId, callerSdkId, callerSdkVersion,
-                CacheRefreshReason.ProactivelyRefreshed, apiEvent.TokenType, rawStsErrorCode);
+                CacheRefreshReason.ProactivelyRefreshed, apiEvent.TokenType, rawStsErrorCode,
+                logger, executionResult, tagsEnricher);
 
             otel.LogFailureHttpDuration(
-                platform, apiEvent, httpStatusCode);
+                platform, apiEvent, httpStatusCode, logger, executionResult, tagsEnricher);
         }
 
         private static Random s_random = new Random();

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -149,8 +149,11 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         // Builds the final TagList for a metric by appending the caller-supplied extra tags (if any) after
         // MSAL's canonical base tags. The extra tags are materialized once per acquisition by the caller
         // (see OtelEnrichmentHelper.MaterializeExtraTags) and the same fixed set is merged into every
-        // instrument, so this method never invokes the enricher and never throws on its behalf. Base tags
-        // are emitted first and are append-only, so the canonical metric set cannot be removed or altered.
+        // instrument, so this method never invokes the enricher and never throws on its behalf. The
+        // canonical base tags are emitted first and are protected: an extra tag with a null/empty key is
+        // skipped, and an extra tag whose key collides with a canonical base tag key is dropped (a duplicate
+        // key would otherwise shadow MSAL's canonical value in last-wins backends). So the canonical metric
+        // set cannot be removed, overridden, or altered by the enricher.
         private static TagList BuildTagList(
             IReadOnlyList<KeyValuePair<string, object>> extraTags,
             params KeyValuePair<string, object>[] baseTags)
@@ -161,13 +164,22 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             }
 
             var tagList = new TagList();
+            var baseKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (KeyValuePair<string, object> tag in baseTags)
             {
                 tagList.Add(tag);
+                baseKeys.Add(tag.Key);
             }
 
             foreach (KeyValuePair<string, object> tag in extraTags)
             {
+                // Never let a caller-supplied tag remove, override, or corrupt a canonical tag:
+                // drop tags with a null/empty key and tags whose key collides with a base tag key.
+                if (string.IsNullOrEmpty(tag.Key) || baseKeys.Contains(tag.Key))
+                {
+                    continue;
+                }
+
                 tagList.Add(tag);
             }
 

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
@@ -145,6 +147,45 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         private static string MsalVersionPlatformTag(string platform) =>
             $"{MsalIdHelper.GetMsalVersion()},{platform}";
 
+        // Builds the final TagList for a metric, applying the optional caller-supplied enricher on top
+        // of the base tags. When no enricher is configured this is a thin wrapper over the base tags and
+        // allocates nothing extra. When an enricher is configured, the base tags are copied into a mutable
+        // list the enricher can append to, then materialized into a TagList for recording.
+        private static TagList BuildTagList(
+            ILoggerAdapter logger,
+            ExecutionResult executionResult,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher,
+            params KeyValuePair<string, object>[] baseTags)
+        {
+            if (tagsEnricher == null)
+            {
+                return new TagList(baseTags);
+            }
+
+            var tags = new List<KeyValuePair<string, object>>(baseTags);
+            try
+            {
+                tagsEnricher(executionResult, tags);
+            }
+            catch (Exception ex)
+            {
+                // A caller-supplied enricher must never break telemetry recording or the auth flow.
+                // On failure, log a warning, discard any partial mutations and fall back to the base tags.
+                logger?.WarningPii(
+                    $"[OpenTelemetry] The OTel tags enricher threw an exception and was ignored. {ex}",
+                    "[OpenTelemetry] The OTel tags enricher threw an exception and was ignored.");
+                tags = new List<KeyValuePair<string, object>>(baseTags);
+            }
+
+            var tagList = new TagList();
+            foreach (KeyValuePair<string, object> tag in tags)
+            {
+                tagList.Add(tag);
+            }
+
+            return tagList;
+        }
+
         // Aggregates the successful requests based on token source and cache refresh reason.
         // Counter, L1, L2, and extension are always emitted.
         // When the MSAL_ENABLE_EXTENDED_TOKEN_METRICS env var is not set: V1 total duration and V1 HTTP duration are emitted.
@@ -158,7 +199,9 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             long totalDurationInUs,
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger,
-            DateTimeOffset expiresOn)
+            DateTimeOffset expiresOn,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             IncrementSuccessCounter(
                 platform,
@@ -169,46 +212,51 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 authResultMetadata.CacheRefreshReason,
                 cacheLevel,
                 logger,
-                authResultMetadata.TelemetryTokenType);
+                authResultMetadata.TelemetryTokenType,
+                executionResult,
+                tagsEnricher);
 
             if (s_durationInL1CacheInUs.Value.Enabled && authResultMetadata.TokenSource == TokenSource.Cache
                 && authResultMetadata.CacheLevel.Equals(CacheLevel.L1Cache))
             {
-                s_durationInL1CacheInUs.Value.Record(totalDurationInUs,
+                var tags = BuildTagList(logger, executionResult, tagsEnricher,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
                     new(TelemetryConstants.TokenSource, authResultMetadata.TokenSource),
                     new(TelemetryConstants.CacheLevel, authResultMetadata.CacheLevel),
                     new(TelemetryConstants.CacheRefreshReason, authResultMetadata.CacheRefreshReason));
+                s_durationInL1CacheInUs.Value.Record(totalDurationInUs, in tags);
             }
 
             // Only log cache duration if L2 cache was used.
             if (s_durationInL2Cache.Value.Enabled && cacheLevel == CacheLevel.L2Cache)
             {
-                s_durationInL2Cache.Value.Record(authResultMetadata.DurationInCacheInMs,
+                var tags = BuildTagList(logger, executionResult, tagsEnricher,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
                     new(TelemetryConstants.CacheRefreshReason, authResultMetadata.CacheRefreshReason));
+                s_durationInL2Cache.Value.Record(authResultMetadata.DurationInCacheInMs, in tags);
             }
 
             if (s_durationInExtensionInMs.Value.Enabled)
             {
-                s_durationInExtensionInMs.Value.Record(authResultMetadata.DurationCreatingExtendedTokenInUs,
+                var tags = BuildTagList(logger, executionResult, tagsEnricher,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
                     new(TelemetryConstants.TokenSource, authResultMetadata.TokenSource),
                     new(TelemetryConstants.CacheLevel, authResultMetadata.CacheLevel),
                     new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
+                s_durationInExtensionInMs.Value.Record(authResultMetadata.DurationCreatingExtendedTokenInUs, in tags);
             }
 
             if (!_isExtendedMetricsEnabled)
             {
                 if (s_durationTotal.Value.Enabled)
                 {
-                    s_durationTotal.Value.Record(authResultMetadata.DurationTotalInMs,
+                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -216,23 +264,25 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                         new(TelemetryConstants.CacheLevel, cacheLevel),
                         new(TelemetryConstants.CacheRefreshReason, authResultMetadata.CacheRefreshReason),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
+                    s_durationTotal.Value.Record(authResultMetadata.DurationTotalInMs, in tags);
                 }
 
                 // Only log duration in HTTP when token is fetched from IDP.
                 if (s_durationInHttp.Value.Enabled && authResultMetadata.TokenSource == TokenSource.IdentityProvider)
                 {
-                    s_durationInHttp.Value.Record(authResultMetadata.DurationInHttpInMs,
+                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
+                    s_durationInHttp.Value.Record(authResultMetadata.DurationInHttpInMs, in tags);
                 }
             }
             else
             {
                 if (s_durationTotalV2.Value.Enabled)
                 {
-                    s_durationTotalV2.Value.Record(authResultMetadata.DurationTotalInMs,
+                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenSource, authResultMetadata.TokenSource),
@@ -241,16 +291,18 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType),
                         new(TelemetryConstants.ErrorCode, string.Empty),
                         new(TelemetryConstants.Succeeded, true));
+                    s_durationTotalV2.Value.Record(authResultMetadata.DurationTotalInMs, in tags);
                 }
 
                 // Only log duration in HTTP when token is fetched from IDP.
                 if (s_durationInHttpV2.Value.Enabled && authResultMetadata.TokenSource == TokenSource.IdentityProvider)
                 {
-                    s_durationInHttpV2.Value.Record(authResultMetadata.DurationInHttpInMs,
+                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType),
                         new(TelemetryConstants.HttpStatusCode, 200));
+                    s_durationInHttpV2.Value.Record(authResultMetadata.DurationInHttpInMs, in tags);
                 }
             }
 
@@ -261,7 +313,10 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 cacheLevel,
                 authResultMetadata.CacheRefreshReason,
                 authResultMetadata.TelemetryTokenType,
-                expiresOn);
+                expiresOn,
+                logger,
+                executionResult,
+                tagsEnricher);
         }
 
         public void IncrementSuccessCounter(string platform,
@@ -272,11 +327,13 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             CacheRefreshReason cacheRefreshReason,
             CacheLevel cacheLevel,
             ILoggerAdapter logger,
-            int tokenType)
+            int tokenType,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             if (s_successCounter.Value.Enabled)
             {
-                s_successCounter.Value.Add(1,
+                var tags = BuildTagList(logger, executionResult, tagsEnricher,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -285,6 +342,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                         new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
                         new(TelemetryConstants.CacheLevel, cacheLevel),
                         new(TelemetryConstants.TokenType, tokenType));
+                s_successCounter.Value.Add(1, in tags);
                 logger.Verbose(() => "[OpenTelemetry] Completed incrementing to success counter.");
             }
         }
@@ -292,7 +350,10 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         public void LogSuccessHttpDuration(
             string platform,
             ApiEvent.ApiIds apiId,
-            AuthenticationResultMetadata authResultMetadata)
+            AuthenticationResultMetadata authResultMetadata,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             if (authResultMetadata.TokenSource != TokenSource.IdentityProvider)
                 return;
@@ -301,22 +362,24 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationInHttp.Value.Enabled)
                 {
-                    s_durationInHttp.Value.Record(authResultMetadata.DurationInHttpInMs,
+                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType));
+                    s_durationInHttp.Value.Record(authResultMetadata.DurationInHttpInMs, in tags);
                 }
             }
             else
             {
                 if (s_durationInHttpV2.Value.Enabled)
                 {
-                    s_durationInHttpV2.Value.Record(authResultMetadata.DurationInHttpInMs,
+                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType),
                         new(TelemetryConstants.HttpStatusCode, 200));
+                    s_durationInHttpV2.Value.Record(authResultMetadata.DurationInHttpInMs, in tags);
                 }
             }
         }
@@ -333,7 +396,10 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             int tokenType,
             int httpStatusCode,
             long totalDurationInMs,
-            string rawStsErrorCode = null)
+            string rawStsErrorCode = null,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             IncrementFailureCounter(
                 platform,
@@ -343,12 +409,15 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 callerSdkVersion,
                 cacheRefreshReason,
                 tokenType,
-                rawStsErrorCode);
+                rawStsErrorCode,
+                logger,
+                executionResult,
+                tagsEnricher);
 
             if (_isExtendedMetricsEnabled && s_durationTotalV2.Value.Enabled)
             {
                 // TokenSource is empty on failure: no token was acquired, so no source applies.
-                s_durationTotalV2.Value.Record(totalDurationInMs,
+                var tags = BuildTagList(logger, executionResult, tagsEnricher,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiEvent.ApiId),
                     new(TelemetryConstants.TokenSource, string.Empty),
@@ -357,9 +426,10 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                     new(TelemetryConstants.TokenType, apiEvent.TokenType),
                     new(TelemetryConstants.ErrorCode, errorCode),
                     new(TelemetryConstants.Succeeded, false));
+                s_durationTotalV2.Value.Record(totalDurationInMs, in tags);
             }
 
-            LogFailureHttpDuration(platform, apiEvent, httpStatusCode);
+            LogFailureHttpDuration(platform, apiEvent, httpStatusCode, logger, executionResult, tagsEnricher);
         }
 
         public void IncrementFailureCounter(
@@ -370,24 +440,29 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             string callerSdkVersion,
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
-            string rawStsErrorCode = null)
+            string rawStsErrorCode = null,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             if (!s_failureCounter.Value.Enabled)
                 return;
 
-            var tags = new TagList
+            var baseTags = new List<KeyValuePair<string, object>>
             {
-                { TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion() },
-                { TelemetryConstants.Platform, platform },
-                { TelemetryConstants.ErrorCode, errorCode },
-                { TelemetryConstants.ApiId, apiId },
-                { TelemetryConstants.CallerSdkId, callerSdkId ?? string.Empty + "," + callerSdkVersion ?? string.Empty },
-                { TelemetryConstants.CacheRefreshReason, cacheRefreshReason },
-                { TelemetryConstants.TokenType, tokenType }
+                new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
+                new(TelemetryConstants.Platform, platform),
+                new(TelemetryConstants.ErrorCode, errorCode),
+                new(TelemetryConstants.ApiId, apiId),
+                new(TelemetryConstants.CallerSdkId, callerSdkId ?? string.Empty + "," + callerSdkVersion ?? string.Empty),
+                new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
+                new(TelemetryConstants.TokenType, tokenType)
             };
 
             if (!string.IsNullOrEmpty(rawStsErrorCode))
-                tags.Add(TelemetryConstants.RawStsErrorCode, rawStsErrorCode);
+                baseTags.Add(new(TelemetryConstants.RawStsErrorCode, rawStsErrorCode));
+
+            var tags = BuildTagList(logger, executionResult, tagsEnricher, baseTags.ToArray());
 
             s_failureCounter.Value.Add(1, in tags);
         }
@@ -400,18 +475,22 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         public void LogFailureHttpDuration(
             string platform,
             ApiEvent apiEvent,
-            int httpStatusCode)
+            int httpStatusCode,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             if (!_isExtendedMetricsEnabled || !s_durationInHttpV2.Value.Enabled)
                 return;
 
             if (apiEvent.DurationInHttpInMs > 0)
             {
-                s_durationInHttpV2.Value.Record(apiEvent.DurationInHttpInMs,
+                var tags = BuildTagList(logger, executionResult, tagsEnricher,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiEvent.ApiId),
                     new(TelemetryConstants.TokenType, apiEvent.TokenType),
                     new(TelemetryConstants.HttpStatusCode, httpStatusCode));
+                s_durationInHttpV2.Value.Record(apiEvent.DurationInHttpInMs, in tags);
             }
         }
 
@@ -422,19 +501,23 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             CacheLevel cacheLevel,
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
-            DateTimeOffset expiresOn)
+            DateTimeOffset expiresOn,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             if (s_remainingTokenLifetime.Value.Enabled)
             {
                 long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
 
-                s_remainingTokenLifetime.Value.Record(remainingSeconds,
+                var tags = BuildTagList(logger, executionResult, tagsEnricher,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiId),
                     new(TelemetryConstants.TokenSource, tokenSource),
                     new(TelemetryConstants.CacheLevel, cacheLevel),
                     new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
                     new(TelemetryConstants.TokenType, tokenType));
+                s_remainingTokenLifetime.Value.Record(remainingSeconds, in tags);
             }
         }
     }

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
@@ -147,53 +146,32 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         private static string MsalVersionPlatformTag(string platform) =>
             $"{MsalIdHelper.GetMsalVersion()},{platform}";
 
-        // Builds the final TagList for a metric, applying the optional caller-supplied enricher on top
-        // of the base tags. When no enricher is configured this is a thin wrapper over the base tags and
-        // allocates nothing extra. When an enricher is configured, it receives a separate, initially empty
-        // additions list so it can only append tags — MSAL's canonical base tags are append-only and cannot
-        // be removed or altered by the enricher. The base tags followed by the additions are then
-        // materialized into a TagList for recording.
+        // Builds the final TagList for a metric by appending the caller-supplied extra tags (if any) after
+        // MSAL's canonical base tags. The extra tags are materialized once per acquisition by the caller
+        // (see OtelEnrichmentHelper.MaterializeExtraTags) and the same fixed set is merged into every
+        // instrument, so this method never invokes the enricher and never throws on its behalf. Base tags
+        // are emitted first and are append-only, so the canonical metric set cannot be removed or altered.
         private static TagList BuildTagList(
-            ILoggerAdapter logger,
-            ExecutionResult executionResult,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher,
+            IReadOnlyList<KeyValuePair<string, object>> extraTags,
             params KeyValuePair<string, object>[] baseTags)
         {
-            if (tagsEnricher == null)
+            if (extraTags == null || extraTags.Count == 0)
             {
                 return new TagList(baseTags);
             }
 
-            var additions = new List<KeyValuePair<string, object>>();
             var tagList = new TagList();
-            try
+            foreach (KeyValuePair<string, object> tag in baseTags)
             {
-                // The enricher only ever sees the additions list, so it cannot remove or mutate the
-                // canonical base tags. Materialization is inside the try as well, so a malformed tag
-                // (e.g. one that throws on Add) also falls back to the base-tags-only path below.
-                tagsEnricher(executionResult, additions);
-
-                foreach (KeyValuePair<string, object> tag in baseTags)
-                {
-                    tagList.Add(tag);
-                }
-
-                foreach (KeyValuePair<string, object> tag in additions)
-                {
-                    tagList.Add(tag);
-                }
-
-                return tagList;
+                tagList.Add(tag);
             }
-            catch (Exception ex)
+
+            foreach (KeyValuePair<string, object> tag in extraTags)
             {
-                // A caller-supplied enricher must never break telemetry recording or the auth flow.
-                // On failure, log a warning, discard any partial mutations and fall back to the base tags.
-                logger?.WarningPii(
-                    $"[OpenTelemetry] The OTel tags enricher threw an exception and was ignored. {ex}",
-                    "[OpenTelemetry] The OTel tags enricher threw an exception and was ignored.");
-                return new TagList(baseTags);
+                tagList.Add(tag);
             }
+
+            return tagList;
         }
 
         // Aggregates the successful requests based on token source and cache refresh reason.
@@ -210,8 +188,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger,
             DateTimeOffset expiresOn,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             IncrementSuccessCounter(
                 platform,
@@ -223,13 +200,12 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 cacheLevel,
                 logger,
                 authResultMetadata.TelemetryTokenType,
-                executionResult,
-                tagsEnricher);
+                extraTags);
 
             if (s_durationInL1CacheInUs.Value.Enabled && authResultMetadata.TokenSource == TokenSource.Cache
                 && authResultMetadata.CacheLevel.Equals(CacheLevel.L1Cache))
             {
-                var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                var tags = BuildTagList(extraTags,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
@@ -242,7 +218,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             // Only log cache duration if L2 cache was used.
             if (s_durationInL2Cache.Value.Enabled && cacheLevel == CacheLevel.L2Cache)
             {
-                var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                var tags = BuildTagList(extraTags,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
@@ -252,7 +228,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
 
             if (s_durationInExtensionInMs.Value.Enabled)
             {
-                var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                var tags = BuildTagList(extraTags,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
@@ -266,7 +242,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationTotal.Value.Enabled)
                 {
-                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                    var tags = BuildTagList(extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -280,7 +256,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 // Only log duration in HTTP when token is fetched from IDP.
                 if (s_durationInHttp.Value.Enabled && authResultMetadata.TokenSource == TokenSource.IdentityProvider)
                 {
-                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                    var tags = BuildTagList(extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -292,7 +268,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationTotalV2.Value.Enabled)
                 {
-                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                    var tags = BuildTagList(extraTags,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenSource, authResultMetadata.TokenSource),
@@ -307,7 +283,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 // Only log duration in HTTP when token is fetched from IDP.
                 if (s_durationInHttpV2.Value.Enabled && authResultMetadata.TokenSource == TokenSource.IdentityProvider)
                 {
-                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                    var tags = BuildTagList(extraTags,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType),
@@ -325,8 +301,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 authResultMetadata.TelemetryTokenType,
                 expiresOn,
                 logger,
-                executionResult,
-                tagsEnricher);
+                extraTags);
         }
 
         public void IncrementSuccessCounter(string platform,
@@ -338,12 +313,11 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             CacheLevel cacheLevel,
             ILoggerAdapter logger,
             int tokenType,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             if (s_successCounter.Value.Enabled)
             {
-                var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                var tags = BuildTagList(extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -362,8 +336,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             ApiEvent.ApiIds apiId,
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             if (authResultMetadata.TokenSource != TokenSource.IdentityProvider)
                 return;
@@ -372,7 +345,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationInHttp.Value.Enabled)
                 {
-                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                    var tags = BuildTagList(extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -384,7 +357,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationInHttpV2.Value.Enabled)
                 {
-                    var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                    var tags = BuildTagList(extraTags,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType),
@@ -408,8 +381,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             long totalDurationInMs,
             string rawStsErrorCode = null,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             IncrementFailureCounter(
                 platform,
@@ -421,13 +393,12 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 tokenType,
                 rawStsErrorCode,
                 logger,
-                executionResult,
-                tagsEnricher);
+                extraTags);
 
             if (_isExtendedMetricsEnabled && s_durationTotalV2.Value.Enabled)
             {
                 // TokenSource is empty on failure: no token was acquired, so no source applies.
-                var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                var tags = BuildTagList(extraTags,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiEvent.ApiId),
                     new(TelemetryConstants.TokenSource, string.Empty),
@@ -439,7 +410,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 s_durationTotalV2.Value.Record(totalDurationInMs, in tags);
             }
 
-            LogFailureHttpDuration(platform, apiEvent, httpStatusCode, logger, executionResult, tagsEnricher);
+            LogFailureHttpDuration(platform, apiEvent, httpStatusCode, logger, extraTags);
         }
 
         public void IncrementFailureCounter(
@@ -452,8 +423,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             int tokenType,
             string rawStsErrorCode = null,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             if (!s_failureCounter.Value.Enabled)
                 return;
@@ -472,7 +442,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             if (!string.IsNullOrEmpty(rawStsErrorCode))
                 baseTags.Add(new(TelemetryConstants.RawStsErrorCode, rawStsErrorCode));
 
-            var tags = BuildTagList(logger, executionResult, tagsEnricher, baseTags.ToArray());
+            var tags = BuildTagList(extraTags, baseTags.ToArray());
 
             s_failureCounter.Value.Add(1, in tags);
         }
@@ -487,15 +457,14 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             ApiEvent apiEvent,
             int httpStatusCode,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             if (!_isExtendedMetricsEnabled || !s_durationInHttpV2.Value.Enabled)
                 return;
 
             if (apiEvent.DurationInHttpInMs > 0)
             {
-                var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                var tags = BuildTagList(extraTags,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiEvent.ApiId),
                     new(TelemetryConstants.TokenType, apiEvent.TokenType),
@@ -513,14 +482,13 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             int tokenType,
             DateTimeOffset expiresOn,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             if (s_remainingTokenLifetime.Value.Enabled)
             {
                 long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
 
-                var tags = BuildTagList(logger, executionResult, tagsEnricher,
+                var tags = BuildTagList(extraTags,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiId),
                     new(TelemetryConstants.TokenSource, tokenSource),

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -149,8 +149,10 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
 
         // Builds the final TagList for a metric, applying the optional caller-supplied enricher on top
         // of the base tags. When no enricher is configured this is a thin wrapper over the base tags and
-        // allocates nothing extra. When an enricher is configured, the base tags are copied into a mutable
-        // list the enricher can append to, then materialized into a TagList for recording.
+        // allocates nothing extra. When an enricher is configured, it receives a separate, initially empty
+        // additions list so it can only append tags — MSAL's canonical base tags are append-only and cannot
+        // be removed or altered by the enricher. The base tags followed by the additions are then
+        // materialized into a TagList for recording.
         private static TagList BuildTagList(
             ILoggerAdapter logger,
             ExecutionResult executionResult,
@@ -162,10 +164,26 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 return new TagList(baseTags);
             }
 
-            var tags = new List<KeyValuePair<string, object>>(baseTags);
+            var additions = new List<KeyValuePair<string, object>>();
+            var tagList = new TagList();
             try
             {
-                tagsEnricher(executionResult, tags);
+                // The enricher only ever sees the additions list, so it cannot remove or mutate the
+                // canonical base tags. Materialization is inside the try as well, so a malformed tag
+                // (e.g. one that throws on Add) also falls back to the base-tags-only path below.
+                tagsEnricher(executionResult, additions);
+
+                foreach (KeyValuePair<string, object> tag in baseTags)
+                {
+                    tagList.Add(tag);
+                }
+
+                foreach (KeyValuePair<string, object> tag in additions)
+                {
+                    tagList.Add(tag);
+                }
+
+                return tagList;
             }
             catch (Exception ex)
             {
@@ -174,16 +192,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 logger?.WarningPii(
                     $"[OpenTelemetry] The OTel tags enricher threw an exception and was ignored. {ex}",
                     "[OpenTelemetry] The OTel tags enricher threw an exception and was ignored.");
-                tags = new List<KeyValuePair<string, object>>(baseTags);
+                return new TagList(baseTags);
             }
-
-            var tagList = new TagList();
-            foreach (KeyValuePair<string, object> tag in tags)
-            {
-                tagList.Add(tag);
-            }
-
-            return tagList;
         }
 
         // Aggregates the successful requests based on token source and cache refresh reason.

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 
 namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
@@ -22,8 +21,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger,
             DateTimeOffset expiresOn,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null);
 
         internal void IncrementSuccessCounter(
             string platform,
@@ -35,8 +33,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheLevel cacheLevel,
             ILoggerAdapter logger,
             int TokenType,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null);
 
         internal void LogFailureMetrics(
             string platform,
@@ -50,8 +47,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             long totalDurationInMs,
             string rawStsErrorCode = null,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null);
 
         internal void IncrementFailureCounter(
             string platform,
@@ -63,16 +59,14 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             int tokenType,
             string rawStsErrorCode = null,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null);
 
         internal void LogFailureHttpDuration(
             string platform,
             ApiEvent apiEvent,
             int httpStatusCode,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null);
 
         internal void LogRemainingTokenLifetime(
             string platform,
@@ -83,15 +77,13 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             int tokenType,
             DateTimeOffset expiresOn,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null);
 
         internal void LogSuccessHttpDuration(
             string platform,
             ApiEvent.ApiIds apiId,
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null);
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/IOtelInstrumentation.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 
 namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
@@ -20,7 +21,9 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             long totalDurationInUs,
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger,
-            DateTimeOffset expiresOn);
+            DateTimeOffset expiresOn,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
 
         internal void IncrementSuccessCounter(
             string platform,
@@ -31,7 +34,9 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheRefreshReason cacheRefreshReason,
             CacheLevel cacheLevel,
             ILoggerAdapter logger,
-            int TokenType);
+            int TokenType,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
 
         internal void LogFailureMetrics(
             string platform,
@@ -43,7 +48,10 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             int tokenType,
             int httpStatusCode,
             long totalDurationInMs,
-            string rawStsErrorCode = null);
+            string rawStsErrorCode = null,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
 
         internal void IncrementFailureCounter(
             string platform,
@@ -53,12 +61,18 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             string callerSdkVersion,
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
-            string rawStsErrorCode = null);
+            string rawStsErrorCode = null,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
 
         internal void LogFailureHttpDuration(
             string platform,
             ApiEvent apiEvent,
-            int httpStatusCode);
+            int httpStatusCode,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
 
         internal void LogRemainingTokenLifetime(
             string platform,
@@ -67,11 +81,17 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheLevel cacheLevel,
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
-            DateTimeOffset expiresOn);
+            DateTimeOffset expiresOn,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
 
         internal void LogSuccessHttpDuration(
             string platform,
             ApiEvent.ApiIds apiId,
-            AuthenticationResultMetadata authResultMetadata);
+            AuthenticationResultMetadata authResultMetadata,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null);
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 
 namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
@@ -23,7 +24,9 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             long totalDurationInUs,
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger,
-            DateTimeOffset expiresOn)
+            DateTimeOffset expiresOn,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             // No op
         }
@@ -31,7 +34,10 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
         public void LogSuccessHttpDuration(
             string platform,
             ApiEvent.ApiIds apiId,
-            AuthenticationResultMetadata authResultMetadata)
+            AuthenticationResultMetadata authResultMetadata,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             // No op
         }
@@ -45,7 +51,10 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             int tokenType,
             int httpStatusCode,
             long totalDurationInMs,
-            string rawStsErrorCode = null)
+            string rawStsErrorCode = null,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             // No op
         }
@@ -57,27 +66,35 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             string callerSdkVersion,
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
-            string rawStsErrorCode = null)
+            string rawStsErrorCode = null,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             // No op
         }
 
         public void LogFailureHttpDuration(string platform,
             ApiEvent apiEvent,
-            int httpStatusCode)
+            int httpStatusCode,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             // No op
         }
 
-        void IOtelInstrumentation.IncrementSuccessCounter(string platform, 
+        void IOtelInstrumentation.IncrementSuccessCounter(string platform,
             ApiEvent.ApiIds apiId,
             string callerSdkId,
             string callerSdkVersion,
-            TokenSource tokenSource, 
-            CacheRefreshReason cacheRefreshReason, 
-            CacheLevel cacheLevel, 
+            TokenSource tokenSource,
+            CacheRefreshReason cacheRefreshReason,
+            CacheLevel cacheLevel,
             ILoggerAdapter logger,
-            int tokenType)
+            int tokenType,
+            ExecutionResult executionResult,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher)
         {
             // No op
         }
@@ -89,7 +106,10 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheLevel cacheLevel,
             CacheRefreshReason cacheRefreshReason,
             int tokenType,
-            DateTimeOffset expiresOn)
+            DateTimeOffset expiresOn,
+            ILoggerAdapter logger = null,
+            ExecutionResult executionResult = null,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
         {
             // No op
         }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/NullOtelInstrumentation.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
-using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;
 
 namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
@@ -25,8 +24,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger,
             DateTimeOffset expiresOn,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             // No op
         }
@@ -36,8 +34,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             ApiEvent.ApiIds apiId,
             AuthenticationResultMetadata authResultMetadata,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             // No op
         }
@@ -53,8 +50,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             long totalDurationInMs,
             string rawStsErrorCode = null,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             // No op
         }
@@ -68,8 +64,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             int tokenType,
             string rawStsErrorCode = null,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             // No op
         }
@@ -78,8 +73,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             ApiEvent apiEvent,
             int httpStatusCode,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             // No op
         }
@@ -93,8 +87,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             CacheLevel cacheLevel,
             ILoggerAdapter logger,
             int tokenType,
-            ExecutionResult executionResult,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags)
         {
             // No op
         }
@@ -108,8 +101,7 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
             int tokenType,
             DateTimeOffset expiresOn,
             ILoggerAdapter logger = null,
-            ExecutionResult executionResult = null,
-            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher = null)
+            IReadOnlyList<KeyValuePair<string, object>> extraTags = null)
         {
             // No op
         }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/OtelEnrichmentHelper.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/OtelEnrichmentHelper.cs
@@ -51,7 +51,11 @@ namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
                 return null;
             }
 
-            return extraTags;
+            // Return a snapshot, not the list handed to the enricher. A misbehaving enricher that retained the
+            // reference (e.g. via a captured field or a fire-and-forget task) cannot then mutate the set we
+            // enumerate while recording metrics, which would otherwise risk a "Collection was modified" throw
+            // on the auth path. Empty -> null so the no-tags case allocates nothing (BuildTagList treats both alike).
+            return extraTags.Count == 0 ? null : extraTags.ToArray();
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/OtelEnrichmentHelper.cs
+++ b/src/client/Microsoft.Identity.Client/TelemetryCore/OpenTelemetry/OtelEnrichmentHelper.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Extensibility;
+
+namespace Microsoft.Identity.Client.TelemetryCore.OpenTelemetry
+{
+    internal static class OtelEnrichmentHelper
+    {
+        /// <summary>
+        /// Invokes the caller-supplied OTel tags enricher exactly once per acquisition and returns the
+        /// materialized set of extra tags. The same fixed set is then merged into every instrument's
+        /// canonical base tags, so the delegate runs once (not once per metric) and a throwing enricher
+        /// logs at most one warning per acquisition.
+        /// </summary>
+        /// <param name="tagsEnricher">The caller-supplied enricher delegate, or <c>null</c> when none is configured.</param>
+        /// <param name="executionResultFactory">
+        /// Factory for the <see cref="ExecutionResult"/> passed to the enricher. Invoked only when an enricher
+        /// is configured, so the result is not allocated on the no-enricher hot path.
+        /// </param>
+        /// <param name="logger">Logger used to emit the single warning if the enricher throws.</param>
+        /// <returns>
+        /// The materialized extra tags, or <c>null</c> when no enricher is configured or the enricher threw
+        /// (in which case any partial mutations are discarded and only the canonical base tags are recorded).
+        /// </returns>
+        public static IReadOnlyList<KeyValuePair<string, object>> MaterializeExtraTags(
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher,
+            Func<ExecutionResult> executionResultFactory,
+            ILoggerAdapter logger)
+        {
+            if (tagsEnricher == null)
+            {
+                return null;
+            }
+
+            var extraTags = new List<KeyValuePair<string, object>>();
+            try
+            {
+                tagsEnricher(executionResultFactory(), extraTags);
+            }
+            catch (Exception ex)
+            {
+                // A caller-supplied enricher must never break telemetry recording or the auth flow.
+                // On failure, log a single warning and discard any partial mutations.
+                logger?.WarningPii(
+                    $"[OpenTelemetry] The OTel tags enricher threw an exception and was ignored. {ex}",
+                    "[OpenTelemetry] The OTel tags enricher threw an exception and was ignored.");
+                return null;
+            }
+
+            return extraTags;
+        }
+    }
+}

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1041,8 +1041,9 @@ namespace Microsoft.Identity.Test.Unit
 
                 lock (warnings)
                 {
-                    Assert.IsTrue(warnings.Any(m => m.Contains("OTel tags enricher threw an exception")),
-                        "A warning should be logged when the enricher throws.");
+                    int enricherWarnings = warnings.Count(m => m.Contains("OTel tags enricher threw an exception"));
+                    Assert.AreEqual(1, enricherWarnings,
+                        "A throwing enricher runs once per acquisition and must log exactly one warning, not one per metric instrument.");
                 }
             }
         }
@@ -1088,6 +1089,51 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.IsTrue(tags.TryGetValue("CustomTag", out var value) && (string)value == "CustomValue",
                         "The enricher's added tag should still be present.");
                 }
+            }
+        }
+
+        [TestMethod]
+        [Description("The OTel tags enricher is invoked exactly once per acquisition, not once per metric instrument, " +
+            "even though several instruments are recorded for a single successful acquisition.")]
+        public async Task WithOtelTagsEnricher_InvokedOncePerAcquisitionAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                CreateApplication();
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                int invocationCount = 0;
+
+                AuthenticationResult result = await _cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithExtraQueryParameters(extraQueryParams)
+                    .WithOtelTagsEnricher((executionResult, tags) =>
+                    {
+                        Interlocked.Increment(ref invocationCount);
+                        tags.Add(new KeyValuePair<string, object>("CustomTag", "CustomValue"));
+                    })
+                    .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+
+                s_meterProvider.ForceFlush();
+
+                // A single IDP success records several instruments (success counter, total duration, HTTP duration,
+                // extension duration, remaining token lifetime). The enricher must still run only once.
+                Assert.AreEqual(1, invocationCount,
+                    "Enricher must be invoked exactly once per acquisition, regardless of how many instruments are recorded.");
+
+                // The single materialized tag set is still merged into every recorded instrument.
+                var msalSuccess = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalSuccess");
+                Assert.IsNotNull(msalSuccess, "MsalSuccess metric should be emitted.");
+                bool foundCustomTag = false;
+                foreach (var metricPoint in msalSuccess.GetMetricPoints())
+                {
+                    var tags = GetTagDictionary(metricPoint.Tags);
+                    if (tags.TryGetValue("CustomTag", out var value) && (string)value == "CustomValue")
+                        foundCustomTag = true;
+                }
+                Assert.IsTrue(foundCustomTag, "The single materialized tag set should be merged into the recorded metrics.");
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -913,6 +913,140 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        [TestMethod]
+        [Description("WithOtelTagsEnricher adds caller-supplied tags to MSAL's success metrics and receives a populated ExecutionResult.")]
+        public async Task WithOtelTagsEnricher_SuccessfulAcquisition_AddsCustomTagAndReceivesResultAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                CreateApplication();
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                bool? capturedSuccessful = null;
+                bool capturedHasResult = false;
+
+                // Do not assert inside the enricher — exceptions there are swallowed by design.
+                AuthenticationResult result = await _cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithExtraQueryParameters(extraQueryParams)
+                    .WithOtelTagsEnricher((executionResult, tags) =>
+                    {
+                        capturedSuccessful = executionResult.Successful;
+                        capturedHasResult = executionResult.Result != null;
+                        tags.Add(new KeyValuePair<string, object>("CustomTag", "CustomValue"));
+                    })
+                    .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+
+                s_meterProvider.ForceFlush();
+
+                Assert.IsTrue(capturedSuccessful.HasValue, "Enricher should have been invoked.");
+                Assert.IsTrue(capturedSuccessful.Value, "ExecutionResult.Successful should be true for a successful acquisition.");
+                Assert.IsTrue(capturedHasResult, "ExecutionResult.Result should be populated for a successful acquisition.");
+
+                var msalSuccess = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalSuccess");
+                Assert.IsNotNull(msalSuccess, "MsalSuccess metric should be emitted.");
+
+                bool foundCustomTag = false;
+                foreach (var metricPoint in msalSuccess.GetMetricPoints())
+                {
+                    var tags = GetTagDictionary(metricPoint.Tags);
+                    if (tags.TryGetValue("CustomTag", out var value) && (string)value == "CustomValue")
+                        foundCustomTag = true;
+                }
+                Assert.IsTrue(foundCustomTag, "MsalSuccess should include the custom tag added by the enricher.");
+            }
+        }
+
+        [TestMethod]
+        [Description("WithOtelTagsEnricher adds caller-supplied tags to MSAL's failure metrics and receives an ExecutionResult carrying the exception.")]
+        public async Task WithOtelTagsEnricher_FailedAcquisition_AddsCustomTagAndReceivesExceptionAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                CreateApplication();
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddTokenResponse(TokenResponseType.InvalidClient);
+
+                bool? capturedSuccessful = null;
+                bool capturedHasException = false;
+
+                await AssertException.TaskThrowsAsync<MsalServiceException>(
+                    () => _cca.AcquireTokenForClient(TestConstants.s_scopeForAnotherResource)
+                        .WithExtraQueryParameters(extraQueryParams)
+                        .WithTenantId(TestConstants.Utid)
+                        .WithOtelTagsEnricher((executionResult, tags) =>
+                        {
+                            capturedSuccessful = executionResult.Successful;
+                            capturedHasException = executionResult.Exception != null;
+                            tags.Add(new KeyValuePair<string, object>("CustomTag", "CustomValue"));
+                        })
+                        .ExecuteAsync(CancellationToken.None)).ConfigureAwait(false);
+
+                s_meterProvider.ForceFlush();
+
+                Assert.IsTrue(capturedSuccessful.HasValue, "Enricher should have been invoked.");
+                Assert.IsFalse(capturedSuccessful.Value, "ExecutionResult.Successful should be false for a failed acquisition.");
+                Assert.IsTrue(capturedHasException, "ExecutionResult.Exception should be populated for a failed acquisition.");
+
+                var failureMetric = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalFailure");
+                Assert.IsNotNull(failureMetric, "MsalFailure metric should be emitted.");
+
+                bool foundCustomTag = false;
+                foreach (var metricPoint in failureMetric.GetMetricPoints())
+                {
+                    var tags = GetTagDictionary(metricPoint.Tags);
+                    if (tags.TryGetValue("CustomTag", out var value) && (string)value == "CustomValue")
+                        foundCustomTag = true;
+                }
+                Assert.IsTrue(foundCustomTag, "MsalFailure should include the custom tag added by the enricher.");
+            }
+        }
+
+        [TestMethod]
+        [Description("A throwing OTel tags enricher must not break the token acquisition or telemetry recording, and a warning is logged.")]
+        public async Task WithOtelTagsEnricher_ThrowingEnricher_DoesNotBreakAcquisitionAndLogsWarningAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                var warnings = new List<string>();
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
+                    .WithClientSecret(TestConstants.ClientSecret)
+                    .WithHttpManager(_harness.HttpManager)
+                    .WithLogging((level, message, containsPii) =>
+                    {
+                        if (level == LogLevel.Warning)
+                        {
+                            lock (warnings) { warnings.Add(message); }
+                        }
+                    })
+                    .BuildConcrete();
+
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                AuthenticationResult result = await cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithExtraQueryParameters(extraQueryParams)
+                    .WithOtelTagsEnricher((executionResult, tags) => throw new InvalidOperationException("boom"))
+                    .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+
+                Assert.IsNotNull(result, "Acquisition should succeed even if the enricher throws.");
+
+                s_meterProvider.ForceFlush();
+                var msalSuccess = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalSuccess");
+                Assert.IsNotNull(msalSuccess, "MsalSuccess metric should still be emitted when the enricher throws.");
+
+                lock (warnings)
+                {
+                    Assert.IsTrue(warnings.Any(m => m.Contains("OTel tags enricher threw an exception")),
+                        "A warning should be logged when the enricher throws.");
+                }
+            }
+        }
+
         private static IDictionary<string, object> GetTagDictionary(ReadOnlyTagCollection tags)
         {
             var dict = new Dictionary<string, object>();

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1137,6 +1137,56 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        [TestMethod]
+        [Description("An enricher tag whose key collides with a canonical tag key is dropped (the canonical value wins), " +
+            "and tags with null/empty keys are skipped, so the enricher cannot override or corrupt the canonical metric set.")]
+        public async Task WithOtelTagsEnricher_CollidingAndInvalidKeys_AreDroppedAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                CreateApplication();
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                AuthenticationResult result = await _cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithExtraQueryParameters(extraQueryParams)
+                    .WithOtelTagsEnricher((executionResult, tags) =>
+                    {
+                        // Collides with a canonical key — must NOT override MSAL's value.
+                        tags.Add(new KeyValuePair<string, object>(TelemetryConstants.ApiId, "BOGUS_OVERRIDE"));
+                        // Invalid keys — must be skipped without breaking recording.
+                        tags.Add(new KeyValuePair<string, object>(null, "nullKey"));
+                        tags.Add(new KeyValuePair<string, object>(string.Empty, "emptyKey"));
+                        // A normal tag still gets through.
+                        tags.Add(new KeyValuePair<string, object>("CustomTag", "CustomValue"));
+                    })
+                    .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+
+                Assert.IsNotNull(result, "Acquisition should succeed even when the enricher adds colliding/invalid tags.");
+
+                s_meterProvider.ForceFlush();
+
+                var msalSuccess = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalSuccess");
+                Assert.IsNotNull(msalSuccess, "MsalSuccess metric should be emitted.");
+
+                foreach (var metricPoint in msalSuccess.GetMetricPoints())
+                {
+                    var tags = GetTagDictionary(metricPoint.Tags);
+
+                    // Canonical ApiId is preserved — the colliding enricher value is dropped.
+                    Assert.AreNotEqual("BOGUS_OVERRIDE", tags[TelemetryConstants.ApiId],
+                        "The enricher must not override the canonical ApiId tag.");
+
+                    // The empty-key tag is skipped (a null-key tag is likewise skipped before recording).
+                    Assert.IsFalse(tags.ContainsKey(string.Empty), "Empty-key tag should be skipped.");
+
+                    // The valid custom tag still made it through.
+                    Assert.IsTrue(tags.TryGetValue("CustomTag", out var value) && (string)value == "CustomValue",
+                        "A valid custom tag should still be recorded.");
+                }
+            }
+        }
+
         private static IDictionary<string, object> GetTagDictionary(ReadOnlyTagCollection tags)
         {
             var dict = new Dictionary<string, object>();

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1047,6 +1047,50 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        [TestMethod]
+        [Description("An enricher that tries to clear or mutate the tag list it receives cannot remove MSAL's canonical tags — " +
+            "the enricher only ever sees its own additions list, so the canonical metric set is append-only.")]
+        public async Task WithOtelTagsEnricher_AttemptsToRemoveCanonicalTags_CanonicalTagsArePreservedAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                CreateApplication();
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                AuthenticationResult result = await _cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithExtraQueryParameters(extraQueryParams)
+                    .WithOtelTagsEnricher((executionResult, tags) =>
+                    {
+                        // A hostile/buggy enricher tries to wipe and overwrite the canonical tags.
+                        tags.Clear();
+                        tags.Add(new KeyValuePair<string, object>("CustomTag", "CustomValue"));
+                    })
+                    .ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+
+                s_meterProvider.ForceFlush();
+
+                var msalSuccess = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalSuccess");
+                Assert.IsNotNull(msalSuccess, "MsalSuccess metric should be emitted.");
+
+                foreach (var metricPoint in msalSuccess.GetMetricPoints())
+                {
+                    var tags = GetTagDictionary(metricPoint.Tags);
+
+                    // Canonical tags survive despite the enricher's Clear().
+                    Assert.IsTrue(tags.ContainsKey(TelemetryConstants.MsalVersion), "Canonical MsalVersion tag must be preserved.");
+                    Assert.IsTrue(tags.ContainsKey(TelemetryConstants.Platform), "Canonical Platform tag must be preserved.");
+                    Assert.IsTrue(tags.ContainsKey(TelemetryConstants.ApiId), "Canonical ApiId tag must be preserved.");
+
+                    // The enricher's own addition is still applied on top.
+                    Assert.IsTrue(tags.TryGetValue("CustomTag", out var value) && (string)value == "CustomValue",
+                        "The enricher's added tag should still be present.");
+                }
+            }
+        }
+
         private static IDictionary<string, object> GetTagDictionary(ReadOnlyTagCollection tags)
         {
             var dict = new Dictionary<string, object>();


### PR DESCRIPTION
This PR proposes an extensibility mechanism to enrich existing MSAL OpenTelemetry metrics with additional dimensions, without changing or replacing MSAL’s canonical metric set.