### PR TITLE
Fix mTLS PoP incorrectly rejecting sovereign cloud aliases (login.chinacloudapi.cn / login.usgovcloudapi.net)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionAndMtlsDiscoveryProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/RegionAndMtlsDiscoveryProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Core;
 using Microsoft.Identity.Client.Http;
@@ -17,14 +16,6 @@ namespace Microsoft.Identity.Client.Region
         public const string PublicEnvForRegional = "login.microsoft.com";
         public const string PublicEnvForRegionalMtlsAuth = "mtlsauth.microsoft.com";
 
-        // Map of unsupported sovereign cloud hosts for mTLS PoP to their error messages
-        private static readonly Dictionary<string, string> s_unsupportedMtlsHosts =
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                { "login.usgovcloudapi.net", MsalErrorMessage.MtlsPopNotSupportedForUsGovCloudApiMessage },
-                { "login.chinacloudapi.cn", MsalErrorMessage.MtlsPopNotSupportedForChinaCloudApiMessage }
-            };
-
         public RegionAndMtlsDiscoveryProvider(IHttpManager httpManager)
         {
             _regionManager = new RegionManager(httpManager);
@@ -32,19 +23,13 @@ namespace Microsoft.Identity.Client.Region
 
         public async Task<InstanceDiscoveryMetadataEntry> GetMetadataAsync(Uri authority, RequestContext requestContext)
         {
-            // Fail fast: Check for unsupported mTLS hosts before any region discovery
+            // Fail fast: mTLS PoP requires a login.* host before any region discovery. Known sovereign
+            // aliases (for example login.chinacloudapi.cn and login.usgovcloudapi.net) are valid; they are
+            // normalized to their preferred-network host and swapped to the correct mtlsauth.* endpoint
+            // during region resolution, so they must not be rejected here.
             if (requestContext.IsMtlsRequested)
             {
                 string host = authority.Host;
-
-                // Check if host is in the unsupported list
-                if (s_unsupportedMtlsHosts.TryGetValue(host, out string errorMessage))
-                {
-                    requestContext.Logger.Error($"[Region discovery] mTLS PoP is not supported for host: {host}");
-                    throw new MsalClientException(
-                        MsalError.MtlsPopNotSupportedForEnvironment,
-                        errorMessage);
-                }
 
                 // Check if host starts with "login."
                 if (!host.StartsWith("login.", StringComparison.OrdinalIgnoreCase))

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/MtlsPopTests.cs
@@ -900,6 +900,10 @@ namespace Microsoft.Identity.Test.Unit
         [DataRow("login.sovcloud-identity.fr", "mtlsauth.sovcloud-identity.fr")]
         [DataRow("login.sovcloud-identity.de", "mtlsauth.sovcloud-identity.de")]
         [DataRow("login.sovcloud-identity.sg", "mtlsauth.sovcloud-identity.sg")]
+        // Legacy sovereign aliases must resolve to their preferred-network mTLS endpoint
+        // (regression: #5684 wrongly rejected these for mTLS PoP).
+        [DataRow("login.chinacloudapi.cn", "mtlsauth.partner.microsoftonline.cn")]
+        [DataRow("login.usgovcloudapi.net", "mtlsauth.microsoftonline.us")]
         public async Task PublicAndSovereignCloud_UsesPreferredNetwork_AndNoDiscovery_Async(string inputEnv, string expectedEnv)
         {
             // Append the input environment to create the authority URL
@@ -964,6 +968,10 @@ namespace Microsoft.Identity.Test.Unit
         [DataRow("login.sovcloud-identity.fr", "mtlsauth.sovcloud-identity.fr")]
         [DataRow("login.sovcloud-identity.de", "mtlsauth.sovcloud-identity.de")]
         [DataRow("login.sovcloud-identity.sg", "mtlsauth.sovcloud-identity.sg")]
+        // Legacy sovereign aliases must resolve to their preferred-network global mTLS endpoint
+        // (regression: #5684 wrongly rejected these for mTLS PoP). login.chinacloudapi.cn reproduces the Mooncake case.
+        [DataRow("login.chinacloudapi.cn", "mtlsauth.partner.microsoftonline.cn")]
+        [DataRow("login.usgovcloudapi.net", "mtlsauth.microsoftonline.us")]
         public async Task PublicAndSovereignCloud_NoRegion_UsesGlobalMtlsEndpoint_Async(string inputEnv, string expectedMtlsEnv)
         {
             string tenantId = "17b189bc-2b81-4ec5-aa51-3e628cbc931b";
@@ -1103,43 +1111,6 @@ namespace Microsoft.Identity.Test.Unit
                     Assert.AreEqual("header.payload.signature", result.AccessToken);
                     Assert.AreEqual(Constants.MtlsPoPAuthHeaderPrefix, result.TokenType);
                     Assert.AreEqual(expectedTokenEndpoint, result.AuthenticationResultMetadata.TokenEndpoint);
-                }
-            }
-        }
-
-        [TestMethod]
-        [DataRow("login.usgovcloudapi.net", MsalErrorMessage.MtlsPopNotSupportedForUsGovCloudApiMessage)]
-        [DataRow("login.chinacloudapi.cn", MsalErrorMessage.MtlsPopNotSupportedForChinaCloudApiMessage)]
-        public async Task UnsupportedSovereignHosts_ThrowsMsalClientException_Async(string unsupportedHost, string expectedErrorMessage)
-        {
-            // Arrange
-            string authorityUrl = $"https://{unsupportedHost}/17b189bc-2b81-4ec5-aa51-3e628cbc931b";
-
-            using (var envContext = new EnvVariableContext())
-            {
-                Environment.SetEnvironmentVariable("REGION_NAME", EastUsRegion);
-
-                using (var harness = new MockHttpAndServiceBundle())
-                {
-                    var app = ConfidentialClientApplicationBuilder
-                                        .Create(TestConstants.ClientId)
-                                        .WithAuthority(authorityUrl)
-                                        .WithHttpManager(harness.HttpManager)
-                                        .WithAzureRegion(ConfidentialClientApplication.AttemptRegionDiscovery)
-                                        .WithCertificate(s_testCertificate)
-                                        .Build();
-
-                    // Act & Assert
-                    var exception = await Assert.ThrowsAsync<MsalClientException>(async () =>
-                    {
-                        await app.AcquireTokenForClient(TestConstants.s_scope)
-                            .WithMtlsProofOfPossession()
-                            .ExecuteAsync()
-                            .ConfigureAwait(false);
-                    }).ConfigureAwait(false);
-
-                    Assert.AreEqual(MsalError.MtlsPopNotSupportedForEnvironment, exception.ErrorCode);
-                    Assert.AreEqual(expectedErrorMessage, exception.Message);
                 }
             }
         }


### PR DESCRIPTION
## Summary

`login.chinacloudapi.cn` (Azure China) and `login.usgovcloudapi.net` (Azure US Government) are valid **aliases** of `login.partner.microsoftonline.cn` and `login.microsoftonline.us` respectively (see `KnownMetadataProvider`). Both clouds support mTLS Proof-of-Possession, and these aliases are normalized to their preferred-network host and swapped to the correct `{region}.mtlsauth.*` endpoint during region resolution.

Since #5684, `RegionAndMtlsDiscoveryProvider.GetMetadataAsync` hard-rejected these alias hosts with `MtlsPopNotSupportedForEnvironment` **before** that normalization ran. This broke mTLS PoP for confidential-client (SN/I) flows configured with the alias authority — most notably Azure China via `login.chinacloudapi.cn`.

## Fix

- Remove the `s_unsupportedMtlsHosts` reject list and its check in `RegionAndMtlsDiscoveryProvider`. Both entries were valid aliases, so the list had no legitimate members.
- Keep the non-`login.` host guard unchanged, so hosts such as `sts.windows.net`, `mtlsauth.microsoft.com`, and `graph.microsoft.com` still fail fast.
- No public API change — `MsalError.MtlsPopNotSupportedForEnvironment` and the associated message constants are retained.

Resulting endpoints:

| Authority host | Regional | No region (global) |
| --- | --- | --- |
| `login.chinacloudapi.cn` | `{region}.mtlsauth.partner.microsoftonline.cn` | `mtlsauth.partner.microsoftonline.cn` |
| `login.usgovcloudapi.net` | `{region}.mtlsauth.microsoftonline.us` | `mtlsauth.microsoftonline.us` |

## Tests

- Added `login.chinacloudapi.cn` and `login.usgovcloudapi.net` cases to `PublicAndSovereignCloud_UsesPreferredNetwork_AndNoDiscovery_Async` (regional) and `PublicAndSovereignCloud_NoRegion_UsesGlobalMtlsEndpoint_Async` (global / no region).
- Removed the now-invalid `UnsupportedSovereignHosts_ThrowsMsalClientException_Async`.
- `dotnet test ... --filter FullyQualifiedName~MtlsPopTests -f net8.0` → **79 passed, 0 failed**.

## Regression range

Introduced in **4.82.0** (#5684). This restores the pre-4.82.0 behavior for these sovereign aliases.
