### PR TITLE
Detach ImdsV2ManagedIdentitySource from AbstractManagedIdentity (refused-bequest cleanup)

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityClient.cs
@@ -83,31 +83,55 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 }
             }
 
-            // Route through the shared source selection so the same guards apply as the bespoke path
+            // Route through the shared source decision so the same guards apply as the bearer path
             // (e.g. throwing MtlsPopTokenNotSupportedinImdsV1 when only IMDSv1 is available). mTLS PoP
             // always resolves to the IMDSv2 source.
-            AbstractManagedIdentity selected = await GetOrSelectManagedIdentitySourceAsync(
-                requestContext, isMtlsPopRequested: true, cancellationToken).ConfigureAwait(false);
+            (ManagedIdentitySource source, bool isImdsV2) = SelectManagedIdentitySourceType(
+                requestContext, isMtlsPopRequested: true, cancellationToken);
 
             // An environment-detected source (App Service, Service Fabric, Cloud Shell, Azure Arc,
-            // Machine Learning) does not support mTLS PoP. Fail fast with a clear MSAL error rather
-            // than an opaque InvalidCastException from an unchecked cast.
-            if (selected is not ImdsV2ManagedIdentitySource imdsV2Source)
+            // Machine Learning) does not support mTLS PoP. Fail fast with a clear MSAL error.
+            if (source != ManagedIdentitySource.Imds || !isImdsV2)
             {
                 throw new MsalClientException(
                     MsalError.MtlsPopNotSupportedForEnvironment,
                     MsalErrorMessage.MtlsPopNotSupportedForManagedIdentityEnvironmentMessage);
             }
 
+            IImdsV2MtlsBindingSource imdsV2Source = ImdsV2ManagedIdentitySource.Create(requestContext);
+
             return await imdsV2Source
                 .AcquireMtlsBindingForDelegationAsync(parameters, forceRemint, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        // This method selects the managed identity source for token acquisition.
+        // This method selects and instantiates the managed identity source for the bearer token
+        // path. IMDSv2 (mTLS PoP) does not derive from AbstractManagedIdentity and is created via
+        // AcquireImdsV2MtlsBindingAsync, so the IMDS source here always resolves to IMDSv1.
+        private Task<AbstractManagedIdentity> GetOrSelectManagedIdentitySourceAsync(
+            RequestContext requestContext,
+            bool isMtlsPopRequested,
+            CancellationToken cancellationToken)
+        {
+            (ManagedIdentitySource source, _) = SelectManagedIdentitySourceType(
+                requestContext, isMtlsPopRequested, cancellationToken);
+
+            return Task.FromResult<AbstractManagedIdentity>(source switch
+            {
+                ManagedIdentitySource.ServiceFabric => ServiceFabricManagedIdentitySource.Create(requestContext),
+                ManagedIdentitySource.AppService => AppServiceManagedIdentitySource.Create(requestContext),
+                ManagedIdentitySource.MachineLearning => MachineLearningManagedIdentitySource.Create(requestContext),
+                ManagedIdentitySource.CloudShell => CloudShellManagedIdentitySource.Create(requestContext),
+                ManagedIdentitySource.AzureArc => AzureArcManagedIdentitySource.Create(requestContext),
+                ManagedIdentitySource.Imds => ImdsManagedIdentitySource.Create(requestContext),
+                _ => throw CreateManagedIdentityUnavailableException(s_cachedSourceResult)
+            });
+        }
+
+        // Decides the managed identity source (and IMDS version) without instantiating it.
         // It does NOT probe IMDS. It uses the cached explicit discovery result if available,
         // otherwise checks environment variables, and defaults to IMDS without probing.
-        private Task<AbstractManagedIdentity> GetOrSelectManagedIdentitySourceAsync(
+        private (ManagedIdentitySource Source, bool IsImdsV2) SelectManagedIdentitySourceType(
             RequestContext requestContext,
             bool isMtlsPopRequested,
             CancellationToken cancellationToken)
@@ -142,12 +166,12 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                         {
                             // Route mTLS PoP requests directly to IMDSv2 (no probing)
                             requestContext.Logger.Info("[Managed Identity] mTLS PoP requested, routing to IMDSv2 directly without probing.");
-                            return Task.FromResult<AbstractManagedIdentity>(ImdsV2ManagedIdentitySource.Create(requestContext));
+                            return (ManagedIdentitySource.Imds, true);
                         }
 
                         // Default to IMDSv1 without probing
                         requestContext.Logger.Info("[Managed Identity] Defaulting to IMDSv1 without probing.");
-                        return Task.FromResult<AbstractManagedIdentity>(ImdsManagedIdentitySource.Create(requestContext));
+                        return (ManagedIdentitySource.Imds, false);
                     }
                 }
 
@@ -177,18 +201,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                         MsalErrorMessage.MtlsPopTokenNotSupportedinImdsV1);
                 }
 
-                return Task.FromResult<AbstractManagedIdentity>(source switch
-                {
-                    ManagedIdentitySource.ServiceFabric => ServiceFabricManagedIdentitySource.Create(requestContext),
-                    ManagedIdentitySource.AppService => AppServiceManagedIdentitySource.Create(requestContext),
-                    ManagedIdentitySource.MachineLearning => MachineLearningManagedIdentitySource.Create(requestContext),
-                    ManagedIdentitySource.CloudShell => CloudShellManagedIdentitySource.Create(requestContext),
-                    ManagedIdentitySource.AzureArc => AzureArcManagedIdentitySource.Create(requestContext),
-                    ManagedIdentitySource.Imds => isImdsV2
-                        ? ImdsV2ManagedIdentitySource.Create(requestContext)
-                        : ImdsManagedIdentitySource.Create(requestContext),
-                    _ => throw CreateManagedIdentityUnavailableException(s_cachedSourceResult)
-                });
+                return (source, isImdsV2);
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/IImdsV2MtlsBindingSource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/IImdsV2MtlsBindingSource.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.ApiConfig.Parameters;
+
+namespace Microsoft.Identity.Client.ManagedIdentity.V2
+{
+    /// <summary>
+    /// Abstraction for the IMDSv2 mTLS Proof-of-Possession binding source. IMDSv2 mints (or reuses)
+    /// an mTLS binding (certificate + ESTS-R endpoint + canonical client_id) and then delegates the
+    /// token leg to MSAL's internal <see cref="OAuth2.TokenClient"/> exchange. Because IMDSv2 does not
+    /// use the <see cref="AbstractManagedIdentity"/> token template, it is modeled by this focused
+    /// interface instead of inheriting that base.
+    /// </summary>
+    internal interface IImdsV2MtlsBindingSource
+    {
+        /// <summary>
+        /// Performs the cert-mint flow and returns the resulting mTLS binding so the caller can
+        /// delegate the token leg to the internal exchange path.
+        /// </summary>
+        /// <param name="parameters">The managed identity request parameters (carries the attestation provider).</param>
+        /// <param name="forceRemint">When <c>true</c>, evicts any cached binding certificate and mints a fresh one.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        Task<MtlsBindingInfo> AcquireMtlsBindingForDelegationAsync(
+            AcquireTokenForManagedIdentityParameters parameters,
+            bool forceRemint,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
@@ -22,12 +22,14 @@ using Microsoft.Identity.Client.Utils;
 
 namespace Microsoft.Identity.Client.ManagedIdentity.V2
 {
-    internal class ImdsV2ManagedIdentitySource : AbstractManagedIdentity
+    internal class ImdsV2ManagedIdentitySource : IImdsV2MtlsBindingSource
     {
         // Central, process-local cache for mTLS binding (cert + endpoint + canonical client_id).
         internal static readonly ICertificateCache s_mtlsCertificateCache = new InMemoryCertificateCache();
 
+        private readonly RequestContext _requestContext;
         private readonly IMtlsCertificateCache _mtlsCache;
+        private bool _isMtlsPopRequested;
         private Func<string, SafeHandle, string, string, ILoggerAdapter, CancellationToken, Task<string>> _attestationTokenProvider;
 
         // used in unit tests
@@ -162,7 +164,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             return csrMetadata;
         }
 
-        public static AbstractManagedIdentity Create(RequestContext requestContext)
+        public static ImdsV2ManagedIdentitySource Create(RequestContext requestContext)
         {
             return new ImdsV2ManagedIdentitySource(requestContext);
         }
@@ -177,8 +179,8 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
         internal ImdsV2ManagedIdentitySource(
             RequestContext requestContext,
             IMtlsCertificateCache mtlsCache)
-            : base(requestContext, ManagedIdentitySource.Imds)
         {
+            _requestContext = requestContext;
             _mtlsCache = mtlsCache ?? throw new ArgumentNullException(nameof(mtlsCache));
         }
 
@@ -297,19 +299,6 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
             return certificateRequestResponse;
         }
 
-        // IMDSv2 delegates its token leg to MSAL's internal TokenClient exchange (see
-        // ManagedIdentityAuthRequest.SendDelegatedImdsV2TokenRequestAsync). The cert-mint flow is exposed
-        // via AcquireMtlsBindingForDelegationAsync, so the base AuthenticateAsync/CreateRequestAsync path
-        // is not used for IMDSv2. This override only satisfies the abstract base contract.
-        // DO NOT restore a bespoke token request here: the IMDSv2 token leg must go through TokenClient so
-        // client-originated claims, client-capability (CP1) merge, and claims-based cache keying are preserved.
-        protected override Task<ManagedIdentityRequest> CreateRequestAsync(string resource)
-        {
-            throw new InvalidOperationException(
-                "IMDSv2 delegates its token leg to the internal exchange path; CreateRequestAsync is not used. " +
-                "Mint the mTLS binding via AcquireMtlsBindingForDelegationAsync instead.");
-        }
-
         /// <summary>
         /// Performs the cert-mint flow (/getplatformmetadata + /issuecredential) and returns the
         /// resulting mTLS binding (cert + ESTS-R endpoint + canonical client_id). Extracted so the
@@ -402,7 +391,13 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
         /// provider and mTLS-PoP flag from the request parameters, optionally evicts a rejected cert
         /// (invalid_client / SCHANNEL re-mint), and returns the mTLS binding. Does NOT send the token request.
         /// </summary>
-        internal async Task<MtlsBindingInfo> AcquireMtlsBindingForDelegationAsync(
+        /// <remarks>
+        /// IMDSv2 delegates its token leg to MSAL's internal TokenClient exchange (see
+        /// ManagedIdentityAuthRequest.SendDelegatedImdsV2TokenRequestAsync). DO NOT restore a bespoke
+        /// token request: the IMDSv2 token leg must go through TokenClient so client-originated claims,
+        /// client-capability (CP1) merge, and claims-based cache keying are preserved.
+        /// </remarks>
+        public async Task<MtlsBindingInfo> AcquireMtlsBindingForDelegationAsync(
             ApiConfig.Parameters.AcquireTokenForManagedIdentityParameters parameters,
             bool forceRemint,
             CancellationToken cancellationToken)

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -1489,26 +1489,6 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
             }
         }
 
-        [TestMethod]
-        public void ValidateServerCertificate_NotSetForImdsV2()
-        {
-            using (new EnvVariableContext())
-            using (var httpManager = new MockHttpManager())
-            {
-                SetEnvironmentVariables(ManagedIdentitySource.Imds, "https://identity.endpoint.com");
-
-                var managedIdentityApp = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
-                    .WithHttpManager(httpManager)
-                    .BuildConcrete();
-                RequestContext requestContext = new RequestContext(managedIdentityApp.ServiceBundle, Guid.NewGuid(), null);
-
-                AbstractManagedIdentity managedIdentity = new ImdsV2ManagedIdentitySource(requestContext);
-
-                Assert.IsNull(managedIdentity.GetValidationCallback(),
-                    "IMDSv2 source should not have ValidateServerCertificate set");
-            }
-        }
-
         private AbstractManagedIdentity CreateManagedIdentitySource(ManagedIdentitySource sourceType, MockHttpManager httpManager)
         {
             string endpoint = "https://identity.endpoint.com";


### PR DESCRIPTION
## What

Removes the "refused bequest" code smell introduced by #6070: `ImdsV2ManagedIdentitySource` inherited `AbstractManagedIdentity` but used none of its token template, was forced to stub the abstract `CreateRequestAsync` with a `throw`, and was reached via a downcast in `ManagedIdentityClient`.

Fixes #6088.

## Changes

- **New** internal interface `IImdsV2MtlsBindingSource` exposing `AcquireMtlsBindingForDelegationAsync`.
- `ImdsV2ManagedIdentitySource` now implements `IImdsV2MtlsBindingSource` instead of inheriting `AbstractManagedIdentity`; it owns its `_requestContext`/`_isMtlsPopRequested` fields, and the throwing `CreateRequestAsync` override is deleted.
- `ManagedIdentityClient` source selection is split into a decision helper (`SelectManagedIdentitySourceType` → `(source, isImdsV2)`) and instantiation. The PoP path constructs IMDSv2 directly through the interface — the downcast (`is not ImdsV2ManagedIdentitySource`) is gone. The bearer path resolves IMDS to IMDSv1 only.
- Removed the obsolete `ValidateServerCertificate_NotSetForImdsV2` test (asserted a base-class validation-callback behavior IMDSv2 no longer has).

## Behavior preserved

All source-selection guards are unchanged: `NoneFound` throw, the per-request IMDSv1 fallback (`isImdsV2 && !isMtlsPopRequested`), the IMDSv1+PoP `MtlsPopTokenNotSupportedinImdsV1` throw, the no-environment defaults, and the discovery cache (`s_cachedSourceResult`). The PoP→delegation vs. bearer routing in `ManagedIdentityAuthRequest` keeps the two paths mutually exclusive, and the mTLS PoP min-strength enforcement added in #6059 is retained at the top of `AcquireImdsV2MtlsBindingAsync`.

## Validation

- Build: 0 warnings / 0 errors across all TFMs (`TreatWarningsAsErrors=true`).
- `ImdsV2Tests`: 92/92 pass.
- `ManagedIdentityTests`: 433 pass / 1 skip / 0 fail.
- No public API changes (all affected types are `internal`; `PublicAPI.Unshipped.txt` untouched).

## Context

Follow-up to review feedback on #6070 ([thread](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6070#discussion_r3462560678)).