### PR TITLE
Expose MsalServiceException.ErrorCodesForLogging for diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ======
 
 ### New Features
-- Exposed `MsalServiceException.ErrorCodes` (as a public `IReadOnlyList<string>`), surfacing the raw STS-specific error codes (for example the numeric `AADSTS` codes) for diagnostics and logging. [#TBD](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/TBD)
+- Exposed `MsalServiceException.ErrorCodesForLogging` (as a public `IReadOnlyList<string>`), surfacing the raw STS-specific error codes (for example the numeric `AADSTS` codes) for diagnostics and logging. [#6138](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6138)
 
 4.86.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.87.0
+======
+
+### New Features
+- Exposed `MsalServiceException.ErrorCodes` (as a public `IReadOnlyList<string>`), surfacing the raw STS-specific error codes (for example the numeric `AADSTS` codes) for diagnostics and logging. [#TBD](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/TBD)
+
 4.86.1
 ======
 

--- a/src/client/Microsoft.Identity.Client/Internal/Logger/LoggerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Logger/LoggerHelper.cs
@@ -109,9 +109,9 @@ namespace Microsoft.Identity.Client.Internal.Logger
             {
                 sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "HTTP StatusCode {0}", msalServiceException.StatusCode));
                 sb.AppendLine($"CorrelationId {msalServiceException.CorrelationId}");
-                if (msalServiceException.ErrorCodes is {Count: > 0})
+                if (msalServiceException.ErrorCodesForLogging is {Count: > 0})
                 {
-                    sb.AppendLine($"Microsoft Entra ID Error Code AADSTS{string.Join(" ", msalServiceException.ErrorCodes)}");
+                    sb.AppendLine($"Microsoft Entra ID Error Code AADSTS{string.Join(" ", msalServiceException.ErrorCodesForLogging)}");
                 }
             }
 

--- a/src/client/Microsoft.Identity.Client/Internal/Logger/LoggerHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Logger/LoggerHelper.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Identity.Client.Internal.Logger
             {
                 sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "HTTP StatusCode {0}", msalServiceException.StatusCode));
                 sb.AppendLine($"CorrelationId {msalServiceException.CorrelationId}");
-                if (msalServiceException.ErrorCodes is {Length: > 0})
+                if (msalServiceException.ErrorCodes is {Count: > 0})
                 {
                     sb.AppendLine($"Microsoft Entra ID Error Code AADSTS{string.Join(" ", msalServiceException.ErrorCodes)}");
                 }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     httpStatusCode,
                     totalDurationInMs,
                     exception: ex,
-                    rawStsErrorCode: serviceException?.ErrorCodes?.FirstOrDefault());
+                    rawStsErrorCode: serviceException?.ErrorCodesForLogging?.FirstOrDefault());
                 throw;
             }
             catch (Exception ex)

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Identity.Client.Internal
                     logger.ErrorPiiWithPrefix(ex, logMsg);
 
                     LogBackgroundFailureTelemetry(serviceBundle, apiEvent, callerSdkId, callerSdkVersion,
-                        ex.ErrorCode, ex.StatusCode, ex.ErrorCodes?.FirstOrDefault(), ex, tagsEnricher, logger);
+                        ex.ErrorCode, ex.StatusCode, ex.ErrorCodesForLogging?.FirstOrDefault(), ex, tagsEnricher, logger);
 
                     // Background refresh doesn't go through RunAsync, so the exception isn't carrying metadata yet.
                     // Fill it in from apiEvent so the callback can see the HTTP duration and cache-refresh reason.

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Identity.Client
         /// without notice; intended for diagnostics and logging — do not branch production behavior
         /// on this value. Returns <see langword="null"/> when the service did not supply error codes.
         /// </summary>
-        public IReadOnlyList<string> ErrorCodes { get; internal set; }
+        public IReadOnlyList<string> ErrorCodesForLogging { get; internal set; }
 
         /// <summary>
         /// As per discussion with Evo, AAD 

--- a/src/client/Microsoft.Identity.Client/MsalServiceException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
@@ -214,9 +215,13 @@ namespace Microsoft.Identity.Client
         public string SubErrorForLogging { get; internal set; }
 
         /// <summary>
-        /// A list of STS-specific error codes that can help in diagnostics.
+        /// The list of STS-specific error codes returned by the token service (for example the
+        /// numeric <c>AADSTS</c> codes such as <c>50076</c>, <c>50079</c>) that refine
+        /// <see cref="MsalException.ErrorCode"/>. Values are emitted by the service and may change
+        /// without notice; intended for diagnostics and logging — do not branch production behavior
+        /// on this value. Returns <see langword="null"/> when the service did not supply error codes.
         /// </summary>
-        internal string[] ErrorCodes { get; set; }
+        public IReadOnlyList<string> ErrorCodes { get; internal set; }
 
         /// <summary>
         /// As per discussion with Evo, AAD 

--- a/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
+++ b/src/client/Microsoft.Identity.Client/MsalServiceExceptionFactory.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Identity.Client
             ex.Claims = oAuth2Response?.Claims;
             ex.CorrelationId = oAuth2Response?.CorrelationId;
             ex.SubErrorForLogging = oAuth2Response?.SubError;
-            ex.ErrorCodes = oAuth2Response?.ErrorCodes;
+            ex.ErrorCodesForLogging = oAuth2Response?.ErrorCodes is { } errorCodes ? Array.AsReadOnly(errorCodes) : null;
 
             return ex;
         }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.Identity.Client.MsalServiceException.ErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string>

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -870,7 +870,7 @@ namespace Microsoft.Identity.Test.Unit
                         .WithTenantId(TestConstants.Utid)
                         .ExecuteAsync(CancellationToken.None)).ConfigureAwait(false);
 
-                Assert.IsNotNull(ex.ErrorCodes, "ErrorCodes should be populated from IDP response.");
+                Assert.IsNotNull(ex.ErrorCodesForLogging, "ErrorCodesForLogging should be populated from IDP response.");
 
                 s_meterProvider.ForceFlush();
 
@@ -880,7 +880,7 @@ namespace Microsoft.Identity.Test.Unit
                     var tags = GetTagDictionary(metricPoint.Tags);
                     Assert.IsTrue(tags.ContainsKey(TelemetryConstants.RawStsErrorCode),
                         "RawStsErrorCode tag should be present when the IDP response contains error_codes.");
-                    Assert.AreEqual(ex.ErrorCodes.FirstOrDefault(), tags[TelemetryConstants.RawStsErrorCode]);
+                    Assert.AreEqual(ex.ErrorCodesForLogging.FirstOrDefault(), tags[TelemetryConstants.RawStsErrorCode]);
                 }
             }
         }


### PR DESCRIPTION
## What
Promote `MsalServiceException.ErrorCodesForLogging` from `internal string[]` to a public `IReadOnlyList<string>` (getter only; setter stays internal).

## Why
Downstream diagnostics need the raw STS-specific error codes (numeric `AADSTS` codes, e.g. `50076`, `500011`) that refine `ErrorCode`. They were already populated internally but not observable by callers.

## Notes
- Named `ErrorCodesForLogging` (matching `SubErrorForLogging`) to signal it is diagnostics-only; values are service-emitted and may change — not intended for branching production behavior.
- Returns an `Array.AsReadOnly` view so callers cannot downcast the `IReadOnlyList` and mutate the exception's error codes.
- `LoggerHelper` updated (`{Length:>0}` → `{Count:>0}`), the only array-specific usage.
- `OTelInstrumentationTests` asserts population + the `RawStsErrorCode` telemetry tag.

## Related
- Abstractions: AzureAD/microsoft-identity-abstractions-for-dotnet#264 (adds `TokenAcquisitionFailureDetails.ServiceErrorCodes`, which mirrors this value).
- Consumed downstream by MISE (draft, ADO): https://identitydivision.visualstudio.com/DevEx/_git/MISE/pullrequest/25683