### PR TITLE
Include ManagedIdentitySource in managed identity error messages and request-failure logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Exposed canonical OpenTelemetry tag names per metric via `MsalMetricsCatalog.CanonicalTagsByMetric` for discoverability and validation. [#6076](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6076)
 
 ### Changes
-- Managed identity error messages and request-failure logs now include the detected `ManagedIdentitySource` (e.g., `AppService`, `Imds`, `ServiceFabric`) so the host-issued `Managed Identity Correlation ID` can be traced to the correct host's telemetry. [#TBD](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+- Managed identity error messages and request-failure logs now include the detected `ManagedIdentitySource` (e.g., `AppService`, `Imds`, `ServiceFabric`) so the host-issued `Managed Identity Correlation ID` can be traced to the correct host's telemetry. [#6095](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6095)
 
 4.85.0
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### New Features
 - Exposed canonical OpenTelemetry tag names per metric via `MsalMetricsCatalog.CanonicalTagsByMetric` for discoverability and validation. [#6076](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6076)
 
+### Changes
+- Managed identity error messages and request-failure logs now include the detected `ManagedIdentitySource` (e.g., `AppService`, `Imds`, `ServiceFabric`) so the host-issued `Managed Identity Correlation ID` can be traced to the correct host's telemetry. [#TBD](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet)
+
 4.85.0
 ======
 

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/AbstractManagedIdentity.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
             string message = GetMessageFromErrorResponse(response);
 
-            _requestContext.Logger.Error($"[Managed Identity] request failed, HttpStatusCode: {response.StatusCode} Error message: {message}");
+            _requestContext.Logger.Error($"[Managed Identity] request failed, Source: {_sourceType}, HttpStatusCode: {response.StatusCode} Error message: {message}");
 
             MsalException exception = MsalServiceExceptionFactory.CreateManagedIdentityException(
                 MsalError.ManagedIdentityRequestFailed,
@@ -281,7 +281,10 @@ namespace Microsoft.Identity.Client.ManagedIdentity
 
             if (!string.IsNullOrEmpty(managedIdentityErrorResponse.CorrelationId))
             {
-                stringBuilder.Append($"Managed Identity Correlation ID: {managedIdentityErrorResponse.CorrelationId} Use this Correlation ID for further investigation.");
+                stringBuilder.Append(
+                    $"Managed Identity Correlation ID: {managedIdentityErrorResponse.CorrelationId} " +
+                    $"(issued by the '{_sourceType}' managed identity source; search that source's telemetry with this correlation ID). " +
+                    $"Use this Correlation ID for further investigation.");
             }
 
             if (stringBuilder.Length == ManagedIdentityPrefix.Length)

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -559,8 +559,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        [DataRow("{\"statusCode\":500,\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID" })]
-        [DataRow("{\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID" })]
+        [DataRow("{\"statusCode\":500,\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID", "AppService", "managed identity source" })]
+        [DataRow("{\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID", "AppService", "managed identity source" })]
         [DataRow("{\"error\":\"errorCode\",\"error_description\":\"Error message\"}", new string[] { "errorCode", "Error message" })]
         [DataRow("{\"error_description\":\"Error message\"}", new string[] { "Error message" })]
         [DataRow("{\"message\":\"Error message\"}", new string[] { "Error message" })]

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -559,8 +559,8 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        [DataRow("{\"statusCode\":500,\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID", "AppService", "managed identity source" })]
-        [DataRow("{\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID", "AppService", "managed identity source" })]
+        [DataRow("{\"statusCode\":500,\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID", "issued by the 'AppService' managed identity source" })]
+        [DataRow("{\"message\":\"Error message\",\"correlationId\":\"GUID\"}", new string[] { "Error message", "GUID", "issued by the 'AppService' managed identity source" })]
         [DataRow("{\"error\":\"errorCode\",\"error_description\":\"Error message\"}", new string[] { "errorCode", "Error message" })]
         [DataRow("{\"error_description\":\"Error message\"}", new string[] { "Error message" })]
         [DataRow("{\"message\":\"Error message\"}", new string[] { "Error message" })]
@@ -603,6 +603,48 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 {
                     Assert.Contains(expectedErrorSubString, ex.Message, $"Expected to contain string {expectedErrorSubString}. Actual error message: {ex.Message}");
                 }
+            }
+        }
+
+        // The correlation-ID branch that attributes the host-issued correlation ID to a managed
+        // identity source is source-agnostic, so this guards it against regression for a
+        // non-AppService source (Imds) as well. It also asserts the full composed phrase rather
+        // than a bare source name, so the check cannot pass merely because the source name appears
+        // in the echoed error body.
+        [TestMethod]
+        [DataRow(ManagedIdentitySource.AppService, AppServiceEndpoint)]
+        [DataRow(ManagedIdentitySource.Imds, ImdsEndpoint)]
+        public async Task ManagedIdentityErrorMessageAttributesCorrelationIdToSourceAsync(ManagedIdentitySource managedIdentitySource, string endpoint)
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager(disableInternalRetries: true))
+            {
+                SetEnvironmentVariables(managedIdentitySource, endpoint);
+
+                var mi = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .Build();
+
+                // camelCase "correlationId" maps to ManagedIdentityErrorResponse.CorrelationId, which
+                // triggers the correlation-ID branch that names the managed identity source.
+                const string errorResponse = "{\"statusCode\":500,\"message\":\"Error message\",\"correlationId\":\"some-correlation-id\"}";
+
+                httpManager.AddManagedIdentityMockHandler(endpoint, Resource, errorResponse,
+                    managedIdentitySource, statusCode: HttpStatusCode.InternalServerError);
+
+                MsalServiceException ex = await Assert.ThrowsAsync<MsalServiceException>(async () =>
+                    await mi.AcquireTokenForManagedIdentity(Resource)
+                    .ExecuteAsync().ConfigureAwait(false)).ConfigureAwait(false);
+
+                Assert.IsNotNull(ex);
+                Assert.AreEqual(managedIdentitySource.ToString(), ex.AdditionalExceptionData[MsalException.ManagedIdentitySource]);
+                Assert.AreEqual(MsalError.ManagedIdentityRequestFailed, ex.ErrorCode);
+
+                // Assert the exact composed phrase (position-independent-proof): only MSAL's message
+                // builder produces this text, so it cannot be satisfied by the echoed error body.
+                string expectedSourcePhrase = $"issued by the '{managedIdentitySource}' managed identity source";
+                Assert.Contains(expectedSourcePhrase, ex.Message,
+                    $"Expected the message to attribute the correlation ID to the '{managedIdentitySource}' source. Actual error message: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
## Summary

Managed identity authentication failures surface a host-issued **Managed Identity Correlation ID**, but neither the customer-facing error message nor the request-failure log indicated *which* managed identity source (`AppService`, `Imds`, `ServiceFabric`, `AzureArc`, `CloudShell`, `MachineLearning`, etc.) produced that correlation ID. During live-site investigations this is ambiguous: each host emits its correlation ID into its own telemetry, so without the source you don't know which host's telemetry to search.

This change appends the detected `ManagedIdentitySource` to:
- the **request-failure log line** (`[Managed Identity] request failed, Source: {source}, ...`), and
- the **customer-facing correlation ID message**, clarifying that the correlation ID should be searched in that source's telemetry.

The source is taken from the existing `_sourceType` value already known to `AbstractManagedIdentity` at runtime — it is not hardcoded; the value reflects the host detected at runtime.

## Motivation

We recently root-caused a `ManagedIdentityCredential authentication failed` incident where the failure originated in the host (App Service) with an `AADSTS500011` resource-principal-not-found error. The host-issued correlation ID was present, but the exception did not say it came from the App Service host, slowing down the investigation. Surfacing the source makes the correlation ID directly actionable.

## Changes

- `AbstractManagedIdentity.cs`: include `_sourceType` in the request-failure log line and in the correlation ID message (only when a host correlation ID is present).
- `ManagedIdentityTests.cs`: updated `ManagedIdentityTestErrorResponseParsing` rows that carry a host `correlationId` to assert the source (`AppService`) and the new explanatory text appear in the message.
- `CHANGELOG.md`: added a `### Changes` entry under the in-progress version.

## Testing

- `ManagedIdentityTestErrorResponseParsing` — all rows pass.
- `ManagedIdentityTestWrongScopeAsync` (cross-source regression coverage) — passes.
- Local build of `Microsoft.Identity.Client` is clean; no public API surface changes.

## Notes

- No behavioral/auth changes — message/log content only.
- The CHANGELOG link placeholder will be updated with this PR number.
