### PR TITLE
Post-release steps for 4.87.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 
 ### New Features
 - Exposed `MsalServiceException.ErrorCodesForLogging` (as a public `IReadOnlyList<string>`), surfacing the raw STS-specific error codes (for example the numeric `AADSTS` codes) for diagnostics and logging. [#6138](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6138)
+- Added `WithOtelTagsEnricher` on the managed identity request builder, allowing callers to enrich the OpenTelemetry tags emitted for managed identity token requests. [#6144](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6144)
+- Added `AssertionRequestOptions.OtelTagsEnricher`, forwarding the OpenTelemetry tags enricher to the client-assertion callback. [#6142](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6142)
+- Added a client-side opaque-token log scrubber that redacts token-like values from MSAL logs. [#6119](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6119)
+
+### Bug Fixes
+- Populated `ExecutionResult.Exception` for non-MSAL failures and exposed the `MsalException.AuthenticationResultMetadataKey` constant so callbacks can retrieve the associated authentication-result metadata. [#6139](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6139)
+- Hardened the KeyGuard liveness probe to use RSA-PSS padding (CodeQL SM03799). [#6141](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6141)
+
+### Changes
+- Removed managed identity support from `WithClaimsFromClient`; it now applies to confidential-client scenarios only. [#6113](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6113)
+- Removed experimental features from the default client setup. [#6143](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6143)
+- Updated the Azure Arc managed identity endpoint API version from `2019-11-01` to `2020-06-01`. [#6130](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6130)
 
 4.86.1
 ======

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Shipped.txt
@@ -88,6 +88,7 @@ const Microsoft.Identity.Client.MsalError.ManagedIdentityAllSourcesUnavailable =
 const Microsoft.Identity.Client.MsalError.ManagedIdentityRequestFailed = "managed_identity_request_failed" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityResponseParseFailure = "managed_identity_response_parse_failure" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityUnreachableNetwork = "managed_identity_unreachable_network" -> string
+const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
 const Microsoft.Identity.Client.MsalError.MissingFederationMetadataUrl = "missing_federation_metadata_url" -> string
 const Microsoft.Identity.Client.MsalError.MissingManagedIdentityEnvVar = "missing_managed_identity_env_var" -> string
 const Microsoft.Identity.Client.MsalError.MissingPassiveAuthEndpoint = "missing_passive_auth_endpoint" -> string
@@ -168,6 +169,7 @@ const Microsoft.Identity.Client.MsalError.WebView2LoaderNotFound = "webview2load
 const Microsoft.Identity.Client.MsalError.WebView2NotInstalled = "webview2_runtime_not_installed" -> string
 const Microsoft.Identity.Client.MsalError.WebviewUnavailable = "no_system_webview" -> string
 const Microsoft.Identity.Client.MsalError.WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found" -> string
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorCode = "BrokerErrorCode" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorContext = "BrokerErrorContext" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorStatus = "BrokerErrorStatus" -> string
@@ -319,6 +321,10 @@ Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProv
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProvider.set -> void
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.get -> bool
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
 Microsoft.Identity.Client.ApplicationBase
 Microsoft.Identity.Client.ApplicationOptions
 Microsoft.Identity.Client.ApplicationOptions.AadAuthorityAudience.get -> Microsoft.Identity.Client.AadAuthorityAudience
@@ -362,6 +368,8 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientID.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.ClientID.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TokenEndpoint.get -> string
@@ -462,6 +470,9 @@ Microsoft.Identity.Client.AzureCloudInstance.AzureChina = 2 -> Microsoft.Identit
 Microsoft.Identity.Client.AzureCloudInstance.AzureGermany = 3 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzurePublic = 1 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzureUsGovernment = 4 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.None = 0 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.BaseAbstractAcquireTokenParameterBuilder() -> void
@@ -597,6 +608,7 @@ Microsoft.Identity.Client.EmbeddedWebViewOptions.Title.set -> void
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.get -> string
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.set -> void
 Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
 Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions
@@ -626,6 +638,7 @@ Microsoft.Identity.Client.Extensibility.ExecutionResult.Result.get -> Microsoft.
 Microsoft.Identity.Client.Extensibility.ExecutionResult.Successful.get -> bool
 Microsoft.Identity.Client.Extensibility.ICustomWebUi
 Microsoft.Identity.Client.Extensibility.ICustomWebUi.AcquireAuthorizationCodeAsync(System.Uri authorizationUri, System.Uri redirectUri, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Uri>
+Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.set -> void
@@ -634,6 +647,7 @@ Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.Authenticati
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.MsalAuthenticationExtension() -> void
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.get -> System.Func<Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData, System.Threading.Tasks.Task>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.set -> void
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.BodyParameters.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.CancellationToken.get -> System.Threading.CancellationToken
@@ -824,6 +838,7 @@ Microsoft.Identity.Client.MsalError
 Microsoft.Identity.Client.MsalException
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.set -> void
+Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
 Microsoft.Identity.Client.MsalException.CorrelationId.get -> string
 Microsoft.Identity.Client.MsalException.CorrelationId.set -> void
 Microsoft.Identity.Client.MsalException.ErrorCode.get -> string
@@ -842,6 +857,7 @@ Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityExcept
 Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.MsalServiceException
 Microsoft.Identity.Client.MsalServiceException.Claims.get -> string
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Identity.Client.MsalServiceException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders
 Microsoft.Identity.Client.MsalServiceException.Headers.set -> void
 Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string errorCode, string errorMessage, int statusCode, string claims, System.Exception innerException) -> void
@@ -852,6 +868,7 @@ Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string error
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.get -> string
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.set -> void
 Microsoft.Identity.Client.MsalServiceException.StatusCode.get -> int
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.MsalThrottledServiceException
 Microsoft.Identity.Client.MsalThrottledServiceException.MsalThrottledServiceException(Microsoft.Identity.Client.MsalServiceException originalException) -> void
 Microsoft.Identity.Client.MsalThrottledServiceException.OriginalServiceException.get -> Microsoft.Identity.Client.MsalServiceException
@@ -924,6 +941,7 @@ Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.AutodetectSuccess = 4 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.FallbackToGlobal = 5 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.None = 0 -> Microsoft.Identity.Client.Region.RegionOutcome
+Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedAutodetectionFailed = 2 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedInvalid = 3 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedValid = 1 -> Microsoft.Identity.Client.Region.RegionOutcome
@@ -1089,20 +1107,26 @@ static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquire
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraClientAssertionClaims<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string clientAssertionClaims) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithFmiPathForClientAssertion<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string fmiPath) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithProofOfPosessionKeyId<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithExtraBodyParameters(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extrabodyparams) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithProofOfPosessionKeyId(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions.WithCustomWebUi(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, Microsoft.Identity.Client.Extensibility.ICustomWebUi customWebUi) -> Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions.WithSearchInCacheForLongRunningProcess(this Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = true) -> Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IDictionary<string, string> extraHttpHeaders) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnCompletion(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onCompletion) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnMsalServiceFailure(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task<bool>> onMsalServiceFailure) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithAppTokenProvider(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.AppTokenProviderParameters, System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensibility.AppTokenProviderResult>> appTokenProvider) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, System.Threading.Tasks.Task<System.Security.Cryptography.X509Certificates.X509Certificate2>> certificateProvider, Microsoft.Identity.Client.AppConfig.CertificateOptions certificateOptions) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync(this Microsoft.Identity.Client.ILongRunningWebApi clientApp, string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.FromIdToken(string idToken) -> Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName, long logonId) -> byte[]
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName) -> byte[]
@@ -1111,6 +1135,7 @@ static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.Save
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) -> void
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySource() -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 static Microsoft.Identity.Client.ManagedIdentityApplicationBuilder.Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId managedIdentityId) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromBroker.get -> long
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromCache.get -> long
@@ -1161,22 +1186,3 @@ virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> vo
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.OnAuthenticate(System.Threading.CancellationToken cancellationToken) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserBeforeNavigateHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserBeforeNavigateEventArgs e) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserNavigateErrorHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserNavigateErrorEventArgs e) -> void
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
-Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
-static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
-Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
-const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
-Microsoft.Identity.Client.AppConfig.PoPOptions
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
-Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
-static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
-static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
-Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
-static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
-static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net462/PublicAPI.Unshipped.txt
@@ -1,6 +1,0 @@
-const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
-Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
-Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
-static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Shipped.txt
@@ -88,6 +88,7 @@ const Microsoft.Identity.Client.MsalError.ManagedIdentityAllSourcesUnavailable =
 const Microsoft.Identity.Client.MsalError.ManagedIdentityRequestFailed = "managed_identity_request_failed" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityResponseParseFailure = "managed_identity_response_parse_failure" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityUnreachableNetwork = "managed_identity_unreachable_network" -> string
+const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
 const Microsoft.Identity.Client.MsalError.MissingFederationMetadataUrl = "missing_federation_metadata_url" -> string
 const Microsoft.Identity.Client.MsalError.MissingManagedIdentityEnvVar = "missing_managed_identity_env_var" -> string
 const Microsoft.Identity.Client.MsalError.MissingPassiveAuthEndpoint = "missing_passive_auth_endpoint" -> string
@@ -168,6 +169,7 @@ const Microsoft.Identity.Client.MsalError.WebView2LoaderNotFound = "webview2load
 const Microsoft.Identity.Client.MsalError.WebView2NotInstalled = "webview2_runtime_not_installed" -> string
 const Microsoft.Identity.Client.MsalError.WebviewUnavailable = "no_system_webview" -> string
 const Microsoft.Identity.Client.MsalError.WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found" -> string
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorCode = "BrokerErrorCode" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorContext = "BrokerErrorContext" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorStatus = "BrokerErrorStatus" -> string
@@ -319,6 +321,10 @@ Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProv
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProvider.set -> void
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.get -> bool
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
 Microsoft.Identity.Client.ApplicationBase
 Microsoft.Identity.Client.ApplicationOptions
 Microsoft.Identity.Client.ApplicationOptions.AadAuthorityAudience.get -> Microsoft.Identity.Client.AadAuthorityAudience
@@ -362,6 +368,8 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientID.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.ClientID.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TokenEndpoint.get -> string
@@ -462,6 +470,9 @@ Microsoft.Identity.Client.AzureCloudInstance.AzureChina = 2 -> Microsoft.Identit
 Microsoft.Identity.Client.AzureCloudInstance.AzureGermany = 3 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzurePublic = 1 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzureUsGovernment = 4 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.None = 0 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.BaseAbstractAcquireTokenParameterBuilder() -> void
@@ -597,6 +608,7 @@ Microsoft.Identity.Client.EmbeddedWebViewOptions.Title.set -> void
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.get -> string
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.set -> void
 Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
 Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions
@@ -626,6 +638,7 @@ Microsoft.Identity.Client.Extensibility.ExecutionResult.Result.get -> Microsoft.
 Microsoft.Identity.Client.Extensibility.ExecutionResult.Successful.get -> bool
 Microsoft.Identity.Client.Extensibility.ICustomWebUi
 Microsoft.Identity.Client.Extensibility.ICustomWebUi.AcquireAuthorizationCodeAsync(System.Uri authorizationUri, System.Uri redirectUri, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Uri>
+Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.set -> void
@@ -634,6 +647,7 @@ Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.Authenticati
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.MsalAuthenticationExtension() -> void
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.get -> System.Func<Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData, System.Threading.Tasks.Task>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.set -> void
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.BodyParameters.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.CancellationToken.get -> System.Threading.CancellationToken
@@ -824,6 +838,7 @@ Microsoft.Identity.Client.MsalError
 Microsoft.Identity.Client.MsalException
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.set -> void
+Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
 Microsoft.Identity.Client.MsalException.CorrelationId.get -> string
 Microsoft.Identity.Client.MsalException.CorrelationId.set -> void
 Microsoft.Identity.Client.MsalException.ErrorCode.get -> string
@@ -842,6 +857,7 @@ Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityExcept
 Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.MsalServiceException
 Microsoft.Identity.Client.MsalServiceException.Claims.get -> string
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Identity.Client.MsalServiceException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders
 Microsoft.Identity.Client.MsalServiceException.Headers.set -> void
 Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string errorCode, string errorMessage, int statusCode, string claims, System.Exception innerException) -> void
@@ -852,6 +868,7 @@ Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string error
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.get -> string
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.set -> void
 Microsoft.Identity.Client.MsalServiceException.StatusCode.get -> int
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.MsalThrottledServiceException
 Microsoft.Identity.Client.MsalThrottledServiceException.MsalThrottledServiceException(Microsoft.Identity.Client.MsalServiceException originalException) -> void
 Microsoft.Identity.Client.MsalThrottledServiceException.OriginalServiceException.get -> Microsoft.Identity.Client.MsalServiceException
@@ -924,6 +941,7 @@ Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.AutodetectSuccess = 4 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.FallbackToGlobal = 5 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.None = 0 -> Microsoft.Identity.Client.Region.RegionOutcome
+Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedAutodetectionFailed = 2 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedInvalid = 3 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedValid = 1 -> Microsoft.Identity.Client.Region.RegionOutcome
@@ -1089,20 +1107,26 @@ static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquire
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraClientAssertionClaims<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string clientAssertionClaims) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithFmiPathForClientAssertion<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string fmiPath) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithProofOfPosessionKeyId<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithExtraBodyParameters(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extrabodyparams) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithProofOfPosessionKeyId(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions.WithCustomWebUi(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, Microsoft.Identity.Client.Extensibility.ICustomWebUi customWebUi) -> Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions.WithSearchInCacheForLongRunningProcess(this Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = true) -> Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IDictionary<string, string> extraHttpHeaders) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnCompletion(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onCompletion) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnMsalServiceFailure(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task<bool>> onMsalServiceFailure) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithAppTokenProvider(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.AppTokenProviderParameters, System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensibility.AppTokenProviderResult>> appTokenProvider) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, System.Threading.Tasks.Task<System.Security.Cryptography.X509Certificates.X509Certificate2>> certificateProvider, Microsoft.Identity.Client.AppConfig.CertificateOptions certificateOptions) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync(this Microsoft.Identity.Client.ILongRunningWebApi clientApp, string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.FromIdToken(string idToken) -> Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName, long logonId) -> byte[]
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName) -> byte[]
@@ -1111,6 +1135,7 @@ static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.Save
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) -> void
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySource() -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 static Microsoft.Identity.Client.ManagedIdentityApplicationBuilder.Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId managedIdentityId) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromBroker.get -> long
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromCache.get -> long
@@ -1161,22 +1186,3 @@ virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> vo
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.OnAuthenticate(System.Threading.CancellationToken cancellationToken) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserBeforeNavigateHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserBeforeNavigateEventArgs e) -> void
 virtual Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WindowsFormsWebAuthenticationDialogBase.WebBrowserNavigateErrorHandler(object sender, Microsoft.Identity.Client.Platforms.Features.WinFormsLegacyWebUi.WebBrowserNavigateErrorEventArgs e) -> void
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
-Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
-static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
-Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
-const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
-Microsoft.Identity.Client.AppConfig.PoPOptions
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
-Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
-static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
-static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
-Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
-static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
-static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,0 @@
-const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
-Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
-Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
-static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Shipped.txt
@@ -88,6 +88,7 @@ const Microsoft.Identity.Client.MsalError.ManagedIdentityAllSourcesUnavailable =
 const Microsoft.Identity.Client.MsalError.ManagedIdentityRequestFailed = "managed_identity_request_failed" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityResponseParseFailure = "managed_identity_response_parse_failure" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityUnreachableNetwork = "managed_identity_unreachable_network" -> string
+const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
 const Microsoft.Identity.Client.MsalError.MissingFederationMetadataUrl = "missing_federation_metadata_url" -> string
 const Microsoft.Identity.Client.MsalError.MissingManagedIdentityEnvVar = "missing_managed_identity_env_var" -> string
 const Microsoft.Identity.Client.MsalError.MissingPassiveAuthEndpoint = "missing_passive_auth_endpoint" -> string
@@ -169,6 +170,7 @@ const Microsoft.Identity.Client.MsalError.WebView2LoaderNotFound = "webview2load
 const Microsoft.Identity.Client.MsalError.WebView2NotInstalled = "webview2_runtime_not_installed" -> string
 const Microsoft.Identity.Client.MsalError.WebviewUnavailable = "no_system_webview" -> string
 const Microsoft.Identity.Client.MsalError.WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found" -> string
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorCode = "BrokerErrorCode" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorContext = "BrokerErrorContext" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorStatus = "BrokerErrorStatus" -> string
@@ -319,6 +321,10 @@ Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProv
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProvider.set -> void
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.get -> bool
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
 Microsoft.Identity.Client.ApplicationBase
 Microsoft.Identity.Client.ApplicationOptions
 Microsoft.Identity.Client.ApplicationOptions.AadAuthorityAudience.get -> Microsoft.Identity.Client.AadAuthorityAudience
@@ -362,6 +368,8 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientID.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.ClientID.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TokenEndpoint.get -> string
@@ -463,6 +471,9 @@ Microsoft.Identity.Client.AzureCloudInstance.AzureChina = 2 -> Microsoft.Identit
 Microsoft.Identity.Client.AzureCloudInstance.AzureGermany = 3 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzurePublic = 1 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzureUsGovernment = 4 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.None = 0 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.BaseAbstractAcquireTokenParameterBuilder() -> void
@@ -600,6 +611,7 @@ Microsoft.Identity.Client.EmbeddedWebViewOptions.Title.set -> void
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.get -> string
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.set -> void
 Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
 Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions
@@ -629,6 +641,7 @@ Microsoft.Identity.Client.Extensibility.ExecutionResult.Result.get -> Microsoft.
 Microsoft.Identity.Client.Extensibility.ExecutionResult.Successful.get -> bool
 Microsoft.Identity.Client.Extensibility.ICustomWebUi
 Microsoft.Identity.Client.Extensibility.ICustomWebUi.AcquireAuthorizationCodeAsync(System.Uri authorizationUri, System.Uri redirectUri, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Uri>
+Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.set -> void
@@ -637,6 +650,7 @@ Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.Authenticati
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.MsalAuthenticationExtension() -> void
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.get -> System.Func<Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData, System.Threading.Tasks.Task>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.set -> void
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.BodyParameters.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.CancellationToken.get -> System.Threading.CancellationToken
@@ -827,6 +841,7 @@ Microsoft.Identity.Client.MsalError
 Microsoft.Identity.Client.MsalException
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.set -> void
+Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
 Microsoft.Identity.Client.MsalException.CorrelationId.get -> string
 Microsoft.Identity.Client.MsalException.CorrelationId.set -> void
 Microsoft.Identity.Client.MsalException.ErrorCode.get -> string
@@ -845,6 +860,7 @@ Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityExcept
 Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.MsalServiceException
 Microsoft.Identity.Client.MsalServiceException.Claims.get -> string
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Identity.Client.MsalServiceException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders
 Microsoft.Identity.Client.MsalServiceException.Headers.set -> void
 Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string errorCode, string errorMessage, int statusCode, string claims, System.Exception innerException) -> void
@@ -855,6 +871,7 @@ Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string error
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.get -> string
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.set -> void
 Microsoft.Identity.Client.MsalServiceException.StatusCode.get -> int
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.MsalThrottledServiceException
 Microsoft.Identity.Client.MsalThrottledServiceException.MsalThrottledServiceException(Microsoft.Identity.Client.MsalServiceException originalException) -> void
 Microsoft.Identity.Client.MsalThrottledServiceException.OriginalServiceException.get -> Microsoft.Identity.Client.MsalServiceException
@@ -899,6 +916,7 @@ Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.AutodetectSuccess = 4 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.FallbackToGlobal = 5 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.None = 0 -> Microsoft.Identity.Client.Region.RegionOutcome
+Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedAutodetectionFailed = 2 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedInvalid = 3 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedValid = 1 -> Microsoft.Identity.Client.Region.RegionOutcome
@@ -1062,20 +1080,26 @@ static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquire
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraClientAssertionClaims<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string clientAssertionClaims) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithFmiPathForClientAssertion<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string fmiPath) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithProofOfPosessionKeyId<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithExtraBodyParameters(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extrabodyparams) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithProofOfPosessionKeyId(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions.WithCustomWebUi(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, Microsoft.Identity.Client.Extensibility.ICustomWebUi customWebUi) -> Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions.WithSearchInCacheForLongRunningProcess(this Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = true) -> Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IDictionary<string, string> extraHttpHeaders) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnCompletion(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onCompletion) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnMsalServiceFailure(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task<bool>> onMsalServiceFailure) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithAppTokenProvider(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.AppTokenProviderParameters, System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensibility.AppTokenProviderResult>> appTokenProvider) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, System.Threading.Tasks.Task<System.Security.Cryptography.X509Certificates.X509Certificate2>> certificateProvider, Microsoft.Identity.Client.AppConfig.CertificateOptions certificateOptions) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync(this Microsoft.Identity.Client.ILongRunningWebApi clientApp, string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.FromIdToken(string idToken) -> Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName, long logonId) -> byte[]
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName) -> byte[]
@@ -1084,6 +1108,7 @@ static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.Save
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) -> void
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySource() -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 static Microsoft.Identity.Client.ManagedIdentityApplicationBuilder.Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId managedIdentityId) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromBroker.get -> long
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromCache.get -> long
@@ -1127,22 +1152,3 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
-Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
-static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
-Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
-const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
-Microsoft.Identity.Client.AppConfig.PoPOptions
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
-Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
-static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
-static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
-Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
-static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
-static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-android/PublicAPI.Unshipped.txt
@@ -1,6 +1,0 @@
-const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
-Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
-Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
-static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Shipped.txt
@@ -89,6 +89,7 @@ const Microsoft.Identity.Client.MsalError.ManagedIdentityAllSourcesUnavailable =
 const Microsoft.Identity.Client.MsalError.ManagedIdentityRequestFailed = "managed_identity_request_failed" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityResponseParseFailure = "managed_identity_response_parse_failure" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityUnreachableNetwork = "managed_identity_unreachable_network" -> string
+const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
 const Microsoft.Identity.Client.MsalError.MissingEntitlements = "missing_entitlements" -> string
 const Microsoft.Identity.Client.MsalError.MissingFederationMetadataUrl = "missing_federation_metadata_url" -> string
 const Microsoft.Identity.Client.MsalError.MissingManagedIdentityEnvVar = "missing_managed_identity_env_var" -> string
@@ -173,6 +174,7 @@ const Microsoft.Identity.Client.MsalError.WebView2NotInstalled = "webview2_runti
 const Microsoft.Identity.Client.MsalError.WebviewUnavailable = "no_system_webview" -> string
 const Microsoft.Identity.Client.MsalError.WritingApplicationTokenToKeychainFailed = "writing_application_token_to_keychain_failed" -> string
 const Microsoft.Identity.Client.MsalError.WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found" -> string
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorCode = "BrokerErrorCode" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorContext = "BrokerErrorContext" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorStatus = "BrokerErrorStatus" -> string
@@ -323,6 +325,10 @@ Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProv
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProvider.set -> void
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.get -> bool
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
 Microsoft.Identity.Client.ApplicationBase
 Microsoft.Identity.Client.ApplicationOptions
 Microsoft.Identity.Client.ApplicationOptions.AadAuthorityAudience.get -> Microsoft.Identity.Client.AadAuthorityAudience
@@ -366,6 +372,8 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientID.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.ClientID.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TokenEndpoint.get -> string
@@ -467,6 +475,9 @@ Microsoft.Identity.Client.AzureCloudInstance.AzureChina = 2 -> Microsoft.Identit
 Microsoft.Identity.Client.AzureCloudInstance.AzureGermany = 3 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzurePublic = 1 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzureUsGovernment = 4 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.None = 0 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.BaseAbstractAcquireTokenParameterBuilder() -> void
@@ -602,6 +613,7 @@ Microsoft.Identity.Client.EmbeddedWebViewOptions.Title.set -> void
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.get -> string
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.set -> void
 Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
 Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions
@@ -631,6 +643,7 @@ Microsoft.Identity.Client.Extensibility.ExecutionResult.Result.get -> Microsoft.
 Microsoft.Identity.Client.Extensibility.ExecutionResult.Successful.get -> bool
 Microsoft.Identity.Client.Extensibility.ICustomWebUi
 Microsoft.Identity.Client.Extensibility.ICustomWebUi.AcquireAuthorizationCodeAsync(System.Uri authorizationUri, System.Uri redirectUri, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Uri>
+Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.set -> void
@@ -639,6 +652,7 @@ Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.Authenticati
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.MsalAuthenticationExtension() -> void
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.get -> System.Func<Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData, System.Threading.Tasks.Task>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.set -> void
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.BodyParameters.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.CancellationToken.get -> System.Threading.CancellationToken
@@ -830,6 +844,7 @@ Microsoft.Identity.Client.MsalError
 Microsoft.Identity.Client.MsalException
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.set -> void
+Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
 Microsoft.Identity.Client.MsalException.CorrelationId.get -> string
 Microsoft.Identity.Client.MsalException.CorrelationId.set -> void
 Microsoft.Identity.Client.MsalException.ErrorCode.get -> string
@@ -848,6 +863,7 @@ Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityExcept
 Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.MsalServiceException
 Microsoft.Identity.Client.MsalServiceException.Claims.get -> string
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Identity.Client.MsalServiceException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders
 Microsoft.Identity.Client.MsalServiceException.Headers.set -> void
 Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string errorCode, string errorMessage, int statusCode, string claims, System.Exception innerException) -> void
@@ -858,6 +874,7 @@ Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string error
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.get -> string
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.set -> void
 Microsoft.Identity.Client.MsalServiceException.StatusCode.get -> int
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.MsalThrottledServiceException
 Microsoft.Identity.Client.MsalThrottledServiceException.MsalThrottledServiceException(Microsoft.Identity.Client.MsalServiceException originalException) -> void
 Microsoft.Identity.Client.MsalThrottledServiceException.OriginalServiceException.get -> Microsoft.Identity.Client.MsalServiceException
@@ -902,6 +919,7 @@ Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.AutodetectSuccess = 4 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.FallbackToGlobal = 5 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.None = 0 -> Microsoft.Identity.Client.Region.RegionOutcome
+Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedAutodetectionFailed = 2 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedInvalid = 3 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedValid = 1 -> Microsoft.Identity.Client.Region.RegionOutcome
@@ -1064,20 +1082,26 @@ static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquire
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraClientAssertionClaims<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string clientAssertionClaims) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithFmiPathForClientAssertion<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string fmiPath) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithProofOfPosessionKeyId<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithExtraBodyParameters(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extrabodyparams) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithProofOfPosessionKeyId(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions.WithCustomWebUi(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, Microsoft.Identity.Client.Extensibility.ICustomWebUi customWebUi) -> Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions.WithSearchInCacheForLongRunningProcess(this Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = true) -> Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IDictionary<string, string> extraHttpHeaders) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnCompletion(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onCompletion) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnMsalServiceFailure(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task<bool>> onMsalServiceFailure) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithAppTokenProvider(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.AppTokenProviderParameters, System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensibility.AppTokenProviderResult>> appTokenProvider) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, System.Threading.Tasks.Task<System.Security.Cryptography.X509Certificates.X509Certificate2>> certificateProvider, Microsoft.Identity.Client.AppConfig.CertificateOptions certificateOptions) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync(this Microsoft.Identity.Client.ILongRunningWebApi clientApp, string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.FromIdToken(string idToken) -> Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName, long logonId) -> byte[]
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName) -> byte[]
@@ -1086,6 +1110,7 @@ static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.Save
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) -> void
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySource() -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 static Microsoft.Identity.Client.ManagedIdentityApplicationBuilder.Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId managedIdentityId) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromBroker.get -> long
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromCache.get -> long
@@ -1129,22 +1154,3 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
-Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
-static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
-Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
-const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
-Microsoft.Identity.Client.AppConfig.PoPOptions
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
-Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
-static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
-static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
-Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
-static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
-static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0-ios/PublicAPI.Unshipped.txt
@@ -1,6 +1,0 @@
-const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
-Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
-Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
-static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Shipped.txt
@@ -86,6 +86,7 @@ const Microsoft.Identity.Client.MsalError.ManagedIdentityAllSourcesUnavailable =
 const Microsoft.Identity.Client.MsalError.ManagedIdentityRequestFailed = "managed_identity_request_failed" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityResponseParseFailure = "managed_identity_response_parse_failure" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityUnreachableNetwork = "managed_identity_unreachable_network" -> string
+const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
 const Microsoft.Identity.Client.MsalError.MissingFederationMetadataUrl = "missing_federation_metadata_url" -> string
 const Microsoft.Identity.Client.MsalError.MissingManagedIdentityEnvVar = "missing_managed_identity_env_var" -> string
 const Microsoft.Identity.Client.MsalError.MissingPassiveAuthEndpoint = "missing_passive_auth_endpoint" -> string
@@ -166,6 +167,7 @@ const Microsoft.Identity.Client.MsalError.WebView2LoaderNotFound = "webview2load
 const Microsoft.Identity.Client.MsalError.WebView2NotInstalled = "webview2_runtime_not_installed" -> string
 const Microsoft.Identity.Client.MsalError.WebviewUnavailable = "no_system_webview" -> string
 const Microsoft.Identity.Client.MsalError.WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found" -> string
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorCode = "BrokerErrorCode" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorContext = "BrokerErrorContext" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorStatus = "BrokerErrorStatus" -> string
@@ -316,6 +318,10 @@ Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProv
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProvider.set -> void
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.get -> bool
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
 Microsoft.Identity.Client.ApplicationBase
 Microsoft.Identity.Client.ApplicationOptions
 Microsoft.Identity.Client.ApplicationOptions.AadAuthorityAudience.get -> Microsoft.Identity.Client.AadAuthorityAudience
@@ -359,6 +365,8 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientID.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.ClientID.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TokenEndpoint.get -> string
@@ -459,6 +467,9 @@ Microsoft.Identity.Client.AzureCloudInstance.AzureChina = 2 -> Microsoft.Identit
 Microsoft.Identity.Client.AzureCloudInstance.AzureGermany = 3 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzurePublic = 1 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzureUsGovernment = 4 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.None = 0 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.BaseAbstractAcquireTokenParameterBuilder() -> void
@@ -594,6 +605,7 @@ Microsoft.Identity.Client.EmbeddedWebViewOptions.Title.set -> void
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.get -> string
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.set -> void
 Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
 Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions
@@ -623,6 +635,7 @@ Microsoft.Identity.Client.Extensibility.ExecutionResult.Result.get -> Microsoft.
 Microsoft.Identity.Client.Extensibility.ExecutionResult.Successful.get -> bool
 Microsoft.Identity.Client.Extensibility.ICustomWebUi
 Microsoft.Identity.Client.Extensibility.ICustomWebUi.AcquireAuthorizationCodeAsync(System.Uri authorizationUri, System.Uri redirectUri, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Uri>
+Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.set -> void
@@ -631,6 +644,7 @@ Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.Authenticati
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.MsalAuthenticationExtension() -> void
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.get -> System.Func<Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData, System.Threading.Tasks.Task>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.set -> void
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.BodyParameters.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.CancellationToken.get -> System.Threading.CancellationToken
@@ -821,6 +835,7 @@ Microsoft.Identity.Client.MsalError
 Microsoft.Identity.Client.MsalException
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.set -> void
+Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
 Microsoft.Identity.Client.MsalException.CorrelationId.get -> string
 Microsoft.Identity.Client.MsalException.CorrelationId.set -> void
 Microsoft.Identity.Client.MsalException.ErrorCode.get -> string
@@ -839,6 +854,7 @@ Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityExcept
 Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.MsalServiceException
 Microsoft.Identity.Client.MsalServiceException.Claims.get -> string
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Identity.Client.MsalServiceException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders
 Microsoft.Identity.Client.MsalServiceException.Headers.set -> void
 Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string errorCode, string errorMessage, int statusCode, string claims, System.Exception innerException) -> void
@@ -849,6 +865,7 @@ Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string error
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.get -> string
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.set -> void
 Microsoft.Identity.Client.MsalServiceException.StatusCode.get -> int
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.MsalThrottledServiceException
 Microsoft.Identity.Client.MsalThrottledServiceException.MsalThrottledServiceException(Microsoft.Identity.Client.MsalServiceException originalException) -> void
 Microsoft.Identity.Client.MsalThrottledServiceException.OriginalServiceException.get -> Microsoft.Identity.Client.MsalServiceException
@@ -895,6 +912,7 @@ Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.AutodetectSuccess = 4 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.FallbackToGlobal = 5 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.None = 0 -> Microsoft.Identity.Client.Region.RegionOutcome
+Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedAutodetectionFailed = 2 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedInvalid = 3 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedValid = 1 -> Microsoft.Identity.Client.Region.RegionOutcome
@@ -1055,20 +1073,26 @@ static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquire
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraClientAssertionClaims<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string clientAssertionClaims) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithFmiPathForClientAssertion<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string fmiPath) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithProofOfPosessionKeyId<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithExtraBodyParameters(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extrabodyparams) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithProofOfPosessionKeyId(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions.WithCustomWebUi(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, Microsoft.Identity.Client.Extensibility.ICustomWebUi customWebUi) -> Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions.WithSearchInCacheForLongRunningProcess(this Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = true) -> Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IDictionary<string, string> extraHttpHeaders) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnCompletion(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onCompletion) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnMsalServiceFailure(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task<bool>> onMsalServiceFailure) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithAppTokenProvider(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.AppTokenProviderParameters, System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensibility.AppTokenProviderResult>> appTokenProvider) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, System.Threading.Tasks.Task<System.Security.Cryptography.X509Certificates.X509Certificate2>> certificateProvider, Microsoft.Identity.Client.AppConfig.CertificateOptions certificateOptions) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync(this Microsoft.Identity.Client.ILongRunningWebApi clientApp, string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.FromIdToken(string idToken) -> Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName, long logonId) -> byte[]
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName) -> byte[]
@@ -1077,6 +1101,7 @@ static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.Save
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) -> void
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySource() -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 static Microsoft.Identity.Client.ManagedIdentityApplicationBuilder.Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId managedIdentityId) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromBroker.get -> long
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromCache.get -> long
@@ -1123,22 +1148,3 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
-Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
-static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
-Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
-const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
-Microsoft.Identity.Client.AppConfig.PoPOptions
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
-Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
-static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
-static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
-Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
-static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
-static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,0 @@
-const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
-Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
-Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
-static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -86,6 +86,7 @@ const Microsoft.Identity.Client.MsalError.ManagedIdentityAllSourcesUnavailable =
 const Microsoft.Identity.Client.MsalError.ManagedIdentityRequestFailed = "managed_identity_request_failed" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityResponseParseFailure = "managed_identity_response_parse_failure" -> string
 const Microsoft.Identity.Client.MsalError.ManagedIdentityUnreachableNetwork = "managed_identity_unreachable_network" -> string
+const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
 const Microsoft.Identity.Client.MsalError.MissingFederationMetadataUrl = "missing_federation_metadata_url" -> string
 const Microsoft.Identity.Client.MsalError.MissingManagedIdentityEnvVar = "missing_managed_identity_env_var" -> string
 const Microsoft.Identity.Client.MsalError.MissingPassiveAuthEndpoint = "missing_passive_auth_endpoint" -> string
@@ -166,6 +167,7 @@ const Microsoft.Identity.Client.MsalError.WebView2LoaderNotFound = "webview2load
 const Microsoft.Identity.Client.MsalError.WebView2NotInstalled = "webview2_runtime_not_installed" -> string
 const Microsoft.Identity.Client.MsalError.WebviewUnavailable = "no_system_webview" -> string
 const Microsoft.Identity.Client.MsalError.WsTrustEndpointNotFoundInMetadataDocument = "wstrust_endpoint_not_found" -> string
+const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorCode = "BrokerErrorCode" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorContext = "BrokerErrorContext" -> string
 const Microsoft.Identity.Client.MsalException.BrokerErrorStatus = "BrokerErrorStatus" -> string
@@ -316,6 +318,10 @@ Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProv
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.PopCryptoProvider.set -> void
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.get -> bool
 Microsoft.Identity.Client.AppConfig.PoPAuthenticationConfiguration.SignHttpRequest.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
+Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
+Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
 Microsoft.Identity.Client.ApplicationBase
 Microsoft.Identity.Client.ApplicationOptions
 Microsoft.Identity.Client.ApplicationOptions.AadAuthorityAudience.get -> Microsoft.Identity.Client.AadAuthorityAudience
@@ -359,6 +365,8 @@ Microsoft.Identity.Client.AssertionRequestOptions.ClientID.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.ClientID.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.get -> System.Guid
 Microsoft.Identity.Client.AssertionRequestOptions.CorrelationId.set -> void
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
+Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.get -> string
 Microsoft.Identity.Client.AssertionRequestOptions.TenantId.set -> void
 Microsoft.Identity.Client.AssertionRequestOptions.TokenEndpoint.get -> string
@@ -459,6 +467,9 @@ Microsoft.Identity.Client.AzureCloudInstance.AzureChina = 2 -> Microsoft.Identit
 Microsoft.Identity.Client.AzureCloudInstance.AzureGermany = 3 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzurePublic = 1 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.AzureUsGovernment = 4 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
+Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.AzureCloudInstance.None = 0 -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>
 Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.BaseAbstractAcquireTokenParameterBuilder() -> void
@@ -594,6 +605,7 @@ Microsoft.Identity.Client.EmbeddedWebViewOptions.Title.set -> void
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.get -> string
 Microsoft.Identity.Client.EmbeddedWebViewOptions.WebView2BrowserExecutableFolder.set -> void
 Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension
+Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
 Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions
 Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions
@@ -623,6 +635,7 @@ Microsoft.Identity.Client.Extensibility.ExecutionResult.Result.get -> Microsoft.
 Microsoft.Identity.Client.Extensibility.ExecutionResult.Successful.get -> bool
 Microsoft.Identity.Client.Extensibility.ICustomWebUi
 Microsoft.Identity.Client.Extensibility.ICustomWebUi.AcquireAuthorizationCodeAsync(System.Uri authorizationUri, System.Uri redirectUri, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Uri>
+Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.AdditionalCacheParameters.set -> void
@@ -631,6 +644,7 @@ Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.Authenticati
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.MsalAuthenticationExtension() -> void
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.get -> System.Func<Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData, System.Threading.Tasks.Task>
 Microsoft.Identity.Client.Extensibility.MsalAuthenticationExtension.OnBeforeTokenRequestHandler.set -> void
+Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.BodyParameters.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.Identity.Client.Extensibility.OnBeforeTokenRequestData.CancellationToken.get -> System.Threading.CancellationToken
@@ -821,6 +835,7 @@ Microsoft.Identity.Client.MsalError
 Microsoft.Identity.Client.MsalException
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 Microsoft.Identity.Client.MsalException.AdditionalExceptionData.set -> void
+Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
 Microsoft.Identity.Client.MsalException.CorrelationId.get -> string
 Microsoft.Identity.Client.MsalException.CorrelationId.set -> void
 Microsoft.Identity.Client.MsalException.ErrorCode.get -> string
@@ -839,6 +854,7 @@ Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityExcept
 Microsoft.Identity.Client.MsalManagedIdentityException.MsalManagedIdentityException(string errorCode, string errorMessage, System.Exception innerException, Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource source) -> void
 Microsoft.Identity.Client.MsalServiceException
 Microsoft.Identity.Client.MsalServiceException.Claims.get -> string
+Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
 Microsoft.Identity.Client.MsalServiceException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders
 Microsoft.Identity.Client.MsalServiceException.Headers.set -> void
 Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string errorCode, string errorMessage, int statusCode, string claims, System.Exception innerException) -> void
@@ -849,6 +865,7 @@ Microsoft.Identity.Client.MsalServiceException.MsalServiceException(string error
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.get -> string
 Microsoft.Identity.Client.MsalServiceException.ResponseBody.set -> void
 Microsoft.Identity.Client.MsalServiceException.StatusCode.get -> int
+Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
 Microsoft.Identity.Client.MsalThrottledServiceException
 Microsoft.Identity.Client.MsalThrottledServiceException.MsalThrottledServiceException(Microsoft.Identity.Client.MsalServiceException originalException) -> void
 Microsoft.Identity.Client.MsalThrottledServiceException.OriginalServiceException.get -> Microsoft.Identity.Client.MsalServiceException
@@ -895,6 +912,7 @@ Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.AutodetectSuccess = 4 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.FallbackToGlobal = 5 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.None = 0 -> Microsoft.Identity.Client.Region.RegionOutcome
+Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedAutodetectionFailed = 2 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedInvalid = 3 -> Microsoft.Identity.Client.Region.RegionOutcome
 Microsoft.Identity.Client.Region.RegionOutcome.UserProvidedValid = 1 -> Microsoft.Identity.Client.Region.RegionOutcome
@@ -1055,20 +1073,26 @@ static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquire
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraBodyParameters<T>(this Microsoft.Identity.Client.AbstractConfidentialClientAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extraBodyParams) -> T
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithExtraClientAssertionClaims<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string clientAssertionClaims) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithFmiPathForClientAssertion<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string fmiPath) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithProofOfPosessionKeyId<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
+static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithExtraBodyParameters(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, System.Collections.Generic.Dictionary<string, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<string>>> extrabodyparams) -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenForClientBuilderExtensions.WithProofOfPosessionKeyId(this Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder builder, string keyId, string expectedTokenTypeFromAad = "Bearer") -> Microsoft.Identity.Client.AcquireTokenForClientParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenInteractiveParameterBuilderExtensions.WithCustomWebUi(this Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder builder, Microsoft.Identity.Client.Extensibility.ICustomWebUi customWebUi) -> Microsoft.Identity.Client.AcquireTokenInteractiveParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AcquireTokenOnBehalfOfParameterBuilderExtensions.WithSearchInCacheForLongRunningProcess(this Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder builder, bool searchInCache = true) -> Microsoft.Identity.Client.AcquireTokenOnBehalfOfParameterBuilder
+static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithExtraHttpHeaders<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Collections.Generic.IDictionary<string, string> extraHttpHeaders) -> T
 static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithReservedScopes(this Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder builder, bool offlineAccessScope) -> Microsoft.Identity.Client.AcquireTokenByAuthorizationCodeParameterBuilder
 static Microsoft.Identity.Client.Extensibility.AuthenticationResultExtensions.GetRefreshToken(this Microsoft.Identity.Client.AuthenticationResult result) -> string
+static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnCompletion(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onCompletion) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnMsalServiceFailure(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task<bool>> onMsalServiceFailure) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithAppTokenProvider(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.AppTokenProviderParameters, System.Threading.Tasks.Task<Microsoft.Identity.Client.Extensibility.AppTokenProviderResult>> appTokenProvider) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.WithCertificate(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.AssertionRequestOptions, System.Threading.Tasks.Task<System.Security.Cryptography.X509Certificates.X509Certificate2>> certificateProvider, Microsoft.Identity.Client.AppConfig.CertificateOptions certificateOptions) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
 static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationExtensions.StopLongRunningProcessInWebApiAsync(this Microsoft.Identity.Client.ILongRunningWebApi clientApp, string longRunningProcessSessionKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.FromIdToken(string idToken) -> Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName, long logonId) -> byte[]
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.GetKerberosTicketFromWindowsTicketCache(string servicePrincipalName) -> byte[]
@@ -1077,6 +1101,7 @@ static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.Save
 static Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicketManager.SaveToWindowsTicketCache(Microsoft.Identity.Client.Kerberos.KerberosSupplementalTicket ticket) -> void
 static Microsoft.Identity.Client.ManagedIdentityApplication.GetManagedIdentitySource() -> Microsoft.Identity.Client.ManagedIdentity.ManagedIdentitySource
 static Microsoft.Identity.Client.ManagedIdentityApplicationBuilder.Create(Microsoft.Identity.Client.AppConfig.ManagedIdentityId managedIdentityId) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder
+static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromBroker.get -> long
 static Microsoft.Identity.Client.Metrics.TotalAccessTokensFromCache.get -> long
@@ -1123,22 +1148,3 @@ static readonly Microsoft.Identity.Client.Prompt.NoPrompt -> Microsoft.Identity.
 static readonly Microsoft.Identity.Client.Prompt.SelectAccount -> Microsoft.Identity.Client.Prompt
 virtual Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T>.Validate() -> void
 virtual Microsoft.Identity.Client.MsalServiceException.UpdateIsRetryable() -> void
-Microsoft.Identity.Client.MsalServiceException.SubErrorForLogging.get -> string
-Microsoft.Identity.Client.AzureCloudInstance.GovFr = 5 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovDe = 6 -> Microsoft.Identity.Client.AzureCloudInstance
-Microsoft.Identity.Client.AzureCloudInstance.GovSg = 7 -> Microsoft.Identity.Client.AzureCloudInstance
-static Microsoft.Identity.Client.Extensibility.AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractAcquireTokenParameterBuilder<T>
-Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog
-static Microsoft.Identity.Client.Extensibility.MsalMetricsCatalog.CanonicalTagsByMetric.get -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>>
-Microsoft.Identity.Client.Region.RegionOutcome.UserProvided = 6 -> Microsoft.Identity.Client.Region.RegionOutcome
-const Microsoft.Identity.Client.MsalError.MinStrengthNotMet = "min_strength_not_met" -> string
-Microsoft.Identity.Client.AppConfig.PoPOptions
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.get -> Microsoft.Identity.Client.AppConfig.MtlsBindingStrength
-Microsoft.Identity.Client.AppConfig.PoPOptions.MinStrength.set -> void
-Microsoft.Identity.Client.AppConfig.PoPOptions.PoPOptions() -> void
-static Microsoft.Identity.Client.Extensibility.AcquireTokenParameterBuilderExtensions.WithCachePartitionKey<T>(this Microsoft.Identity.Client.BaseAbstractAcquireTokenParameterBuilder<T> builder, string key, string value, bool partitionRefreshToken) -> T
-static Microsoft.Identity.Client.ManagedIdentityPopExtensions.WithMtlsProofOfPossession(this Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder builder, Microsoft.Identity.Client.AppConfig.PoPOptions options) -> Microsoft.Identity.Client.AcquireTokenForManagedIdentityParameterBuilder
-Microsoft.Identity.Client.MsalException.AuthenticationResultMetadata.get -> Microsoft.Identity.Client.AuthenticationResultMetadata
-Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions
-static Microsoft.Identity.Client.Extensibility.ConfidentialClientApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ConfidentialClientApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ConfidentialClientApplicationBuilder
-static Microsoft.Identity.Client.Extensibility.ManagedIdentityApplicationBuilderExtensions.OnBackgroundTokenRefreshCompleted(this Microsoft.Identity.Client.ManagedIdentityApplicationBuilder builder, System.Func<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Threading.Tasks.Task> onBackgroundTokenRefreshCompleted) -> Microsoft.Identity.Client.ManagedIdentityApplicationBuilder

--- a/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/client/Microsoft.Identity.Client/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,0 @@
-const Microsoft.Identity.Client.MsalException.AuthenticationResultMetadataKey = "MsalAuthenticationResultMetadata" -> string
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.get -> System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>>
-Microsoft.Identity.Client.AssertionRequestOptions.OtelTagsEnricher.set -> void
-Microsoft.Identity.Client.MsalServiceException.ErrorCodesForLogging.get -> System.Collections.Generic.IReadOnlyList<string>
-Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension
-static Microsoft.Identity.Client.Extensibility.AbstractManagedIdentityAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher<T>(this Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T> builder, System.Action<Microsoft.Identity.Client.Extensibility.ExecutionResult, System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, object>>> tagsEnricher) -> Microsoft.Identity.Client.AbstractManagedIdentityAcquireTokenParameterBuilder<T>

--- a/src/client/Microsoft.Identity.Lab.Api/PublicAPI.Shipped.txt
+++ b/src/client/Microsoft.Identity.Lab.Api/PublicAPI.Shipped.txt
@@ -14,6 +14,7 @@ const Microsoft.Identity.Test.Common.TestCategories.UnifiedSchemaValidation = "U
 const Microsoft.Identity.Test.LabInfrastructure.KeyVaultInstance.MsalTeam = "https://id4skeyvault.vault.azure.net/" -> string
 const Microsoft.Identity.Test.LabInfrastructure.KeyVaultInstance.MSIDLab = "https://msidlabs.vault.azure.net" -> string
 const Microsoft.Identity.Test.LabInfrastructure.KeyVaultSecrets.AppAdfsNativeClient = "App-AdfsNativeClient-Config" -> string
+const Microsoft.Identity.Test.LabInfrastructure.KeyVaultSecrets.AppOBOService = "MSAL-APP-TodoListService-JSON" -> string
 const Microsoft.Identity.Test.LabInfrastructure.KeyVaultSecrets.AppPCAClient = "App-PCAClient-Config" -> string
 const Microsoft.Identity.Test.LabInfrastructure.KeyVaultSecrets.AppS2S = "App-S2S-Config" -> string
 const Microsoft.Identity.Test.LabInfrastructure.KeyVaultSecrets.AppWebApi = "App-WebApi-Config" -> string
@@ -505,4 +506,3 @@ static readonly Microsoft.Identity.Test.Unit.TestConstants.s_extraHttpHeader -> 
 static readonly Microsoft.Identity.Test.Unit.TestConstants.s_graphScopes -> string[]
 static readonly Microsoft.Identity.Test.Unit.TestConstants.s_scopeForAnotherResource -> System.Collections.Generic.SortedSet<string>
 static readonly Microsoft.Identity.Test.Unit.TestConstants.s_userIdentifier -> string
-const Microsoft.Identity.Test.LabInfrastructure.KeyVaultSecrets.AppOBOService = "MSAL-APP-TodoListService-JSON" -> string


### PR DESCRIPTION
Post-release steps for **4.87.0**.

### Changes
- **CHANGELOG.md** — completed the `4.87.0` section with all shipped changes (new features, bug fixes, and behavior changes) merged since 4.86.1.
- **Public API** — ran `tools/mark-shipped.ps1` to promote the 4.87.0 public APIs from `PublicAPI.Unshipped.txt` to `PublicAPI.Shipped.txt` (6 APIs; remaining diff is re-sorting only, no removals).

### Notes
- No version bump required — MSAL .NET version is set by the pipeline variable `MicrosoftIdentityClientVersion` (4.87.0).
- Packages 4.87.0 verified live on nuget.org and the IDDP feed.