### PR TITLE
Surface AuthenticationResultMetadata on non-MSAL failures via Exception.Data (3696194)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -142,6 +142,19 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // value logged to OpenTelemetry (the stopwatch keeps running, so re-reading it drifts).
                 long totalDurationInMs = requestStopwatch.ElapsedMilliseconds + measureTelemetryDurationResult.Milliseconds;
 
+                AuthenticationResultMetadata failureMetadata = CreateFailureMetadata(apiEvent, totalDurationInMs);
+
+                // Expose the failure metadata on the ORIGINAL exception via its Data bag so downstream
+                // header-creation providers - which catch the raw non-MSAL exception, not the enricher
+                // wrapper - can surface token-acquisition diagnostics (Bug 3696194). The value is the same
+                // strongly-typed object MSAL builds for the success path, so consumers reuse their mapper.
+                // Guarded because a derived exception may expose a null or read-only Data bag, and telemetry
+                // plumbing must never throw here and mask the caller's original exception.
+                if (ex.Data is { IsReadOnly: false })
+                {
+                    ex.Data[MsalException.AuthenticationResultMetadataKey] = failureMetadata;
+                }
+
                 // The original exception is re-thrown below; MSAL never surfaces this wrapper. It exists only
                 // so the OpenTelemetry tag enricher observes a populated ExecutionResult.Exception (carrying
                 // failure metadata) for non-MSAL failures, mirroring the MsalException path above. The
@@ -155,7 +168,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
                 MsalException enricherException = new MsalException(enricherErrorCode, enricherErrorMessage, ex)
                 {
-                    AuthenticationResultMetadata = CreateFailureMetadata(apiEvent, totalDurationInMs),
+                    AuthenticationResultMetadata = failureMetadata,
                     CorrelationId = AuthenticationRequestParameters.CorrelationId.ToString(),
                 };
 

--- a/src/client/Microsoft.Identity.Client/MsalException.cs
+++ b/src/client/Microsoft.Identity.Client/MsalException.cs
@@ -48,6 +48,14 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string ManagedIdentitySource = "ManagedIdentitySource";
 
+        /// <summary>
+        /// A key on <see cref="System.Exception.Data"/> under which MSAL stores the
+        /// <see cref="AuthenticationResultMetadata"/> captured when a token acquisition fails with a
+        /// non-<see cref="MsalException"/>. Lets downstream consumers surface token-acquisition diagnostics
+        /// even though the originating exception is re-thrown unchanged.
+        /// </summary>
+        public const string AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata";
+
         private string _errorCode;
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -1126,6 +1126,45 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
+        [Description("For a non-MSAL failure MSAL stashes the AuthenticationResultMetadata on the original exception's Data bag so header-creation providers can surface token-acquisition diagnostics (Bug 3696194).")]
+        public async Task NonMsalFailure_ExposesAuthenticationResultMetadataOnExceptionDataAsync()
+        {
+            using (_harness = CreateTestHarness())
+            {
+                var transportException = new HttpRequestException("Simulated transport failure while fetching the federated credential assertion.");
+
+                Func<CancellationToken, Task<string>> throwingAssertion = async _ =>
+                {
+                    await Task.Yield();
+                    throw transportException;
+                };
+
+                var cca = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithAuthority(TestConstants.AuthorityUtidTenant)
+                    .WithClientAssertion(throwingAssertion)
+                    .WithHttpManager(_harness.HttpManager)
+                    .BuildConcrete();
+
+                _harness.HttpManager.AddInstanceDiscoveryMockHandler();
+
+                var thrown = await AssertException.TaskThrowsAsync<HttpRequestException>(
+                    () => cca.AcquireTokenForClient(TestConstants.s_scope)
+                        .ExecuteAsync(CancellationToken.None)).ConfigureAwait(false);
+
+                // The original exception propagates unchanged; the metadata rides along on its Data bag and
+                // casts cleanly for consumers (e.g. IdWeb, in a separate assembly) that read the same public
+                // getters their success-path mapper uses.
+                Assert.AreSame(transportException, thrown, "Original exception must propagate unchanged.");
+
+                var metadata = thrown.Data[MsalException.AuthenticationResultMetadataKey] as AuthenticationResultMetadata;
+                Assert.IsNotNull(metadata, "AuthenticationResultMetadata should be exposed on the exception's Data bag for a non-MSAL failure.");
+                Assert.AreEqual(TestConstants.AuthorityUtidTenant + "oauth2/v2.0/token", metadata.TokenEndpoint, "Metadata should carry the MSAL-internal token endpoint.");
+                Assert.AreEqual(CacheRefreshReason.NoCachedAccessToken, metadata.CacheRefreshReason, "Metadata should carry the MSAL-internal cache-refresh reason.");
+            }
+        }
+
+        [TestMethod]
         [Description("A throwing OTel tags enricher must not break the token acquisition or telemetry recording, and a warning is logged.")]
         public async Task WithOtelTagsEnricher_ThrowingEnricher_DoesNotBreakAcquisitionAndLogsWarningAsync()
         {


### PR DESCRIPTION
### Bug
[3696194](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3696194) — token-acquisition metadata (durations, cache-refresh reason, token endpoint, region) is `null` on the failure path when the failure is a **non-`MsalException`** (e.g. an `HttpRequestException` thrown from a FIC client-assertion callback). Downstream header-creation providers read metadata off the caught exception; MSAL 4.86.0 (#6096) already covers the `MsalException`-origin case via `MsalException.AuthenticationResultMetadata`, leaving only the non-MSAL-origin gap.

### Change
On the non-`MsalException` failure path, MSAL now stashes the failure `AuthenticationResultMetadata` on the **original exception's `Data`** bag under a new public, documented key `MsalException.AuthenticationResultMetadataKey`. The typed object is stored (not flattened primitives) so consumers can reuse their existing `AuthenticationResultMetadata` mappers verbatim.

- The original exception is **re-thrown unchanged** — MSAL does not wrap/convert it (that would be a breaking change).
- The write is guarded (`if (ex.Data is { IsReadOnly: false })`) so telemetry plumbing can never mask the caller's real exception.
- `Exception.Data` is the only built-in per-instance bag that survives a re-throw.

### Notes
- Additive public surface: one `const string` key + PublicAPI.Unshipped entries (6 TFMs). No behavioral change to the thrown exception.
- Stacked on / depends on #6139 (companion fix for the same non-MSAL failure path, bug 3696306). Related: #6138, #6096.
- CHANGELOG intentionally not touched (handled at release).