### PR TITLE
Post-release 4.85.0: changelog and public API shipped move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@
 - Added `GovFr`, `GovDe`, and `GovSg` values to the `AzureCloudInstance` enum for sovereign cloud support. [#6023](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6023)
 
 ### Changes
-- Migrated region discovery to the IMDS `/compute` JSON endpoint. [#6057](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6057)
+- Migrated region discovery to the IMDS `/compute` JSON endpoint. [#6039](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6039)
 
 ### Bug Fixes
-- Excluded caller SDK telemetry headers (`caller-sdk-id`, `caller-sdk-ver`) from access token cache keys to prevent cache fragmentation. [#6074](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6074)
-- Service Fabric Managed Identity now sends `principalId` for `ObjectId` and rejects `ClientId`/`ResourceId` identifiers. [#6069](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6069)
-- Validated Azure region format to prevent region poisoning. [#6061](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6061)
-- Fixed proactive token refresh bypassing cancellation, which could lead to unbounded semaphore waits. [#6054](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6054)
-- Fall back to the home account from the request when not available elsewhere. [#5657](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5657)
+- Excluded caller SDK telemetry headers (`caller-sdk-id`, `caller-sdk-ver`) from access token cache keys to prevent cache fragmentation. [#6073](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6073)
+- Service Fabric Managed Identity now sends `principalId` for `ObjectId` and rejects `ClientId`/`ResourceId` identifiers. [#6065](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6065)
+- Validated Azure region format to prevent region poisoning. [#6060](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6060)
+- Fixed proactive token refresh bypassing cancellation, which could lead to unbounded semaphore waits. [#6053](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/6053)
+- Fall back to the home account from the request when not available elsewhere. [#5618](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5618)
 
 4.84.2
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+4.85.0
+======
+
+### New Features
+- Added `WithOtelTagsEnricher` extension on `AbstractAcquireTokenParameterBuilder<T>` to enrich OpenTelemetry tags from token acquisition results. [#6071](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6071)
+- Promoted `MsalServiceException.SubErrorForLogging` to public for diagnostic logging of service sub-errors. [#6063](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6063)
+- Added `GovFr`, `GovDe`, and `GovSg` values to the `AzureCloudInstance` enum for sovereign cloud support. [#6023](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6023)
+
+### Changes
+- Migrated region discovery to the IMDS `/compute` JSON endpoint. [#6057](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6057)
+
+### Bug Fixes
+- Excluded caller SDK telemetry headers (`caller-sdk-id`, `caller-sdk-ver`) from access token cache keys to prevent cache fragmentation. [#6074](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6074)
+- Service Fabric Managed Identity now sends `principalId` for `ObjectId` and rejects `ClientId`/`ResourceId` identifiers. [#6069](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6069)
+- Validated Azure region format to prevent region poisoning. [#6061](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6061)
+- Fixed proactive token refresh bypassing cancellation, which could lead to unbounded semaphore waits. [#6054](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6054)
+- Fall back to the home account from the request when not available elsewhere. [#5657](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5657)
+
 4.84.2
 ======
 

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
@@ -1162,3 +1162,8 @@ virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> vo
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.OnAuthenticate(System.Threading.CancellationToken cancellationToken) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserBeforeNavigateHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserBeforeNavigateEventArgs e) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserNavigateErrorHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserNavigateErrorEventArgs e) -> void
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
@@ -1162,3 +1162,8 @@ virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> vo
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.OnAuthenticate(System.Threading.CancellationToken cancellationToken) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserBeforeNavigateHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserBeforeNavigateEventArgs e) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserNavigateErrorHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserNavigateErrorEventArgs e) -> void
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
@@ -1128,3 +1128,8 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
@@ -1130,3 +1130,8 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
@@ -1124,3 +1124,8 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -1124,3 +1124,8 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,0 @@
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>


### PR DESCRIPTION
Post-release housekeeping for 4.85.0: adds 4.85.0 changelog entry and moves additive public API entries from Unshipped to Shipped across all 6 TFMs (no breaking changes).