### PR TITLE
Do not carry authority port to global instance discovery

### DIFF
--- a/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
+++ b/src/client/Microsoft.Identity.Client/Instance/Discovery/NetworkMetadataProvider.cs
@@ -118,9 +118,13 @@ namespace Microsoft.Identity.Client.Instance.Discovery
                 authority.Host :
                 AadAuthority.DefaultTrustedHost;
 
-            string instanceDiscoveryEndpoint = UriBuilderExtensions.GetHttpsUriWithOptionalPort(
-                $"https://{discoveryHost}/common/discovery/instance",
-                authority.Port);
+            string instanceDiscoveryEndpoint = $"https://{discoveryHost}/common/discovery/instance";
+            if (string.Equals(discoveryHost, authority.Host, StringComparison.OrdinalIgnoreCase))
+            {
+                instanceDiscoveryEndpoint = UriBuilderExtensions.GetHttpsUriWithOptionalPort(
+                    instanceDiscoveryEndpoint,
+                    authority.Port);
+            }
 
             requestContext.Logger.InfoPii(
                 () => $"Fetching instance discovery from the network from host {discoveryHost}. Endpoint {instanceDiscoveryEndpoint}. ",

--- a/src/client/Microsoft.Identity.Lab.Api/Http/MockHttpManagerExtensions.cs
+++ b/src/client/Microsoft.Identity.Lab.Api/Http/MockHttpManagerExtensions.cs
@@ -40,7 +40,11 @@ namespace Microsoft.Identity.Test.Common.Core.Mocks
                                            ? authorityURI.Host
                                            : AadAuthority.DefaultTrustedHost;
 
-                discoveryEndpoint = UriBuilderExtensions.GetHttpsUriWithOptionalPort($"https://{discoveryHost}/common/discovery/instance", authorityURI.Port);
+                discoveryEndpoint = $"https://{discoveryHost}/common/discovery/instance";
+                if (string.Equals(discoveryHost, authorityURI.Host, StringComparison.OrdinalIgnoreCase))
+                {
+                    discoveryEndpoint = UriBuilderExtensions.GetHttpsUriWithOptionalPort(discoveryEndpoint, authorityURI.Port);
+                }
             }
             else
             {

--- a/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/CoreTests/InstanceTests/AadAuthorityTests.cs
@@ -297,12 +297,14 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.InstanceTests
 
         [TestMethod]
         //Test for bug #1292 (https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1292)
-        public void AuthorityCustomPortTest()
+        public void AuthorityCustomPortIsPreservedAndNotUsedForGlobalInstanceDiscoveryTest()
         {
             const string customPortAuthority = "https://localhost:5215/common/";
 
             using var harness = CreateTestHarness();
-            harness.HttpManager.AddInstanceDiscoveryMockHandler(customPortAuthority);
+            harness.HttpManager.AddInstanceDiscoveryMockHandler(
+                customPortAuthority,
+                new Uri("https://login.microsoftonline.com/common/discovery/instance"));
 
             PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
                                                                         .WithAuthority(new Uri(customPortAuthority), false)


### PR DESCRIPTION
## Summary

- use an authority's custom port for instance discovery only when discovery targets that same host
- use the default HTTPS port when an unknown authority is redirected to the global discovery host
- preserve the custom port on authorization and token endpoints
- update the custom-port regression coverage and shared discovery mock behavior

Fixes #6154

## Testing

- `dotnet build src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj --framework net8.0 --no-restore --verbosity quiet`

## Review follow-up

- Added a direct network-provider test proving a custom port is retained when discovery uses the authority host.
- Local targeted tests were attempted on net8.0 and net48. Execution was blocked by an MSTest adapter get_DataRow implementation error on net8.0 and a missing System.Memory assembly on net48. Cleaning net8.0 outputs and restoring dependencies did not resolve the net8.0 runner error. No passing test result is claimed.

- Added a negative regression test with no custom discovery endpoint supplied to MSAL or the mock helper. For https://localhost:5215/common/, it explicitly asserts the discovery host, port 443, and full endpoint path.
- Re-ran the three targeted custom-port tests on net8.0 and net48; execution remains blocked by the runner errors noted above.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: bug
agent-tool: copilot-cli
agent-model: gpt-6-astra
work-item: AB#n/a
<!-- END pr-telemetry -->