### PR TITLE
Fix mTLS PoP token cache key: hash certificate DER (x5t#S256) instead of public key

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -403,17 +403,17 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 string expectedKid = CoreHelpers.ComputeX5tS256KeyId(requestCert);
 
-                // If the certificate cannot produce a valid KeyId (SPKI-SHA256), expectedKid will be null or empty.
+                // If the certificate cannot produce a valid KeyId (x5t#S256 over the cert DER), expectedKid will be null or empty.
                 // In this case, the cache will be bypassed, as we cannot safely match the cached token to the certificate.
                 if (!string.Equals(cacheItem.KeyId, expectedKid, StringComparison.Ordinal))
                 {
                     AuthenticationRequestParameters.RequestContext.Logger.Verbose(() =>
-                    "[ClientCredentialRequest] Cached token KeyId does not match request certificate (SPKI-SHA256 mismatch). Bypassing cache.");
+                    "[ClientCredentialRequest] Cached token KeyId does not match request certificate (x5t#S256 DER mismatch). Bypassing cache.");
                     return false;
                 }
                 
                 AuthenticationRequestParameters.RequestContext.Logger.Verbose(() =>
-                "[ClientCredentialRequest] Cached token KeyId matches request certificate (SPKI-SHA256). Using cached token.");
+                "[ClientCredentialRequest] Cached token KeyId matches request certificate (x5t#S256 DER). Using cached token.");
             }
 
             // 3) If the token's hash matches AccessTokenHashToRefresh, ignore it

--- a/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
+++ b/src/client/Microsoft.Identity.Client/Utils/CoreHelpers.cs
@@ -238,13 +238,13 @@ namespace Microsoft.Identity.Client.Utils
 
         internal static string ComputeX5tS256KeyId(X509Certificate2 certificate)
         {
-            // Extract the raw bytes of the certificate’s public key.
-            var publicKey = certificate.GetPublicKey();
-
-            // Compute the SHA-256 hash of the public key.
+            // The mTLS PoP token is bound by ESTS/MSS to the SHA-256 hash of the full DER-encoded
+            // certificate (x5t#S256, RFC 8705) — NOT to the public key alone. Deriving the cache KeyId
+            // from the DER ensures a same-key certificate renewal (identical public key, new
+            // DER/serial/validity) is treated as a distinct credential instead of a stale cache hit.
             using (var sha256 = SHA256.Create())
             {
-                byte[] hash = sha256.ComputeHash(publicKey);
+                byte[] hash = sha256.ComputeHash(certificate.RawData);
 
                 // Return the hash encoded in Base64 URL format.
                 return Base64UrlHelpers.Encode(hash);

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
@@ -530,6 +530,123 @@ namespace Microsoft.Identity.Test.Unit
             }
         }
 
+        /// <summary>
+        /// Repro for AADSTS500181 (CertificateValidationFailedTlsCertMismatch) in the two-leg mTLS PoP flow.
+        ///
+        /// MSAL keys the mTLS-PoP token cache with <see cref="CoreHelpers.ComputeX5tS256KeyId"/>, which hashes
+        /// only the certificate's PUBLIC KEY. ESTS/MSS, however, bind and validate the token against the DER of
+        /// the presented certificate (x5t#S256, RFC 8705).
+        ///
+        /// When the binding certificate is renewed with the SAME key but a new DER (serial/validity) — exactly
+        /// what IMDS/KeyGuard produces when it reissues the cert over the same non-exportable key — the
+        /// public-key-hash cache key is unchanged. MSAL therefore cannot tell the old cert from the renewed one
+        /// and serves the STALE token (bound to the old cert's DER) while the renewed cert is on the wire,
+        /// producing the certificate/assertion mismatch.
+        ///
+        /// Correct behavior: a same-key renewal is a DIFFERENT certificate and MUST cause a cache miss, re-minting
+        /// a token bound to the renewed cert. This test FAILS on current code (second acquisition returns
+        /// TokenSource.Cache with the cert-A-bound token) and PASSES once the cache key is derived from the DER.
+        /// </summary>
+        [TestMethod]
+        public async Task MtlsPop_SameKeyCertRenewal_MustNotServeStaleCachedTokenAsync()
+        {
+            const string region = "eastus";
+
+            // Two certificates that share ONE RSA key pair but differ in DER (validity + serial).
+            // This models a same-key certificate renewal.
+            using RSA sharedKey = RSA.Create(2048);
+
+            X509Certificate2 certA = new CertificateRequest(
+                    "CN=MtlsPopSameKeyRenewal", sharedKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+                .CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-2), DateTimeOffset.UtcNow.AddDays(30));
+
+            X509Certificate2 certB = new CertificateRequest(
+                    "CN=MtlsPopSameKeyRenewal", sharedKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+                .CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(60));
+
+            try
+            {
+                // Precondition 1: identical public key (same key pair).
+                CollectionAssert.AreEqual(
+                    certA.GetPublicKey(), certB.GetPublicKey(),
+                    "Test setup invalid: the two certificates must share the same public key.");
+
+                // Precondition 2: different certificates (different DER => different x5t#S256 => different thumbprint).
+                Assert.AreNotEqual(
+                    certA.Thumbprint, certB.Thumbprint,
+                    "Test setup invalid: the two certificates must be different (different DER).");
+
+                // The binding certificate presented on the wire. Starts as cert A, then "renews" to cert B.
+                X509Certificate2 currentCert = certA;
+
+                using (var envContext = new EnvVariableContext())
+                {
+                    Environment.SetEnvironmentVariable("REGION_NAME", region);
+
+                    using (var httpManager = new MockHttpManager())
+                    {
+                        // Distinct tokens per mint so we can prove exactly which one is served.
+                        httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                            token: "token_bound_to_certA", tokenType: "mtls_pop");
+
+                        var app = ConfidentialClientApplicationBuilder.Create(TestConstants.ClientId)
+                            .WithExperimentalFeatures()
+                            .WithCertificate(_ => Task.FromResult(currentCert), new CertificateOptions())
+                            .WithAuthority("https://login.microsoftonline.com/123456-1234-2345-1234561234")
+                            .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
+                            .WithHttpManager(httpManager)
+                            .BuildConcrete();
+
+                        // ── Request 1: bind a PoP token to cert A. Hits the IdP and caches. ──
+                        AuthenticationResult first = await app.AcquireTokenForClient(TestConstants.s_scope)
+                            .WithMtlsProofOfPossession()
+                            .ExecuteAsync()
+                            .ConfigureAwait(false);
+
+                        Assert.AreEqual(TokenSource.IdentityProvider, first.AuthenticationResultMetadata.TokenSource);
+                        Assert.AreEqual("token_bound_to_certA", first.AccessToken);
+                        Assert.AreEqual(certA.Thumbprint, first.BindingCertificate.Thumbprint);
+
+                        // ── Same-key renewal: the platform reissues the binding cert over the same key. ──
+                        currentCert = certB;
+
+                        // A fresh IdP response is available for the (expected) cache miss on the renewed cert.
+                        httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage(
+                            token: "token_bound_to_certB", tokenType: "mtls_pop");
+
+                        // ── Request 2: cert B is now on the wire. ──
+                        AuthenticationResult second = await app.AcquireTokenForClient(TestConstants.s_scope)
+                            .WithMtlsProofOfPossession()
+                            .ExecuteAsync()
+                            .ConfigureAwait(false);
+
+                        // ─────────────────────────────── The bug ───────────────────────────────
+                        // Cert B has a different DER than cert A, so the cert-A-bound cached token is invalid for
+                        // cert B. Correct behavior is a cache MISS and a re-mint bound to cert B. On current code,
+                        // ComputeX5tS256KeyId hashes the public key (identical across the renewal), so the lookup
+                        // HITS the cert-A-bound token and returns it from cache while cert B is on the wire —
+                        // reproducing AADSTS500181.
+                        Assert.AreEqual(
+                            TokenSource.IdentityProvider,
+                            second.AuthenticationResultMetadata.TokenSource,
+                            "A same-key certificate renewal (same public key, different DER) MUST invalidate the " +
+                            "cached mTLS-PoP token. Serving the stale cert-A-bound token while cert B is on the wire " +
+                            "is the root cause of AADSTS500181 (CertificateValidationFailedTlsCertMismatch).");
+
+                        Assert.AreEqual(
+                            "token_bound_to_certB",
+                            second.AccessToken,
+                            "MSAL served the cert-A-bound token for a request presenting cert B.");
+                    }
+                }
+            }
+            finally
+            {
+                certA.Dispose();
+                certB.Dispose();
+            }
+        }
+
         [TestMethod]
         public async Task MtlsPop_KnownRegionAsync()
         {

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Identity.Test.Unit
         {
             var scheme = new MtlsPopAuthenticationOperation(s_testCertificate);
 
-            // Compute the expected KeyId using SHA-256 on the public key
+            // Compute the expected KeyId using SHA-256 over the certificate DER (x5t#S256)
             var expectedKeyId = ComputeExpectedKeyId(s_testCertificate);
 
             Assert.AreEqual(expectedKeyId, scheme.KeyId);
@@ -332,13 +332,11 @@ namespace Microsoft.Identity.Test.Unit
 
         private static string ComputeExpectedKeyId(X509Certificate2 certificate)
         {
-            // Get the raw public key bytes
-            var publicKey = certificate.GetPublicKey();
-
-            // Compute the SHA-256 hash of the public key
+            // Compute the SHA-256 hash of the full DER-encoded certificate (x5t#S256, RFC 8705),
+            // matching what ESTS/MSS bind the mTLS PoP token to.
             using (var sha256 = SHA256.Create())
             {
-                byte[] hash = sha256.ComputeHash(publicKey);
+                byte[] hash = sha256.ComputeHash(certificate.RawData);
                 return Base64UrlHelpers.Encode(hash);
             }
         }


### PR DESCRIPTION
## Summary

The mTLS Proof-of-Possession (PoP) token cache is keyed by a value derived from the certificate's **public key**, but ESTS/MSS bind and validate the PoP token against the **full certificate DER** (`x5t#S256`, RFC 8705). On a **same-key certificate renewal** (identical public key, new DER) these diverge: MSAL serves a cached token bound to the *previous* certificate while the *renewed* certificate is presented on the wire, and the server rejects the call.

## Symptom

A two-leg mTLS PoP flow — acquire a binding certificate, acquire a PoP token bound to it, then call a downstream mTLS endpoint — fails intermittently with:

```
AADSTS500181: The TLS certificate provided does not match the certificate in the assertion.
error: CertificateValidationFailedTlsCertMismatch  (HTTP 400)
```

Both token acquisitions report `TokenSource=Cache`, yet the downstream mTLS call is rejected: the cached PoP token's `cnf` is bound to a certificate whose DER no longer matches the certificate presented on the wire. It is transient — it lasts until the stale cached token expires and is re-minted.

## Root cause

`CoreHelpers.ComputeX5tS256KeyId` produces the mTLS PoP cache KeyId by hashing the **public key**:

```csharp
// before
var publicKey = certificate.GetPublicKey();
byte[] hash = sha256.ComputeHash(publicKey);
```

A same-key renewal keeps the public key identical but changes the DER (serial / validity), so this KeyId is unchanged. `ClientCredentialRequest.ShouldUseCachedToken` then treats the renewed certificate as the same credential and returns the stale token, whose `cnf` no longer matches the presented certificate's DER.

This is inconsistent with what the server actually binds to — the `x5t#S256` over the DER — which MSAL already computes correctly for the wire in `JsonWebToken` (`GetCertHash(SHA256)` / `SHA256(RawData)`).

## Fix

Derive the cache KeyId from the certificate **DER**, matching `x5t#S256`:

```csharp
// after
byte[] hash = sha256.ComputeHash(certificate.RawData);
```

Now a certificate renewal (even same-key) yields a distinct KeyId → cache miss → the token is re-minted bound to the current certificate → the wire certificate and the token `cnf` match again.

**Wire-safe:** this KeyId is used only as a cache/lookup identity; it is never sent on the wire. The only runtime effect is a one-time cache miss when a certificate is renewed.

## Test

`MtlsPop_SameKeyCertRenewal_MustNotServeStaleCachedTokenAsync` (added as the first commit) builds two certificates that **share one RSA key pair but differ in DER**, mints a PoP token bound to cert A, then presents cert B (the renewal):

- **Before the fix:** the second acquisition returns `TokenSource.Cache` (the stale cert-A token) — the test fails, reproducing the mismatch.
- **After the fix:** the second acquisition returns `TokenSource.IdentityProvider`, re-bound to cert B — the test passes.

Full unit suite: **2236 passed, 0 failed**.

## Changes

- `CoreHelpers.ComputeX5tS256KeyId` — hash `certificate.RawData` (DER) instead of `GetPublicKey()`.
- `ClientCredentialRequest` — cache-match diagnostics updated to reflect DER-based key identity (behavior unchanged; it calls the corrected helper).
- `MtlsPopTests` — new proving test + `ComputeExpectedKeyId` helper updated to DER.
