### PR TITLE
Fix GetDurationFromManagedIdentityTimestamp to return 0 for past timestamps

### DIFF
--- a/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
@@ -87,10 +87,11 @@ namespace Microsoft.Identity.Client.Utils
             {
                 var timestamp = expiresOnUnixTimestamp - DateTimeHelpers.CurrDateTimeInUnixTimestamp();
 
-                // If the timestamp is negative, return the original expiresOnUnixTimestamp. Its format is "seconds from now".
+                // A negative delta means the absolute timestamp is in the past (stale token).
+                // Return 0 so the caller treats this as an expired response and re-fetches.
                 if (timestamp < 0)
                 {
-                    return expiresOnUnixTimestamp;
+                    return 0;
                 }
 
                 return timestamp;

--- a/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/DateTimeHelpers.cs
@@ -81,20 +81,33 @@ namespace Microsoft.Identity.Client.Utils
                 return 0;
             }
 
-            // First, try to parse as Unix timestamp (number of seconds since epoch)
-            // Example: "1697490590" (Unix timestamp representing seconds since 1970-01-01)
+            // First, try to parse as a numeric value. This covers two shapes:
+            //
+            // 1. Absolute Unix timestamp ("expires_on"): a large epoch value such as
+            //    "1697490590" (2023-10-17). Values at or above the year-2001 epoch
+            //    (978307200) are treated as absolute timestamps; the remaining time is
+            //    computed and clamped to 0 for past values so stale tokens are re-fetched.
+            //
+            // 2. Relative lifetime ("expires_in"): a small number of seconds such as
+            //    "3600". Values below the year-2001 threshold are returned as-is because
+            //    they represent seconds-from-now, not an epoch point.
+            //
+            // The threshold 978307200 = 2001-01-01T00:00:00Z, well below any real
+            // future `expires_on` and well above any reasonable `expires_in` value.
+            const long AbsoluteTimestampThreshold = 978307200L;
+
             if (long.TryParse(dateTimeStamp, out long expiresOnUnixTimestamp))
             {
-                var timestamp = expiresOnUnixTimestamp - DateTimeHelpers.CurrDateTimeInUnixTimestamp();
-
-                // A negative delta means the absolute timestamp is in the past (stale token).
-                // Return 0 so the caller treats this as an expired response and re-fetches.
-                if (timestamp < 0)
+                if (expiresOnUnixTimestamp < AbsoluteTimestampThreshold)
                 {
-                    return 0;
+                    // Relative lifetime (expires_in): return directly.
+                    return expiresOnUnixTimestamp;
                 }
 
-                return timestamp;
+                // Absolute timestamp (expires_on): compute remaining seconds.
+                // Return 0 for past values so the caller treats this as expired.
+                long remaining = expiresOnUnixTimestamp - DateTimeHelpers.CurrDateTimeInUnixTimestamp();
+                return remaining < 0 ? 0 : remaining;
             }
 
             // Try parsing as ISO 8601 

--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
@@ -66,10 +66,12 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
             result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(commonFormat1);
             Assert.IsGreaterThanOrEqualTo(-1, result, "Common Format 1 failed");
 
-            // Example 4: Common format (yyyy-MM-dd HH:mm:ss)
-            string commonFormat2 = currentTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture); // e.g., 2024-10-18 19:51:37
+            // Example 4: Common format (yyyy-MM-dd HH:mm:ss) — no timezone indicator, parsed as local time.
+            // Use a timestamp well in the future so local-time offset doesn't cause a near-zero result
+            // to flip negative on machines where local time is ahead of UTC.
+            string commonFormat2 = (currentTime + TimeSpan.FromHours(2)).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
             result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(commonFormat2);
-            Assert.IsGreaterThanOrEqualTo(-1, result, "Common Format 2 failed");
+            Assert.IsGreaterThan(0, result, $"Common Format 2 with a future timestamp should return positive duration, got {result}.");
 
             // Example 5: Invalid format (should throw an MsalClientException)
             string invalidFormat = "invalid-date-format";
@@ -77,6 +79,31 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
             {
                 DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(invalidFormat);
             }, "Invalid format did not throw an exception as expected.");
+        }
+
+        [TestMethod]
+        public void TestGetDurationFromManagedIdentityTimestamp_PastTimestamp_ReturnsZero()
+        {
+            // A past absolute Unix timestamp must return 0 so the caller treats the
+            // response as expired and re-fetches, rather than caching the token with
+            // the raw epoch value as a lifetime (which would be decades).
+
+            long currentUnix = DateTimeHelpers.CurrDateTimeInUnixTimestamp();
+
+            // 1 hour in the past
+            string pastByOneHour = (currentUnix - 3600).ToString(CultureInfo.InvariantCulture);
+            long result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(pastByOneHour);
+            Assert.AreEqual(0, result, "A timestamp 1 hour in the past should return 0.");
+
+            // 24 hours in the past (typical IMDS token lifetime already elapsed)
+            string pastByOneDay = (currentUnix - 86400).ToString(CultureInfo.InvariantCulture);
+            result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(pastByOneDay);
+            Assert.AreEqual(0, result, "A timestamp 24 hours in the past should return 0.");
+
+            // Well in the past (2024-era absolute timestamp)
+            string ancientTimestamp = "1697490590"; // 2023-10-17 — always in the past
+            result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(ancientTimestamp);
+            Assert.AreEqual(0, result, "A well-past absolute timestamp should return 0, not the raw epoch value.");
         }
     }
 }

--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
@@ -67,9 +67,9 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
             Assert.IsGreaterThanOrEqualTo(-1, result, "Common Format 1 failed");
 
             // Example 4: Common format (yyyy-MM-dd HH:mm:ss) — no timezone indicator, parsed as local time.
-            // Use a timestamp well in the future so local-time offset doesn't cause a near-zero result
-            // to flip negative on machines where local time is ahead of UTC.
-            string commonFormat2 = (currentTime + TimeSpan.FromHours(2)).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+            // Use a timestamp 1 day in the future so the local-time offset (max UTC+14) can't flip
+            // the result negative on any machine timezone.
+            string commonFormat2 = (currentTime + TimeSpan.FromDays(1)).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
             result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(commonFormat2);
             Assert.IsGreaterThan(0, result, $"Common Format 2 with a future timestamp should return positive duration, got {result}.");
 
@@ -105,5 +105,23 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
             result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp(ancientTimestamp);
             Assert.AreEqual(0, result, "A well-past absolute timestamp should return 0, not the raw epoch value.");
         }
-    }
-}
+
+        [TestMethod]
+        public void TestGetDurationFromManagedIdentityTimestamp_RelativeExpiresIn_ReturnedDirectly()
+        {
+            // Some MI endpoints (e.g. Azure Arc IMDS) return "expires_in" as a relative
+            // number of seconds-from-now rather than an absolute Unix timestamp. These small
+            // values are stored in ManagedIdentityResponse.ExpiresOn via ExpiresInRaw, so
+            // GetDurationFromManagedIdentityTimestamp must return them as-is, not treat them
+            // as epoch timestamps and subtract current time (which would give a huge negative
+            // value and force an erroneous re-fetch).
+
+            long result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp("3600");
+            Assert.AreEqual(3600, result, "A relative expires_in of 3600 should be returned as-is.");
+
+            result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp("86400");
+            Assert.AreEqual(86400, result, "A relative expires_in of 86400 should be returned as-is.");
+
+            result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp("0");
+            Assert.AreEqual(0, result, "A relative expires_in of 0 should return 0.");
+        }

--- a/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/UtilTests/DateTimeHelperTests.cs
@@ -125,3 +125,5 @@ namespace Microsoft.Identity.Test.Unit.UtilTests
             result = DateTimeHelpers.GetDurationFromManagedIdentityTimestamp("0");
             Assert.AreEqual(0, result, "A relative expires_in of 0 should return 0.");
         }
+    }
+}


### PR DESCRIPTION
`GetDurationFromManagedIdentityTimestamp` returns the raw Unix epoch value when the computed delta is negative, which causes callers to cache a response using the absolute timestamp as a relative lifetime. This change returns `0` instead, so the existing `<= 0` guard in the caller treats the response as expired and re-fetches normally.

Also fixes an existing test that compared a current-time `yyyy-MM-dd HH:mm:ss` value against UTC now — on machines where local time is ahead of UTC, `TryParse` with `RoundtripKind` adds the local offset and the result appears negative. Updated to use a future timestamp so the assertion is timezone-safe. Added test cases for past Unix timestamps.
