### PR TITLE
[POC] Linux Managed Identity key provider (KMPP/OP-TEE non-exportable RSA-PSS)

### DIFF
--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/KmppNativeMethods.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/KmppNativeMethods.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
+{
+    /// <summary>
+    /// P/Invoke declarations for the Linux KMPP (Key Management and Protection Platform) client
+    /// library <c>libkmpp.so</c> (a.k.a. KeyIso).
+    /// <para>
+    /// These are used to create and use a <b>non-exportable</b> RSA-PSS key that is isolated in the
+    /// OP-TEE / TrustZone enclave ("KeyGuard" equivalent) on Azure Linux VMs. The private key material
+    /// never leaves the enclave; only the public certificate and in-enclave signatures are returned.
+    /// </para>
+    /// <para>
+    /// Signatures mirror <c>/usr/include/keyisoclient.h</c> and <c>/usr/include/keyisopfxclient.h</c>.
+    /// All functions return <c>1</c> for success and <c>0</c> for error unless noted otherwise, and any
+    /// returned buffer must be released with <see cref="KeyIso_free"/> / <see cref="KeyIso_clear_free"/> /
+    /// <see cref="KeyIso_clear_free_string"/>.
+    /// </para>
+    /// </summary>
+    internal static class KmppNativeMethods
+    {
+        // libkmpp.so (SONAME libkmpp.so.1). The runtime resolves "kmpp" -> libkmpp.so on Linux.
+        internal const string KmppLib = "kmpp";
+
+        // keyisoFlags: TrustZone / OP-TEE isolation (non-exportable, KeyGuard-equivalent).
+        // Matches kmpptest's "-f0x10000".
+        internal const int KEYISO_KEY_FLAG_TZ_ISOLATION = 0x10000;
+
+        // RSA-PSS padding id (6) passed to KeyIso_CLIENT_pkey_rsa_sign. Id 6 selects RSASSA-PSS - the
+        // only RSA signature scheme wired into the SymCrypt-only enclave path, and the only
+        // CryptoBoard-approved RSA padding. PSS is the sole padding this provider ever uses.
+        internal const int RSA_PSS_PADDING = 6;
+
+        // NID_sha256.
+        internal const int NID_sha256 = 672;
+
+        // RSA_PSS_SALTLEN_DIGEST (-1): salt length equals the digest length. Matches MSAL's CSR
+        // AlgorithmIdentifier (RSASSA-PSS, SHA-256, MGF1-SHA256, salt = digest length).
+        internal const int RSA_PSS_SALTLEN_DIGEST = -1;
+
+        internal const int SizeOfCorrelationId = 16; // uuid_t
+
+        /// <summary>
+        /// Generates a new key inside the enclave from an OpenSSL-style configuration string and returns
+        /// its opaque KMPP <c>keyId</c>. The key material is sealed in the enclave and is non-exportable.
+        /// </summary>
+        /// <returns>1 on success, 0 on error.</returns>
+        [DllImport(KmppLib, CharSet = CharSet.Ansi)]
+        internal static extern int KeyIso_create_self_sign_pfx_to_key_id(
+            byte[] correlationId,
+            int keyisoFlags,
+            string confStr,
+            out IntPtr keyId); // KeyIso_clear_free_string()
+
+        /// <summary>
+        /// Parses a KMPP <c>keyId</c> string into the encrypted PFX bytes and (base64) client data.
+        /// </summary>
+        /// <returns>1 on success, 0 on error.</returns>
+        [DllImport(KmppLib, CharSet = CharSet.Ansi)]
+        internal static extern int KeyIso_parse_pfx_engine_key_id(
+            byte[] correlationId,
+            string keyId,
+            out int pfxLength,
+            out IntPtr pfxBytes,     // KeyIso_clear_free(pfxBytes, pfxLength)
+            out IntPtr clientData);  // KeyIso_clear_free_string()
+
+        /// <summary>Returns <c>true</c> when the key blob uses the PBES2 ("P8") format.</summary>
+        [DllImport(KmppLib)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        internal static extern bool KeyIso_is_oid_pbe2(
+            byte[] correlationId,
+            IntPtr keyBytes,
+            int keyLength);
+
+        /// <summary>
+        /// Opens the enclave private key (routing the request to the KMPP / KeyGuard service) and returns
+        /// an opaque key context used for signing.
+        /// </summary>
+        /// <returns>1 on success, 0 on error.</returns>
+        [DllImport(KmppLib)]
+        internal static extern int KeyIso_open_key_by_compatibility(
+            byte[] correlationId,
+            out IntPtr keyContext,
+            IntPtr pfxBytes,
+            int pfxLength,
+            IntPtr clientData,
+            [MarshalAs(UnmanagedType.I1)] bool keyIsP8,
+            [MarshalAs(UnmanagedType.I1)] bool serviceIsP8);
+
+        /// <summary>
+        /// Serializes a digest into the buffer layout the enclave RSA-PSS sign expects
+        /// (fixed-size header describing salt length / digest / MGF, followed by the digest bytes).
+        /// </summary>
+        [DllImport(KmppLib)]
+        internal static extern void KeyIso_CLIENT_pkey_rsa_sign_serialization(
+            byte[] serializedInput,
+            byte[] toBeSigned,
+            UIntPtr toBeSignedLength,
+            int saltLength,
+            int mdType,
+            int mgfType,
+            UIntPtr signatureLength,
+            int getMaxLength);
+
+        /// <summary>Performs the RSA sign operation inside the enclave.</summary>
+        /// <returns>The signature length in bytes, or a negative value on error.</returns>
+        [DllImport(KmppLib)]
+        internal static extern int KeyIso_CLIENT_pkey_rsa_sign(
+            IntPtr keyContext,
+            int fromLength,
+            byte[] from,
+            int toLength,
+            byte[] to,
+            int padding);
+
+        /// <summary>Releases the enclave key context created by <see cref="KeyIso_open_key_by_compatibility"/>.</summary>
+        [DllImport(KmppLib)]
+        internal static extern void KeyIso_CLIENT_pfx_close(IntPtr keyContext);
+
+        /// <summary>
+        /// Returns the public certificate chain (PEM) for a <c>keyId</c>. The end-entity certificate's
+        /// public key is used to expose <see cref="System.Security.Cryptography.RSAParameters"/> without
+        /// ever touching the private key.
+        /// </summary>
+        /// <returns>+1 complete chain, -1 chain error (still usable), 0 error.</returns>
+        [DllImport(KmppLib, CharSet = CharSet.Ansi)]
+        internal static extern int KeyIso_build_cert_chain_from_key_id(
+            byte[] correlationId,
+            int keyisoFlags,
+            string keyId,
+            out int verifyChainError,
+            out int pemCertLength,
+            out IntPtr pemCert); // KeyIso_free()
+
+        [DllImport(KmppLib)]
+        internal static extern void KeyIso_free(IntPtr ptr);
+
+        [DllImport(KmppLib)]
+        internal static extern void KeyIso_clear_free(IntPtr ptr, int length);
+
+        [DllImport(KmppLib)]
+        internal static extern void KeyIso_clear_free_string(IntPtr ptr);
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/KmppRsa.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/KmppRsa.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using static Microsoft.Identity.Client.ManagedIdentity.KeyProviders.KmppNativeMethods;
+
+namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
+{
+    /// <summary>
+    /// An <see cref="RSA"/> implementation whose private key lives inside the Linux KMPP
+    /// (KeyIso / OP-TEE / TrustZone) enclave and is <b>non-exportable</b>. This is the Linux
+    /// equivalent of a Windows CredentialGuard / KeyGuard key.
+    /// <para>
+    /// Only public parameters (read from the enclave's self-signed certificate) can be exported.
+    /// Signing (<see cref="SignHash"/>) is RSA-PSS / SHA-256 and is executed <b>inside</b> the enclave
+    /// via <c>libkmpp.so</c>; the private key never crosses the process boundary. This matches MSAL's
+    /// MSI v2 mTLS-PoP CSR profile (RSASSA-PSS, SHA-256, MGF1-SHA256, salt length = digest length).
+    /// </para>
+    /// </summary>
+    internal sealed class KmppRsa : RSA
+    {
+        // Size of KEYISO_EVP_PKEY_SIGN (tbsLen[8] + saltLen[4] + sigmdType[4] + mgfmdType[4] +
+        // getMaxLen[4] + sigLen[8], 8-byte aligned) that prefixes the digest in the serialized
+        // sign input. See KeyIso_CLIENT_pkey_rsa_sign_serialization in keyisoclient.c.
+        private const int SignHeaderSize = 32;
+
+        private readonly string _keyId;
+        private RSAParameters _publicParameters;
+        private bool _publicLoaded;
+
+        /// <summary>The opaque KMPP keyId identifying the sealed enclave key.</summary>
+        internal string KeyId => _keyId;
+
+        internal KmppRsa(string keyId)
+        {
+            _keyId = keyId ?? throw new ArgumentNullException(nameof(keyId));
+            KeySizeValue = 2048;
+        }
+
+        private static byte[] NewCorrelationId()
+        {
+            byte[] correlationId = new byte[SizeOfCorrelationId];
+            RandomNumberGenerator.Fill(correlationId);
+            return correlationId;
+        }
+
+        private void EnsurePublic()
+        {
+            if (_publicLoaded)
+            {
+                return;
+            }
+
+            byte[] correlationId = NewCorrelationId();
+            int rc = KeyIso_build_cert_chain_from_key_id(
+                correlationId,
+                KEYISO_KEY_FLAG_TZ_ISOLATION,
+                _keyId,
+                out int _,
+                out int pemCertLength,
+                out IntPtr pemCert);
+
+            if (rc == 0 || pemCert == IntPtr.Zero)
+            {
+                throw new CryptographicException("KMPP: failed to read the enclave public certificate for the keyId.");
+            }
+
+            try
+            {
+                string pem = Marshal.PtrToStringAnsi(pemCert, pemCertLength);
+                using X509Certificate2 cert = X509Certificate2.CreateFromPem(pem);
+                using RSA publicKey = cert.GetRSAPublicKey()
+                    ?? throw new CryptographicException("KMPP: enclave certificate does not contain an RSA public key.");
+
+                _publicParameters = publicKey.ExportParameters(false);
+                KeySizeValue = _publicParameters.Modulus!.Length * 8;
+                _publicLoaded = true;
+            }
+            finally
+            {
+                KeyIso_free(pemCert);
+            }
+        }
+
+        public override RSAParameters ExportParameters(bool includePrivateParameters)
+        {
+            if (includePrivateParameters)
+            {
+                throw new CryptographicException(
+                    "KMPP enclave key is non-exportable; the private key never leaves the OP-TEE/TrustZone enclave.");
+            }
+
+            EnsurePublic();
+            return _publicParameters;
+        }
+
+        public override void ImportParameters(RSAParameters parameters) =>
+            throw new NotSupportedException("KMPP enclave key material cannot be imported.");
+
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
+            hashAlgorithm == HashAlgorithmName.SHA256
+                ? SHA256.HashData(new ReadOnlySpan<byte>(data, offset, count))
+                : throw new NotSupportedException("KMPP enclave supports SHA-256 only.");
+
+        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
+            hashAlgorithm == HashAlgorithmName.SHA256
+                ? SHA256.HashData(data)
+                : throw new NotSupportedException("KMPP enclave supports SHA-256 only.");
+
+        public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            if (hash is null)
+            {
+                throw new ArgumentNullException(nameof(hash));
+            }
+
+            if (hashAlgorithm != HashAlgorithmName.SHA256)
+            {
+                throw new NotSupportedException("KMPP enclave supports SHA-256 only.");
+            }
+
+            if (padding != RSASignaturePadding.Pss)
+            {
+                throw new NotSupportedException(
+                    "KMPP enclave supports RSA-PSS only (SymCrypt/FIPS enclave path).");
+            }
+
+            EnsurePublic();
+            int signatureSize = KeySize / 8; // 256 for RSA-2048
+
+            // Serialize: 32-byte header (salt/digest/MGF metadata) followed by the digest bytes.
+            byte[] serializedInput = new byte[SignHeaderSize + hash.Length];
+            KeyIso_CLIENT_pkey_rsa_sign_serialization(
+                serializedInput,
+                hash,
+                (UIntPtr)hash.Length,
+                RSA_PSS_SALTLEN_DIGEST,
+                NID_sha256,
+                NID_sha256,
+                (UIntPtr)signatureSize,
+                0);
+
+            IntPtr keyContext = OpenKeyContext();
+            try
+            {
+                byte[] signature = new byte[signatureSize];
+                int rc = KeyIso_CLIENT_pkey_rsa_sign(
+                    keyContext,
+                    serializedInput.Length,
+                    serializedInput,
+                    signature.Length,
+                    signature,
+                    RSA_PSS_PADDING);
+
+                if (rc <= 0)
+                {
+                    throw new CryptographicException($"KMPP enclave RSA-PSS sign failed (rc={rc}).");
+                }
+
+                // RSA-2048 PSS signatures are always 256 bytes; the enclave fills the full buffer.
+                return signature;
+            }
+            finally
+            {
+                KeyIso_CLIENT_pfx_close(keyContext);
+            }
+        }
+
+        public override bool VerifyHash(
+            byte[] hash,
+            byte[] signature,
+            HashAlgorithmName hashAlgorithm,
+            RSASignaturePadding padding)
+        {
+            EnsurePublic();
+            using RSA publicKey = Create();
+            publicKey.ImportParameters(_publicParameters);
+            return publicKey.VerifyHash(hash, signature, hashAlgorithm, padding);
+        }
+
+        private IntPtr OpenKeyContext()
+        {
+            byte[] correlationId = NewCorrelationId();
+            if (KeyIso_parse_pfx_engine_key_id(correlationId, _keyId, out int pfxLength, out IntPtr pfxBytes, out IntPtr clientData) == 0
+                || pfxBytes == IntPtr.Zero)
+            {
+                throw new CryptographicException("KMPP: failed to parse the keyId into a PFX blob.");
+            }
+
+            try
+            {
+                // Keys created by LinuxManagedIdentityKeyProvider are modern P8 (PBES2) encrypted keys and
+                // the KMPP service on current images is P8-capable, so both compatibility flags are true.
+                // This routes to KeyIso_CLIENT_private_key_open_from_pfx (P8 path) rather than the legacy
+                // salt-based path.
+                if (KeyIso_open_key_by_compatibility(correlationId, out IntPtr keyContext, pfxBytes, pfxLength, clientData, keyIsP8: true, serviceIsP8: true) == 0
+                    || keyContext == IntPtr.Zero)
+                {
+                    throw new CryptographicException("KMPP: failed to open the enclave key (KeyGuard/OP-TEE service).");
+                }
+
+                return keyContext;
+            }
+            finally
+            {
+                if (pfxBytes != IntPtr.Zero)
+                {
+                    KeyIso_clear_free(pfxBytes, pfxLength);
+                }
+
+                if (clientData != IntPtr.Zero)
+                {
+                    KeyIso_clear_free_string(clientData);
+                }
+            }
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/LinuxManagedIdentityKeyProvider.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/KeyProviders/LinuxManagedIdentityKeyProvider.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client.Core;
+using static Microsoft.Identity.Client.ManagedIdentity.KeyProviders.KmppNativeMethods;
+
+namespace Microsoft.Identity.Client.ManagedIdentity.KeyProviders
+{
+    /// <summary>
+    /// Linux managed identity key provider. Creates a <b>non-exportable</b> RSA-PSS key inside the
+    /// KMPP (KeyIso / OP-TEE / TrustZone) enclave — the Linux equivalent of a Windows CredentialGuard /
+    /// KeyGuard key — and reports it as <see cref="ManagedIdentityKeyType.KeyGuard"/> so the MSI v2
+    /// mTLS-PoP flow treats it as attestable. Falls back to an in-memory software RSA key when the
+    /// KMPP enclave is unavailable (e.g. OP-TEE not initialized on the host).
+    /// </summary>
+    internal sealed class LinuxManagedIdentityKeyProvider : IManagedIdentityKeyProvider
+    {
+        private static readonly SemaphoreSlim s_once = new(1, 1);
+        private volatile ManagedIdentityKeyInfo _cachedKey;
+
+        // OpenSSL-style KMPP configuration for a non-exportable RSA-PSS 2048 signing key.
+        // Parsed by KMPP's KeyIso_conf_load; every value is read from the "[self_sign]" section.
+        // rsa_padding = 6 selects RSASSA-PSS, making the self-signed certificate RSA-PSS, and
+        // sign_digest = sha256 selects SHA-256 — matching MSAL's MSI v2 mTLS-PoP CSR profile.
+        // (Empirically validated against libkmpp on Azure Linux 3.) Can be overridden at runtime via
+        // the MSAL_KMPP_KEYGEN_CONF environment variable.
+        private const string DefaultRsaKeyConf =
+            "[self_sign]\n" +
+            "key_type = rsa\n" +
+            "rsa_bits = 2048\n" +
+            "rsa_exp = 65537\n" +
+            "rsa_padding = 6\n" +
+            "sign_digest = sha256\n" +
+            "key_usage = digitalSignature\n" +
+            "days = 365\n" +
+            "distinguished_name = dn_sect\n" +
+            "\n" +
+            "[dn_sect]\n" +
+            "CN = MSAL-ManagedIdentity-KMPP\n";
+
+        public async Task<ManagedIdentityKeyInfo> GetOrCreateKeyAsync(ILoggerAdapter logger, CancellationToken ct)
+        {
+            if (_cachedKey is not null)
+            {
+                logger?.Info("[MI][LinuxKeyProvider] Returning cached key.");
+                return _cachedKey;
+            }
+
+            logger?.Info(() => "[MI][LinuxKeyProvider] Waiting on creation semaphore.");
+            await s_once.WaitAsync(ct).ConfigureAwait(false);
+
+            try
+            {
+                if (_cachedKey is not null)
+                {
+                    return _cachedKey;
+                }
+
+                ct.ThrowIfCancellationRequested();
+
+                // 1) Try the KMPP/OP-TEE enclave key (non-exportable, KeyGuard-equivalent).
+                try
+                {
+                    logger?.Info(() => "[MI][LinuxKeyProvider] Trying KMPP/OP-TEE enclave key.");
+                    if (TryCreateKmppKey(logger, out KmppRsa kmppRsa))
+                    {
+                        _cachedKey = new ManagedIdentityKeyInfo(
+                            kmppRsa,
+                            ManagedIdentityKeyType.KeyGuard,
+                            "KMPP/OP-TEE enclave RSA-PSS key (non-exportable) created for Managed Identity.");
+                        logger?.Info("[MI][LinuxKeyProvider] Using KMPP/OP-TEE enclave key (non-exportable).");
+                        return _cachedKey;
+                    }
+
+                    logger?.Info(() => "[MI][LinuxKeyProvider] KMPP enclave key not available.");
+                }
+                catch (Exception ex)
+                {
+                    logger?.WarningPii(
+                        $"[MI][LinuxKeyProvider] Exception creating KMPP key: {ex}",
+                        $"[MI][LinuxKeyProvider] Exception creating KMPP key: {ex.GetType().Name}");
+                }
+
+                // 2) Fallback: in-memory software RSA.
+                logger?.Info("[MI][LinuxKeyProvider] Falling back to in-memory RSA key (software).");
+                ct.ThrowIfCancellationRequested();
+                var fallback = new InMemoryManagedIdentityKeyProvider();
+                _cachedKey = await fallback.GetOrCreateKeyAsync(logger, ct).ConfigureAwait(false);
+                return _cachedKey;
+            }
+            finally
+            {
+                s_once.Release();
+            }
+        }
+
+        private static bool TryCreateKmppKey(ILoggerAdapter logger, out KmppRsa kmppRsa)
+        {
+            kmppRsa = null;
+
+            string conf = Environment.GetEnvironmentVariable("MSAL_KMPP_KEYGEN_CONF");
+            if (string.IsNullOrEmpty(conf))
+            {
+                conf = DefaultRsaKeyConf;
+            }
+
+            byte[] correlationId = new byte[SizeOfCorrelationId];
+            RandomNumberGenerator.Fill(correlationId);
+
+            int rc = KeyIso_create_self_sign_pfx_to_key_id(
+                correlationId,
+                KEYISO_KEY_FLAG_TZ_ISOLATION,
+                conf,
+                out IntPtr keyIdPtr);
+
+            if (rc == 0 || keyIdPtr == IntPtr.Zero)
+            {
+                logger?.Info(() => $"[MI][LinuxKeyProvider] KMPP keygen (KeyIso_create_self_sign_pfx_to_key_id) returned rc={rc}.");
+                return false;
+            }
+
+            string keyId;
+            try
+            {
+                keyId = Marshal.PtrToStringAnsi(keyIdPtr);
+            }
+            finally
+            {
+                KeyIso_clear_free_string(keyIdPtr);
+            }
+
+            if (string.IsNullOrEmpty(keyId))
+            {
+                logger?.Info(() => "[MI][LinuxKeyProvider] KMPP keygen returned an empty keyId.");
+                return false;
+            }
+
+            var rsa = new KmppRsa(keyId);
+
+            // Validate the key is usable by reading its public parameters from the enclave certificate.
+            _ = rsa.ExportParameters(false);
+
+            logger?.Info(() => $"[MI][LinuxKeyProvider] KMPP enclave key created ({rsa.KeySize}-bit, non-exportable).");
+            kmppRsa = rsa;
+            return true;
+        }
+    }
+}

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityKeyProviderFactory.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityKeyProviderFactory.cs
@@ -106,8 +106,19 @@ namespace Microsoft.Identity.Client.ManagedIdentity
                 return new WindowsManagedIdentityKeyProvider();
             }
 
-            // Non-Windows OS - we will fall back to in-memory implementation.
-            logger?.Info("[MI][KeyProviderFactory] Non-Windows platform (with CNG) - using InMemory provider.");
+#if NET8_0_OR_GREATER
+            if (DesktopOsHelper.IsLinux())
+            {
+                // Linux: source a non-exportable RSA-PSS key from the KMPP/OP-TEE enclave
+                // (KeyGuard-equivalent), falling back to in-memory inside the provider when the
+                // enclave is unavailable.
+                logger?.Info("[MI][KeyProviderFactory] Linux detected - using KMPP/OP-TEE managed identity key provider.");
+                return new LinuxManagedIdentityKeyProvider();
+            }
+#endif
+
+            // Other non-Windows OS (e.g. macOS) - fall back to in-memory implementation.
+            logger?.Info("[MI][KeyProviderFactory] Non-Windows platform - using InMemory provider.");
             return new InMemoryManagedIdentityKeyProvider();
         }
     }

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityPopExtensions.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/ManagedIdentityPopExtensions.cs
@@ -51,7 +51,13 @@ namespace Microsoft.Identity.Client
                 throw new System.ArgumentNullException(nameof(options));
             }
 
-            if (!DesktopOsHelper.IsWindows())
+            // mTLS PoP needs a platform that can source a binding key:
+            // Windows (CNG/KeyGuard) on all TFMs, or Linux (KMPP/OP-TEE enclave) on net8.0+.
+            bool isSupportedOs = DesktopOsHelper.IsWindows();
+#if NET8_0_OR_GREATER
+            isSupportedOs = isSupportedOs || DesktopOsHelper.IsLinux();
+#endif
+            if (!isSupportedOs)
             {
                 throw new MsalClientException(
                     MsalError.MtlsNotSupportedForManagedIdentity,

--- a/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/src/client/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -75,6 +75,15 @@
     <None Include="$(PathToMsalSources)\..\..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <!-- KMPP (Linux KeyGuard/OP-TEE) managed identity key provider uses net8.0+ crypto APIs
+       (X509Certificate2.CreateFromPem, SHA256.HashData, RandomNumberGenerator.Fill).
+       Exclude it from the older target frameworks; Linux there falls back to InMemory. -->
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetDesktop462)' or '$(TargetFramework)' == '$(TargetFrameworkNetDesktop472)' or '$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
+    <Compile Remove="$(PathToMsalSources)\ManagedIdentity\KeyProviders\KmppNativeMethods.cs" />
+    <Compile Remove="$(PathToMsalSources)\ManagedIdentity\KeyProviders\KmppRsa.cs" />
+    <Compile Remove="$(PathToMsalSources)\ManagedIdentity\KeyProviders\LinuxManagedIdentityKeyProvider.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkNetStandard)'">
     <Compile Include="$(PathToMsalSources)\Platforms\netstandard\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Platforms\Features\DesktopOS\**\*.cs" />


### PR DESCRIPTION
## Summary (POC / draft)

Adds a **Linux Managed Identity key provider** that sources a **non-exportable RSA-PSS key** from the KMPP (KeyIso / OP-TEE / TrustZone) enclave via `libkmpp.so` — the Linux equivalent of a Windows CredentialGuard / KeyGuard key.

This is a **proof of concept** for the MSI v2 mTLS-PoP story on Linux. It gets the flow to where **MSAL itself creates the non-exportable key and builds the CSR**; attestation is the remaining gap (below).

## Changes
- `ManagedIdentity/KeyProviders/KmppNativeMethods.cs` — P/Invoke into `libkmpp.so` (keygen, open, in-enclave sign, public cert).
- `ManagedIdentity/KeyProviders/KmppRsa.cs` — `RSA` whose private key stays in the enclave. Public key read from the enclave self-signed cert; RSA-PSS/SHA-256 signing runs in-enclave; private-key export throws (non-exportable).
- `ManagedIdentity/KeyProviders/LinuxManagedIdentityKeyProvider.cs` — creates the KMPP key (`KeyIso_create_self_sign_pfx_to_key_id`), reports it as `KeyGuard`, falls back to in-memory RSA when the enclave is unavailable.
- `ManagedIdentityKeyProviderFactory.cs` — selects the Linux provider on `net8.0+`.
- `ManagedIdentityPopExtensions.cs` — allows MI mTLS PoP on Linux (`net8.0+`), previously Windows-only.
- `Microsoft.Identity.Client.csproj` — excludes the net8-only KMPP files from `net462`/`net472`/`netstandard2.0`.

## Validation
Built (all TFMs) and run E2E on an **Azure Linux 3 (LVBS "shielded secrets")** Trusted Launch VM:

```
[MI][KeyProviderFactory] Linux detected - using KMPP/OP-TEE managed identity key provider.
GET .../metadata/identity/getplatformmetadata?cred-api-version=2.0
[MI][LinuxKeyProvider] KMPP enclave key created (2048-bit, non-exportable).
MsalClientException: credential_guard_requires_cng -
  [ImdsV2] Credential Guard attestation currently supports only RSA CNG keys on Windows.
```

A standalone probe confirmed the native path: keygen -> public key -> **in-enclave RSA-PSS sign -> verify = VALID**; private key non-exportable (only the public cert is extractable).

## Known gap / not in scope
- **Attestation on Linux** — fails at `ImdsV2ManagedIdentitySource.GetAttestationJwtAsync` (MSAL only attests Windows CNG/CredentialGuard keys). A Linux attestation path (e.g. KMPP `KeyIso_create_key_claim` -> MAA) is the follow-up.
- No unit tests yet (POC). KMPP requires OP-TEE initialized on the host.

Draft for discussion — feedback welcome on the provider seam, the `net8.0+` gating, and the attestation follow-up.