### PR TITLE
Hide request authority override APIs

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs
@@ -314,6 +314,8 @@ namespace Microsoft.Identity.Client
         /// <param name="validateAuthority">Whether the authority should be validated against the server metadata.</param>
         /// <remarks>MSAL.NET supports ADFS 2019 or later.</remarks>
         /// <returns>The builder to chain the .With methods.</returns>                
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("This API has been deprecated. Configure the ADFS authority at the application level instead. See https://aka.ms/msal-net-application-configuration")]
         public T WithAdfsAuthority(string authorityUri, bool validateAuthority = true)
         {
             if (string.IsNullOrWhiteSpace(authorityUri))
@@ -331,6 +333,7 @@ namespace Microsoft.Identity.Client
         /// <param name="authorityUri">Azure AD B2C authority, including the B2C policy (for instance
         /// <c>"https://fabrikamb2c.b2clogin.com/tfp/{Tenant}/{policy}</c></param>).
         /// <returns>The builder to chain the .With methods.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public T WithB2CAuthority(string authorityUri)
         {
             if (string.IsNullOrWhiteSpace(authorityUri))

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AdfsAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AdfsAuthorityTests.cs
@@ -27,9 +27,11 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
                 .WithClientSecret(TestConstants.ClientSecret)
                 .Build();
 
+#pragma warning disable CS0618 // Test obsolete request-level authority override behavior
             Assert.Throws<ArgumentException>(() =>
                 app.AcquireTokenByAuthorizationCode(TestConstants.s_scope, "code")
                    .WithAdfsAuthority(malformedAuthority));
+#pragma warning restore CS0618
         }
     }
 }


### PR DESCRIPTION
Hide and obsolete request level WithAuthority. We only support WithTenantId at request level. 

But some are used by Azure.Identity / Identity.Web, so we just hide them. 