### PR TITLE
Cache instance discovery fallback failures

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/InstanceDiscoveryManager.cs
@@ -202,15 +202,24 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 requestContext.Logger.Error($"[Instance Discovery] Instance discovery failed - invalid instance! ");
                 throw;
             }
+            catch (OperationCanceledException) when (requestContext.UserCancellationToken.IsCancellationRequested)
+            {
+                requestContext.Logger.Info("[Instance Discovery] Instance discovery was canceled by the caller. ");
+                throw;
+            }
             catch (Exception e) 
             { 
                 requestContext.Logger.Warning(
                     $"[Instance Discovery] Instance Discovery failed. MSAL will continue without network instance metadata. \n\r" +
                     $" Exception: {e} ");
-                
-                return 
-                    _knownMetadataProvider.GetMetadata(authorityUri.Host, Enumerable.Empty<string>(), requestContext.Logger)
-                ?? CreateEntryForSingleAuthority(authorityUri);
+
+                InstanceDiscoveryMetadataEntry entry =
+                    _knownMetadataProvider.GetMetadata(authorityUri.Host, Enumerable.Empty<string>(), requestContext.Logger) ??
+                    CreateEntryForSingleAuthority(authorityUri);
+
+                _networkCacheMetadataProvider.AddMetadata(authorityUri.Host, entry);
+
+                return entry;
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkCacheMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkCacheMetadataProvider.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 {
     internal class NetworkCacheMetadataProvider : INetworkCacheMetadataProvider
     {
+        internal const int MaxCacheEntries = 10_000;
+
         private static readonly ConcurrentDictionary<string, InstanceDiscoveryMetadataEntry> s_cache =
              new ConcurrentDictionary<string, InstanceDiscoveryMetadataEntry>();
 
@@ -24,6 +26,11 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         {
             // Always take the most recent value
             s_cache.AddOrUpdate(environment, entry, (_, _) => entry);
+
+            if (s_cache.Count >= MaxCacheEntries)
+            {
+                s_cache.Clear();
+            }
         }
 
         internal static void ResetStaticCacheForTest()

--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Linq;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Http;
+using Microsoft.Identity.Client.Http.Retry;
 using Microsoft.Identity.Client.OAuth2;
 using Microsoft.Identity.Client.TelemetryCore;
 using Microsoft.Identity.Client.Utils;
@@ -21,15 +23,20 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         private readonly IHttpManager _httpManager;
         private readonly INetworkCacheMetadataProvider _networkCacheMetadataProvider;
         private readonly Uri _userProvidedInstanceDiscoveryUri; // can be null
+        private readonly TimeSpan _instanceDiscoveryTimeout;
+        internal static readonly TimeSpan DefaultInstanceDiscoveryTimeout = TimeSpan.FromSeconds(10);
+        private static readonly IRetryPolicy s_instanceDiscoveryRetryPolicy = new InstanceDiscoveryRetryPolicy();
 
         public NetworkMetadataProvider(
             IHttpManager httpManager,
             INetworkCacheMetadataProvider networkCacheMetadataProvider,
-            Uri userProvidedInstanceDiscoveryUri = null)
+            Uri userProvidedInstanceDiscoveryUri = null,
+            TimeSpan? instanceDiscoveryTimeout = null)
         {
             _httpManager = httpManager ?? throw new ArgumentNullException(nameof(httpManager));
             _networkCacheMetadataProvider = networkCacheMetadataProvider ?? throw new ArgumentNullException(nameof(networkCacheMetadataProvider));
             _userProvidedInstanceDiscoveryUri = userProvidedInstanceDiscoveryUri; // can be null
+            _instanceDiscoveryTimeout = instanceDiscoveryTimeout ?? DefaultInstanceDiscoveryTimeout;
         }
 
         public async Task<InstanceDiscoveryMetadataEntry> GetMetadataAsync(Uri authority, RequestContext requestContext)
@@ -83,11 +90,21 @@ namespace Microsoft.Identity.Client.Instance.Discovery
 
             Uri instanceDiscoveryEndpoint = ComputeHttpEndpoint(authority, requestContext);
 
-            InstanceDiscoveryResponse discoveryResponse = await client
-                .DiscoverAadInstanceAsync(instanceDiscoveryEndpoint, requestContext)
-                .ConfigureAwait(false);
+            using (var timeoutCancellationSource = new CancellationTokenSource(_instanceDiscoveryTimeout))
+            using (var linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
+                requestContext.UserCancellationToken,
+                timeoutCancellationSource.Token))
+            {
+                InstanceDiscoveryResponse discoveryResponse = await client
+                    .DiscoverAadInstanceAsync(
+                        instanceDiscoveryEndpoint,
+                        requestContext,
+                        linkedCancellationSource.Token,
+                        s_instanceDiscoveryRetryPolicy)
+                    .ConfigureAwait(false);
 
-            return discoveryResponse;
+                return discoveryResponse;
+            }
         }
 
         private Uri ComputeHttpEndpoint(Uri authority, RequestContext requestContext)
@@ -121,6 +138,14 @@ namespace Microsoft.Identity.Client.Instance.Discovery
         {
             // AAD specific
             return uri.AbsolutePath.Split('/')[1];
+        }
+
+        private sealed class InstanceDiscoveryRetryPolicy : IRetryPolicy
+        {
+            public Task<bool> PauseForRetryAsync(HttpResponse response, Exception exception, int retryCount, ILoggerAdapter logger)
+            {
+                return Task.FromResult(false);
+            }
         }
 
     }

--- a/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/OAuth2Client.cs
@@ -17,6 +17,7 @@ using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Utils;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Identity.Client.Http.Retry;
+using System.Threading;
 
 using System.Text.Json;
 
@@ -76,6 +77,20 @@ namespace Microsoft.Identity.Client.OAuth2
             return ExecuteRequestAsync<InstanceDiscoveryResponse>(endpoint, HttpMethod.Get, requestContext);
         }
 
+        public Task<InstanceDiscoveryResponse> DiscoverAadInstanceAsync(
+            Uri endpoint,
+            RequestContext requestContext,
+            CancellationToken cancellationToken,
+            IRetryPolicy retryPolicy)
+        {
+            return ExecuteRequestAsync<InstanceDiscoveryResponse>(
+                endpoint,
+                HttpMethod.Get,
+                requestContext,
+                cancellationToken: cancellationToken,
+                retryPolicy: retryPolicy);
+        }
+
         public Task<OidcMetadata> DiscoverOidcMetadataAsync(Uri endpoint, RequestContext requestContext)
         {
             return ExecuteRequestAsync<OidcMetadata>(endpoint, HttpMethod.Get, requestContext);
@@ -102,7 +117,9 @@ namespace Microsoft.Identity.Client.OAuth2
             RequestContext requestContext,
             bool expectErrorsOn200OK = false,
             bool addCommonHeaders = true,
-            IList<Func<OnBeforeTokenRequestData, Task>> onBeforePostRequestHandlers = null)
+            IList<Func<OnBeforeTokenRequestData, Task>> onBeforePostRequestHandlers = null,
+            CancellationToken? cancellationToken = null,
+            IRetryPolicy retryPolicy = null)
         {
             //Requests that are replayed by PKeyAuth do not need to have headers added because they already exist
             if (addCommonHeaders)
@@ -116,7 +133,8 @@ namespace Microsoft.Identity.Client.OAuth2
             using (requestContext.Logger.LogBlockDuration($"[Oauth2Client] Sending {method} request "))
             {
                 IRetryPolicyFactory retryPolicyFactory = requestContext.ServiceBundle.Config.RetryPolicyFactory;
-                IRetryPolicy retryPolicy = retryPolicyFactory.GetRetryPolicy(RequestType.STS);
+                IRetryPolicy effectiveRetryPolicy = retryPolicy ?? retryPolicyFactory.GetRetryPolicy(RequestType.STS);
+                CancellationToken effectiveCancellationToken = cancellationToken ?? requestContext.UserCancellationToken;
 
                 try
                 {
@@ -125,7 +143,7 @@ namespace Microsoft.Identity.Client.OAuth2
                         if (onBeforePostRequestHandlers != null)
                         {
                             requestContext.Logger.Verbose(() => "[Oauth2Client] Processing onBeforePostRequestData ");
-                            var requestData = new OnBeforeTokenRequestData(_bodyParameters, _headers, endpointUri, requestContext.UserCancellationToken);
+                            var requestData = new OnBeforeTokenRequestData(_bodyParameters, _headers, endpointUri, effectiveCancellationToken);
                             
                             foreach(var handler in onBeforePostRequestHandlers)
                             {
@@ -144,8 +162,8 @@ namespace Microsoft.Identity.Client.OAuth2
                             doNotThrow: false,
                             mtlsCertificate: _mtlsCertificate,
                             validateServerCertificate: null,
-                            cancellationToken: requestContext.UserCancellationToken,
-                            retryPolicy: retryPolicy)
+                            cancellationToken: effectiveCancellationToken,
+                            retryPolicy: effectiveRetryPolicy)
                         .ConfigureAwait(false);
                     }
                     else
@@ -159,8 +177,8 @@ namespace Microsoft.Identity.Client.OAuth2
                             doNotThrow: false,
                             mtlsCertificate: null,
                             validateServerCertificate: null,
-                            cancellationToken: requestContext.UserCancellationToken,
-                            retryPolicy: retryPolicy)
+                            cancellationToken: effectiveCancellationToken,
+                            retryPolicy: effectiveRetryPolicy)
                         .ConfigureAwait(false);
                     }
                 }

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/InstanceDiscoveryManagerTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/InstanceDiscoveryManagerTests.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.AppConfig;
 using Microsoft.Identity.Client.Core;
@@ -274,6 +275,72 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
             // Assert
             _knownMetadataProvider.Received(1).GetMetadata("some_env.com", Enumerable.Empty<string>(), Arg.Any<ILoggerAdapter>());
             ValidateSingleEntryMetadata(new Uri("https://some_env.com/tid"), actualResult);
+        }
+
+        [TestMethod]
+        [WorkItem(5804)]
+        public async Task NetworkProviderFailures_AreCachedAsSingleAuthorityFallback_Async()
+        {
+            // Arrange
+            _networkCacheMetadataProvider = new NetworkCacheMetadataProvider();
+            _knownMetadataProvider.GetMetadata(null, null, Arg.Any<ILoggerAdapter>()).ReturnsForAnyArgs((InstanceDiscoveryMetadataEntry)null);
+
+            _discoveryManager = new InstanceDiscoveryManager(
+                _harness.HttpManager,
+                null,
+                null,
+                _knownMetadataProvider,
+                _networkCacheMetadataProvider,
+                _networkMetadataProvider);
+
+            _networkMetadataProvider
+                .When(x => x.GetMetadataAsync(Arg.Any<Uri>(), _testRequestContext))
+                .Do(_ => throw new MsalServiceException("endpoint_busy", "some exception message"));
+
+            AuthorityInfo authorityInfo = AuthorityInfo.FromAuthorityUri("https://some_env.com/tid", true);
+
+            // Act
+            InstanceDiscoveryMetadataEntry firstResult = await _discoveryManager.GetMetadataEntryAsync(
+                authorityInfo,
+                _testRequestContext)
+                .ConfigureAwait(false);
+
+            InstanceDiscoveryMetadataEntry secondResult = await _discoveryManager.GetMetadataEntryTryAvoidNetworkAsync(
+                authorityInfo,
+                Enumerable.Empty<string>(),
+                _testRequestContext)
+                .ConfigureAwait(false);
+
+            // Assert
+            ValidateSingleEntryMetadata(new Uri("https://some_env.com/tid"), firstResult);
+            Assert.AreSame(firstResult, secondResult);
+            await _networkMetadataProvider.Received(1).GetMetadataAsync(Arg.Any<Uri>(), _testRequestContext).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        [WorkItem(5805)]
+        public async Task UserCancellationDuringInstanceDiscovery_IsRethrown_Async()
+        {
+            // Arrange
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            var requestContext = new RequestContext(
+                _harness.ServiceBundle,
+                Guid.NewGuid(),
+                null,
+                cancellationTokenSource.Token);
+
+            _networkMetadataProvider
+                .When(x => x.GetMetadataAsync(Arg.Any<Uri>(), requestContext))
+                .Do(_ => throw new TaskCanceledException("user canceled"));
+
+            // Act / Assert
+            await Assert.ThrowsAsync<TaskCanceledException>(() =>
+                _discoveryManager.GetMetadataEntryAsync(
+                    AuthorityInfo.FromAuthorityUri("https://some_env.com/tid", true),
+                    requestContext))
+                .ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/InstanceProviderTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/InstanceProviderTests.cs
@@ -37,6 +37,30 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
         }
 
         [TestMethod]
+        public void StaticProviderClearsCacheWhenEntryLimitIsExceeded()
+        {
+            // Arrange
+            NetworkCacheMetadataProvider.ResetStaticCacheForTest();
+            var staticMetadataProvider = new NetworkCacheMetadataProvider();
+            try
+            {
+                // Act
+                for (int i = 0; i < NetworkCacheMetadataProvider.MaxCacheEntries; i++)
+                {
+                    staticMetadataProvider.AddMetadata($"env-{i}", new InstanceDiscoveryMetadataEntry());
+                }
+
+                // Assert
+                Assert.IsNull(staticMetadataProvider.GetMetadata("env-0", _logger));
+                Assert.IsNull(staticMetadataProvider.GetMetadata($"env-{NetworkCacheMetadataProvider.MaxCacheEntries - 1}", _logger));
+            }
+            finally
+            {
+                NetworkCacheMetadataProvider.ResetStaticCacheForTest();
+            }
+        }
+
+        [TestMethod]
         public void KnownMetadataProvider_RespondsIfEnvironmentsAreKnown()
         {
             // Arrange

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/InstanceDiscoveryTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/InstanceDiscoveryTests.cs
@@ -156,5 +156,103 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 // Assert happens when httpManager disposes and checks for unconsumed handlers 
             }
         }
+
+        [TestMethod]
+        [WorkItem(5804)]
+        [DataRow(HttpStatusCode.NotFound)]
+        [DataRow(HttpStatusCode.BadGateway)]
+        public async Task FailedInstanceDiscoveryIsCachedForUnknownAuthorityAsync(HttpStatusCode discoveryStatusCode)
+        {
+            using (var httpManager = new MockHttpManager(disableInternalRetries: true))
+            {
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithAuthority(TestConstants.AuthorityNotKnownTenanted)
+                                                              .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithHttpManager(httpManager)
+                                                              .Build();
+
+                AddFailingInstanceDiscoveryMockHandler(httpManager, discoveryStatusCode);
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                // Act
+                AuthenticationResult firstResult = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                                            .ExecuteAsync(CancellationToken.None)
+                                                            .ConfigureAwait(false);
+
+                AuthenticationResult cachedResult = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                                             .ExecuteAsync(CancellationToken.None)
+                                                             .ConfigureAwait(false);
+
+                AuthenticationResult refreshedResult = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                                               .WithForceRefresh(true)
+                                                               .ExecuteAsync(CancellationToken.None)
+                                                               .ConfigureAwait(false);
+
+                // Assert
+                Assert.IsNotNull(firstResult);
+                Assert.IsNotNull(cachedResult);
+                Assert.IsNotNull(refreshedResult);
+            }
+        }
+
+        [TestMethod]
+        [WorkItem(5805)]
+        public async Task TimedOutInstanceDiscoveryIsCachedForUnknownAuthorityAsync()
+        {
+            using (var httpManager = new MockHttpManager(disableInternalRetries: true))
+            {
+                var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                                                              .WithAuthority(TestConstants.AuthorityNotKnownTenanted)
+                                                              .WithClientSecret(TestConstants.ClientSecret)
+                                                              .WithHttpManager(httpManager)
+                                                              .Build();
+
+                httpManager.AddMockHandler(
+                    new MockHttpMessageHandler
+                    {
+                        ExpectedMethod = HttpMethod.Get,
+                        ExpectedUrl = "https://login.microsoftonline.com/common/discovery/instance",
+                        ExceptionToThrow = new TaskCanceledException("Simulated instance discovery timeout")
+                    });
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                // Act
+                AuthenticationResult firstResult = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                                            .ExecuteAsync(CancellationToken.None)
+                                                            .ConfigureAwait(false);
+
+                AuthenticationResult cachedResult = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                                             .ExecuteAsync(CancellationToken.None)
+                                                             .ConfigureAwait(false);
+
+                AuthenticationResult refreshedResult = await app.AcquireTokenForClient(TestConstants.s_scope.ToArray())
+                                                               .WithForceRefresh(true)
+                                                               .ExecuteAsync(CancellationToken.None)
+                                                               .ConfigureAwait(false);
+
+                // Assert
+                Assert.IsNotNull(firstResult);
+                Assert.IsNotNull(cachedResult);
+                Assert.IsNotNull(refreshedResult);
+            }
+        }
+
+        private static void AddFailingInstanceDiscoveryMockHandler(
+            MockHttpManager httpManager,
+            HttpStatusCode discoveryStatusCode)
+        {
+            httpManager.AddMockHandler(
+                new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ExpectedUrl = "https://login.microsoftonline.com/common/discovery/instance",
+                    ResponseMessage = new HttpResponseMessage(discoveryStatusCode)
+                    {
+                        Content = new StringContent(string.Empty)
+                    }
+                });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Cache single-authority fallback metadata after non-`invalid_instance` instance discovery failures so repeated token requests do not re-hit global discovery.
- Add a discovery-only bounded timeout and no-retry policy so discovery failures fall back quickly without changing token endpoint or other HTTP flows.
- Preserve caller cancellation semantics and add regression coverage for failed/time-out discovery paths.

Fixes #5804
Fixes #5805
