### PR TITLE
Exclude caller SDK telemetry from access token cache keys

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -290,6 +290,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
             string callerSdkId;
             string callerSdkVer;
 
+            RemoveCallerSdkCacheKeyComponents();
+
             // Check if ExtraQueryParameters contains caller-sdk-id and caller-sdk-ver
             if (AuthenticationRequestParameters.ExtraQueryParameters.TryGetValue(Constants.CallerSdkIdKey, out callerSdkId))
             {
@@ -311,6 +313,29 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             apiEvent.CallerSdkApiId = callerSdkId == null ? null : callerSdkId.Substring(0, Math.Min(callerSdkId.Length, Constants.CallerSdkIdMaxLength));
             apiEvent.CallerSdkVersion = callerSdkVer == null ? null : callerSdkVer.Substring(0, Math.Min(callerSdkVer.Length, Constants.CallerSdkVersionMaxLength));
+        }
+
+        private void RemoveCallerSdkCacheKeyComponents()
+        {
+            RemoveCacheKeyComponent(Constants.CallerSdkIdKey);
+            RemoveCacheKeyComponent(Constants.CallerSdkVersionKey);
+        }
+
+        private void RemoveCacheKeyComponent(string key)
+        {
+            var cacheKeyComponents = AuthenticationRequestParameters.CacheKeyComponents;
+
+            if (cacheKeyComponents == null)
+            {
+                return;
+            }
+
+            foreach (string cacheKeyComponent in cacheKeyComponents.Keys
+                .Where(cacheKeyComponent => string.Equals(cacheKeyComponent, key, StringComparison.OrdinalIgnoreCase))
+                .ToArray())
+            {
+                cacheKeyComponents.Remove(cacheKeyComponent);
+            }
         }
 
         private AssertionType GetAssertionType()

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
@@ -418,6 +418,48 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
         }
 
         [TestMethod]
+        public async Task CallerSdkDetails_AreNeverIncludedInCacheKeyComponentsAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                // Arrange
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+                _harness.HttpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                var cca = CreateConfidentialClientApp();
+                var extraQueryParameters = new Dictionary<string, (string, bool)>
+                {
+                    { Constants.CallerSdkIdKey, ("testApiId", true) },
+                    { Constants.CallerSdkVersionKey, ("testSdkVersion", true) },
+                    { "custom-cache-key-component", ("custom-value", true) }
+                };
+
+                // Act
+                await cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithExtraQueryParameters(extraQueryParameters)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                await cca.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithExtraQueryParameters(new Dictionary<string, (string, bool)>
+                    {
+                        { Constants.CallerSdkIdKey, ("otherApiId", true) },
+                        { Constants.CallerSdkVersionKey, ("otherSdkVersion", true) },
+                        { "custom-cache-key-component", ("custom-value", true) }
+                    })
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                // Assert
+                var cachedAccessToken = cca.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
+
+                CollectionAssert.AreEquivalent(
+                    new[] { "custom-cache-key-component" },
+                    cachedAccessToken.AdditionalCacheKeyComponents.Keys.ToArray());
+            }
+        }
+
+        [TestMethod]
         public async Task CallerSdkDetailsWithClientNameTestAsync()
         {
             using (_harness = CreateTestHarness())

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/HttpTelemetryTests.cs
@@ -434,12 +434,27 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     { "custom-cache-key-component", ("custom-value", true) }
                 };
 
+                void AssertCallerSdkDetailsAreNotInCacheKeyComponents()
+                {
+                    var cachedAccessToken = cca.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
+
+                    CollectionAssert.AreEquivalent(
+                        new[] { "custom-cache-key-component" },
+                        cachedAccessToken.AdditionalCacheKeyComponents.Keys.ToArray());
+
+                    Assert.AreEqual("custom-value", cachedAccessToken.AdditionalCacheKeyComponents["custom-cache-key-component"]);
+                }
+
                 // Act
                 await cca.AcquireTokenForClient(TestConstants.s_scope)
                     .WithExtraQueryParameters(extraQueryParameters)
                     .ExecuteAsync()
                     .ConfigureAwait(false);
 
+                // Assert
+                AssertCallerSdkDetailsAreNotInCacheKeyComponents();
+
+                // Act
                 await cca.AcquireTokenForClient(TestConstants.s_scope)
                     .WithExtraQueryParameters(new Dictionary<string, (string, bool)>
                     {
@@ -451,11 +466,7 @@ namespace Microsoft.Identity.Test.Unit.TelemetryTests
                     .ConfigureAwait(false);
 
                 // Assert
-                var cachedAccessToken = cca.AppTokenCacheInternal.Accessor.GetAllAccessTokens().Single();
-
-                CollectionAssert.AreEquivalent(
-                    new[] { "custom-cache-key-component" },
-                    cachedAccessToken.AdditionalCacheKeyComponents.Keys.ToArray());
+                AssertCallerSdkDetailsAreNotInCacheKeyComponents();
             }
         }
 


### PR DESCRIPTION
## Summary
- Prevent `caller-sdk-id` and `caller-sdk-ver` from remaining in cache key components after caller SDK telemetry is extracted.
- Preserve other explicitly included extra query parameters in AT cache key components.
- Add regression coverage proving caller SDK telemetry does not fragment the app AT cache even when `IncludeInCacheKey=true`.

Fixes #6073

## Testing
- `dotnet test tests\Microsoft.Identity.Test.Unit\Microsoft.Identity.Test.Unit.csproj --framework net8.0 --filter "FullyQualifiedName~CallerSdkDetails_AreNeverIncludedInCacheKeyComponentsAsync" --no-restore --verbosity minimal`
- `dotnet test tests\Microsoft.Identity.Test.Unit\Microsoft.Identity.Test.Unit.csproj --framework net8.0 --filter "FullyQualifiedName~HttpTelemetryTests" --no-restore --verbosity minimal`

Note: a multi-target run without `--framework net8.0` also attempted net48 and hit an existing MSTest adapter dependency load error for `System.Memory, Version=4.0.1.2` before net8.0 passed.