### PR TITLE
Forward OpenTelemetry tags enricher to the client-assertion callback (AB#3696484)

### DIFF
--- a/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
+++ b/src/client/Microsoft.Identity.Client/ApiConfig/Parameters/MtlsPopParametersInitializer.cs
@@ -208,7 +208,8 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 authority: canonicalAuthority,
                 tenantId: tenantId,
                 correlationId: p.CorrelationId,
-                logger: serviceBundle.ApplicationLogger);
+                logger: serviceBundle.ApplicationLogger,
+                otelTagsEnricher: p.OtelTagsEnricher);
         }
 
         private static AssertionRequestOptions CreateAssertionRequestOptions(
@@ -224,6 +225,7 @@ namespace Microsoft.Identity.Client.ApiConfig.Parameters
                 CancellationToken = ct,
                 ClientAssertionFmiPath = p.ClientAssertionFmiPath,
                 CorrelationId = p.CorrelationId,
+                OtelTagsEnricher = p.OtelTagsEnricher,
 
                 // Best-effort context. IMPORTANT: use AbsoluteUri, not Uri.Authority (host only).
                 TokenEndpoint = serviceBundle.Config.Authority.AuthorityInfo.CanonicalAuthority.AbsoluteUri

--- a/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
+++ b/src/client/Microsoft.Identity.Client/AppConfig/AssertionRequestOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.Identity.Client.Extensibility;
 
 namespace Microsoft.Identity.Client
 {
@@ -85,5 +86,14 @@ namespace Microsoft.Identity.Client
         /// to downstream token requests (e.g., Managed Identity) for coherent end-to-end tracing.
         /// </summary>
         public Guid CorrelationId { get; set; }
+
+        /// <summary>
+        /// The OpenTelemetry tags enricher configured on the outer request via <c>WithOtelTagsEnricher</c>, if any.
+        /// When the client-assertion callback acquires the assertion by issuing another token request
+        /// (e.g. via <c>ITokenAcquirer.GetTokenForAppAsync</c> for a Federated Identity Credential), forward this
+        /// delegate to that inner request so the inner acquisition's metrics carry the same enrichment tags as the
+        /// outer request. Null when no enricher was configured.
+        /// </summary>
+        public Action<ExecutionResult, IList<KeyValuePair<string, object>>> OtelTagsEnricher { get; set; }
     }
 }

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CredentialContext.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CredentialContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Identity.Client.Core;
+using Microsoft.Identity.Client.Extensibility;
 using Microsoft.Identity.Client.PlatformsCommon.Interfaces;
 
 namespace Microsoft.Identity.Client.Internal.ClientCredential
@@ -58,6 +59,13 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
         /// <summary>Correlation ID for end-to-end request tracing.</summary>
         public Guid CorrelationId { get; init; }
 
+        /// <summary>
+        /// OpenTelemetry tags enricher from the outer request (set via <c>WithOtelTagsEnricher</c>), forwarded to
+        /// the client-assertion callback so a callback that acquires the assertion via an inner token request
+        /// (e.g. a Federated Identity Credential) can enrich the inner acquisition's metrics identically. May be null.
+        /// </summary>
+        public Action<ExecutionResult, IList<KeyValuePair<string, object>>> OtelTagsEnricher { get; init; }
+
         /// <summary>Logger for credential resolution diagnostics.</summary>
         public ILoggerAdapter Logger { get; init; }
 
@@ -83,7 +91,8 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
             string authority,
             string tenantId,
             Guid correlationId,
-            ILoggerAdapter logger)
+            ILoggerAdapter logger,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> otelTagsEnricher = null)
         {
             return new CredentialContext
             {
@@ -101,6 +110,7 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
                 TenantId = tenantId,
                 CorrelationId = correlationId,
                 Logger = logger,
+                OtelTagsEnricher = otelTagsEnricher,
             };
         }
 
@@ -120,7 +130,8 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
                 TenantId = TenantId,
                 CorrelationId = CorrelationId,
                 ClientAssertionFmiPath = ClientAssertionFmiPath,
-                CancellationToken = cancellationToken
+                CancellationToken = cancellationToken,
+                OtelTagsEnricher = OtelTagsEnricher
             };
         }
     }

--- a/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CredentialMaterialResolver.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/ClientCredential/CredentialMaterialResolver.cs
@@ -112,7 +112,8 @@ namespace Microsoft.Identity.Client.Internal.ClientCredential
                 authority: requestParams.AuthorityManager.Authority.AuthorityInfo.CanonicalAuthority?.ToString(),
                 tenantId: requestParams.AuthorityManager.Authority.TenantId,
                 correlationId: requestParams.RequestContext.CorrelationId,
-                logger: requestParams.RequestContext.Logger);
+                logger: requestParams.RequestContext.Logger,
+                otelTagsEnricher: requestParams.OtelTagsEnricher);
         }
     }
 }

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientAssertionTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/ClientAssertionTests.cs
@@ -65,6 +65,71 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
         }
 
         [TestMethod]
+        public async Task SignedAssertionDelegateClientCredential_ForwardsOtelTagsEnricher()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                Action<ExecutionResult, IList<KeyValuePair<string, object>>> enricher =
+                    (executionResult, tags) => tags.Add(new KeyValuePair<string, object>("k", "v"));
+
+                Action<ExecutionResult, IList<KeyValuePair<string, object>>> capturedEnricher = null;
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithHttpManager(httpManager)
+                    .WithClientAssertion(async (AssertionRequestOptions options) =>
+                    {
+                        // The enricher configured on the outer request must be forwarded to the
+                        // assertion callback so a callback that acquires the assertion via an inner
+                        // token request (e.g. a Federated Identity Credential) can enrich it identically.
+                        capturedEnricher = options.OtelTagsEnricher;
+                        return await Task.FromResult("dummy_assertion").ConfigureAwait(false);
+                    })
+                    .BuildConcrete();
+
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .WithOtelTagsEnricher(enricher)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.AreSame(enricher, capturedEnricher, "OtelTagsEnricher should be forwarded to the assertion callback.");
+            }
+        }
+
+        [TestMethod]
+        public async Task SignedAssertionDelegateClientCredential_NoEnricher_LeavesOtelTagsEnricherNull()
+        {
+            using (var httpManager = new MockHttpManager())
+            {
+                httpManager.AddInstanceDiscoveryMockHandler();
+                httpManager.AddMockHandlerSuccessfulClientCredentialTokenResponseMessage();
+
+                bool enricherWasNull = false;
+
+                var app = ConfidentialClientApplicationBuilder
+                    .Create(TestConstants.ClientId)
+                    .WithHttpManager(httpManager)
+                    .WithClientAssertion(async (AssertionRequestOptions options) =>
+                    {
+                        enricherWasNull = options.OtelTagsEnricher == null;
+                        return await Task.FromResult("dummy_assertion").ConfigureAwait(false);
+                    })
+                    .BuildConcrete();
+
+                var result = await app.AcquireTokenForClient(TestConstants.s_scope)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+
+                Assert.IsNotNull(result);
+                Assert.IsTrue(enricherWasNull, "OtelTagsEnricher should be null when no enricher is configured.");
+            }
+        }
+
+        [TestMethod]
         public async Task SignedAssertionDelegateClientCredential_WithClaims()
         {
             using (var httpManager = new MockHttpManager())


### PR DESCRIPTION
## What
Surfaces the outer request's OpenTelemetry tags enricher (configured via `WithOtelTagsEnricher`) on `AssertionRequestOptions.OtelTagsEnricher`, so a client-assertion callback that acquires the assertion by issuing another token request (e.g. a Federated Identity Credential exchange) can forward the enricher onto that inner request.

## Why
SEAL telemetry bug AB#3696484: on the FIC flow the inner client-assertion leg's metrics were not enriched, because the enricher configured on the outer request never reached the assertion callback. This threads it through the single `CredentialContext` choke-point, alongside the existing `CorrelationId` "flow to downstream token requests" pattern.

## Changes
- New public `AssertionRequestOptions.OtelTagsEnricher` (added to `PublicAPI.Unshipped.txt` across all TFMs).
- Threaded through `CredentialContext.Create` / `ToAssertionRequestOptions` (runtime + mTLS-PoP preflight paths).
- Unit tests in `ClientAssertionTests`.

No public behavior change when no enricher is configured (property is null).

## Related
- Consumer-side fix (Microsoft.Identity.Web FIC provider): AzureAD/microsoft-identity-web#3968