### PR TITLE
Always record RawStsErrorCode on MsalFailure metric

### DIFF
--- a/src/client/Microsoft.Identity.Client/Extensibility/MsalMetricsCatalog.cs
+++ b/src/client/Microsoft.Identity.Client/Extensibility/MsalMetricsCatalog.cs
@@ -16,13 +16,10 @@ namespace Microsoft.Identity.Client.Extensibility
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The tag names listed for a metric are the canonical base tags MSAL emits for it (some are conditional). They do not
+    /// The tag names listed for a metric are the canonical base tags MSAL emits for it. They do not
     /// include any extra tags supplied through
     /// <see cref="AbstractConfidentialClientAcquireTokenParameterBuilderExtension.WithOtelTagsEnricher{T}"/>,
-    /// which are caller-defined and therefore not part of this catalog. Some canonical tags are emitted only
-    /// under certain conditions (for example the raw STS error-code tag is present on the failure counter only
-    /// when the STS returns a sub-error); they are listed here because they are part of the metric's canonical
-    /// schema.
+    /// which are caller-defined and therefore not part of this catalog.
     /// </para>
     /// <para>
     /// Both the metric names (the dictionary keys) and the tag names (the dictionary values) are plain strings

--- a/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
+++ b/src/client/Microsoft.Identity.Client/Platforms/Features/OpenTelemetry/OtelInstrumentation.cs
@@ -474,11 +474,9 @@ namespace Microsoft.Identity.Client.Platforms.Features.OpenTelemetry
                 new(TelemetryConstants.ApiId, apiId),
                 new(TelemetryConstants.CallerSdkId, callerSdkId ?? string.Empty + "," + callerSdkVersion ?? string.Empty),
                 new(TelemetryConstants.CacheRefreshReason, cacheRefreshReason),
-                new(TelemetryConstants.TokenType, tokenType)
+                new(TelemetryConstants.TokenType, tokenType),
+                new(TelemetryConstants.RawStsErrorCode, rawStsErrorCode ?? string.Empty)
             };
-
-            if (!string.IsNullOrEmpty(rawStsErrorCode))
-                baseTags.Add(new(TelemetryConstants.RawStsErrorCode, rawStsErrorCode));
 
             var tags = BuildTagList(MsalMetricsCatalog.FailureCounterName, extraTags, baseTags.ToArray());
 

--- a/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
+++ b/tests/Microsoft.Identity.Test.Unit/TelemetryTests/OTelInstrumentationTests.cs
@@ -886,7 +886,7 @@ namespace Microsoft.Identity.Test.Unit
         }
 
         [TestMethod]
-        public async Task MsalFailure_ClientException_RawStsErrorCodeTag_NotIncludedAsync()
+        public async Task MsalFailure_ClientException_RawStsErrorCodeTag_IncludedWithEmptyValueAsync()
         {
             using (_harness = CreateTestHarness())
             {
@@ -907,8 +907,10 @@ namespace Microsoft.Identity.Test.Unit
                 foreach (var metricPoint in failureMetric.GetMetricPoints())
                 {
                     var tags = GetTagDictionary(metricPoint.Tags);
-                    Assert.IsFalse(tags.ContainsKey(TelemetryConstants.RawStsErrorCode),
-                        "RawStsErrorCode tag should not be present for non-service exceptions.");
+                    Assert.IsTrue(tags.ContainsKey(TelemetryConstants.RawStsErrorCode),
+                        "RawStsErrorCode tag should always be present on MsalFailure.");
+                    Assert.AreEqual(string.Empty, tags[TelemetryConstants.RawStsErrorCode],
+                        "RawStsErrorCode should be empty when the failure has no STS error code.");
                 }
             }
         }
@@ -1495,15 +1497,13 @@ namespace Microsoft.Identity.Test.Unit
                         expectedTags.Add(TelemetryConstants.CallerSdkId);
                         expectedTags.Add(TelemetryConstants.CacheRefreshReason);
                         expectedTags.Add(TelemetryConstants.TokenType);
+                        expectedTags.Add(TelemetryConstants.RawStsErrorCode);
 
                         long totalFailedRequests = 0;
                         foreach (var metricPoint in exportedItem.GetMetricPoints())
                         {
                             totalFailedRequests += metricPoint.GetSumLong();
-                            var pointExpectedTags = new List<string>(expectedTags);
-                            if (GetTagDictionary(metricPoint.Tags).ContainsKey(TelemetryConstants.RawStsErrorCode))
-                                pointExpectedTags.Add(TelemetryConstants.RawStsErrorCode);
-                            AssertTags(metricPoint.Tags, pointExpectedTags, true);
+                            AssertTags(metricPoint.Tags, expectedTags, true);
                         }
 
                         Assert.AreEqual(expectedFailedRequests, totalFailedRequests);


### PR DESCRIPTION
Always emit the RawStsErrorCode dimension on MsalFailure, using an empty value when no STS error code is available.
This keeps the metric schema stable for Geneva pre-aggregates.