### PR TITLE
Fix region failure-metadata test broken by explicit-region IMDS skip

### DIFF
--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientCredentialWithRegionTests.cs
@@ -595,7 +595,6 @@ namespace Microsoft.Identity.Test.Unit
             using (var harness = base.CreateTestHarness())
             {
                 var httpManager = harness.HttpManager;
-                httpManager.AddRegionDiscoveryMockHandler(TestConstants.Region);
                 httpManager.AddMockHandler(new MockHttpMessageHandler()
                 {
                     ExpectedUrl = $"https://{TestConstants.Region}.login.microsoft.com/common/oauth2/v2.0/token",


### PR DESCRIPTION
`FailedTokenRequest_SurfacesMetadataOnMsalServiceException_Async` (added in #6096) fails on main. #6092 stopped calling IMDS for explicitly-configured regions and removed the region-discovery mocks from the sibling region tests, but this one was landing at the same time and got missed.

Its stale `AddRegionDiscoveryMockHandler` left the IMDS mock first in the queue, so the token POST dequeued it and the URL assertion failed (expected `169.254.169.254...` / actual `.../login.microsoft.com/.../token`).

Removes the stale mock — the region still surfaces via explicit config. Test + the full region suite (45) pass locally.