### PR TITLE
Add AOT support to .WinUI package, and stop using WinAppSDK meta-package

### DIFF
--- a/.github/workflows/benchmark-action.yml
+++ b/.github/workflows/benchmark-action.yml
@@ -26,7 +26,10 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          # .NET 10 is required by global.json; .NET 8 is required to build and run the net8.0 benchmarks.
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Restore NuGet packages
         run: dotnet restore tests/Microsoft.Identity.Test.Performance
       - name: Run benchmark

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="8.14.0" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
     <PackageVersion Include="Microsoft.WindowsAppSDK.WinUI" Version="1.8.250906003" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6901" />
     <PackageVersion Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <!-- Should match Azure Functions runtime: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4456 -->
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.Identity.Client.NativeInterop" Version="$(MSALRuntimeNativeInteropVersion)" IncludeAssets="all" />
     <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="8.14.0" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.WinUI" Version="1.8.250906003" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6901" />
     <PackageVersion Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <!-- Should match Azure Functions runtime: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4456 -->

--- a/build/template-deploy-managed-identity-webapp-and-test.yaml
+++ b/build/template-deploy-managed-identity-webapp-and-test.yaml
@@ -55,6 +55,18 @@ parameters:
   default: 'e9207e64-f339-4a63-b074-90dc105a1954'
 
 steps:
+
+# Ensure the required SDKs are available on the agent.
+# The .NET 10 SDK is required to satisfy global.json (rollForward: latestFeature stays within 10.0.x and won't fall back to 8.x).
+- task: UseDotNet@2
+  displayName: 'Install .NET SDK 10.0.302 (required by global.json)'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.302'
+    includePreviewVersions: false
+    performMultiLevelLookup: true
+
+# The .NET 8 SDK is required to build and publish the net8.0 ManagedIdentityWebApi.
 - task: UseDotNet@2
   displayName: 'Install .NET 8 SDK'
   inputs:

--- a/build/template-run-mi-e2e-imds.yaml
+++ b/build/template-run-mi-e2e-imds.yaml
@@ -4,7 +4,17 @@ parameters:
 
 steps:
 
-# Ensure the exact SDK is available on the agent
+# Ensure the exact SDKs are available on the agent.
+# The .NET 10 SDK is required to satisfy global.json (rollForward: latestFeature stays within 10.0.x and won't fall back to 8.x).
+- task: UseDotNet@2
+  displayName: 'Install .NET SDK 10.0.302 (required by global.json)'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.302'
+    includePreviewVersions: false
+    performMultiLevelLookup: true
+
+# The .NET 8 SDK/runtime is required to build and run the net8.0 E2E tests.
 - task: UseDotNet@2
   displayName: 'Install .NET SDK 8.0.418'
   inputs:

--- a/build/template-run-mi-e2e-imdsv2.yaml
+++ b/build/template-run-mi-e2e-imdsv2.yaml
@@ -4,7 +4,17 @@ parameters:
 
 steps:
 
-# Ensure the exact SDK is available on the agent
+# Ensure the exact SDKs are available on the agent.
+# The .NET 10 SDK is required to satisfy global.json (rollForward: latestFeature stays within 10.0.x and won't fall back to 8.x).
+- task: UseDotNet@2
+  displayName: 'Install .NET SDK 10.0.302 (required by global.json)'
+  inputs:
+    packageType: 'sdk'
+    version: '10.0.302'
+    includePreviewVersions: false
+    performMultiLevelLookup: true
+
+# The .NET 8 SDK/runtime is required to build and run the net8.0 E2E tests.
 - task: UseDotNet@2
   displayName: 'Install .NET SDK 8.0.418'
   inputs:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.100",
+        "version": "10.0.302",
         "rollForward": "latestFeature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.418",
+        "version": "10.0.100",
         "rollForward": "latestFeature"
     }
 }

--- a/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
@@ -9,7 +9,16 @@
     <!-- The Windows App SDK only supports Native AOT on .NET 10+, so only claim AOT
          compatibility (and run the AOT/trim analyzers) for the net10 target. The explicit
          assignment also overrides the net8.0-wide default from src/Directory.Build.props. -->
-    <IsAotCompatible>$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
+
+    <!-- Disable runtime marshalling (CsWinRT doesn't rely on it anymore) -->
+    <DisableRuntimeMarshalling Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</DisableRuntimeMarshalling>
+
+    <!-- Ensure the CsWinRT AOT analyzer is enabled (it should be the default, but it doesn't seem to be running
+         in this project without explicitly setting these properties. Can be removed in the future once fixed.
+         For now, leaving these in doesn't cause any issues anyway, these are the same as the default values. -->
+    <CsWinRTAotOptimizerEnabled>true</CsWinRTAotOptimizerEnabled>
+    <CsWinRTAotWarningLevel>2</CsWinRTAotWarningLevel>
     
     <PathToMsalSources>$(MSBuildThisFileDirectory)../Microsoft.Identity.Client/</PathToMsalSources>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -48,7 +57,6 @@
   <!-- WinUI3 and Windows App SDK dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
   </ItemGroup>
   
   <!-- Project references -->

--- a/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
@@ -5,7 +5,11 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WINUI3</DefineConstants>
-    <IsAotCompatible>true</IsAotCompatible>
+
+    <!-- The Windows App SDK only supports Native AOT on .NET 10+, so only claim AOT
+         compatibility (and run the AOT/trim analyzers) for the net10 target. The explicit
+         assignment also overrides the net8.0-wide default from src/Directory.Build.props. -->
+    <IsAotCompatible>$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))</IsAotCompatible>
     
     <PathToMsalSources>$(MSBuildThisFileDirectory)../Microsoft.Identity.Client/</PathToMsalSources>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFrameworks>net8.0-windows10.0.17763.0;net10.0-windows10.0.17763.0</TargetFrameworks>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WINUI3</DefineConstants>
+    <IsAotCompatible>true</IsAotCompatible>
     
     <PathToMsalSources>$(MSBuildThisFileDirectory)../Microsoft.Identity.Client/</PathToMsalSources>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
@@ -43,7 +43,7 @@
 
   <!-- WinUI3 and Windows App SDK dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
   </ItemGroup>
   

--- a/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
@@ -6,11 +6,6 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WINUI3</DefineConstants>
 
-    <!-- The Windows App SDK only supports Native AOT on .NET 10+, so only claim AOT
-         compatibility (and run the AOT/trim analyzers) for the net10 target. The explicit
-         assignment also overrides the net8.0-wide default from src/Directory.Build.props. -->
-    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
-
     <!-- Disable runtime marshalling (CsWinRT doesn't rely on it anymore) -->
     <DisableRuntimeMarshalling Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</DisableRuntimeMarshalling>
 

--- a/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
+++ b/src/client/Microsoft.Identity.Client.Desktop.WinUI3/Microsoft.Identity.Client.Desktop.WinUI3.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0-windows10.0.17763.0;net10.0-windows10.0.17763.0</TargetFrameworks>
     <UseWinUI>true</UseWinUI>
-    <EnableMsixTooling>true</EnableMsixTooling>
     <DefineConstants>$(DefineConstants);WINUI3</DefineConstants>
 
     <!-- Disable runtime marshalling (CsWinRT doesn't rely on it anymore) -->

--- a/src/client/Microsoft.Identity.Client.Desktop.WinUI3/WebView2WebUi/WinUI3WindowWithWebView2.cs
+++ b/src/client/Microsoft.Identity.Client.Desktop.WinUI3/WebView2WebUi/WinUI3WindowWithWebView2.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 
 namespace Microsoft.Identity.Client.Desktop.WebView2WebUi
 {
-    internal sealed class WinUI3WindowWithWebView2 : Window, IDisposable
+    internal sealed partial class WinUI3WindowWithWebView2 : Window, IDisposable
     {
         private const int UIWidth = 566;
         private readonly EmbeddedWebViewOptions _embeddedWebViewOptions;


### PR DESCRIPTION
Fixes #6122
<!-- Add the issue number above. If this PR only partially fixes the issue, remove the Fixes word above so that the issue is not automatically closed. -->

**Changes proposed in this request**
- Bumps the global.json version to latest .NET 10 SDK
- Adds a .NET 10 TFM to the .WinUI package (needed for AOT support)
- Enables AOT support in the .WinUI package
- Stops using the WinAppSDK meta-package in the NuGet package and just uses the .WinUI subset
