### PR TITLE
Fix IMDSv2 SCHANNEL failures bypassing certificate re-mint retry

### DIFF
--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -280,9 +280,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
         // failure where SCHANNEL cannot use the cert's private key. The latter can surface either as an
         // MsalServiceException (bespoke MI path, or the delegated path after transport normalization) or as a
         // raw transport exception, so the whole chain is inspected rather than just the outermost type.
-        // Failures from the mint step itself are intentionally in scope: minting talks to the IMDS endpoint over
-        // TLS, so a handshake failure there is just as recoverable by re-minting. The retry is bounded to a
-        // single additional attempt either way. Cancellation is never retried.
+        // Failures from the mint step itself fall in scope because the whole delegated leg is guarded, but the
+        // mint endpoints are plain HTTP and present no binding certificate, so a SCHANNEL failure cannot
+        // originate there. A mint-step failure that did match this filter would simply get one more bounded
+        // attempt, which is harmless. Cancellation is never retried.
         private static bool ShouldRemintImdsV2Binding(Exception ex)
         {
             if (ex is OperationCanceledException)
@@ -370,10 +371,20 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 // whole call is guarded: body/header construction, client credential and certificate handling,
                 // throttling, the request itself, and response deserialization. That matches the surface
                 // HandleException used to normalize.
+                // The error-code mapping mirrors HandleException: an unreachable endpoint keeps
+                // ManagedIdentityUnreachableNetwork, and a malformed endpoint keeps InvalidManagedIdentityEndpoint.
+                // The latter is reachable here because the token endpoint is built from binding.Endpoint, a value
+                // supplied by IMDS, so a malformed value throws UriFormatException (a FormatException) rather than
+                // a generic failure. Everything else falls back to the generic request-failed code.
+                string errorCode = ex switch
+                {
+                    HttpRequestException => MsalError.ManagedIdentityUnreachableNetwork,
+                    FormatException => MsalError.InvalidManagedIdentityEndpoint,
+                    _ => MsalError.ManagedIdentityRequestFailed
+                };
+
                 throw MsalServiceExceptionFactory.CreateManagedIdentityException(
-                    ex is HttpRequestException
-                        ? MsalError.ManagedIdentityUnreachableNetwork
-                        : MsalError.ManagedIdentityRequestFailed,
+                    errorCode,
                     ex.Message,
                     ex,
                     ManagedIdentitySource.Imds,
@@ -384,6 +395,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
         // Identifies failures from the delegated token leg that the bespoke MI path used to normalize into
         // MsalServiceException. Exceptions MSAL already owns are passed through untouched so service errors
         // (for example invalid_client) keep their error codes, and cancellation is never converted.
+        // This gate is deliberately broader than HandleException's, which only skipped MsalServiceException and
+        // therefore rewrapped MsalClientException as managed_identity_request_failed. Preserving the more
+        // specific client-side error code is strictly more diagnosable, so that one case is not restored.
         private static bool IsUnwrappedNonMsalFailure(Exception ex)
         {
             return ex is not MsalException && ex is not OperationCanceledException;

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -260,9 +261,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 msalTokenResponse = await DelegateImdsV2TokenLegAsync(resource, forceRemint: false, cancellationToken)
                     .ConfigureAwait(false);
             }
-            catch (MsalServiceException ex) when (
-                string.Equals(ex.ErrorCode, MsalError.InvalidClient, StringComparison.OrdinalIgnoreCase) ||
-                ImdsV2ManagedIdentitySource.IsSchanelFailure(ex))
+            catch (Exception ex) when (ShouldRemintImdsV2Binding(ex))
             {
                 logger.Info("[ManagedIdentityRequest] mTLS binding rejected (invalid_client/SCHANNEL); re-minting binding certificate and retrying once.");
                 msalTokenResponse = await DelegateImdsV2TokenLegAsync(resource, forceRemint: true, cancellationToken)
@@ -274,6 +273,30 @@ namespace Microsoft.Identity.Client.Internal.Requests
             msalTokenResponse.Scope = AuthenticationRequestParameters.Scope.AsSingleString();
 
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Decides whether a failed IMDSv2 token leg warrants evicting the binding certificate and re-minting it.
+        // Two signals qualify: ESTS-R rejecting the bound cert with invalid_client, and a local mTLS handshake
+        // failure where SCHANNEL cannot use the cert's private key. The latter can surface either as an
+        // MsalServiceException (bespoke MI path, or the delegated path after transport normalization) or as a
+        // raw transport exception, so the whole chain is inspected rather than just the outermost type.
+        // Failures from the mint step itself are intentionally in scope: minting talks to the IMDS endpoint over
+        // TLS, so a handshake failure there is just as recoverable by re-minting. The retry is bounded to a
+        // single additional attempt either way. Cancellation is never retried.
+        private static bool ShouldRemintImdsV2Binding(Exception ex)
+        {
+            if (ex is OperationCanceledException)
+            {
+                return false;
+            }
+
+            if (ex is MsalServiceException serviceException &&
+                string.Equals(serviceException.ErrorCode, MsalError.InvalidClient, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return ImdsV2ManagedIdentitySource.IsSchannelFailure(ex);
         }
 
         private async Task<MsalTokenResponse> DelegateImdsV2TokenLegAsync(
@@ -326,12 +349,44 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             var tokenClient = new TokenClient(AuthenticationRequestParameters);
 
-            return await tokenClient.SendTokenRequestAsync(
-                bodyParameters,
-                scopeOverride: scopeOverride,
-                tokenEndpointOverride: tokenEndpoint,
-                cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                return await tokenClient.SendTokenRequestAsync(
+                    bodyParameters,
+                    scopeOverride: scopeOverride,
+                    tokenEndpointOverride: tokenEndpoint,
+                    cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (IsUnwrappedNonMsalFailure(ex))
+            {
+                // The delegated TokenClient/OAuth2Client path rethrows failures MSAL does not already own
+                // without wrapping them (HttpManager only normalizes timeouts). The bespoke MI token path
+                // normalized these via AbstractManagedIdentity.HandleException, so restore that shape here:
+                // callers keep receiving MsalServiceException from AcquireTokenForManagedIdentity, and the
+                // binding re-mint filter above sees a consistent exception type. The original exception is
+                // preserved as the inner exception so SCHANNEL detection can still walk the chain.
+                // This covers everything SendTokenRequestAsync does - not just the socket write - because the
+                // whole call is guarded: body/header construction, client credential and certificate handling,
+                // throttling, the request itself, and response deserialization. That matches the surface
+                // HandleException used to normalize.
+                throw MsalServiceExceptionFactory.CreateManagedIdentityException(
+                    ex is HttpRequestException
+                        ? MsalError.ManagedIdentityUnreachableNetwork
+                        : MsalError.ManagedIdentityRequestFailed,
+                    ex.Message,
+                    ex,
+                    ManagedIdentitySource.Imds,
+                    null);
+            }
+        }
+
+        // Identifies failures from the delegated token leg that the bespoke MI path used to normalize into
+        // MsalServiceException. Exceptions MSAL already owns are passed through untouched so service errors
+        // (for example invalid_client) keep their error codes, and cancellation is never converted.
+        private static bool IsUnwrappedNonMsalFailure(Exception ex)
+        {
+            return ex is not MsalException && ex is not OperationCanceledException;
         }
 
         private async Task<MsalAccessTokenCacheItem> GetCachedAccessTokenAsync()

--- a/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
+++ b/src/client/Microsoft.Identity.Client/Internal/Requests/ManagedIdentityAuthRequest.cs
@@ -275,15 +275,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             return await CacheTokenResponseAndCreateAuthenticationResultAsync(msalTokenResponse, cancellationToken).ConfigureAwait(false);
         }
 
-        // Decides whether a failed IMDSv2 token leg warrants evicting the binding certificate and re-minting it.
-        // Two signals qualify: ESTS-R rejecting the bound cert with invalid_client, and a local mTLS handshake
-        // failure where SCHANNEL cannot use the cert's private key. The latter can surface either as an
-        // MsalServiceException (bespoke MI path, or the delegated path after transport normalization) or as a
-        // raw transport exception, so the whole chain is inspected rather than just the outermost type.
-        // Failures from the mint step itself fall in scope because the whole delegated leg is guarded, but the
-        // mint endpoints are plain HTTP and present no binding certificate, so a SCHANNEL failure cannot
-        // originate there. A mint-step failure that did match this filter would simply get one more bounded
-        // attempt, which is harmless. Cancellation is never retried.
+        // A SCHANNEL handshake failure means the cached binding cert is unusable (its KeyGuard key was
+        // re-minted underneath it), so the cert must be evicted rather than retried as-is. It can arrive
+        // wrapped or raw depending on the path, hence the chain walk in IsSchannelFailure.
         private static bool ShouldRemintImdsV2Binding(Exception ex)
         {
             if (ex is OperationCanceledException)
@@ -361,21 +355,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
             catch (Exception ex) when (IsUnwrappedNonMsalFailure(ex))
             {
-                // The delegated TokenClient/OAuth2Client path rethrows failures MSAL does not already own
-                // without wrapping them (HttpManager only normalizes timeouts). The bespoke MI token path
-                // normalized these via AbstractManagedIdentity.HandleException, so restore that shape here:
-                // callers keep receiving MsalServiceException from AcquireTokenForManagedIdentity, and the
-                // binding re-mint filter above sees a consistent exception type. The original exception is
-                // preserved as the inner exception so SCHANNEL detection can still walk the chain.
-                // This covers everything SendTokenRequestAsync does - not just the socket write - because the
-                // whole call is guarded: body/header construction, client credential and certificate handling,
-                // throttling, the request itself, and response deserialization. That matches the surface
-                // HandleException used to normalize.
-                // The error-code mapping mirrors HandleException: an unreachable endpoint keeps
-                // ManagedIdentityUnreachableNetwork, and a malformed endpoint keeps InvalidManagedIdentityEndpoint.
-                // The latter is reachable here because the token endpoint is built from binding.Endpoint, a value
-                // supplied by IMDS, so a malformed value throws UriFormatException (a FormatException) rather than
-                // a generic failure. Everything else falls back to the generic request-failed code.
+                // The bespoke MI token path normalized transport failures via
+                // AbstractManagedIdentity.HandleException; TokenClient does not. Without this, callers stop
+                // receiving MsalServiceException and the re-mint filter above no longer matches (issue #6172).
+                // Error codes mirror HandleException. The original exception is preserved as the inner one so
+                // SCHANNEL detection can still walk the chain.
                 string errorCode = ex switch
                 {
                     HttpRequestException => MsalError.ManagedIdentityUnreachableNetwork,
@@ -392,12 +376,10 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
         }
 
-        // Identifies failures from the delegated token leg that the bespoke MI path used to normalize into
-        // MsalServiceException. Exceptions MSAL already owns are passed through untouched so service errors
-        // (for example invalid_client) keep their error codes, and cancellation is never converted.
-        // This gate is deliberately broader than HandleException's, which only skipped MsalServiceException and
-        // therefore rewrapped MsalClientException as managed_identity_request_failed. Preserving the more
-        // specific client-side error code is strictly more diagnosable, so that one case is not restored.
+        // Exceptions MSAL already owns pass through untouched so service errors (for example invalid_client)
+        // keep their error codes, and cancellation is never converted. Deliberately broader than
+        // HandleException's gate, which rewrapped MsalClientException as the generic managed_identity_request_failed;
+        // keeping the more specific client-side code is strictly more diagnosable.
         private static bool IsUnwrappedNonMsalFailure(Exception ex)
         {
             return ex is not MsalException && ex is not OperationCanceledException;

--- a/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
+++ b/src/client/Microsoft.Identity.Client/ManagedIdentity/V2/ImdsV2ManagedIdentitySource.cs
@@ -186,12 +186,14 @@ namespace Microsoft.Identity.Client.ManagedIdentity.V2
         }
 
         /// <summary>
-        /// Detects if the exception was caused by a SCHANNEL failure during mTLS authentication, 
-        /// which can occur if the client certificate becomes invalid.
+        /// Detects if the exception was caused by a SCHANNEL failure during mTLS authentication,
+        /// which can occur if the client certificate becomes invalid. The whole inner-exception chain is
+        /// inspected because the failure can arrive either wrapped in an <see cref="MsalServiceException"/>
+        /// or as a raw transport exception from the delegated TokenClient path.
         /// </summary>
-        /// <param name="ex"></param>
-        /// <returns></returns>
-        internal static bool IsSchanelFailure(MsalServiceException ex)
+        /// <param name="ex">The exception to inspect, including its inner exception chain.</param>
+        /// <returns><see langword="true"/> if the chain indicates a SCHANNEL mTLS failure.</returns>
+        internal static bool IsSchannelFailure(Exception ex)
         {
             for (Exception e = ex; e != null; e = e.InnerException)
             {

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -745,6 +745,49 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         /// <summary>
+        /// AbstractManagedIdentity.HandleException mapped FormatException onto invalid_managed_identity_endpoint
+        /// rather than the generic request-failed code, and the delegated path must preserve that contract. This
+        /// arm is reachable in practice because the token endpoint is built from binding.Endpoint - a value IMDS
+        /// supplies - so a malformed value surfaces as UriFormatException (a FormatException). Fails against the
+        /// pre-fix mapping, which returned managed_identity_request_failed for this case.
+        /// </summary>
+        [TestMethod]
+        public async Task mTLSPop_TokenLeg_FormatFailure_IsWrappedAsInvalidEndpointAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange - only ONE mint+token cycle is queued; a re-mint would exhaust the queue.
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                handler.ExceptionToThrow = new UriFormatException("The token endpoint is not a well-formed URI.");
+                httpManager.AddMockHandler(handler);
+
+                // Act
+                var ex = await Assert.ThrowsAsync<MsalServiceException>(async () =>
+                    await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithMtlsProofOfPossession()
+                        .WithAttestationSupport()
+                        .ExecuteAsync().ConfigureAwait(false)
+                ).ConfigureAwait(false);
+
+                // Assert - the endpoint-specific error code is preserved, not flattened onto the generic one.
+                Assert.AreEqual(MsalError.InvalidManagedIdentityEndpoint, ex.ErrorCode);
+                Assert.IsInstanceOfType<UriFormatException>(ex.InnerException);
+
+                // No re-mint was attempted.
+                Assert.AreEqual(0, httpManager.QueueSize, "A malformed-endpoint failure must not trigger a re-mint.");
+            }
+        }
+
+        /// <summary>
         /// Acceptance criterion from #6172: "Retry behavior is identical for mTLS PoP and bearer-over-mTLS."
         /// WithRequestOverMtls() shares SendDelegatedImdsV2TokenRequestAsync with the PoP path, so a SCHANNEL
         /// failure must drive the same evict/re-mint/retry-once behavior. Both attempts fail here, which proves

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -588,15 +588,19 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     httpManager,
                     managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
 
-                // First attempt: full mint, then the local mTLS handshake fails inside SCHANNEL.
+                // First attempt mints cert A, then the local mTLS handshake fails inside SCHANNEL.
+                string certA = CreateRawCertFromXml("CN=imdsv2-bad-binding", DateTimeOffset.UtcNow.AddDays(30));
+                string certB = CreateRawCertFromXml("CN=imdsv2-fresh-binding", DateTimeOffset.UtcNow.AddDays(30));
+
                 httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
-                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: certA));
                 var failingTokenHandler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
                 failingTokenHandler.ExceptionToThrow = CreateSchannelTransportException();
                 httpManager.AddMockHandler(failingTokenHandler);
 
-                // Retry: binding is re-minted (RemoveBadCert → fresh CSR + issuecredential), then token succeeds.
-                AddMocksToGetEntraToken(httpManager);
+                // Retry: binding is re-minted (RemoveBadCert → fresh CSR + issuecredential) and IMDS issues
+                // cert B, then token succeeds.
+                AddMocksToGetEntraToken(httpManager, certificateRequestCertificate: certB);
 
                 // Act
                 var result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
@@ -608,8 +612,17 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result);
                 Assert.IsNotNull(result.AccessToken);
                 Assert.AreEqual(MTLSPoP, result.TokenType);
-                Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                // The rejected cert A was evicted and the token is bound to the freshly minted cert B.
+                // This is the assertion that distinguishes a real re-mint from a cache reuse.
+                using var expectedFreshCert = new X509Certificate2(Convert.FromBase64String(certB));
+                using var rejectedCert = new X509Certificate2(Convert.FromBase64String(certA));
+                Assert.IsNotNull(result.BindingCertificate);
+                Assert.AreEqual(expectedFreshCert.Thumbprint, result.BindingCertificate.Thumbprint,
+                    "Token must be bound to the re-minted certificate, not the rejected one.");
+                Assert.AreNotEqual(rejectedCert.Thumbprint, result.BindingCertificate.Thumbprint,
+                    "The SCHANNEL-rejected certificate must have been evicted.");
 
                 // Both the failed attempt and the re-minted retry ran: every queued mock was consumed.
                 Assert.AreEqual(0, httpManager.QueueSize, "Expected exactly one re-mint and one retry.");
@@ -907,15 +920,18 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     httpManager,
                     managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
 
-                // First attempt: full mint, then the local mTLS handshake fails inside SCHANNEL.
+                // First attempt mints cert A, then the local mTLS handshake fails inside SCHANNEL.
+                string certA = CreateRawCertFromXml("CN=imdsv2-unattested-bad", DateTimeOffset.UtcNow.AddDays(30));
+                string certB = CreateRawCertFromXml("CN=imdsv2-unattested-fresh", DateTimeOffset.UtcNow.AddDays(30));
+
                 httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
-                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: certA));
                 var failingTokenHandler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
                 failingTokenHandler.ExceptionToThrow = CreateSchannelTransportException();
                 httpManager.AddMockHandler(failingTokenHandler);
 
-                // Retry: binding is re-minted, then the token succeeds.
-                AddMocksToGetEntraToken(httpManager);
+                // Retry: binding is re-minted and IMDS issues cert B, then the token succeeds.
+                AddMocksToGetEntraToken(httpManager, certificateRequestCertificate: certB);
 
                 // Act - no attestation.
                 var result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
@@ -927,6 +943,12 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.AreEqual(MTLSPoP, result.TokenType);
                 Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                // Bound to the re-minted cert B, not the SCHANNEL-rejected cert A.
+                using var expectedFreshCert = new X509Certificate2(Convert.FromBase64String(certB));
+                Assert.AreEqual(expectedFreshCert.Thumbprint, result.BindingCertificate.Thumbprint,
+                    "Token must be bound to the re-minted certificate, not the rejected one.");
+
                 Assert.AreEqual(0, httpManager.QueueSize, "Expected exactly one re-mint and one retry.");
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -745,6 +745,130 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         /// <summary>
+        /// Acceptance criterion from #6172: "Retry behavior is identical for mTLS PoP and bearer-over-mTLS."
+        /// WithRequestOverMtls() shares SendDelegatedImdsV2TokenRequestAsync with the PoP path, so a SCHANNEL
+        /// failure must drive the same evict/re-mint/retry-once behavior. Both attempts fail here, which proves
+        /// the retry fired without needing a bearer success-response mock.
+        /// </summary>
+        [TestMethod]
+        public async Task BearerOverMtls_TokenLeg_SchannelFailure_ReMintsBindingAndRetriesOnceAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange - two full mint+token cycles, both failing in SCHANNEL.
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                for (int attempt = 0; attempt < 2; attempt++)
+                {
+                    httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                    httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                    var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                    handler.ExceptionToThrow = CreateSchannelTransportException();
+                    httpManager.AddMockHandler(handler);
+                }
+
+                // Act - bearer over mTLS, not PoP.
+                var ex = await Assert.ThrowsAsync<MsalServiceException>(async () =>
+                    await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithRequestOverMtls()
+                        .ExecuteAsync().ConfigureAwait(false)
+                ).ConfigureAwait(false);
+
+                // Assert - same normalization and same SCHANNEL classification as the PoP path.
+                Assert.AreEqual(MsalError.ManagedIdentityUnreachableNetwork, ex.ErrorCode);
+                Assert.IsTrue(ImdsV2ManagedIdentitySource.IsSchannelFailure(ex), "Expected the SCHANNEL chain to be preserved.");
+
+                // Exactly two attempts: the bearer path re-minted once, identical to mTLS PoP.
+                Assert.AreEqual(0, httpManager.QueueSize, "Bearer over mTLS must re-mint and retry exactly once.");
+            }
+        }
+
+        /// <summary>
+        /// Acceptance criterion from #6172: cancellation is not retried. A cancellation surfacing from the
+        /// token leg must propagate untouched - not re-minted, and not normalized into an MsalServiceException.
+        /// </summary>
+        [TestMethod]
+        public async Task mTLSPop_TokenLeg_Cancellation_IsNotRetriedAndIsNotWrappedAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange - only ONE mint+token cycle is queued; a re-mint would exhaust the queue.
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                handler.ExceptionToThrow = new OperationCanceledException("The operation was canceled.");
+                httpManager.AddMockHandler(handler);
+
+                // Act
+                var ex = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                    await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithMtlsProofOfPossession()
+                        .WithAttestationSupport()
+                        .ExecuteAsync().ConfigureAwait(false)
+                ).ConfigureAwait(false);
+
+                // Assert - propagated as-is, never converted into an MSAL exception.
+                Assert.IsNotInstanceOfType<MsalException>(ex, "Cancellation must not be normalized into an MSAL exception.");
+
+                // No re-mint was attempted.
+                Assert.AreEqual(0, httpManager.QueueSize, "Cancellation must not trigger a re-mint.");
+            }
+        }
+
+        /// <summary>
+        /// Acceptance criterion from #6172: the fix must hold on unattested IMDSv2 flows too. Same SCHANNEL
+        /// recovery, but without .WithAttestationSupport().
+        /// </summary>
+        [TestMethod]
+        public async Task mTLSPop_Unattested_TokenLeg_SchannelFailure_ReMintsBindingAndRetriesOnceAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                // First attempt: full mint, then the local mTLS handshake fails inside SCHANNEL.
+                httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                var failingTokenHandler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                failingTokenHandler.ExceptionToThrow = CreateSchannelTransportException();
+                httpManager.AddMockHandler(failingTokenHandler);
+
+                // Retry: binding is re-minted, then the token succeeds.
+                AddMocksToGetEntraToken(httpManager);
+
+                // Act - no attestation.
+                var result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                // Assert
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(MTLSPoP, result.TokenType);
+                Assert.IsNotNull(result.BindingCertificate);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+                Assert.AreEqual(0, httpManager.QueueSize, "Expected exactly one re-mint and one retry.");
+            }
+        }
+
+        /// <summary>
         /// Builds the exception chain Windows produces when SCHANNEL cannot acquire credentials for the
         /// IMDSv2 binding certificate (stale or inaccessible CNG/KeyGuard private key). The handshake
         /// fails locally, so this is what the delegated TokenClient transport surfaces.

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -797,6 +797,7 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         {
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager())
+            using (var cts = new CancellationTokenSource())
             {
                 // Arrange - only ONE mint+token cycle is queued; a re-mint would exhaust the queue.
                 SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
@@ -807,22 +808,35 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
                 httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
                 httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+
+                // Cancel while the token leg is in flight. The mock validates the request first, then calls
+                // ThrowIfCancellationRequested, so the token leg is provably reached and cancellation is raised
+                // with the caller's token genuinely canceled. That last part is what makes this deterministic:
+                // HttpManager only rethrows a cancellation when the token is actually canceled, otherwise it
+                // classifies it as a timeout and converts it into MsalServiceException(request_timeout).
                 var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
-                handler.ExceptionToThrow = new OperationCanceledException("The operation was canceled.");
+                handler.AdditionalRequestValidation = _ => cts.Cancel();
                 httpManager.AddMockHandler(handler);
 
                 // Act
-                var ex = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                Exception caught = null;
+                try
+                {
                     await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
                         .WithMtlsProofOfPossession()
                         .WithAttestationSupport()
-                        .ExecuteAsync().ConfigureAwait(false)
-                ).ConfigureAwait(false);
+                        .ExecuteAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    caught = ex;
+                }
 
                 // Assert - propagated as-is, never converted into an MSAL exception.
-                Assert.IsNotInstanceOfType<MsalException>(ex, "Cancellation must not be normalized into an MSAL exception.");
+                Assert.IsInstanceOfType(caught, typeof(OperationCanceledException), "Cancellation must propagate unchanged.");
+                Assert.IsNotInstanceOfType(caught, typeof(MsalException), "Cancellation must not be normalized into an MSAL exception.");
 
-                // No re-mint was attempted.
+                // The token leg was reached and no re-mint was attempted.
                 Assert.AreEqual(0, httpManager.QueueSize, "Cancellation must not trigger a re-mint.");
             }
         }

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.IO;
+using System.Net.Http;
+using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -564,6 +567,194 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.IsNotNull(result.BindingCertificate);
                 Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
             }
+        }
+
+        /// <summary>
+        /// Regression test for the delegated TokenClient path losing SCHANNEL recovery.
+        /// The mTLS handshake fails locally in SCHANNEL (the binding cert's private key is unusable),
+        /// so the transport throws a raw HttpRequestException chain and no request reaches ESTS-R.
+        /// MSAL must still evict the binding, re-mint it, and retry once.
+        /// </summary>
+        [TestMethod]
+        public async Task mTLSPop_TokenLeg_RawSchannelFailure_ReMintsBindingAndRetriesOnceAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                // First attempt: full mint, then the local mTLS handshake fails inside SCHANNEL.
+                httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                var failingTokenHandler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                failingTokenHandler.ExceptionToThrow = CreateSchannelTransportException();
+                httpManager.AddMockHandler(failingTokenHandler);
+
+                // Retry: binding is re-minted (RemoveBadCert → fresh CSR + issuecredential), then token succeeds.
+                AddMocksToGetEntraToken(httpManager);
+
+                // Act
+                var result = await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                    .WithMtlsProofOfPossession()
+                    .WithAttestationSupport()
+                    .ExecuteAsync().ConfigureAwait(false);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.AccessToken);
+                Assert.AreEqual(MTLSPoP, result.TokenType);
+                Assert.IsNotNull(result.BindingCertificate);
+                Assert.AreEqual(TokenSource.IdentityProvider, result.AuthenticationResultMetadata.TokenSource);
+
+                // Both the failed attempt and the re-minted retry ran: every queued mock was consumed.
+                Assert.AreEqual(0, httpManager.QueueSize, "Expected exactly one re-mint and one retry.");
+            }
+        }
+
+        /// <summary>
+        /// The re-mint retry is bounded to a single additional attempt. When the freshly minted binding
+        /// also fails in SCHANNEL, the exception propagates instead of looping.
+        /// </summary>
+        [TestMethod]
+        public async Task mTLSPop_TokenLeg_RepeatedSchannelFailure_RetriesOnceThenPropagatesAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange - two full mint+token cycles, both failing in SCHANNEL.
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                for (int attempt = 0; attempt < 2; attempt++)
+                {
+                    httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                    httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                    var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                    handler.ExceptionToThrow = CreateSchannelTransportException();
+                    httpManager.AddMockHandler(handler);
+                }
+
+                // Act
+                var ex = await Assert.ThrowsAsync<MsalServiceException>(async () =>
+                    await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithMtlsProofOfPossession()
+                        .WithAttestationSupport()
+                        .ExecuteAsync().ConfigureAwait(false)
+                ).ConfigureAwait(false);
+
+                // Assert - the second failure surfaces, normalized but with the SCHANNEL chain intact.
+                Assert.AreEqual(MsalError.ManagedIdentityUnreachableNetwork, ex.ErrorCode);
+                Assert.IsTrue(ImdsV2ManagedIdentitySource.IsSchannelFailure(ex), "Expected the SCHANNEL chain to be preserved.");
+
+                // Exactly two attempts were made - no third mint/token cycle was queued or needed.
+                Assert.AreEqual(0, httpManager.QueueSize, "Expected exactly two attempts (initial + one retry).");
+            }
+        }
+
+        /// <summary>
+        /// An unrelated transport failure (no SCHANNEL signature) must not trigger a certificate re-mint,
+        /// and must surface as an MsalServiceException rather than a raw HttpRequestException.
+        /// </summary>
+        [TestMethod]
+        public async Task mTLSPop_TokenLeg_UnrelatedNetworkFailure_IsNotRetriedAndIsWrappedAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange - only ONE mint+token cycle is queued. A re-mint would exhaust the queue and fail.
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                handler.ExceptionToThrow = new HttpRequestException(
+                    "No such host is known.",
+                    new IOException("The remote name could not be resolved."));
+                httpManager.AddMockHandler(handler);
+
+                // Act
+                var ex = await Assert.ThrowsAsync<MsalServiceException>(async () =>
+                    await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithMtlsProofOfPossession()
+                        .WithAttestationSupport()
+                        .ExecuteAsync().ConfigureAwait(false)
+                ).ConfigureAwait(false);
+
+                // Assert - normalized to the managed identity contract, and NOT classified as SCHANNEL.
+                Assert.AreEqual(MsalError.ManagedIdentityUnreachableNetwork, ex.ErrorCode);
+                Assert.IsInstanceOfType<HttpRequestException>(ex.InnerException);
+                Assert.IsFalse(ImdsV2ManagedIdentitySource.IsSchannelFailure(ex), "Unrelated failures must not look like SCHANNEL failures.");
+
+                // No re-mint was attempted: the single queued cycle covered the whole request.
+                Assert.AreEqual(0, httpManager.QueueSize, "An unrelated network failure must not trigger a re-mint.");
+            }
+        }
+
+        /// <summary>
+        /// A non-transport failure that MSAL does not already own (anything other than HttpRequestException)
+        /// must still be normalized, but onto managed_identity_request_failed rather than the unreachable-network
+        /// code. Covers the second arm of the normalization introduced for this fix.
+        /// </summary>
+        [TestMethod]
+        public async Task mTLSPop_TokenLeg_NonHttpFailure_IsWrappedAsRequestFailedAsync()
+        {
+            using (new EnvVariableContext())
+            using (var httpManager = new MockHttpManager())
+            {
+                // Arrange - only ONE mint+token cycle is queued; a re-mint would exhaust the queue.
+                SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
+
+                var managedIdentityApp = await CreateManagedIdentityAsync(
+                    httpManager,
+                    managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
+
+                httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
+                var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
+                handler.ExceptionToThrow = new InvalidOperationException("Unexpected failure in the token exchange path.");
+                httpManager.AddMockHandler(handler);
+
+                // Act
+                var ex = await Assert.ThrowsAsync<MsalServiceException>(async () =>
+                    await managedIdentityApp.AcquireTokenForManagedIdentity(ManagedIdentityTests.Resource)
+                        .WithMtlsProofOfPossession()
+                        .WithAttestationSupport()
+                        .ExecuteAsync().ConfigureAwait(false)
+                ).ConfigureAwait(false);
+
+                // Assert - normalized onto the non-network managed identity error code, original preserved.
+                Assert.AreEqual(MsalError.ManagedIdentityRequestFailed, ex.ErrorCode);
+                Assert.IsInstanceOfType<InvalidOperationException>(ex.InnerException);
+                Assert.IsFalse(ImdsV2ManagedIdentitySource.IsSchannelFailure(ex), "A non-SCHANNEL failure must not be classified as one.");
+
+                // No re-mint was attempted.
+                Assert.AreEqual(0, httpManager.QueueSize, "A non-SCHANNEL failure must not trigger a re-mint.");
+            }
+        }
+
+        /// <summary>
+        /// Builds the exception chain Windows produces when SCHANNEL cannot acquire credentials for the
+        /// IMDSv2 binding certificate (stale or inaccessible CNG/KeyGuard private key). The handshake
+        /// fails locally, so this is what the delegated TokenClient transport surfaces.
+        /// </summary>
+        private static HttpRequestException CreateSchannelTransportException()
+        {
+            // SEC_E_UNKNOWN_CREDENTIALS - "The credentials supplied to the package were not recognized"
+            var win32 = new Win32Exception(unchecked((int)0x8009030D), "The credentials supplied to the package were not recognized");
+            var authentication = new AuthenticationException("Authentication failed.", win32);
+            return new HttpRequestException("The SSL connection could not be established.", authentication);
         }
         #endregion Acceptance Tests
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/ImdsV2Tests.cs
@@ -746,18 +746,19 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
 
         /// <summary>
         /// AbstractManagedIdentity.HandleException mapped FormatException onto invalid_managed_identity_endpoint
-        /// rather than the generic request-failed code, and the delegated path must preserve that contract. This
-        /// arm is reachable in practice because the token endpoint is built from binding.Endpoint - a value IMDS
-        /// supplies - so a malformed value surfaces as UriFormatException (a FormatException). Fails against the
-        /// pre-fix mapping, which returned managed_identity_request_failed for this case.
+        /// rather than the generic request-failed code, and the delegated path must preserve that contract.
+        /// Drives the real scenario rather than injecting the exception: IMDS returns a malformed
+        /// mtls_authentication_endpoint (only checked for null/empty during the mint step), which flows into
+        /// binding.Endpoint and throws UriFormatException inside the token leg when OAuth2Client parses it.
+        /// Fails against the pre-fix mapping, which returned managed_identity_request_failed for this case.
         /// </summary>
         [TestMethod]
-        public async Task mTLSPop_TokenLeg_FormatFailure_IsWrappedAsInvalidEndpointAsync()
+        public async Task mTLSPop_TokenLeg_MalformedEndpoint_IsWrappedAsInvalidEndpointAsync()
         {
             using (new EnvVariableContext())
             using (var httpManager = new MockHttpManager())
             {
-                // Arrange - only ONE mint+token cycle is queued; a re-mint would exhaust the queue.
+                // Arrange - the mint succeeds but hands back an endpoint that cannot be parsed as a URI.
                 SetEnvironmentVariables(ManagedIdentitySource.Imds, TestConstants.ImdsEndpoint);
 
                 var managedIdentityApp = await CreateManagedIdentityAsync(
@@ -765,10 +766,10 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                     managedIdentityKeyType: ManagedIdentityKeyType.KeyGuard).ConfigureAwait(false);
 
                 httpManager.AddMockHandler(MockHelpers.MockCsrResponse());
-                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(certificate: TestConstants.ValidRawCertificate));
-                var handler = MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter);
-                handler.ExceptionToThrow = new UriFormatException("The token endpoint is not a well-formed URI.");
-                httpManager.AddMockHandler(handler);
+                httpManager.AddMockHandler(MockHelpers.MockCertificateRequestResponse(
+                    certificate: TestConstants.ValidRawCertificate,
+                    mtlsEndpointOverride: "http://[invalid"));
+                httpManager.AddMockHandler(MockHelpers.MockImdsV2EntraTokenRequestResponse(_identityLoggerAdapter));
 
                 // Act
                 var ex = await Assert.ThrowsAsync<MsalServiceException>(async () =>
@@ -782,8 +783,13 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
                 Assert.AreEqual(MsalError.InvalidManagedIdentityEndpoint, ex.ErrorCode);
                 Assert.IsInstanceOfType<UriFormatException>(ex.InnerException);
 
-                // No re-mint was attempted.
-                Assert.AreEqual(0, httpManager.QueueSize, "A malformed-endpoint failure must not trigger a re-mint.");
+                // No re-mint was attempted. The URI is rejected before any token request goes out, so the token
+                // handler is still queued; a re-mint would have consumed it against the mint URL and failed the
+                // handler's ExpectedUrl assertion.
+                Assert.AreEqual(1, httpManager.QueueSize, "A malformed-endpoint failure must not trigger a re-mint.");
+
+                // The deliberately unconsumed handler above would otherwise trip the dispose-time queue check.
+                httpManager.ClearQueue();
             }
         }
 

--- a/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/ManagedIdentityTests/PersistentCertificateStoreUnitTests.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -755,26 +756,47 @@ namespace Microsoft.Identity.Test.Unit.ManagedIdentityTests
         }
 
         [TestMethod]
-        public void IsSchanelFailure_ReturnsTrue_For_SocketException_10054_Chain()
+        public void IsSchannelFailure_ReturnsTrue_For_SocketException_10054_Chain()
         {
-            // Build exception chain like your logs
+            // Arrange - build the exception chain seen in production logs
             var sock = new SocketException(10054);
             var io = new IOException("Unable to write data to the transport connection: An existing connection was forcibly closed by the remote host.", sock);
             var http = new HttpRequestException("An error occurred while sending the request.", io);
-
-            // ErrorCode must be managed_identity_unreachable_network for the catch filter,
-            // but the private method only checks ToString() content.
             var msal = new MsalServiceException(MsalError.ManagedIdentityUnreachableNetwork, "An error occurred while sending the request.", http);
 
-            // Invoke private static bool IsSchanelFailure(MsalServiceException ex)
-            var mi = typeof(ImdsV2ManagedIdentitySource)
-                .GetMethod("IsSchanelFailure", BindingFlags.NonPublic | BindingFlags.Static);
+            // Act
+            bool result = ImdsV2ManagedIdentitySource.IsSchannelFailure(msal);
 
-            Assert.IsNotNull(mi, "Could not find IsSchanelFailure via reflection.");
-
-            var result = (bool)mi.Invoke(null, new object[] { msal });
-
+            // Assert
             Assert.IsTrue(result, "Expected 10054 chain to be detected as SCHANNEL failure.");
+        }
+
+        [TestMethod]
+        public void IsSchannelFailure_ReturnsTrue_For_RawTransportChain_WithoutMsalWrapper()
+        {
+            // Arrange - the shape the delegated TokenClient path produces: no MsalServiceException wrapper.
+            var win32 = new Win32Exception(unchecked((int)0x8009030D), "The credentials supplied to the package were not recognized");
+            var auth = new AuthenticationException("Authentication failed.", win32);
+            var http = new HttpRequestException("The SSL connection could not be established.", auth);
+
+            // Act
+            bool result = ImdsV2ManagedIdentitySource.IsSchannelFailure(http);
+
+            // Assert
+            Assert.IsTrue(result, "Expected a raw SCHANNEL transport chain to be detected without an MsalServiceException wrapper.");
+        }
+
+        [TestMethod]
+        public void IsSchannelFailure_ReturnsFalse_For_UnrelatedNetworkFailure()
+        {
+            // Arrange - a generic connectivity failure with no SCHANNEL signature.
+            var http = new HttpRequestException("Name or service not known.", new IOException("boom"));
+
+            // Act
+            bool result = ImdsV2ManagedIdentitySource.IsSchannelFailure(http);
+
+            // Assert
+            Assert.IsFalse(result, "Unrelated network failures must not be classified as SCHANNEL failures.");
         }
 
         private static X509Certificate2 CreateSelfSignedCert(TimeSpan lifetime, string subjectCn = "CN=RemoveBadCertTest")


### PR DESCRIPTION
Fixes #6172

### What broke

#6070 (`3680c2fe2`) moved the IMDSv2 mTLS-PoP token leg to the shared `TokenClient` → `OAuth2Client` → `HttpManager` path. The retry logic survived that move — it was re-implemented in `ManagedIdentityAuthRequest`. What did not survive was `AbstractManagedIdentity.HandleException`, which normalized raw transport failures into `MsalServiceException(ManagedIdentityUnreachableNetwork)`.

That method manufactured **both halves** of the catch filter the retry depends on — the exception type *and* the error code. Once it left the path, the filter could never match:

| | Exception reaching the filter |
|---|---|
| Before #6070 | `MsalServiceException` → `HttpRequestException` → `AuthenticationException` — matched |
| After #6070 | `HttpRequestException` → `AuthenticationException` → `Win32Exception` — type mismatch |

Net effect: a KeyGuard/CNG-bound cert Schannel can no longer use (`SEC_E_UNKNOWN_CREDENTIALS`, 0x8009030D) surfaced as a bare `HttpRequestException` instead of triggering the re-mint-and-retry that exists precisely for it. No packet leaves the machine — this is not a transient network condition, it's a stale binding cert that only a re-mint fixes.

Unintended exception-contract change, not a behavior change anyone signed off on.

### Fix

**`DelegateImdsV2TokenLegAsync` — restore normalization.** Wrap `tokenClient.SendTokenRequestAsync` and re-normalize failures MSAL doesn't already own into `MsalServiceException`, mirroring `HandleException`. Scoped to the token call only — the mint step already throws MSAL-shaped exceptions, so wrapping it would double-wrap. The error-code mapping mirrors `HandleException`: `HttpRequestException` → `managed_identity_unreachable_network`, `FormatException` → `invalid_managed_identity_endpoint` (reachable because the token endpoint is built from `binding.Endpoint`, an IMDS-supplied value), everything else → `managed_identity_request_failed`. Guard is `ex is not MsalException`, stricter than the old `MsalServiceException` check, so `MsalClientException` is preserved rather than masked. `OperationCanceledException` passes through untouched.

**`ShouldRemintImdsV2Binding` — defense in depth.** Widen the catch from `catch (MsalServiceException ex)` to `catch (Exception ex) when (...)`. Being explicit: **this layer is not required to fix the bug** — the normalization change alone makes every new test pass, and I isolated the layers to confirm that. It's here because the original filter only worked by accident of a wrapper three call-frames away. That coupling is what let this regress silently. Cancellation is explicitly excluded.

**`IsSchanelFailure` → `IsSchannelFailure(Exception)`.** Typo fix, parameter generalized from `MsalServiceException`. `internal static` — no public API surface change, no `PublicAPI.Unshipped.txt` entry. Detection logic byte-for-byte unchanged: it still keys on `AuthenticationException` broadly, which also catches server-cert validation failures. That over-trigger is bounded (one wasted re-mint, then the real error propagates) and narrowing it to `SEC_E_UNKNOWN_CREDENTIALS` / `SEC_E_NO_CREDENTIALS` is a semantic change I'm keeping out of a regression fix. Happy to pull it forward if a reviewer wants it here.

### Compatibility

The regression shipped in **4.85.2 through 4.88.0**. On those versions this failure surfaces as a raw `HttpRequestException`; after this fix it surfaces as `MsalServiceException` again, with the original exception preserved as `InnerException`. That restores the documented managed identity contract, but anyone who added a `catch (HttpRequestException)` workaround on 4.85.2+ will find it no longer fires and should revert it. No public API added, removed, or annotated.

### Tests

Eight end-to-end regression tests in `ImdsV2Tests.cs`. Attempt counts are asserted via `MockHttpManager.QueueSize`, so "retries exactly once" is proven rather than inferred from a successful return.

| Test | Covers |
|---|---|
| `mTLSPop_TokenLeg_RawSchannelFailure_...` | Re-mint + retry on a raw Schannel failure |
| `mTLSPop_TokenLeg_RepeatedSchannelFailure_...` | Retries once, then propagates |
| `mTLSPop_TokenLeg_UnrelatedNetworkFailure_...` | Unrelated failures neither retried nor swallowed |
| `mTLSPop_TokenLeg_NonHttpFailure_...` | Non-`HttpRequestException` normalized onto `managed_identity_request_failed` |
| `mTLSPop_TokenLeg_FormatFailure_...` | `FormatException` keeps `invalid_managed_identity_endpoint`, not the generic code |
| `BearerOverMtls_TokenLeg_SchannelFailure_...` | Same behavior for `WithRequestOverMtls` as for PoP |
| `mTLSPop_Unattested_TokenLeg_SchannelFailure_...` | Same behavior without `WithAttestationSupport` |
| `mTLSPop_TokenLeg_Cancellation_...` | Cancellation still propagates un-wrapped, consumes no re-mint |

`WithRequestOverMtls` had zero coverage in `Test.Unit` before this.

Three detector tests in `PersistentCertificateStoreUnitTests.cs`. These also drop a reflection-based lookup of the old method name — the rename would have broken it, and reflection-coupled tests are how a rename becomes a silent hole.

**Reverted the fix in place and re-ran.** All six Schannel/normalization tests fail against the pre-fix behavior with exactly the reported symptom (`Actual exception type:<System.Net.Http.HttpRequestException>`) and pass against the new. `mTLSPop_TokenLeg_FormatFailure_...` was likewise verified to fail against the pre-fix error-code mapping. The cancellation test passes both before and after by design — it guards the fix against over-reaching, it does not reproduce the bug. Calling that out rather than claiming eight regression tests.

Full ManagedIdentity suite on **both** target frameworks — net8.0 and net48 each report 462 passed, 1 skipped, 0 failed. Clean build under `TreatWarningsAsErrors`.

### Acceptance criteria (#6172)

All five criteria are verbatim from the issue. Unit evidence is from `ImdsV2Tests.cs`; E2E evidence is from CI run `20260901.8` on the MI-enabled Azure VM pool (**20/20 passed**), which exercises real IMDSv2 with Credential Guard.

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | Raw Schannel `HttpRequestException` failures trigger one certificate re-mint and retry | **Met** | `mTLSPop_TokenLeg_RawSchannelFailure_...` (re-mints + retries) and `..._RepeatedSchannelFailure_...` (retries **once**, then propagates). Attempt counts asserted via `QueueSize`; both fail against pre-fix code |
| 2 | Retry behavior is identical for mTLS PoP and bearer-over-mTLS | **Met** | `BearerOverMtls_TokenLeg_SchannelFailure_...` mirrors the PoP test — both paths share `SendDelegatedImdsV2TokenRequestAsync`. E2E: `AcquireToken_OnImdsV2_WithRequestOverMtls_ReturnsBearer` passed for SAMI + UAMI |
| 3 | Both attested and unattested IMDSv2 **E2E** tests pass | **Met** | Attested: `AcquireToken_OnImdsV2_MtlsPoP_WithAttestation_Succeeds` (SAMI + UAMI-ClientId) and `AcquireTokenAndCallAKV_...`. Unattested: `AcquireToken_OnImdsV2_MtlsPoP_GracefulDegradation_WhenCredentialGuardUnavailable` |
| 4 | Microsoft.Identity.Web MI FIC two-leg mTLS PoP tests pass | **Met by equivalent coverage** | `ManagedIdentityImdsV2FicTests.FicTwoLeg_MtlsPop_SAMI` / `_UAMI-ClientId` passed E2E (plus both `FicTwoLeg_Bearer_*`). This is the same code path Identity.Web's `ManagedIdentityClientAssertion` drives. Identity.Web's own suite was **not** run against this branch — its test is `[OnlyOnAzureDevopsFact]`; static review found no risk (below) |
| 5 | Cancellation and unrelated network failures are not retried | **Met** | `mTLSPop_TokenLeg_Cancellation_...` (propagates un-wrapped, consumes no re-mint) and `..._UnrelatedNetworkFailure_...` (neither retried nor swallowed). Both assert `QueueSize` |

Being precise on #4: MSAL's own FIC two-leg mTLS PoP E2E tests pass against live Azure MI, which covers the underlying behavior. Executing Identity.Web's suite against an unreleased MSAL build is the one gap, and it's called out rather than papered over.

### Downstream: Microsoft.Identity.Web

Checked against a local `microsoft-identity-web` checkout. No risk found:

- `MsiFic_TwoLeg_FinalMtlsPop_SystemAssignedManagedIdentityAsync` exists (`tests/E2E Tests/TokenAcquirerTests/ManagedIdentityFicTests.cs`). It is `[OnlyOnAzureDevopsFact]` and needs live Azure MI + Credential Guard, so it can only be validated in their CI.
- Identity.Web pins MSAL `4.88.0` (`Directory.Build.props`) — inside the affected range.
- Its managed identity path catches `Exception`, logs, and rethrows unfiltered; it does not discriminate on exception type. `ManagedIdentityClientAssertion` already documents that bind failures "surface as an `MsalServiceException` from `ExecuteAsync`", which is the contract this PR restores.
- Its certificate-retry filter keys on `invalid_client` + specific AADSTS codes, so `managed_identity_*` error codes cannot trigger a spurious retry.
- The `HttpRequestException` filters in `DownstreamApi.HttpMethods.cs` are on downstream API calls, not token acquisition.


```
<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: bug
agent-tool: copilot-cli
agent-model: claude-opus-5
work-item: AB#n/a
<!-- END pr-telemetry -->
```
