### PR TITLE
Populate telemetry metadata on proactive-refresh results (3707191)

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -323,13 +323,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
         }
 
         /// <summary>
-        /// Copies the telemetry captured on <paramref name="apiEvent"/> onto a successful result's metadata.
-        /// Shared by the foreground path (<see cref="UpdateTelemetry"/>) and the proactive-refresh path in
-        /// <see cref="Microsoft.Identity.Client.Internal.SilentRequestHelper.ProcessFetchInBackground"/>, which
-        /// runs the fetch outside <see cref="RunAsync"/> and would otherwise leave TokenEndpoint / duration /
-        /// cache-refresh reason at their constructor defaults (Bug 3707191). The global
-        /// <see cref="Metrics.IncrementTotalDurationInMs"/> counter is intentionally left to the foreground
-        /// caller so background latency does not inflate the user-facing aggregate.
+        /// Copies telemetry from <paramref name="apiEvent"/> onto a successful result's metadata. Shared by the
+        /// foreground path (<see cref="UpdateTelemetry"/>) and proactive refresh, which runs outside
+        /// <see cref="RunAsync"/> (Bug 3707191). Callers own the <see cref="Metrics.IncrementTotalDurationInMs"/>
+        /// increment so background latency does not inflate the foreground aggregate.
         /// </summary>
         internal static void PopulateSuccessMetadata(
             AuthenticationResultMetadata metadata,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -313,17 +313,39 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         private void UpdateTelemetry(long elapsedMilliseconds, ApiEvent apiEvent, AuthenticationResult authenticationResult)
         {
-            authenticationResult.AuthenticationResultMetadata.DurationTotalInMs = elapsedMilliseconds;
-            authenticationResult.AuthenticationResultMetadata.DurationInHttpInMs = apiEvent.DurationInHttpInMs;
-            authenticationResult.AuthenticationResultMetadata.DurationInCacheInMs = apiEvent.DurationInCacheInMs;
-            authenticationResult.AuthenticationResultMetadata.TokenEndpoint = apiEvent.TokenEndpoint;
-            authenticationResult.AuthenticationResultMetadata.CacheRefreshReason = apiEvent.CacheInfo;
-            authenticationResult.AuthenticationResultMetadata.CacheLevel = GetCacheLevel(authenticationResult);
-            authenticationResult.AuthenticationResultMetadata.Telemetry = apiEvent.MsalRuntimeTelemetry;
-            authenticationResult.AuthenticationResultMetadata.RegionDetails = CreateRegionDetails(apiEvent);
-            authenticationResult.AuthenticationResultMetadata.CachedAccessTokenCount = apiEvent.CachedAccessTokenCount;
+            PopulateSuccessMetadata(
+                authenticationResult.AuthenticationResultMetadata,
+                apiEvent,
+                elapsedMilliseconds,
+                GetCacheLevel(authenticationResult));
 
             Metrics.IncrementTotalDurationInMs(authenticationResult.AuthenticationResultMetadata.DurationTotalInMs);
+        }
+
+        /// <summary>
+        /// Copies the telemetry captured on <paramref name="apiEvent"/> onto a successful result's metadata.
+        /// Shared by the foreground path (<see cref="UpdateTelemetry"/>) and the proactive-refresh path in
+        /// <see cref="Microsoft.Identity.Client.Internal.SilentRequestHelper.ProcessFetchInBackground"/>, which
+        /// runs the fetch outside <see cref="RunAsync"/> and would otherwise leave TokenEndpoint / duration /
+        /// cache-refresh reason at their constructor defaults (Bug 3707191). The global
+        /// <see cref="Metrics.IncrementTotalDurationInMs"/> counter is intentionally left to the foreground
+        /// caller so background latency does not inflate the user-facing aggregate.
+        /// </summary>
+        internal static void PopulateSuccessMetadata(
+            AuthenticationResultMetadata metadata,
+            ApiEvent apiEvent,
+            long totalDurationInMs,
+            CacheLevel cacheLevel)
+        {
+            metadata.DurationTotalInMs = totalDurationInMs;
+            metadata.DurationInHttpInMs = apiEvent.DurationInHttpInMs;
+            metadata.DurationInCacheInMs = apiEvent.DurationInCacheInMs;
+            metadata.TokenEndpoint = apiEvent.TokenEndpoint;
+            metadata.CacheRefreshReason = apiEvent.CacheInfo;
+            metadata.CacheLevel = cacheLevel;
+            metadata.Telemetry = apiEvent.MsalRuntimeTelemetry;
+            metadata.RegionDetails = CreateRegionDetails(apiEvent);
+            metadata.CachedAccessTokenCount = apiEvent.CachedAccessTokenCount;
         }
 
         /// <summary>

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         /// <summary>
         /// Copies telemetry from <paramref name="apiEvent"/> onto a successful result's metadata. Shared by the
         /// foreground path (<see cref="UpdateTelemetry"/>) and proactive refresh, which runs outside
-        /// <see cref="RunAsync"/> (Bug 3707191). Callers own the <see cref="Metrics.IncrementTotalDurationInMs"/>
+        /// <see cref="RunAsync"/>. Callers own the <see cref="Metrics.IncrementTotalDurationInMs"/>
         /// increment so background latency does not inflate the foreground aggregate.
         /// </summary>
         internal static void PopulateSuccessMetadata(

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -102,11 +102,8 @@ namespace Microsoft.Identity.Client.Internal
                     var authResult = await fetchAction().ConfigureAwait(false);
                     stopwatch.Stop();
 
-                    // Proactive refresh runs the fetch outside RequestBase.RunAsync, so the telemetry that
-                    // RunAsync normally copies onto the result (token endpoint, durations, cache-refresh reason)
-                    // is missing. Backfill it from the shared apiEvent - which the background HTTP call has
-                    // populated by now - using this background operation's own elapsed time as the total
-                    // duration. TokenSource is IdentityProvider here, so no cache level applies (Bug 3707191).
+                    // Proactive refresh runs outside RequestBase.RunAsync, so backfill the result's telemetry
+                    // from the shared apiEvent using this operation's own elapsed time (Bug 3707191).
                     RequestBase.PopulateSuccessMetadata(
                         authResult.AuthenticationResultMetadata,
                         apiEvent,

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -97,7 +98,21 @@ namespace Microsoft.Identity.Client.Internal
             {
                 try
                 {
+                    var stopwatch = Stopwatch.StartNew();
                     var authResult = await fetchAction().ConfigureAwait(false);
+                    stopwatch.Stop();
+
+                    // Proactive refresh runs the fetch outside RequestBase.RunAsync, so the telemetry that
+                    // RunAsync normally copies onto the result (token endpoint, durations, cache-refresh reason)
+                    // is missing. Backfill it from the shared apiEvent - which the background HTTP call has
+                    // populated by now - using this background operation's own elapsed time as the total
+                    // duration. TokenSource is IdentityProvider here, so no cache level applies (Bug 3707191).
+                    RequestBase.PopulateSuccessMetadata(
+                        authResult.AuthenticationResultMetadata,
+                        apiEvent,
+                        stopwatch.ElapsedMilliseconds,
+                        Cache.CacheLevel.None);
+
                     var executionResult = new ExecutionResult { Successful = true, Result = authResult };
 
                     // Invoke the enricher once for this background refresh and reuse the materialized

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/SilentRequestHelper.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Identity.Client.Internal
                     stopwatch.Stop();
 
                     // Proactive refresh runs outside RequestBase.RunAsync, so backfill the result's telemetry
-                    // from the shared apiEvent using this operation's own elapsed time (Bug 3707191).
+                    // from the shared apiEvent using this operation's own elapsed time.
                     RequestBase.PopulateSuccessMetadata(
                         authResult.AuthenticationResultMetadata,
                         apiEvent,

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -1039,7 +1039,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(capturedResult.Result);
                 Assert.IsNotNull(capturedResult.Result.AuthenticationResultMetadata);
 
-                // Regression (Bug 3707191): the proactive-refresh result must carry telemetry backfilled from the
+                // The proactive-refresh result must carry telemetry backfilled from the
                 // apiEvent. Managed identity does not flow through TokenClient, so TokenEndpoint stays null even in
                 // the foreground; assert the fields that do apply here.
                 AuthenticationResultMetadata metadata = capturedResult.Result.AuthenticationResultMetadata;

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ManagedIdentityTests.cs
@@ -1038,6 +1038,13 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsTrue(capturedResult.Successful);
                 Assert.IsNotNull(capturedResult.Result);
                 Assert.IsNotNull(capturedResult.Result.AuthenticationResultMetadata);
+
+                // Regression (Bug 3707191): the proactive-refresh result must carry telemetry backfilled from the
+                // apiEvent. Managed identity does not flow through TokenClient, so TokenEndpoint stays null even in
+                // the foreground; assert the fields that do apply here.
+                AuthenticationResultMetadata metadata = capturedResult.Result.AuthenticationResultMetadata;
+                Assert.AreEqual(CacheRefreshReason.ProactivelyRefreshed, metadata.CacheRefreshReason);
+                Assert.AreEqual(TokenSource.IdentityProvider, metadata.TokenSource);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/RefreshInTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/RefreshInTests.cs
@@ -565,6 +565,15 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.IsTrue(capturedResult.Successful);
                 Assert.IsNotNull(capturedResult.Result);
                 Assert.IsNotNull(capturedResult.Result.AuthenticationResultMetadata);
+
+                // Regression (Bug 3707191): proactive refresh runs outside RequestBase.RunAsync, which used to
+                // leave the result's telemetry metadata stripped. The result must now carry the same metadata a
+                // foreground refresh would - populated from the shared apiEvent. Assert the deterministically
+                // populated fields (a sub-millisecond mock round-trip makes DurationTotalInMs an unreliable check).
+                AuthenticationResultMetadata metadata = capturedResult.Result.AuthenticationResultMetadata;
+                Assert.AreEqual(CacheRefreshReason.ProactivelyRefreshed, metadata.CacheRefreshReason);
+                Assert.IsFalse(string.IsNullOrEmpty(metadata.TokenEndpoint), "TokenEndpoint must be populated on a proactive-refresh result.");
+                Assert.AreEqual(TokenSource.IdentityProvider, metadata.TokenSource);
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/RefreshInTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/RefreshInTests.cs
@@ -566,7 +566,7 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.IsNotNull(capturedResult.Result);
                 Assert.IsNotNull(capturedResult.Result.AuthenticationResultMetadata);
 
-                // Regression (Bug 3707191): proactive refresh must carry the same metadata a foreground refresh
+                // The proactive-refresh result must carry the same metadata a foreground refresh
                 // would. Assert the deterministically backfilled fields (DurationTotalInMs is flaky under a
                 // sub-millisecond mock round-trip).
                 AuthenticationResultMetadata metadata = capturedResult.Result.AuthenticationResultMetadata;

--- a/tests/Microsoft.Identity.Test.Unit/PublicApiTests/RefreshInTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/PublicApiTests/RefreshInTests.cs
@@ -566,10 +566,9 @@ namespace Microsoft.Identity.Test.Unit.PublicApiTests
                 Assert.IsNotNull(capturedResult.Result);
                 Assert.IsNotNull(capturedResult.Result.AuthenticationResultMetadata);
 
-                // Regression (Bug 3707191): proactive refresh runs outside RequestBase.RunAsync, which used to
-                // leave the result's telemetry metadata stripped. The result must now carry the same metadata a
-                // foreground refresh would - populated from the shared apiEvent. Assert the deterministically
-                // populated fields (a sub-millisecond mock round-trip makes DurationTotalInMs an unreliable check).
+                // Regression (Bug 3707191): proactive refresh must carry the same metadata a foreground refresh
+                // would. Assert the deterministically backfilled fields (DurationTotalInMs is flaky under a
+                // sub-millisecond mock round-trip).
                 AuthenticationResultMetadata metadata = capturedResult.Result.AuthenticationResultMetadata;
                 Assert.AreEqual(CacheRefreshReason.ProactivelyRefreshed, metadata.CacheRefreshReason);
                 Assert.IsFalse(string.IsNullOrEmpty(metadata.TokenEndpoint), "TokenEndpoint must be populated on a proactive-refresh result.");


### PR DESCRIPTION
## Summary
Proactive (background) token refresh produced `AuthenticationResult`s with stripped telemetry metadata. Fixes AB#3707191.

The proactive-refresh path (`SilentRequestHelper.ProcessFetchInBackground`) runs the fetch **outside** `RequestBase.RunAsync`, so the `AuthenticationResultMetadata` that `RunAsync` -> `UpdateTelemetry` normally fills in was left at its constructor defaults:
- `TokenEndpoint` was `null`
- `DurationTotalInMs` was always `0`
- `DurationInHttpInMs`, `CacheRefreshReason`, `RegionDetails`, `CacheLevel`, `CachedAccessTokenCount` were also unset

Affected consumers:
1. The `OnBackgroundTokenRefreshCompleted` callback (`ExecutionResult.Result`).
2. The `LogSuccessHttpDuration` OTel emission inside `ProcessFetchInBackground`, which recorded `DurationInHttpInMs == 0` for every proactive refresh.

Note: the *token* is cached, not the `AuthenticationResult`, so a later foreground read still rebuilds correct metadata via `RunAsync`. The bug affects the background result object specifically.

## Fix
- Extract the metadata-population core of `UpdateTelemetry` into a shared `internal static RequestBase.PopulateSuccessMetadata`.
- Call it from the background success path, backfilling from the shared `apiEvent` (whose HTTP fields the background call populates) and using the background operation's **own** elapsed time as `DurationTotalInMs`.
- This mirrors the existing failure-path treatment (`CreateFailureMetadata`) and avoids a third divergent field-copy.
- Foreground behavior is unchanged: `GetCacheLevel` and the global `Metrics.IncrementTotalDurationInMs` increment stay on the foreground path only, so background latency does not inflate the user-facing aggregate.

### Why background duration (not the parent request's)?
`DurationTotalInMs` means "time to produce *this* result." The parent request returned a cached token in ~0ms; stamping that onto the background result would re-introduce the ~0 symptom and make `Total < Http` (since `apiEvent.DurationInHttpInMs` is overwritten by the background call) - internally inconsistent.

## Tests
- Strengthened `ClientCredentials_BackgroundRefresh_Success_InvokesCallback_Async` to assert the result carries populated metadata (`CacheRefreshReason == ProactivelyRefreshed`, non-empty `TokenEndpoint`, `TokenSource == IdentityProvider`).
- Verified the strengthened assertions **fail** against the pre-fix implementation (regression proof).
- `RefreshInTests` (13 passed) and `TelemetryTests` (28 passed) green on net8.0.

`DurationTotalInMs > 0` is intentionally not asserted - a sub-millisecond in-memory mock round-trip makes it flaky. The deterministic backfilled fields prove the fix.