### PR TITLE
Populate ExecutionResult.Exception for non-MSAL failures (Bug 3696306)

### DIFF
--- a/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
+++ b/src/client/Microsoft.Identity.Client/AuthenticationResultMetadata.cs
@@ -9,6 +9,13 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// Contains metadata of the authentication result. <see cref="Metrics"/> for additional MSAL-wide metrics.
     /// </summary>
+#if NETFRAMEWORK || NETSTANDARD
+    // Marked [Serializable] only on the frameworks whose Exception.Data (ListDictionaryInternal) rejects
+    // non-serializable values, so downstream providers can read this object off the raw exception's Data bag
+    // (Bug 3696194). .NET (Core) removed that check, so the attribute is unnecessary there. The whole member
+    // graph is serializable (enums, strings, numeric types, and the RegionDetails DTO), so this is honest.
+    [Serializable]
+#endif
     public class AuthenticationResultMetadata
     {
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -138,7 +138,28 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 apiEvent.ApiErrorCode = ex.GetType().Name;
                 AuthenticationRequestParameters.RequestContext.Logger.ErrorPii(ex);
 
-                LogFailureTelemetryToOtel(ex.GetType().Name, apiEvent, apiEvent.CacheInfo, httpStatusCode: 0, totalDurationInMs: requestStopwatch.ElapsedMilliseconds + measureTelemetryDurationResult.Milliseconds);
+                // Compute the total duration once so the value on the synthesized metadata matches the
+                // value logged to OpenTelemetry (the stopwatch keeps running, so re-reading it drifts).
+                long totalDurationInMs = requestStopwatch.ElapsedMilliseconds + measureTelemetryDurationResult.Milliseconds;
+
+                // The original exception is re-thrown below; MSAL never surfaces this wrapper. It exists only
+                // so the OpenTelemetry tag enricher observes a populated ExecutionResult.Exception (carrying
+                // failure metadata) for non-MSAL failures, mirroring the MsalException path above. The
+                // originating exception's type is captured as the ErrorCode and it is preserved as the
+                // InnerException so consumers retain full fidelity.
+                MsalException enricherException = new MsalException(ex.GetType().FullName, ex.Message, ex)
+                {
+                    AuthenticationResultMetadata = CreateFailureMetadata(apiEvent, totalDurationInMs),
+                    CorrelationId = AuthenticationRequestParameters.CorrelationId.ToString(),
+                };
+
+                LogFailureTelemetryToOtel(
+                    ex.GetType().Name,
+                    apiEvent,
+                    apiEvent.CacheInfo,
+                    httpStatusCode: 0,
+                    totalDurationInMs: totalDurationInMs,
+                    exception: enricherException);
                 throw;
             }
         }

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -142,6 +142,19 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // value logged to OpenTelemetry (the stopwatch keeps running, so re-reading it drifts).
                 long totalDurationInMs = requestStopwatch.ElapsedMilliseconds + measureTelemetryDurationResult.Milliseconds;
 
+                AuthenticationResultMetadata failureMetadata = CreateFailureMetadata(apiEvent, totalDurationInMs);
+
+                // Expose the failure metadata on the ORIGINAL exception via its Data bag so downstream
+                // header-creation providers - which catch the raw non-MSAL exception, not the enricher
+                // wrapper - can surface token-acquisition diagnostics (Bug 3696194). The value is the same
+                // strongly-typed object MSAL builds for the success path, so consumers reuse their mapper.
+                // Guarded because a derived exception may expose a null or read-only Data bag, and telemetry
+                // plumbing must never throw here and mask the caller's original exception.
+                if (ex.Data is { IsReadOnly: false })
+                {
+                    ex.Data[MsalException.AuthenticationResultMetadataKey] = failureMetadata;
+                }
+
                 // The original exception is re-thrown below; MSAL never surfaces this wrapper. It exists only
                 // so the OpenTelemetry tag enricher observes a populated ExecutionResult.Exception (carrying
                 // failure metadata) for non-MSAL failures, mirroring the MsalException path above. The
@@ -155,7 +168,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
                 MsalException enricherException = new MsalException(enricherErrorCode, enricherErrorMessage, ex)
                 {
-                    AuthenticationResultMetadata = CreateFailureMetadata(apiEvent, totalDurationInMs),
+                    AuthenticationResultMetadata = failureMetadata,
                     CorrelationId = AuthenticationRequestParameters.CorrelationId.ToString(),
                 };
 

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -149,7 +149,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // wrapper - can surface token-acquisition diagnostics (Bug 3696194). The value is the same
                 // strongly-typed object MSAL builds for the success path, so consumers reuse their mapper.
                 // Guarded because a derived exception may expose a null or read-only Data bag, and telemetry
-                // plumbing must never throw here and mask the caller's original exception.
+                // plumbing must never throw here and mask the caller's original exception. On .NET Framework /
+                // netstandard the Data bag also rejects non-serializable values, so AuthenticationResultMetadata
+                // is marked [Serializable] on those targets (see AuthenticationResultMetadata.cs).
                 if (ex.Data is { IsReadOnly: false })
                 {
                     ex.Data[MsalException.AuthenticationResultMetadataKey] = failureMetadata;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -146,8 +146,14 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // so the OpenTelemetry tag enricher observes a populated ExecutionResult.Exception (carrying
                 // failure metadata) for non-MSAL failures, mirroring the MsalException path above. The
                 // originating exception's type is captured as the ErrorCode and it is preserved as the
-                // InnerException so consumers retain full fidelity.
-                MsalException enricherException = new MsalException(ex.GetType().FullName, ex.Message, ex)
+                // InnerException so consumers retain full fidelity. Fall back to the type name when
+                // FullName is null (some generic/array types) or Message is empty/whitespace, because the
+                // MsalException ctor rejects a null/empty errorCode or errorMessage - without the fallback
+                // that ArgumentNullException would replace the original exception we re-throw below.
+                string enricherErrorCode = ex.GetType().FullName ?? ex.GetType().Name;
+                string enricherErrorMessage = string.IsNullOrWhiteSpace(ex.Message) ? ex.GetType().Name : ex.Message;
+
+                MsalException enricherException = new MsalException(enricherErrorCode, enricherErrorMessage, ex)
                 {
                     AuthenticationResultMetadata = CreateFailureMetadata(apiEvent, totalDurationInMs),
                     CorrelationId = AuthenticationRequestParameters.CorrelationId.ToString(),

--- a/src/client/Microsoft.Identity.Client/MsalException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalException.cs
@@ -48,6 +48,14 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string ManagedIdentitySource = "ManagedIdentitySource";
 
+        /// <summary>
+        /// A key on <see cref="System.Exception.Data"/> under which MSAL stores the
+        /// <see cref="AuthenticationResultMetadata"/> captured when a token acquisition fails with a
+        /// non-<see cref="MsalException"/>. Lets downstream consumers surface token-acquisition diagnostics
+        /// even though the originating exception is re-thrown unchanged.
+        /// </summary>
+        public const string AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata";
+
         private string _errorCode;
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/RegionDetails.cs
+++ b/src/client/Microsoft.Identity.Client/RegionDetails.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Identity.Client.Region;
 
 namespace Microsoft.Identity.Client
@@ -11,6 +12,11 @@ namespace Microsoft.Identity.Client
     /// <see cref="AuthenticationResultMetadata"/> for additional metadata 
     /// information of the authentication result.
     /// </summary>
+#if NETFRAMEWORK || NETSTANDARD
+    // Serializable alongside AuthenticationResultMetadata (its container) so the graph stored in
+    // Exception.Data is fully serializable on .NET Framework / netstandard (Bug 3696194).
+    [Serializable]
+#endif
     public class RegionDetails
     {
         /// <summary>

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1005,6 +1005,77 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
+        [Description("For a non-MSAL failure the enricher still receives an ExecutionResult carrying a wrapper MsalException with failure metadata, while the original exception propagates unchanged to the caller.")]
+        public async Task WithOtelTagsEnricher_NonMsalFailure_ReceivesWrappedExceptionWithMetadataAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                // A non-MSAL exception (e.g. a transport failure while a federated-credential callback fetches
+                // the client assertion) propagates out of MSAL unwrapped. This exercises RequestBase's generic
+                // catch, which must still hand the OTel enricher a populated ExecutionResult.Exception.
+                var transportException = new HttpRequestException("Simulated transport failure while fetching the federated credential assertion.");
+
+                Func<CancellationToken, Task<string>> throwingAssertion = async _ =>
+                {
+                    await Task.Yield();
+                    throw transportException;
+                };
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
+                    .WithClientAssertion(throwingAssertion)
+                    .WithHttpManager(_harness.HttpManager)
+                    .BuildConcrete();
+
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                bool? capturedSuccessful = null;
+                Exception capturedException = null;
+
+                var thrown = await AssertException.TaskThrowsAsync<HttpRequestException>(
+                    () => cca.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithExtraQueryParameters(extraQueryParams)
+                        .WithOtelTagsEnricher((executionResult, tags) =>
+                        {
+                            capturedSuccessful = executionResult.Successful;
+                            capturedException = executionResult.Exception;
+                            tags.Add(new KeyValuePair<string, object>("CustomTag", "CustomValue"));
+                        })
+                        .ExecuteAsync(CancellationToken.None)).ConfigureAwait(false);
+
+                s_meterProvider.ForceFlush();
+
+                // The caller must observe the ORIGINAL exception, never the telemetry-only wrapper.
+                Assert.AreSame(transportException, thrown, "The original non-MSAL exception must propagate unchanged to the caller.");
+
+                Assert.IsTrue(capturedSuccessful.HasValue, "Enricher should have been invoked.");
+                Assert.IsFalse(capturedSuccessful.Value, "ExecutionResult.Successful should be false for a failed acquisition.");
+                Assert.IsNotNull(capturedException, "ExecutionResult.Exception should be populated even for a non-MSAL failure.");
+
+                var wrapper = capturedException as MsalException;
+                Assert.IsNotNull(wrapper, "ExecutionResult.Exception should be surfaced as an MsalException wrapper for the enricher.");
+                Assert.AreEqual(typeof(HttpRequestException).FullName, wrapper.ErrorCode, "The wrapper's ErrorCode should capture the originating exception type.");
+                Assert.AreSame(transportException, wrapper.InnerException, "The original exception should be preserved as the wrapper's InnerException.");
+                Assert.AreEqual(transportException.Message, wrapper.Message, "The wrapper should retain the original exception message.");
+
+                Assert.IsNotNull(wrapper.AuthenticationResultMetadata, "The wrapper should carry failure metadata for the enricher.");
+
+                var failureMetric = _exportedMetrics.FirstOrDefault(m => m.Name == "MsalFailure");
+                Assert.IsNotNull(failureMetric, "MsalFailure metric should be emitted.");
+
+                bool foundCustomTag = false;
+                foreach (var metricPoint in failureMetric.GetMetricPoints())
+                {
+                    var tags = GetTagDictionary(metricPoint.Tags);
+                    if (tags.TryGetValue("CustomTag", out var value) && (string)value == "CustomValue")
+                        foundCustomTag = true;
+                }
+                Assert.IsTrue(foundCustomTag, "MsalFailure should include the custom tag added by the enricher.");
+            }
+        }
+
+        [TestMethod]
         [Description("A throwing OTel tags enricher must not break the token acquisition or telemetry recording, and a warning is logged.")]
         public async Task WithOtelTagsEnricher_ThrowingEnricher_DoesNotBreakAcquisitionAndLogsWarningAsync()
         {

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1076,6 +1076,56 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
+        [Description("A non-MSAL failure whose Message is empty must still propagate unchanged: the telemetry-only MsalException wrapper falls back to the type name so its ctor cannot throw and mask the original exception.")]
+        public async Task WithOtelTagsEnricher_NonMsalFailureWithEmptyMessage_PropagatesOriginalAndWrapsSafelyAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                // An exception with an empty message is the edge case: MsalException's ctor rejects a
+                // null/whitespace errorMessage (and errorCode), so without a type-name fallback the wrapper
+                // construction would throw ArgumentNullException and replace the original exception.
+                var emptyMessageException = new InvalidOperationException(string.Empty);
+
+                Func<CancellationToken, Task<string>> throwingAssertion = async _ =>
+                {
+                    await Task.Yield();
+                    throw emptyMessageException;
+                };
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
+                    .WithClientAssertion(throwingAssertion)
+                    .WithHttpManager(_harness.HttpManager)
+                    .BuildConcrete();
+
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                Exception capturedException = null;
+
+                var thrown = await AssertException.TaskThrowsAsync<InvalidOperationException>(
+                    () => cca.AcquireTokenForClient(TestConstants.s_scope)
+                        .WithExtraQueryParameters(extraQueryParams)
+                        .WithOtelTagsEnricher((executionResult, tags) =>
+                        {
+                            capturedException = executionResult.Exception;
+                        })
+                        .ExecuteAsync(CancellationToken.None)).ConfigureAwait(false);
+
+                s_meterProvider.ForceFlush();
+
+                // The caller must still observe the ORIGINAL exception, not an ArgumentNullException from the wrapper.
+                Assert.AreSame(emptyMessageException, thrown, "The original exception must propagate unchanged even when its message is empty.");
+
+                var wrapper = capturedException as MsalException;
+                Assert.IsNotNull(wrapper, "ExecutionResult.Exception should be surfaced as an MsalException wrapper for the enricher.");
+                Assert.AreEqual(typeof(InvalidOperationException).FullName, wrapper.ErrorCode, "The wrapper's ErrorCode should capture the originating exception type.");
+                Assert.AreEqual(typeof(InvalidOperationException).Name, wrapper.Message, "The wrapper should fall back to the type name when the original message is empty.");
+                Assert.AreSame(emptyMessageException, wrapper.InnerException, "The original exception should be preserved as the wrapper's InnerException.");
+            }
+        }
+
+        [TestMethod]
         [Description("A throwing OTel tags enricher must not break the token acquisition or telemetry recording, and a warning is logged.")]
         public async Task WithOtelTagsEnricher_ThrowingEnricher_DoesNotBreakAcquisitionAndLogsWarningAsync()
         {

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1126,6 +1126,45 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
+        [Description("For a non-MSAL failure MSAL stashes the AuthenticationResultMetadata on the original exception's Data bag so header-creation providers can surface token-acquisition diagnostics (Bug 3696194).")]
+        public async Task NonMsalFailure_ExposesAuthenticationResultMetadataOnExceptionDataAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                var transportException = new HttpRequestException("Simulated transport failure while fetching the federated credential assertion.");
+
+                Func<CancellationToken, Task<string>> throwingAssertion = async _ =>
+                {
+                    await Task.Yield();
+                    throw transportException;
+                };
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
+                    .WithClientAssertion(throwingAssertion)
+                    .WithHttpManager(_harness.HttpManager)
+                    .BuildConcrete();
+
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var thrown = await AssertException.TaskThrowsAsync<HttpRequestException>(
+                    () => cca.AcquireTokenForClient(TestConstants.s_scope)
+                        .ExecuteAsync(CancellationToken.None)).ConfigureAwait(false);
+
+                // The original exception propagates unchanged; the metadata rides along on its Data bag and
+                // casts cleanly for consumers (e.g. IdWeb, in a separate assembly) that read the same public
+                // getters their success-path mapper uses.
+                Assert.AreSame(transportException, thrown, "Original exception must propagate unchanged.");
+
+                var metadata = thrown.Data[MsalException.AuthenticationResultMetadataKey] as AuthenticationResultMetadata;
+                Assert.IsNotNull(metadata, "AuthenticationResultMetadata should be exposed on the exception's Data bag for a non-MSAL failure.");
+                Assert.AreEqual(TestConstants.AuthorityUtidTenant + "oauth2/v2.0/token", metadata.TokenEndpoint, "Metadata should carry the MSAL-internal token endpoint.");
+                Assert.AreEqual(CacheRefreshReason.NoCachedAccessToken, metadata.CacheRefreshReason, "Metadata should carry the MSAL-internal cache-refresh reason.");
+            }
+        }
+
+        [TestMethod]
         [Description("A throwing OTel tags enricher must not break the token acquisition or telemetry recording, and a warning is logged.")]
         public async Task WithOtelTagsEnricher_ThrowingEnricher_DoesNotBreakAcquisitionAndLogsWarningAsync()
         {


### PR DESCRIPTION
### Bug 3696306

`WithOtelTagsEnricher` received `ExecutionResult.Exception == null` when a token acquisition failed with a **non-`MsalException`** (e.g. an `HttpRequestException` from a federated-credential/client-assertion callback).

`RequestBase`'s generic `catch (Exception)` passed no `exception` to `LogFailureTelemetryToOtel`, so the enricher's `ExecutionResult.Exception` was null — unlike the `catch (MsalException)` path (#6096), which passes a populated exception.

### Fix

The non-MSAL catch now builds a **telemetry-only** `MsalException` wrapper and hands it to the enricher, mirroring the `MsalException` path:

- `ErrorCode` = originating exception type (`FullName`)
- `Message` = original message
- `InnerException` = original exception (full fidelity)
- `AuthenticationResultMetadata` = failure metadata (durations, region, cache reason)

The **original exception is still re-thrown unchanged** — this wrapper is never surfaced to callers, so caller-observable behavior (the exception type they catch) is unaffected.

### Tests

Added `WithOtelTagsEnricher_NonMsalFailure_ReceivesWrappedExceptionWithMetadataAsync`: a throwing client-assertion callback yields a raw `HttpRequestException`; asserts the enricher observes the populated wrapper (type/inner/message/metadata) **and** that the caller still receives the original `HttpRequestException`. New test + all existing enricher tests pass.

### Related

- #6096 — surfaced diagnostics on the `MsalException` failure path (this extends the same idea to non-MSAL failures for the enricher)
- #6138 — companion SEAL-triage fix (raw ESTS service error codes)

_CHANGELOG intentionally not updated (done post-release)._
