### PR TITLE
Add SNI mTLS E2E coverage for a non-exportable VBS-protected certificate

### DIFF
--- a/LibsAndSamples.sln
+++ b/LibsAndSamples.sln
@@ -194,6 +194,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Lab.Api"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Test.Common", "tests\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj", "{F484DC37-BB44-45B5-A78E-06819D261F53}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Identity.Test.E2E.SniMtls", "tests\Microsoft.Identity.Test.E2E.SniMtls\Microsoft.Identity.Test.E2E.SniMtls.csproj", "{57978D96-8F61-45EC-A406-8407160B9E50}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug + MobileApps|Any CPU = Debug + MobileApps|Any CPU
@@ -1988,6 +1990,48 @@ Global
 		{F484DC37-BB44-45B5-A78E-06819D261F53}.Release|x64.Build.0 = Release|Any CPU
 		{F484DC37-BB44-45B5-A78E-06819D261F53}.Release|x86.ActiveCfg = Release|Any CPU
 		{F484DC37-BB44-45B5-A78E-06819D261F53}.Release|x86.Build.0 = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|Any CPU.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|Any CPU.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|ARM.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|ARM.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|ARM64.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|ARM64.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|iPhone.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|iPhone.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|x64.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|x64.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|x86.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug + MobileApps|x86.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|ARM.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|x64.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Debug|x86.Build.0 = Debug|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|ARM.ActiveCfg = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|ARM.Build.0 = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|ARM64.Build.0 = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|iPhone.Build.0 = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|x64.ActiveCfg = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|x64.Build.0 = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|x86.ActiveCfg = Release|Any CPU
+		{57978D96-8F61-45EC-A406-8407160B9E50}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2046,6 +2090,7 @@ Global
 		{425EAEBE-595F-0037-6FDC-2D08D5184705} = {1A37FD75-94E9-4D6F-953A-0DABBD7B49E9}
 		{5EC9968E-2CB0-0CBB-6FBA-CBEEBB26FCEA} = {9B0B5396-4D95-4C15-82ED-DC22B5A3123F}
 		{F484DC37-BB44-45B5-A78E-06819D261F53} = {9B0B5396-4D95-4C15-82ED-DC22B5A3123F}
+		{57978D96-8F61-45EC-A406-8407160B9E50} = {9B0B5396-4D95-4C15-82ED-DC22B5A3123F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {020399A9-DC27-4B82-9CAA-EF488665AC27}

--- a/build/template-build-and-run-all-tests.yaml
+++ b/build/template-build-and-run-all-tests.yaml
@@ -341,7 +341,27 @@ stages:
         TargetFramework:   'net8.0'
 
 # ──────────────────────────────────────────────
-# Stage 12 — Deploy & Test Managed Identity WebApp (Easy Auth)
+# Stage 12 — SNI mTLS E2E – non-exportable VBS key
+# ──────────────────────────────────────────────
+- stage: SniMtlsE2E
+  displayName: 'SNI mTLS E2E – Non-exportable VBS key'
+  dependsOn: [] # Builds from source — no dependency on Build stage
+  jobs:
+
+  - job: 'RunSniMtlsE2EWithNonExportableVbsKey'
+    displayName: 'SNI mTLS E2E – Non-exportable VBS key'
+    pool:
+      name: 'MISEManagedIdentity'
+    condition: and(succeeded(), eq(variables['RunSniMtlsE2EVmTests'], 'true'))
+
+    steps:
+    - template: template-run-sni-mtls-e2e.yaml
+      parameters:
+        BuildConfiguration: 'Release'
+        TargetFramework: 'net8.0'
+
+# ──────────────────────────────────────────────
+# Stage 13 — Deploy & Test Managed Identity WebApp (Easy Auth)
 # ──────────────────────────────────────────────
 - stage: DeployAndTestManagedIdentityWebApp
   displayName: 'Deploy & Test MI WebApp (Easy Auth)'

--- a/build/template-run-sni-mtls-e2e.yaml
+++ b/build/template-run-sni-mtls-e2e.yaml
@@ -1,0 +1,71 @@
+parameters:
+  BuildConfiguration: 'Release'
+  TargetFramework: 'net8.0'
+
+steps:
+
+- task: UseDotNet@2
+  displayName: 'Install .NET SDK 8.0.418'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.418'
+    includePreviewVersions: false
+    performMultiLevelLookup: true
+
+- task: DotNetCoreCLI@2
+  displayName: Restore SNI mTLS E2E project
+  inputs:
+    command: restore
+    projects: tests/Microsoft.Identity.Test.E2E.SniMtls/Microsoft.Identity.Test.E2E.SniMtls.csproj
+    restoreArguments: >
+      /p:RestoreTargetFrameworks=${{ parameters.TargetFramework }}
+      /p:INCLUDE_MOBILE_AND_LEGACY_TFM=
+- task: DotNetCoreCLI@2
+  displayName: Build SNI mTLS E2E project
+  inputs:
+    command: build
+    projects: tests/Microsoft.Identity.Test.E2E.SniMtls/Microsoft.Identity.Test.E2E.SniMtls.csproj
+    arguments: >
+      --configuration ${{ parameters.BuildConfiguration }}
+      --framework ${{ parameters.TargetFramework }}
+      /p:INCLUDE_MOBILE_AND_LEGACY_TFM=
+
+- task: PowerShell@2
+  displayName: Check SNI certificate expiration
+  inputs:
+    targetType: inline
+    script: |
+      $warningDays = 60
+      $certificate = Get-ChildItem -Path Cert:\LocalMachine\My |
+        Where-Object {
+          $_.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false) -eq 'LabAuth.MSIDLab.com' -and
+          $_.HasPrivateKey
+        } |
+        Sort-Object -Property NotBefore -Descending |
+        Select-Object -First 1
+
+      if ($null -eq $certificate) {
+        Write-Host "##vso[task.logissue type=warning]SNI certificate CN=LabAuth.MSIDLab.com was not found in LocalMachine\My."
+        return
+      }
+
+      $daysRemaining = [Math]::Floor(
+        ($certificate.NotAfter.ToUniversalTime() - [DateTime]::UtcNow).TotalDays)
+
+      if ($daysRemaining -le $warningDays) {
+        Write-Host "##vso[task.logissue type=warning]SNI certificate CN=LabAuth.MSIDLab.com expires in $daysRemaining day(s) on $($certificate.NotAfter.ToUniversalTime().ToString('u')). Rotate it within the 60-day window."
+      }
+
+- task: VSTest@2
+  displayName: Run SNI mTLS E2E test with non-exportable VBS key
+  inputs:
+    testSelector: testAssemblies
+    testAssemblyVer2: '**/Microsoft.Identity.Test.E2E.SniMtls/bin/${{ parameters.BuildConfiguration }}/**/Microsoft.Identity.Test.E2E.SniMtls.dll'
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    runTestsInIsolation: true
+    rerunFailedTests: true
+    rerunMaxAttempts: '3'
+    runInParallel: false
+    failOnMinTestsNotRun: true
+    minimumExpectedTests: '2'
+    testFiltercriteria: 'TestCategory=SNI_MTLS_E2E_NonExportableVbs'

--- a/src/client/Microsoft.Identity.Client/Properties/InternalsVisibleTo.cs
+++ b/src/client/Microsoft.Identity.Client/Properties/InternalsVisibleTo.cs
@@ -16,6 +16,7 @@ using Microsoft.Identity.Client;
 [assembly: InternalsVisibleTo("Microsoft.Identity.Test.Integration.NetFx" + KeyTokens.MSAL)]
 [assembly: InternalsVisibleTo("Microsoft.Identity.Test.Performance" + KeyTokens.MSAL)]
 [assembly: InternalsVisibleTo("Microsoft.Identity.Test.E2E.MSI" + KeyTokens.MSAL)]
+[assembly: InternalsVisibleTo("Microsoft.Identity.Test.E2E.SniMtls" + KeyTokens.MSAL)]
 
 [assembly: InternalsVisibleTo("CommonCache.Test.Common" + KeyTokens.MSAL)]
 [assembly: InternalsVisibleTo("CommonCache.Test.Unit" + KeyTokens.MSAL)]

--- a/tests/Microsoft.Identity.Test.E2E.SniMtls/AssemblyAttributes.cs
+++ b/tests/Microsoft.Identity.Test.E2E.SniMtls/AssemblyAttributes.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: DoNotParallelize]

--- a/tests/Microsoft.Identity.Test.E2E.SniMtls/Microsoft.Identity.Test.E2E.SniMtls.csproj
+++ b/tests/Microsoft.Identity.Test.E2E.SniMtls/Microsoft.Identity.Test.E2E.SniMtls.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Configurations>Debug;Release</Configurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\client\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
+    <ProjectReference Include="..\Microsoft.Identity.Test.Common\Microsoft.Identity.Test.Common.csproj" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Microsoft.Identity.Test.E2E.SniMtls/SniMtlsPopTests.cs
+++ b/tests/Microsoft.Identity.Test.E2E.SniMtls/SniMtlsPopTests.cs
@@ -1,0 +1,250 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.ManagedIdentity.KeyProviders;
+using Microsoft.Identity.Test.Common.Core.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Test.E2E.SniMtls
+{
+    [TestClass]
+    public class SniMtlsPopTests
+    {
+        private const string SniClientId = "163ffef9-a313-45b4-ab2f-c7e2f5e0e23e";
+        private const string SniAuthority = "https://login.microsoftonline.com/bea21ebe-8b64-4d06-9f6d-6a889b120a7c";
+        private const string SniCertificateSubjectName = "LabAuth.MSIDLab.com";
+        private const string GraphScope = "https://graph.microsoft.com/.default";
+        private const string GraphMtlsEndpoint = "https://mtlstb.graph.microsoft.com/v1.0/applications?$top=1";
+
+        [RunOnAzureDevOps]
+        [TestCategory("SNI_MTLS_E2E_NonExportableVbs")]
+        [TestMethod]
+        public async Task SniMtlsPop_WithNonExportableVbsKey_CallsGraphSuccessfully()
+        {
+            // Arrange
+            using X509Certificate2 certificate = FindLocalMachineCertificate(SniCertificateSubjectName);
+            ValidateNonExportableVbsKey(certificate);
+
+            // Act
+            (IConfidentialClientApplication confidentialApp, AuthenticationResult result) =
+                await AcquireMtlsPopTokenAsync(certificate).ConfigureAwait(false);
+            GraphResponse graphResponse = await CallGraphAsync(result, certificate).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(
+                HttpStatusCode.OK,
+                graphResponse.StatusCode,
+                "Graph mTLS request should succeed when the binding certificate is presented.");
+
+            AuthenticationResult cachedResult = await confidentialApp
+                .AcquireTokenForClient(new[] { GraphScope })
+                .WithMtlsProofOfPossession()
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+            Assert.AreEqual(TokenSource.Cache, cachedResult.AuthenticationResultMetadata.TokenSource);
+            Assert.AreEqual(result.AccessToken, cachedResult.AccessToken);
+            Assert.IsNotNull(cachedResult.BindingCertificate, "Cached result should preserve the binding certificate.");
+            CollectionAssert.AreEqual(
+                certificate.RawData,
+                cachedResult.BindingCertificate.RawData,
+                "Cached result must remain bound to the non-exportable SNI certificate.");
+        }
+
+        [RunOnAzureDevOps]
+        [TestCategory("SNI_MTLS_E2E_NonExportableVbs")]
+        [TestMethod]
+        public async Task SniMtlsPop_WithoutBindingCertificate_IsRejectedByGraph()
+        {
+            // Arrange
+            using X509Certificate2 certificate = FindLocalMachineCertificate(SniCertificateSubjectName);
+            ValidateNonExportableVbsKey(certificate);
+            (_, AuthenticationResult result) = await AcquireMtlsPopTokenAsync(certificate).ConfigureAwait(false);
+
+            // Act
+            GraphResponse graphResponse = await CallGraphAsync(result, certificate: null).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(
+                HttpStatusCode.Unauthorized,
+                graphResponse.StatusCode,
+                "Graph should reject an mTLS PoP token when the binding certificate is not presented.");
+            Assert.IsTrue(
+                graphResponse.WwwAuthenticateChallenges.Any(),
+                "Graph should return a WWW-Authenticate challenge.");
+
+            using JsonDocument responseJson = JsonDocument.Parse(graphResponse.ResponseBody);
+            JsonElement error = responseJson.RootElement.GetProperty("error");
+            Assert.AreEqual("InvalidAuthenticationToken", error.GetProperty("code").GetString());
+            Assert.AreEqual("MtlsMissingClientCertificate", error.GetProperty("message").GetString());
+        }
+
+        private static async Task<(IConfidentialClientApplication Application, AuthenticationResult Result)> AcquireMtlsPopTokenAsync(
+            X509Certificate2 certificate)
+        {
+            IConfidentialClientApplication confidentialApp = ConfidentialClientApplicationBuilder
+                .Create(SniClientId)
+                .WithAuthority(SniAuthority)
+                .WithCertificate(certificate, sendX5C: true)
+                .Build();
+
+            AuthenticationResult result = await confidentialApp
+                .AcquireTokenForClient(new[] { GraphScope })
+                .WithMtlsProofOfPossession()
+                .ExecuteAsync()
+                .ConfigureAwait(false);
+
+            Assert.IsFalse(string.IsNullOrEmpty(result.AccessToken), "Access token should not be empty.");
+            Assert.AreEqual("mtls_pop", result.TokenType, "Token type should be mTLS PoP.");
+            Assert.IsNotNull(result.BindingCertificate, "Binding certificate should be returned for mTLS PoP.");
+            CollectionAssert.AreEqual(
+                certificate.RawData,
+                result.BindingCertificate.RawData,
+                "Binding certificate must match the non-exportable SNI certificate.");
+            ValidateMtlsPopBinding(result.AccessToken, certificate);
+            Assert.AreEqual(
+                TokenSource.IdentityProvider,
+                result.AuthenticationResultMetadata.TokenSource,
+                "First acquisition must use the identity provider.");
+
+            return (confidentialApp, result);
+        }
+
+        private static X509Certificate2 FindLocalMachineCertificate(string subjectName)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Inconclusive("The SNI mTLS E2E tests require a Windows certificate store and CNG KeyGuard.");
+            }
+
+            using var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+            store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
+
+            DateTime now = DateTime.Now;
+            X509Certificate2 certificate = store.Certificates
+                .OfType<X509Certificate2>()
+                .Where(candidate =>
+                    candidate.HasPrivateKey &&
+                    string.Equals(
+                        candidate.GetNameInfo(X509NameType.SimpleName, forIssuer: false),
+                        subjectName,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    candidate.NotBefore <= now &&
+                    now <= candidate.NotAfter)
+                .OrderByDescending(candidate => candidate.NotBefore)
+                .FirstOrDefault();
+
+            Assert.IsNotNull(
+                certificate,
+                $"A currently valid certificate with simple name '{subjectName}' and an accessible private key must exist in LocalMachine\\My.");
+
+            return certificate;
+        }
+
+        private static void ValidateNonExportableVbsKey(X509Certificate2 certificate)
+        {
+            Assert.IsTrue(certificate.HasPrivateKey, "Certificate must have an accessible private key.");
+
+            RSA rsa = certificate.GetRSAPrivateKey();
+            Assert.IsNotNull(rsa, "Certificate must have an RSA private key.");
+            Assert.IsInstanceOfType<RSACng>(rsa, "Certificate private key must use CNG.");
+
+            var rsaCng = (RSACng)rsa;
+
+            Assert.AreEqual(
+                CngExportPolicies.None,
+                rsaCng.Key.ExportPolicy,
+                "Certificate private key must be non-exportable.");
+
+            Assert.IsTrue(
+                WindowsCngKeyOperations.IsKeyGuardProtected(rsaCng.Key),
+                "Certificate private key must be protected by VBS virtual isolation.");
+        }
+
+        private static async Task<GraphResponse> CallGraphAsync(
+            AuthenticationResult result,
+            X509Certificate2 certificate)
+        {
+            var handler = new HttpClientHandler
+            {
+                ClientCertificateOptions = ClientCertificateOption.Manual
+            };
+
+            if (certificate is not null)
+            {
+                handler.ClientCertificates.Add(certificate);
+            }
+
+            using var httpClient = new HttpClient(handler);
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue(result.TokenType, result.AccessToken);
+
+            using HttpResponseMessage response = await httpClient
+                .GetAsync(new Uri(GraphMtlsEndpoint))
+                .ConfigureAwait(false);
+
+            string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            string[] challenges = response.Headers.WwwAuthenticate
+                .Select(challenge => challenge.ToString())
+                .ToArray();
+
+            return new GraphResponse(response.StatusCode, responseContent, challenges);
+        }
+
+        private static void ValidateMtlsPopBinding(string accessToken, X509Certificate2 certificate)
+        {
+            var handler = new JwtSecurityTokenHandler();
+            JwtSecurityToken jwtToken = handler.ReadJwtToken(accessToken);
+            var cnfClaim = jwtToken.Claims.FirstOrDefault(claim => claim.Type == "cnf");
+            Assert.IsNotNull(cnfClaim, "Access token should contain a cnf claim.");
+
+            using JsonDocument cnfJson = JsonDocument.Parse(cnfClaim.Value);
+            Assert.IsTrue(
+                cnfJson.RootElement.TryGetProperty("x5t#S256", out JsonElement thumbprintElement),
+                "cnf claim should contain x5t#S256.");
+
+            string tokenThumbprint = thumbprintElement.GetString();
+            Assert.IsFalse(string.IsNullOrEmpty(tokenThumbprint), "x5t#S256 should not be empty.");
+
+            byte[] certificateHash = SHA256.HashData(certificate.RawData);
+            string expectedThumbprint = Convert.ToBase64String(certificateHash)
+                .Replace('+', '-')
+                .Replace('/', '_')
+                .TrimEnd('=');
+
+            Assert.AreEqual(
+                expectedThumbprint,
+                tokenThumbprint,
+                "Token x5t#S256 must match the supplied SNI certificate.");
+        }
+
+        private sealed class GraphResponse
+        {
+            public GraphResponse(
+                HttpStatusCode statusCode,
+                string responseBody,
+                string[] wwwAuthenticateChallenges)
+            {
+                StatusCode = statusCode;
+                ResponseBody = responseBody;
+                WwwAuthenticateChallenges = wwwAuthenticateChallenges;
+            }
+
+            public HttpStatusCode StatusCode { get; }
+
+            public string ResponseBody { get; }
+
+            public string[] WwwAuthenticateChallenges { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds dedicated end-to-end coverage for confidential-client SNI authentication and mTLS proof-of-possession using a non-exportable, VBS/KeyGuard-protected certificate installed on a Windows VM agent.

This is not a managed identity scenario. It uses a separate test project, category, build template, and pipeline stage. The managed identity VM pool is only reused because that machine hosts the required certificate.

## VM prerequisites

The following setup was completed manually on the test VM:

1. Copied the `LabAuth.MSIDLab.com` PFX to the VM.
2. Imported the certificate into `Local Computer\Personal` (`LocalMachine\My`).
3. Imported the private key as non-exportable.
4. Enabled VBS/KeyGuard virtual isolation for the private key.
5. Verified that:
   - The certificate has an accessible RSA private key.
   - The key uses CNG.
   - Its export policy is `None`.
   - MSAL identifies the key as KeyGuard-protected.
6. Ensured the Azure Pipelines agent identity can access the certificate and private key.
7. Configured the SNI application registration with the matching certificate credential.

**Note** - Double click on the cert in your local machine that has VBS enabled. And choose this option 

<img width="571" height="573" alt="image" src="https://github.com/user-attachments/assets/80c46726-e44c-4fb2-b620-4238d407c43e" />


The pipeline must be queued with:

```text
RunSniMtlsE2EVmTests=true
```

## Purpose

The tests verify both successful certificate binding and enforcement by the resource.

### Happy path

1. Loads `LabAuth.MSIDLab.com` specifically from `LocalMachine\My`.
2. Verifies that the key is non-exportable.
3. Uses `WindowsCngKeyOperations.IsKeyGuardProtected` to verify VBS/KeyGuard protection.
4. Authenticates the confidential client using SNI with `sendX5C: true`.
5. Acquires a Graph-scoped `mtls_pop` token.
6. Verifies the returned binding certificate and the token's `cnf.x5t#S256` claim.
7. Calls `https://mtlstb.graph.microsoft.com/v1.0/applications` while presenting the binding certificate.
8. Verifies that Graph returns `200 OK`.
9. Verifies token-cache reuse preserves the token and binding certificate.

### Missing-certificate enforcement

1. Acquires the same certificate-bound `mtls_pop` token.
2. Calls the Graph mTLS endpoint without presenting the certificate.
3. Verifies that Graph returns `401 Unauthorized`.
4. Verifies the response contains:
   - Error code: `InvalidAuthenticationToken`
   - Error message: `MtlsMissingClientCertificate`
   - A `WWW-Authenticate` challenge

## Certificate rotation warning

The build checks the installed certificate before running the tests.

When the certificate has 60 days or fewer remaining, Azure Pipelines emits a warning with its expiration date. The warning does not fail the build.

## Pipeline structure

- Project: `Microsoft.Identity.Test.E2E.SniMtls`
- Category: `SNI_MTLS_E2E_NonExportableVbs`
- Template: `build/template-run-sni-mtls-e2e.yaml`
- Stage: `SniMtlsE2E`
- Agent pool: `MISEManagedIdentity` (host machine only)

## Validation

- [x] Dedicated SNI mTLS E2E project builds successfully.
- [x] Both tests are discovered through the dedicated category.
- [x] Existing SNI Graph mTLS integration test passed locally.
- [x] Local probe returned `200 OK` when presenting the certificate.
- [x] Local probe returned `401 Unauthorized / MtlsMissingClientCertificate` without the certificate.
- [x] Pipeline YAML parses successfully.
- [x] Execute both tests using the VBS-protected certificate on the VM agent.

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: test
agent-tool: copilot-cli
agent-model: gpt-5.6-sol
work-item: AB#n/a
<!-- END pr-telemetry -->
