### PR TITLE
Expose canonical tag names per-metric

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/MsalMetricsCatalog.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/MsalMetricsCatalog.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.Identity.Client.TelemetryCore;
 
-namespace Microsoft.Identity.Client
+namespace Microsoft.Identity.Client.Extensibility
 {
     /// <summary>
     /// Describes the OpenTelemetry metrics that MSAL emits and, for each metric, the canonical
@@ -18,7 +18,7 @@ namespace Microsoft.Identity.Client
     /// <para>
     /// The tag names listed for a metric are the canonical base tags MSAL always emits for it. They do not
     /// include any extra tags supplied through
-    /// <see cref="Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher{T}"/>,
+    /// <see cref="AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher{T}"/>,
     /// which are caller-defined and therefore not part of this catalog. Some canonical tags are emitted only
     /// under certain conditions (for example the raw STS error-code tag is present on the failure counter only
     /// when the STS returns a sub-error); they are listed here because they are part of the metric's canonical

--- a/src/client/Microsoft.Identity.Client/Extensibility/MsalMetricsCatalog.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/MsalMetricsCatalog.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Identity.Client.Extensibility
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The tag names listed for a metric are the canonical base tags MSAL always emits for it. They do not
+    /// The tag names listed for a metric are the canonical base tags MSAL emits for it (some are conditional). They do not
     /// include any extra tags supplied through
     /// <see cref="AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher{T}"/>,
     /// which are caller-defined and therefore not part of this catalog. Some canonical tags are emitted only

--- a/src/client/Microsoft.Identity.Client/MsalMetricsCatalog.cs
+++ b/src/client/Microsoft.Identity.Client/MsalMetricsCatalog.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.Identity.Client.TelemetryCore;
+
+namespace Microsoft.Identity.Client
+{
+    /// <summary>
+    /// Describes the OpenTelemetry metrics that MSAL emits and, for each metric, the canonical
+    /// (MSAL-owned) tag names it records. Consumers such as downstream metric pipelines can use
+    /// <see cref="CanonicalTagsByMetric"/> to discover which tags belong to a given MSAL metric and,
+    /// for example, keep only those tags.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The tag names listed for a metric are the canonical base tags MSAL always emits for it. They do not
+    /// include any extra tags supplied through
+    /// <see cref="Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher{T}"/>,
+    /// which are caller-defined and therefore not part of this catalog. Some canonical tags are emitted only
+    /// under certain conditions (for example the raw STS error-code tag is present on the failure counter only
+    /// when the STS returns a sub-error); they are listed here because they are part of the metric's canonical
+    /// schema.
+    /// </para>
+    /// <para>
+    /// Both the metric names (the dictionary keys) and the tag names (the dictionary values) are plain strings
+    /// that match what MSAL records, so consumers can compare them directly against the metric and tag names
+    /// observed on the OpenTelemetry pipeline, then drive per-metric tag filtering from this mapping (for
+    /// example via OpenTelemetry Views and <c>MetricStreamConfiguration.TagKeys</c>). Keeping the mapping here
+    /// means it stays in sync with MSAL automatically: updating the MSAL package reference updates the canonical
+    /// tag set, with nothing to maintain on the consumer side.
+    /// </para>
+    /// </remarks>
+    public static class MsalMetricsCatalog
+    {
+        // Metric names are defined once here (internal) so the published catalog and the instruments created in
+        // OtelInstrumentation share a single source of truth and cannot drift. They are intentionally not part of
+        // the public surface: consumers read metric names from the keys of CanonicalTagsByMetric (and from the
+        // OpenTelemetry pipeline), so there is no need to expose them as separate public constants.
+        internal const string SuccessCounterName = "MsalSuccess";
+        internal const string FailureCounterName = "MsalFailure";
+        internal const string TotalDurationHistogramName = "MsalTotalDuration.1A";
+        internal const string TotalDurationV2HistogramName = "MsalTotalDurationV2.1A";
+        internal const string DurationInL1CacheHistogramName = "MsalDurationInL1CacheInUs.1B";
+        internal const string DurationInL2CacheHistogramName = "MsalDurationInL2Cache.1A";
+        internal const string DurationInHttpHistogramName = "MsalDurationInHttp.1A";
+        internal const string DurationInHttpV2HistogramName = "MsalDurationInHttpV2.1A";
+        internal const string DurationInExtensionHistogramName = "MsalDurationInExtensionInMs.1B";
+        internal const string RemainingTokenLifetimeHistogramName = "MsalRemainingTokenLifetime.1A";
+
+        /// <summary>
+        /// Maps each MSAL metric name to the read-only list of canonical tag names that metric records.
+        /// Keys are compared with <see cref="System.StringComparer.Ordinal"/>.
+        /// </summary>
+        public static IReadOnlyDictionary<string, IReadOnlyList<string>> CanonicalTagsByMetric { get; } =
+            BuildCanonicalTagsByMetric();
+
+        private static IReadOnlyDictionary<string, IReadOnlyList<string>> BuildCanonicalTagsByMetric()
+        {
+            // Tag names reference the internal TelemetryConstants used when recording, so the mapping cannot
+            // drift from the tags MSAL actually emits.
+            var map = new Dictionary<string, string[]>(StringComparer.Ordinal)
+            {
+                [SuccessCounterName] = new[]
+                {
+                    TelemetryConstants.MsalVersion,
+                    TelemetryConstants.Platform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.CallerSdkId,
+                    TelemetryConstants.TokenSource,
+                    TelemetryConstants.CacheRefreshReason,
+                    TelemetryConstants.CacheLevel,
+                    TelemetryConstants.TokenType,
+                },
+                [FailureCounterName] = new[]
+                {
+                    TelemetryConstants.MsalVersion,
+                    TelemetryConstants.Platform,
+                    TelemetryConstants.ErrorCode,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.CallerSdkId,
+                    TelemetryConstants.CacheRefreshReason,
+                    TelemetryConstants.TokenType,
+                    TelemetryConstants.RawStsErrorCode,
+                },
+                [TotalDurationHistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersion,
+                    TelemetryConstants.Platform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.TokenSource,
+                    TelemetryConstants.CacheLevel,
+                    TelemetryConstants.CacheRefreshReason,
+                    TelemetryConstants.TokenType,
+                },
+                [TotalDurationV2HistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersionPlatform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.TokenSource,
+                    TelemetryConstants.CacheLevel,
+                    TelemetryConstants.CacheRefreshReason,
+                    TelemetryConstants.TokenType,
+                    TelemetryConstants.ErrorCode,
+                    TelemetryConstants.Succeeded,
+                },
+                [DurationInL1CacheHistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersion,
+                    TelemetryConstants.Platform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.TokenSource,
+                    TelemetryConstants.CacheLevel,
+                    TelemetryConstants.CacheRefreshReason,
+                },
+                [DurationInL2CacheHistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersion,
+                    TelemetryConstants.Platform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.CacheRefreshReason,
+                },
+                [DurationInHttpHistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersion,
+                    TelemetryConstants.Platform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.TokenType,
+                },
+                [DurationInHttpV2HistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersionPlatform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.TokenType,
+                    TelemetryConstants.HttpStatusCode,
+                },
+                [DurationInExtensionHistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersion,
+                    TelemetryConstants.Platform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.TokenSource,
+                    TelemetryConstants.CacheLevel,
+                    TelemetryConstants.TokenType,
+                },
+                [RemainingTokenLifetimeHistogramName] = new[]
+                {
+                    TelemetryConstants.MsalVersionPlatform,
+                    TelemetryConstants.ApiId,
+                    TelemetryConstants.TokenSource,
+                    TelemetryConstants.CacheLevel,
+                    TelemetryConstants.CacheRefreshReason,
+                    TelemetryConstants.TokenType,
+                },
+            };
+
+            // Expose each tag list as a ReadOnlyCollection rather than the backing array: an IReadOnlyList that is
+            // actually a string[] can be cast back and mutated by a consumer, which would corrupt this shared
+            // static catalog process-wide. The dictionary itself is already read-only.
+            var readOnlyMap = new Dictionary<string, IReadOnlyList<string>>(map.Count, StringComparer.Ordinal);
+            foreach (KeyValuePair<string, string[]> entry in map)
+            {
+                readOnlyMap[entry.Key] = Array.AsReadOnly(entry.Value);
+            }
+
+            return new ReadOnlyDictionary<string, IReadOnlyList<string>>(readOnlyMap);
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Linq;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Internal;
@@ -19,7 +20,8 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
     internal class OtelInstrumentation : IOtelInstrumentation
     {
         /// <summary>
-        /// Constant to hold the name of the Meter.
+        /// Constant to hold the name of the Meter. This is the single definition of the meter name; it lives
+        /// here because this type constructs the <see cref="Meter"/> that MSAL publishes all of its metrics on.
         /// </summary>
         public const string MeterName = "MicrosoftIdentityClient_Common_Meter";
 
@@ -37,17 +39,6 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                  value.Equals("true", StringComparison.OrdinalIgnoreCase));
         }
 
-        private const string SuccessCounterName = "MsalSuccess";
-        private const string FailedCounterName = "MsalFailure";
-        private const string TotalDurationHistogramName = "MsalTotalDuration.1A";
-        private const string DurationInL1CacheHistogramName = "MsalDurationInL1CacheInUs.1B";
-        private const string DurationInL2CacheHistogramName = "MsalDurationInL2Cache.1A";
-        private const string DurationInHttpHistogramName = "MsalDurationInHttp.1A";
-        private const string DurationInExtensionInMsHistogram = "MsalDurationInExtensionInMs.1B";
-        private const string RemainingTokenLifetimeHistogramName = "MsalRemainingTokenLifetime.1A";
-        private const string TotalDurationV2HistogramName = "MsalTotalDurationV2.1A";
-        private const string DurationInHttpV2HistogramName = "MsalDurationInHttpV2.1A";
-
         /// <summary>
         /// Meter to hold the MSAL metrics.
         /// </summary>
@@ -57,21 +48,21 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Counter to hold the number of successful token acquisition calls.
         /// </summary>
         internal static readonly Lazy<Counter<long>> s_successCounter = new(() => Meter.CreateCounter<long>(
-            SuccessCounterName,
+            MsalMetricsCatalog.SuccessCounterName,
             description: "Number of successful token acquisition calls"));
 
         /// <summary>
         /// Counter to hold the number of failed token acquisition calls.
         /// </summary>
         internal static readonly Lazy<Counter<long>> s_failureCounter = new(() => Meter.CreateCounter<long>(
-            FailedCounterName,
+            MsalMetricsCatalog.FailureCounterName,
             description: "Number of failed token acquisition calls"));
 
         /// <summary>
         /// Histogram to record total duration in milliseconds of token acquisition calls.
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_durationTotal = new(() => Meter.CreateHistogram<long>(
-            TotalDurationHistogramName,
+            MsalMetricsCatalog.TotalDurationHistogramName,
             unit: "ms",
             description: "Performance of token acquisition calls total latency"));
 
@@ -80,7 +71,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Emitted only when extended metrics are enabled via the MSAL_ENABLE_EXTENDED_TOKEN_METRICS environment variable.
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_durationTotalV2 = new(() => Meter.CreateHistogram<long>(
-            TotalDurationV2HistogramName,
+            MsalMetricsCatalog.TotalDurationV2HistogramName,
             unit: "ms",
             description: "Performance of token acquisition calls total latency including both successes and failures"));
 
@@ -88,7 +79,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Histogram to record total duration of token acquisition calls in microseconds(us) when token is fetched from L1 cache.
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_durationInL1CacheInUs = new(() => Meter.CreateHistogram<long>(
-            DurationInL1CacheHistogramName,
+            MsalMetricsCatalog.DurationInL1CacheHistogramName,
             unit: "us",
             description: "Performance of token acquisition calls total latency in microseconds when L1 cache is used."));
 
@@ -96,7 +87,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Histogram to record duration in L2 cache for token acquisition calls.
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_durationInL2Cache = new Lazy<Histogram<long>>(() => Meter.CreateHistogram<long>(
-            DurationInL2CacheHistogramName,
+            MsalMetricsCatalog.DurationInL2CacheHistogramName,
             unit: "ms",
             description: "Performance of token acquisition calls cache latency"));
 
@@ -104,7 +95,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Histogram to record duration in milliseconds in http when the token is fetched from identity provider.
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_durationInHttp = new Lazy<Histogram<long>>(() => Meter.CreateHistogram<long>(
-            DurationInHttpHistogramName,
+            MsalMetricsCatalog.DurationInHttpHistogramName,
             unit: "ms",
             description: "Performance of token acquisition calls network latency"));
 
@@ -113,7 +104,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Emitted only when extended metrics are enabled via the MSAL_ENABLE_EXTENDED_TOKEN_METRICS environment variable.
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_durationInHttpV2 = new(() => Meter.CreateHistogram<long>(
-            DurationInHttpV2HistogramName,
+            MsalMetricsCatalog.DurationInHttpV2HistogramName,
             unit: "ms",
             description: "Performance of token acquisition calls network latency including both successes and failures"));
 
@@ -121,7 +112,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Histogram to record total duration of extension modifications in microseconds(us).
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_durationInExtensionInMs = new(() => Meter.CreateHistogram<long>(
-            DurationInExtensionInMsHistogram,
+            MsalMetricsCatalog.DurationInExtensionHistogramName,
             unit: "us",
             description: "Performance of token acquisition calls extension latency."));
 
@@ -129,7 +120,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         /// Histogram to record the remaining lifetime of acquired tokens in seconds.
         /// </summary>
         internal static readonly Lazy<Histogram<long>> s_remainingTokenLifetime = new(() => Meter.CreateHistogram<long>(
-            RemainingTokenLifetimeHistogramName,
+            MsalMetricsCatalog.RemainingTokenLifetimeHistogramName,
             unit: "s",
             description: "Remaining lifetime of acquired tokens at the time of acquisition."));
 
@@ -154,10 +145,18 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         // skipped, and an extra tag whose key collides with a canonical base tag key is dropped (a duplicate
         // key would otherwise shadow MSAL's canonical value in last-wins backends). So the canonical metric
         // set cannot be removed, overridden, or altered by the enricher.
+        //
+        // metricName identifies the instrument these base tags are recorded on. In Debug builds it is used to
+        // assert that every canonical base tag is declared in MsalMetricsCatalog for that metric, so the public
+        // catalog stays the single source of truth: adding a base tag here without declaring it there fails the
+        // test suite immediately. The check compiles out of shipping builds.
         private static TagList BuildTagList(
+            string metricName,
             IReadOnlyList<KeyValuePair<string, object>> extraTags,
             params KeyValuePair<string, object>[] baseTags)
         {
+            AssertCanonicalTagsDeclared(metricName, baseTags);
+
             if (extraTags == null || extraTags.Count == 0)
             {
                 return new TagList(baseTags);
@@ -184,6 +183,32 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             }
 
             return tagList;
+        }
+
+        // Debug-only guard that keeps the public MsalMetricsCatalog mapping in sync with the tags actually
+        // recorded here. Every canonical base tag emitted for a metric must be declared for that metric in the
+        // catalog; a given call may emit a subset of the declared tags (some are conditional), so this checks
+        // containment, not equality. Compiled out of Release builds, so there is no shipping-path overhead.
+        [Conditional("DEBUG")]
+        private static void AssertCanonicalTagsDeclared(string metricName, KeyValuePair<string, object>[] baseTags)
+        {
+            // Don't rely on the assert to halt execution: Debug.Assert routes to trace listeners and only the
+            // test host's listener throws; the default listener can continue past a failure. So guard the null
+            // case explicitly with a return, otherwise the foreach below would NullReferenceException on the
+            // very drift scenario this check exists to surface.
+            if (!MsalMetricsCatalog.CanonicalTagsByMetric.TryGetValue(metricName, out IReadOnlyList<string> canonicalTags))
+            {
+                Debug.Fail($"Metric '{metricName}' has no entry in MsalMetricsCatalog.CanonicalTagsByMetric. Add it there.");
+                return;
+            }
+
+            foreach (KeyValuePair<string, object> tag in baseTags)
+            {
+                Debug.Assert(
+                    canonicalTags.Contains(tag.Key),
+                    $"Tag '{tag.Key}' is recorded for metric '{metricName}' but is not declared in " +
+                    "MsalMetricsCatalog.CanonicalTagsByMetric. Add it to the metric's canonical tag list.");
+            }
         }
 
         // Aggregates the successful requests based on token source and cache refresh reason.
@@ -217,7 +242,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             if (s_durationInL1CacheInUs.Value.Enabled && authResultMetadata.TokenSource == TokenSource.Cache
                 && authResultMetadata.CacheLevel.Equals(CacheLevel.L1Cache))
             {
-                var tags = BuildTagList(extraTags,
+                var tags = BuildTagList(MsalMetricsCatalog.DurationInL1CacheHistogramName, extraTags,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
@@ -230,7 +255,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             // Only log cache duration if L2 cache was used.
             if (s_durationInL2Cache.Value.Enabled && cacheLevel == CacheLevel.L2Cache)
             {
-                var tags = BuildTagList(extraTags,
+                var tags = BuildTagList(MsalMetricsCatalog.DurationInL2CacheHistogramName, extraTags,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
@@ -240,7 +265,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
 
             if (s_durationInExtensionInMs.Value.Enabled)
             {
-                var tags = BuildTagList(extraTags,
+                var tags = BuildTagList(MsalMetricsCatalog.DurationInExtensionHistogramName, extraTags,
                     new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                     new(TelemetryConstants.Platform, platform),
                     new(TelemetryConstants.ApiId, apiId),
@@ -254,7 +279,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationTotal.Value.Enabled)
                 {
-                    var tags = BuildTagList(extraTags,
+                    var tags = BuildTagList(MsalMetricsCatalog.TotalDurationHistogramName, extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -268,7 +293,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 // Only log duration in HTTP when token is fetched from IDP.
                 if (s_durationInHttp.Value.Enabled && authResultMetadata.TokenSource == TokenSource.IdentityProvider)
                 {
-                    var tags = BuildTagList(extraTags,
+                    var tags = BuildTagList(MsalMetricsCatalog.DurationInHttpHistogramName, extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -280,7 +305,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationTotalV2.Value.Enabled)
                 {
-                    var tags = BuildTagList(extraTags,
+                    var tags = BuildTagList(MsalMetricsCatalog.TotalDurationV2HistogramName, extraTags,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenSource, authResultMetadata.TokenSource),
@@ -295,7 +320,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 // Only log duration in HTTP when token is fetched from IDP.
                 if (s_durationInHttpV2.Value.Enabled && authResultMetadata.TokenSource == TokenSource.IdentityProvider)
                 {
-                    var tags = BuildTagList(extraTags,
+                    var tags = BuildTagList(MsalMetricsCatalog.DurationInHttpV2HistogramName, extraTags,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType),
@@ -329,7 +354,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         {
             if (s_successCounter.Value.Enabled)
             {
-                var tags = BuildTagList(extraTags,
+                var tags = BuildTagList(MsalMetricsCatalog.SuccessCounterName, extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -357,7 +382,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationInHttp.Value.Enabled)
                 {
-                    var tags = BuildTagList(extraTags,
+                    var tags = BuildTagList(MsalMetricsCatalog.DurationInHttpHistogramName, extraTags,
                         new(TelemetryConstants.MsalVersion, MsalIdHelper.GetMsalVersion()),
                         new(TelemetryConstants.Platform, platform),
                         new(TelemetryConstants.ApiId, apiId),
@@ -369,7 +394,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 if (s_durationInHttpV2.Value.Enabled)
                 {
-                    var tags = BuildTagList(extraTags,
+                    var tags = BuildTagList(MsalMetricsCatalog.DurationInHttpV2HistogramName, extraTags,
                         new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                         new(TelemetryConstants.ApiId, apiId),
                         new(TelemetryConstants.TokenType, authResultMetadata.TelemetryTokenType),
@@ -410,7 +435,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             if (_isExtendedMetricsEnabled && s_durationTotalV2.Value.Enabled)
             {
                 // TokenSource is empty on failure: no token was acquired, so no source applies.
-                var tags = BuildTagList(extraTags,
+                var tags = BuildTagList(MsalMetricsCatalog.TotalDurationV2HistogramName, extraTags,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiEvent.ApiId),
                     new(TelemetryConstants.TokenSource, string.Empty),
@@ -454,7 +479,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             if (!string.IsNullOrEmpty(rawStsErrorCode))
                 baseTags.Add(new(TelemetryConstants.RawStsErrorCode, rawStsErrorCode));
 
-            var tags = BuildTagList(extraTags, baseTags.ToArray());
+            var tags = BuildTagList(MsalMetricsCatalog.FailureCounterName, extraTags, baseTags.ToArray());
 
             s_failureCounter.Value.Add(1, in tags);
         }
@@ -476,7 +501,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
 
             if (apiEvent.DurationInHttpInMs > 0)
             {
-                var tags = BuildTagList(extraTags,
+                var tags = BuildTagList(MsalMetricsCatalog.DurationInHttpV2HistogramName, extraTags,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiEvent.ApiId),
                     new(TelemetryConstants.TokenType, apiEvent.TokenType),
@@ -500,7 +525,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
             {
                 long remainingSeconds = Math.Max(0, (long)(expiresOn - DateTimeOffset.UtcNow).TotalSeconds);
 
-                var tags = BuildTagList(extraTags,
+                var tags = BuildTagList(MsalMetricsCatalog.RemainingTokenLifetimeHistogramName, extraTags,
                     new(TelemetryConstants.MsalVersionPlatform, MsalVersionPlatformTag(platform)),
                     new(TelemetryConstants.ApiId, apiId),
                     new(TelemetryConstants.TokenSource, tokenSource),

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         // metricName identifies the instrument these base tags are recorded on. In Debug builds it is used to
         // assert that every canonical base tag is declared in MsalMetricsCatalog for that metric, so the public
         // catalog stays the single source of truth: adding a base tag here without declaring it there fails the
-        // test suite immediately. The check compiles out of shipping builds.
+        // test suite immediately. Calls are omitted from non-DEBUG builds.
         private static TagList BuildTagList(
             string metricName,
             IReadOnlyList<KeyValuePair<string, object>> extraTags,
@@ -189,7 +189,7 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
         // Debug-only guard that keeps the public MsalMetricsCatalog mapping in sync with the tags actually
         // recorded here. Every canonical base tag emitted for a metric must be declared for that metric in the
         // catalog; a given call may emit a subset of the declared tags (some are conditional), so this checks
-        // containment, not equality. Compiled out of Release builds, so there is no shipping-path overhead.
+        // containment, not equality. Calls are omitted from non-DEBUG builds, so there is no shipping-path overhead.
         [Conditional("DEBUG")]
         private static void AssertCanonicalTagsDeclared(string metricName, KeyValuePair<string, object>[] baseTags)
         {

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using Microsoft.Identity.Client.Cache;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.TelemetryCore.Internal.Events;

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Cli
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+Microsoft.Identity.Client.MsalMetricsCatalog
+static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-Microsoft.Identity.Client.MsalMetricsCatalog
-static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Cli
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+Microsoft.Identity.Client.MsalMetricsCatalog
+static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-Microsoft.Identity.Client.MsalMetricsCatalog
-static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Cli
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+Microsoft.Identity.Client.MsalMetricsCatalog
+static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-Microsoft.Identity.Client.MsalMetricsCatalog
-static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Cli
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+Microsoft.Identity.Client.MsalMetricsCatalog
+static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-Microsoft.Identity.Client.MsalMetricsCatalog
-static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Cli
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+Microsoft.Identity.Client.MsalMetricsCatalog
+static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-Microsoft.Identity.Client.MsalMetricsCatalog
-static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Cli
 Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+Microsoft.Identity.Client.MsalMetricsCatalog
+static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-Microsoft.Identity.Client.MsalMetricsCatalog
-static Microsoft.Identity.Client.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1187,6 +1187,99 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        [TestMethod]
+        [Description("MsalMetricsCatalog is internally consistent: it maps every metric-name constant it declares, " +
+            "and every canonical tag it references is one of the declared tag-name constants.")]
+        public void MsalMetricsCatalog_IsInternallyConsistent()
+        {
+            var metricNames = new[]
+            {
+                MsalMetricsCatalog.SuccessCounterName,
+                MsalMetricsCatalog.FailureCounterName,
+                MsalMetricsCatalog.TotalDurationHistogramName,
+                MsalMetricsCatalog.TotalDurationV2HistogramName,
+                MsalMetricsCatalog.DurationInL1CacheHistogramName,
+                MsalMetricsCatalog.DurationInL2CacheHistogramName,
+                MsalMetricsCatalog.DurationInHttpHistogramName,
+                MsalMetricsCatalog.DurationInHttpV2HistogramName,
+                MsalMetricsCatalog.DurationInExtensionHistogramName,
+                MsalMetricsCatalog.RemainingTokenLifetimeHistogramName,
+            };
+
+            foreach (var name in metricNames)
+            {
+                Assert.IsTrue(MsalMetricsCatalog.CanonicalTagsByMetric.ContainsKey(name),
+                    $"Metric-name constant '{name}' has no canonical-tag entry in MsalMetricsCatalog.CanonicalTagsByMetric.");
+            }
+
+            Assert.HasCount(metricNames.Length, MsalMetricsCatalog.CanonicalTagsByMetric,
+                "CanonicalTagsByMetric has an entry for a metric not declared as a metric-name constant (or vice versa).");
+
+            var knownTags = new HashSet<string>(StringComparer.Ordinal)
+            {
+                TelemetryConstants.MsalVersion,
+                TelemetryConstants.MsalVersionPlatform,
+                TelemetryConstants.Platform,
+                TelemetryConstants.ApiId,
+                TelemetryConstants.CallerSdkId,
+                TelemetryConstants.TokenSource,
+                TelemetryConstants.CacheRefreshReason,
+                TelemetryConstants.CacheLevel,
+                TelemetryConstants.TokenType,
+                TelemetryConstants.ErrorCode,
+                TelemetryConstants.RawStsErrorCode,
+                TelemetryConstants.Succeeded,
+                TelemetryConstants.HttpStatusCode,
+            };
+
+            foreach (var entry in MsalMetricsCatalog.CanonicalTagsByMetric)
+            {
+                foreach (var tag in entry.Value)
+                {
+                    Assert.Contains(tag, knownTags,
+                        $"Metric '{entry.Key}' references canonical tag '{tag}' that is not a declared tag-name constant.");
+                }
+            }
+
+            // The meter name is owned by OtelInstrumentation (it constructs the Meter); the catalog only
+            // declares the metric-to-canonical-tag mapping.
+        }
+
+        [TestMethod]
+        [Description("MsalMetricsCatalog stays in sync with what MSAL actually emits: every emitted metric has a catalog " +
+            "entry, and every tag MSAL emits for a metric is declared as a canonical tag for that metric in the catalog.")]
+        public async Task MsalMetricsCatalog_MatchesEmittedMetricsAndTagsAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                CreateApplication();
+                await AcquireTokenSuccessAsync().ConfigureAwait(false);
+                await AcquireTokenMsalServiceExceptionAsync().ConfigureAwait(false);
+                await AcquireTokenMsalClientExceptionAsync().ConfigureAwait(false);
+
+                s_meterProvider.ForceFlush();
+
+                Assert.IsGreaterThan(0, _exportedMetrics.Count, "Expected at least one metric to be exported.");
+
+                foreach (Metric metric in _exportedMetrics)
+                {
+                    Assert.IsTrue(
+                        MsalMetricsCatalog.CanonicalTagsByMetric.TryGetValue(metric.Name, out var canonicalTags),
+                        $"Metric '{metric.Name}' is emitted by MSAL but missing from MsalMetricsCatalog.CanonicalTagsByMetric.");
+
+                    foreach (var metricPoint in metric.GetMetricPoints())
+                    {
+                        foreach (var tag in metricPoint.Tags)
+                        {
+                            Assert.IsTrue(
+                                canonicalTags.Contains(tag.Key),
+                                $"Metric '{metric.Name}' emitted tag '{tag.Key}', which is not declared as a canonical tag in MsalMetricsCatalog.");
+                        }
+                    }
+                }
+            }
+        }
+
         private static IDictionary<string, object> GetTagDictionary(ReadOnlyTagCollection tags)
         {
             var dict = new Dictionary<string, object>();


### PR DESCRIPTION
Add public `MsalMetricsCatalog.CanonicalTagsByMetric`, mapping each MSAL OpenTelemetry metric to its canonical tag names, so consumers can filter metrics to MSAL's known tags (without enrichment).