### PR TITLE
Expose WithOtelTagsEnricher for managed identity requests (AB#3696484)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/AbstractManagedIdentityAcquireTokenParameterBuilderExtension.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/AbstractManagedIdentityAcquireTokenParameterBuilderExtension.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Identity.Client.Extensibility
+{
+    /// <summary>
+    /// Extension methods for managed identity acquire-token requests
+    /// (<see cref="AbstractManagedIdentityAcquireTokenParameterBuilder{T}"/>).
+    /// </summary>
+    public static class AbstractManagedIdentityAcquireTokenParameterBuilderExtension
+    {
+        /// <summary>
+        /// Registers a delegate that adds additional tags (dimensions) to the OpenTelemetry metrics MSAL emits
+        /// for this managed identity token acquisition. The delegate is invoked while MSAL records its metrics and
+        /// receives the <see cref="ExecutionResult"/> of the acquisition (indicating success or failure, with the
+        /// result or exception) together with a mutable list of tags. Tags appended to that list are attached to
+        /// every metric recorded for the request, including metrics emitted during proactive background refresh.
+        /// </summary>
+        /// <typeparam name="T">The concrete managed identity builder type.</typeparam>
+        /// <param name="builder">The builder to chain options to.</param>
+        /// <param name="tagsEnricher">
+        /// A delegate that receives the <see cref="ExecutionResult"/> and a mutable list of tags to enrich.
+        /// The delegate runs on MSAL's metric-recording path, so it should be fast, non-blocking and must not throw.
+        /// The supplied tag list must be populated synchronously; do not retain or mutate it after the delegate returns.
+        /// </param>
+        /// <returns>The builder to chain the .With methods.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="tagsEnricher"/> is null.</exception>
+        /// <remarks>
+        /// Keep both the number of added tags and — more importantly — their value cardinality low. High-cardinality
+        /// tag values (such as correlation ids, timestamps, or user identifiers) can cause an unbounded number of
+        /// metric time series in the downstream telemetry backend. The tags are applied to every metric MSAL records
+        /// for the request, so a large number of tags also adds overhead on the metric-recording path.
+        /// </remarks>
+        public static AbstractManagedIdentityAcquireTokenParameterBuilder<T> WithOtelTagsEnricher<T>(
+            this AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder,
+            Action<ExecutionResult, IList<KeyValuePair<string, object>>> tagsEnricher)
+            where T : AbstractManagedIdentityAcquireTokenParameterBuilder<T>
+        {
+            if (tagsEnricher == null)
+            {
+                throw new ArgumentNullException(nameof(tagsEnricher));
+            }
+
+            builder.CommonParameters.OtelTagsEnricher = tagsEnricher;
+
+            return builder;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = 
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = 
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = 
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = 
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = 
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@ const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = 
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
 Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -1042,6 +1042,60 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
+        [Description("The OpenTelemetry tags enricher can be set on a managed identity request and is invoked with the result, including on the proactive background refresh.")]
+        public async Task ManagedIdentity_BackgroundRefresh_InvokesOtelTagsEnricher_Async()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                SetEnvironmentVariables(ManagedIdentitySource.AppService, AppServiceEndpoint);
+
+                ExecutionResult capturedResult = null;
+                int enricherInvocations = 0;
+                bool backgroundRefreshCompleted = false;
+                Action<ExecutionResult, IList<KeyValuePair<string, object>>> enricher = (executionResult, tags) =>
+                {
+                    Interlocked.Increment(ref enricherInvocations);
+                    capturedResult = executionResult;
+                    tags.Add(new KeyValuePair<string, object>("mi_custom_tag", "mi_value"));
+                };
+
+                // The completion callback is used purely as a reliable barrier: it fires only once the proactive
+                // background refresh has finished, guaranteeing the background enricher invocation has occurred.
+                var mi = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.SystemAssigned)
+                    .WithHttpManager(httpManager)
+                    .WithExperimentalFeatures()
+                    .OnBackgroundTokenRefreshCompleted(r => { backgroundRefreshCompleted = true; return Task.CompletedTask; })
+                    .BuildConcrete();
+
+                // 1. Prime the cache with a token.
+                httpManager.AddManagedIdentityMockHandler(
+                    AppServiceEndpoint, Resource, MockHelpers.GetMsiSuccessfulResponse(), ManagedIdentitySource.AppService);
+                await mi.AcquireTokenForManagedIdentity(Resource).ExecuteAsync().ConfigureAwait(false);
+
+                // 2. Mark the cached token as needing a proactive refresh.
+                TestCommon.UpdateATWithRefreshOn(mi.AppTokenCacheInternal.Accessor);
+
+                // 3. Response the background refresh will consume.
+                httpManager.AddManagedIdentityMockHandler(
+                    AppServiceEndpoint, Resource, MockHelpers.GetMsiSuccessfulResponse(), ManagedIdentitySource.AppService);
+
+                // 4. Foreground returns the cached token and kicks off the background refresh; the enricher supplied
+                //    here is propagated onto the managed identity background-refresh metrics.
+                await mi.AcquireTokenForManagedIdentity(Resource)
+                    .WithOtelTagsEnricher(enricher)
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                // Assert - the background refresh ran and the enricher was invoked with a successful outcome.
+                Assert.IsTrue(TestCommon.YieldTillSatisfied(() => backgroundRefreshCompleted), "Managed identity background refresh did not complete.");
+                Assert.AreNotEqual(0, enricherInvocations, "Managed identity OTel tags enricher was not invoked.");
+                Assert.IsNotNull(capturedResult);
+                Assert.IsTrue(capturedResult.Successful);
+                Assert.IsNotNull(capturedResult.Result);
+            }
+        }
+
+        [TestMethod]
         public async Task ProactiveRefresh_CancelsSuccessfully_Async()
         {
             bool wasErrorLogged = false;


### PR DESCRIPTION
### What

Adds an additive `WithOtelTagsEnricher` overload for **managed identity** request builders, so MI acquisitions can carry the same OpenTelemetry tags enricher that confidential-client and FIC flows already support.

### Why

The existing `WithOtelTagsEnricher` extension targets `AbstractAcquireTokenParameterBuilder<T>`. Managed identity builders don't inherit from it — they derive from `AbstractManagedIdentityAcquireTokenParameterBuilder<T> : BaseAbstractAcquireTokenParameterBuilder<T>`, a sibling subtree. So the enricher could never be set on an MI request, even though the MI background-refresh path (`ManagedIdentityAuthRequest` → `ProcessFetchInBackground`) already reads `CommonParameters.OtelTagsEnricher`. This closed the loop so MI metrics — including proactive background refresh — get the same tags.

### How

- New extension type `AbstractManagedIdentityAcquireTokenParameterBuilderExtension` with a `WithOtelTagsEnricher<T>` overload targeting the MI builder subtree. The existing CCA/FIC method is untouched (purely additive; `CommonParameters` lives on the shared base, so no plumbing change was needed).
- Unit test asserting the enricher fires on the MI proactive background refresh.
- `PublicAPI.Unshipped.txt` updated for all 6 TFMs.

### Related

Follows #6142 (enricher for the client-assertion callback). Consumed by Id.Web PR AzureAD/microsoft-identity-web#3968 to wire the enricher onto MI acquisitions.