### PR TITLE
Scope error-class throttling per-user for public-client flows

### DIFF
--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/HttpStatusProvider.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/HttpStatusProvider.cs
@@ -40,9 +40,19 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
                 logger.Info(() => $"[Throttling] HTTP status code {ex.StatusCode} encountered - " +
                     $"throttling for {s_throttleDuration.TotalSeconds} seconds. ");
 
-                var thumbprint = ThrottleCommon.GetRequestStrictThumbprint(bodyParams,
-                    requestParams.AuthorityInfo.CanonicalAuthority.ToString(),
-                    requestParams.Account?.HomeAccountId?.Identifier);
+                string authority = requestParams.AuthorityInfo.CanonicalAuthority.ToString();
+                string homeAccountId = requestParams.Account?.HomeAccountId?.Identifier;
+
+                // HTTP 5xx is a server/credential error that can be specific to a single user
+                // (e.g. a federated STS returning HTTP 500 for one user's bad password). Key it
+                // per-user so it does not throttle other users.
+                // HTTP 429 is service-directed rate limiting for the whole application, so it keeps
+                // the app-wide strict thumbprint.
+                bool isServerError = ex.StatusCode >= 500 && ex.StatusCode < 600;
+                var thumbprint = isServerError
+                    ? ThrottleCommon.GetRequestUserAwareThumbprint(bodyParams, authority, homeAccountId)
+                    : ThrottleCommon.GetRequestStrictThumbprint(bodyParams, authority, homeAccountId);
+
                 var entry = new ThrottlingCacheEntry(ex, s_throttleDuration);
                 ThrottlingCache.AddAndCleanup(thumbprint, entry, logger);
             }
@@ -60,12 +70,28 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
             {
                 var logger = requestParams.RequestContext.Logger;
 
-                string strictThumbprint = ThrottleCommon.GetRequestStrictThumbprint(
-                    bodyParams,
-                    requestParams.AuthorityInfo.CanonicalAuthority.ToString(),
-                    requestParams.Account?.HomeAccountId?.Identifier);
+                string authority = requestParams.AuthorityInfo.CanonicalAuthority.ToString();
+                string homeAccountId = requestParams.Account?.HomeAccountId?.Identifier;
 
-                ThrottleCommon.TryThrowServiceException(strictThumbprint, ThrottlingCache, logger, nameof(HttpStatusProvider));
+                // App-wide key catches service-directed 429 throttles.
+                string appWideThumbprint = ThrottleCommon.GetRequestStrictThumbprint(
+                    bodyParams,
+                    authority,
+                    homeAccountId);
+
+                ThrottleCommon.TryThrowServiceException(appWideThumbprint, ThrottlingCache, logger, nameof(HttpStatusProvider));
+
+                // Per-user key catches error-class (5xx) throttles so one user does not block another.
+                // Only check it when it actually differs from the app-wide key (i.e. there is a user component).
+                string userAwareThumbprint = ThrottleCommon.GetRequestUserAwareThumbprint(
+                    bodyParams,
+                    authority,
+                    homeAccountId);
+
+                if (!string.Equals(userAwareThumbprint, appWideThumbprint, System.StringComparison.Ordinal))
+                {
+                    ThrottleCommon.TryThrowServiceException(userAwareThumbprint, ThrottlingCache, logger, nameof(HttpStatusProvider));
+                }
             }
         }
 

--- a/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
+++ b/src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs
@@ -48,6 +48,40 @@ namespace Microsoft.Identity.Client.OAuth2.Throttling
             return sb.ToString();
         }
 
+        /// <summary>
+        /// A user-aware variant of the strict thumbprint. It behaves exactly like
+        /// <see cref="GetRequestStrictThumbprint"/> but, when no account (homeAccountId) is available
+        /// (e.g. ROPC / username-password before an account exists), it falls back to a user
+        /// discriminator taken from the request body (username, then login_hint).
+        /// This is used for error-class throttling (HTTP 5xx) so that one user's failure does not
+        /// throttle a different user that shares the same clientId/authority/scope.
+        /// Service-directed throttling (HTTP 429 / Retry-After) intentionally keeps using the
+        /// app-wide <see cref="GetRequestStrictThumbprint"/> instead.
+        /// </summary>
+        public static string GetRequestUserAwareThumbprint(
+            IReadOnlyDictionary<string, string> bodyParams,
+            string authority,
+            string homeAccountId)
+        {
+            string userComponent = homeAccountId;
+
+            if (string.IsNullOrEmpty(userComponent) &&
+                bodyParams.TryGetValue(OAuth2Parameter.Username, out string username) &&
+                !string.IsNullOrEmpty(username))
+            {
+                userComponent = username;
+            }
+
+            if (string.IsNullOrEmpty(userComponent) &&
+                bodyParams.TryGetValue(OAuth2Parameter.LoginHint, out string loginHint) &&
+                !string.IsNullOrEmpty(loginHint))
+            {
+                userComponent = loginHint;
+            }
+
+            return GetRequestStrictThumbprint(bodyParams, authority, userComponent);
+        }
+
         public static void TryThrowServiceException(string thumbprint, ThrottlingCache cache, ILoggerAdapter logger, string providerName)
         {
             if (cache.TryGetOrRemoveExpired(thumbprint, logger, out var ex))

--- a/tests/Microsoft.Identity.Test.Unit/Throttling/ThrottlingAcceptanceTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/Throttling/ThrottlingAcceptanceTests.cs
@@ -465,6 +465,180 @@ namespace Microsoft.Identity.Test.Unit.Throttling
         }
         #endregion
 
+        #region Cross-user (app-wide) throttling fix
+
+        /// <summary>
+        /// Verifies that error-class (HTTP 5xx) throttling is scoped per-user.
+        ///
+        /// With ROPC (username/password) the account is not known before the token request. The
+        /// <see cref="HttpStatusProvider"/> keys HTTP 5xx (error-class) throttles per-user, so a
+        /// 5xx failure for one user does NOT throttle a different user that shares the same
+        /// clientId/authority/scope. The failing user itself remains throttled.
+        /// </summary>
+        [TestMethod]
+        public async Task RopcHttp500_DoesNotThrottleDifferentUser_Async()
+        {
+            using (var httpManagerAndBundle = new MockHttpAndServiceBundle())
+            {
+                var httpManager = httpManagerAndBundle.HttpManager;
+
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                    .WithHttpManager(httpManager)
+                    .BuildConcrete();
+
+                // Arrange - user A's ROPC call fails with HTTP 500 (a per-user failure surfaced as 5xx).
+                httpManager.AddInstanceDiscoveryMockHandler();
+                AddManagedUserRealmMockHandler(httpManager);
+                // MSAL retries 5xx once, so two identical 500 token responses are consumed.
+                Add500TokenResponse(httpManager);
+                Add500TokenResponse(httpManager);
+
+                // Act - user A
+#pragma warning disable CS0618 // AcquireTokenByUsernamePassword is obsolete
+                var exA = await AssertException.TaskThrowsAsync<MsalServiceException>(
+                    () => app.AcquireTokenByUsernamePassword(TestConstants.s_scope, "userA@id.com", "passwordA")
+                             .ExecuteAsync(),
+                    allowDerived: true).ConfigureAwait(false);
+#pragma warning restore CS0618
+                Assert.AreEqual(500, exA.StatusCode);
+
+                var throttlingManager = (SingletonThrottlingManager)httpManagerAndBundle.ServiceBundle.ThrottlingManager;
+                AssertThrottlingCacheEntryCount(throttlingManager, httpStatusEntryCount: 1);
+
+                // Act - user B: a DIFFERENT user, same clientId/authority/scope. With the fix the 5xx
+                // throttle entry is keyed per-user, so user B is NOT throttled and gets a real token.
+                AddManagedUserRealmMockHandler(httpManager);
+                AddSuccessTokenResponse(httpManager);
+#pragma warning disable CS0618 // AcquireTokenByUsernamePassword is obsolete
+                var resultB = await app.AcquireTokenByUsernamePassword(TestConstants.s_scope, "userB@id.com", "passwordB")
+                                       .ExecuteAsync().ConfigureAwait(false);
+#pragma warning restore CS0618
+
+                // Assert - user B succeeded (not throttled by user A's failure).
+                Assert.IsNotNull(resultB);
+                Assert.AreEqual("some-access-token", resultB.AccessToken);
+
+                // And the originally-failing user A is still throttled (per-user throttle preserved).
+                AddManagedUserRealmMockHandler(httpManager);
+#pragma warning disable CS0618 // AcquireTokenByUsernamePassword is obsolete
+                var exAAgain = await AssertException.TaskThrowsAsync<MsalThrottledServiceException>(
+                    () => app.AcquireTokenByUsernamePassword(TestConstants.s_scope, "userA@id.com", "passwordA")
+                             .ExecuteAsync()).ConfigureAwait(false);
+#pragma warning restore CS0618
+                Assert.AreEqual(500, exAAgain.StatusCode);
+                Assert.AreEqual(0, httpManager.QueueSize,
+                    "User A should be throttled before its token request, so no token mock is consumed.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies the response-type-aware part of the fix: HTTP 429 (service-directed rate limiting)
+        /// still throttles app-wide, so a 429 for one user DOES throttle a different user. Only
+        /// error-class 5xx throttling is scoped per-user (see
+        /// <see cref="RopcHttp500_DoesNotThrottleDifferentUser_Async"/>).
+        /// </summary>
+        [TestMethod]
+        public async Task RopcHttp429_StillThrottlesDifferentUser_AppWide_Async()
+        {
+            using (var httpManagerAndBundle = new MockHttpAndServiceBundle())
+            {
+                var httpManager = httpManagerAndBundle.HttpManager;
+
+                PublicClientApplication app = PublicClientApplicationBuilder.Create(TestConstants.ClientId)
+                    .WithAuthority(AadAuthorityAudience.AzureAdMultipleOrgs)
+                    .WithHttpManager(httpManager)
+                    .BuildConcrete();
+
+                // Arrange - user A's ROPC call fails with HTTP 429 (no Retry-After). 429 is not retried.
+                httpManager.AddInstanceDiscoveryMockHandler();
+                AddManagedUserRealmMockHandler(httpManager);
+                Add429TokenResponse(httpManager);
+
+                // Act - user A
+#pragma warning disable CS0618 // AcquireTokenByUsernamePassword is obsolete
+                var exA = await AssertException.TaskThrowsAsync<MsalServiceException>(
+                    () => app.AcquireTokenByUsernamePassword(TestConstants.s_scope, "userA@id.com", "passwordA")
+                             .ExecuteAsync(),
+                    allowDerived: true).ConfigureAwait(false);
+#pragma warning restore CS0618
+                Assert.AreEqual(429, exA.StatusCode);
+
+                var throttlingManager = (SingletonThrottlingManager)httpManagerAndBundle.ServiceBundle.ThrottlingManager;
+                AssertThrottlingCacheEntryCount(throttlingManager, httpStatusEntryCount: 1);
+
+                // Act - user B: 429 is app-wide, so a DIFFERENT user IS throttled (service-directed back-off preserved).
+                AddManagedUserRealmMockHandler(httpManager);
+#pragma warning disable CS0618 // AcquireTokenByUsernamePassword is obsolete
+                var exB = await AssertException.TaskThrowsAsync<MsalThrottledServiceException>(
+                    () => app.AcquireTokenByUsernamePassword(TestConstants.s_scope, "userB@id.com", "passwordB")
+                             .ExecuteAsync()).ConfigureAwait(false);
+#pragma warning restore CS0618
+
+                Assert.AreEqual(429, exB.StatusCode);
+                Assert.AreEqual(0, httpManager.QueueSize,
+                    "User B should be throttled before its token request, so no token mock is consumed.");
+            }
+        }
+
+        private static void AddManagedUserRealmMockHandler(MockHttpManager httpManager)
+        {
+            httpManager.AddMockHandler(
+                new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Get,
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            "{\"ver\":\"1.0\",\"account_type\":\"Managed\",\"domain_name\":\"id.com\"}")
+                    },
+                    ExpectedQueryParams = new Dictionary<string, string>
+                    {
+                        { "api-version", "1.0" }
+                    }
+                });
+        }
+
+        private static void Add500TokenResponse(MockHttpManager httpManager)
+        {
+            httpManager.AddMockHandler(
+                new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Post,
+                    ResponseMessage = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    {
+                        Content = new StringContent(
+                            "{\"error\":\"temporarily_unavailable\",\"error_description\":\"server error\"}")
+                    }
+                });
+        }
+
+        private static void Add429TokenResponse(MockHttpManager httpManager)
+        {
+            httpManager.AddMockHandler(
+                new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Post,
+                    ResponseMessage = new HttpResponseMessage((HttpStatusCode)429)
+                    {
+                        Content = new StringContent(
+                            "{\"error\":\"temporarily_unavailable\",\"error_description\":\"too many requests\"}")
+                    }
+                });
+        }
+
+        private static void AddSuccessTokenResponse(MockHttpManager httpManager)
+        {
+            httpManager.AddMockHandler(
+                new MockHttpMessageHandler
+                {
+                    ExpectedMethod = HttpMethod.Post,
+                    ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage()
+                });
+        }
+
+        #endregion
+
         private async Task<PublicClientApplication> SetupAndAcquireOnceAsync(
             MockHttpAndServiceBundle httpManagerAndBundle,
             int httpStatusCode,


### PR DESCRIPTION
Fixes an issue discovered in MSAL Java [#1019](https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/1019) which appears to also exist in MSAL .NET.

See:
https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1055
https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/8756

## Problem

MSAL .NET's `HttpStatusProvider` throttles requests using a "strict thumbprint" (`ThrottleCommon.GetRequestStrictThumbprint`) = **clientId + authority + scope + homeAccountId**. For the Username/Password (ROPC) flow there is no `Account` yet, so `homeAccountId` is null and the key collapses to **clientId + authority + scope** — no user component.

Consequently, when multiple users acquire tokens under the same app: a **HTTP 5xx** cached for user A (e.g. a single user's bad password against ADFS) throttles **every** other user of the app.

Unlike MSAL Java this was only a latent bug in .NET, as ROPC never populates a user component in the key.

## Fix

Make throttling **response-type-aware** so error-class (5xx) throttling is scoped to the individual user, while service-directed rate limiting (429 / `Retry-After`) stays app-wide.

- `ThrottleCommon.GetRequestUserAwareThumbprint(...)` (new): same as the strict thumbprint but, when no `homeAccountId` is available, falls back to a user discriminator from the request body — `username` (ROPC), then `login_hint`.
- `HttpStatusProvider.RecordException`: HTTP **5xx** → recorded under the **user-aware** key; HTTP **429** → recorded under the **app-wide** strict key (unchanged).
- `HttpStatusProvider.TryThrottle`: checks **both** the app-wide key and, when it differs, the user-aware key.
- `RetryAfterProvider` and `UiRequiredProvider` are unchanged (correctly app-wide / silent-only respectively).

### Files changed

- `src/client/Microsoft.Identity.Client/OAuth2/Throttling/ThrottleCommon.cs`
- `src/client/Microsoft.Identity.Client/OAuth2/Throttling/HttpStatusProvider.cs`

## Behavior change

| Trigger | Before | After |
| --- | --- | --- |
| HTTP 5xx on ROPC (e.g. bad password) | Throttles the whole client (all users) | Throttles **only that user** |
| HTTP 429 | App-wide | App-wide (unchanged) |
| Explicit `Retry-After` | App-wide | App-wide (unchanged) |
| Flows with a real `Account` (silent, etc.) | Keyed by `homeAccountId` | Keyed by `homeAccountId` (unchanged) |

## Tests

`tests/Microsoft.Identity.Test.Unit/Throttling/ThrottlingAcceptanceTests.cs`:

- `Issue1019Fix_RopcHttp500_DoesNotThrottleDifferentUser_Async` — user A's 500 throttles A, but user B still gets a real token; A remains throttled.
- `Issue1019Fix_RopcHttp429_StillThrottlesDifferentUser_AppWide_Async` — user A's 429 also throttles user B (429 stays app-wide).